### PR TITLE
Disables Photon.

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -35,6 +35,10 @@ function amp_add_actions() {
 		return;
 	}
 
+	if ( class_exists( 'Jetpack' ) ) {
+		require_once( dirname( __FILE__ ) . '/jetpack-helper.php' );
+	}
+
 	if ( false !== get_query_var( AMP_QUERY_VAR, false ) ) {
 		// TODO: check if post_type supports amp
 		add_action( 'template_redirect', 'amp_template_redirect' );

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -1,0 +1,16 @@
+<?php
+
+// Jetpack bits.
+
+add_action( 'pre_amp_render', 'amp_jetpack_disable_photon' );
+
+/**
+ * Disables Photon for all images.
+ *
+ * Photon currently strips the height/width attr from the img tag, which nojoys AMP.
+ * For now, let's just disable Photon pending longterm fix.
+ *
+ **/
+function amp_jetpack_disable_photon() {
+	add_filter( 'jetpack_photon_skip_image', '__return_true' );
+}


### PR DESCRIPTION
Photon strips height/width attr from the img tag, causing many problems with AMP.

Fixes #32. See #14 