### PR TITLE
Jetpack: remove Related Posts' placeholder.

### DIFF
--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -2,8 +2,16 @@
 
 // Jetpack bits.
 
-add_action( 'pre_amp_render', 'amp_jetpack_disable_photon' );
-add_action( 'pre_amp_render', 'amp_jetpack_disable_related_posts' );
+add_action( 'pre_amp_render', 'amp_jetpack_mods' );
+
+/**
+ * Disable Jetpack features that are not compatible with AMP.
+ *
+ **/
+function amp_jetpack_mods() {
+	amp_jetpack_disable_photon();
+	amp_jetpack_disable_related_posts();
+}
 
 /**
  * Disables Photon for all images.

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -3,6 +3,7 @@
 // Jetpack bits.
 
 add_action( 'pre_amp_render', 'amp_jetpack_disable_photon' );
+add_action( 'pre_amp_render', 'amp_jetpack_disable_related_posts' );
 
 /**
  * Disables Photon for all images.
@@ -13,4 +14,17 @@ add_action( 'pre_amp_render', 'amp_jetpack_disable_photon' );
  **/
 function amp_jetpack_disable_photon() {
 	add_filter( 'jetpack_photon_skip_image', '__return_true' );
+}
+
+/**
+ * Remove the Related Posts placeholder and headline that gets hooked into the_content
+ *
+ * That placeholder is useless since we can't ouput, and don't want to output Related Posts in AMP.
+ *
+ **/
+function amp_jetpack_disable_related_posts() {
+	if ( class_exists( 'Jetpack_RelatedPosts' ) ) {
+		$jprp = Jetpack_RelatedPosts::init();
+		remove_filter( 'the_content', array( $jprp, 'filter_add_target_to_dom' ), 40 );
+	}
 }


### PR DESCRIPTION
Related Posts are not outputted on AMP pages.
No use to display a "Related" headline at the end of the posts.

This PR removes that headline.

![screen shot 2015-10-08 at 5 00 48 pm](https://cloud.githubusercontent.com/assets/426388/10370223/2cc99078-6dde-11e5-86d6-1c949c915a26.png)
