### PR TITLE
Give kses a bit of help

### DIFF
--- a/class-amp-kses.php
+++ b/class-amp-kses.php
@@ -7,10 +7,20 @@ class AMP_KSES {
 	/**
 	 * Strips blacklisted tags and attributes from content.
 	 *
+	 * See following for blacklist:
+	 *     https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#html-tags
+	 *
 	 * Note: DO NOT run this on content with amp tags (see #34105-core)
 	 */
 	static public function strip( $content ) {
-		// See https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#html-tags
+		// kses does not strip content inside tags
+		// we want it all gone, so clean it ourselves
+		// borrowed from wp_strip_all_tags
+		$blacklisted_tags = self::get_blacklisted_tags();
+		$blacklisted_pattern = '@<(' . implode( '|', $blacklisted_tags ) . ')[^>]*?>.*?</\\1>@si';
+		$content = preg_replace( $blacklisted_pattern, '', $content );
+
+		// kses to strip bad things in valid tags (on* attributes)
 		$allowed_html = self::get_allowed_html();
 		$allowed_protocols = self::get_allowed_protocols();
 		return wp_kses( $content, $allowed_html, $allowed_protocols );

--- a/tests/test-amp-kses.php
+++ b/tests/test-amp-kses.php
@@ -1,0 +1,45 @@
+<?php
+
+class AMP_KSES_Test extends WP_UnitTestCase {
+	function test_strip_empty() {
+		$source = '';
+		$expected = '';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_blacklisted_tags_only() {
+		$source = '<input type="text" /><script>alert("")</script><style>body{ color: red; }</style>';
+		$expected = '';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_whitelisted_tags_only() {
+		$source = '<p>Text</p><img src="/path/to/file.jpg" />';
+		$expected = '<p>Text</p><img src="/path/to/file.jpg" />';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_mixed_tags() {
+		$source = '<input type="text" /><p>Text</p><script>alert("")</script><style>body{ color: red; }</style>';
+		$expected = '<p>Text</p>';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_on_attribute() {
+		$source = '<img src="/path/to/file.jpg" onclick="alert(e);" />';
+		$expected = '<img src="/path/to/file.jpg" />';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_javascript_protocol() {
+		$source = '<a href="alert(\'Hello\');">Click</a>';
+		$expected = '<a href="">Click</a>';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+}

--- a/tests/test-amp-kses.php
+++ b/tests/test-amp-kses.php
@@ -37,8 +37,8 @@ class AMP_KSES_Test extends WP_UnitTestCase {
 	}
 
 	function test_strip_javascript_protocol() {
-		$source = '<a href="alert(\'Hello\');">Click</a>';
-		$expected = '<a href="">Click</a>';
+		$source = '<a href="javascript:alert(\'Hello\');">Click</a>';
+		$expected = '<a href="alert(\'Hello\');">Click</a>';
 		$content = AMP_KSES::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}

--- a/tests/test-amp-kses.php
+++ b/tests/test-amp-kses.php
@@ -8,6 +8,13 @@ class AMP_KSES_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
+	function test_strip_blacklisted_tags_with_innertext() {
+		$source = '<script>alert("")</script>';
+		$expected = '';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
 	function test_strip_blacklisted_tags_only() {
 		$source = '<input type="text" /><script>alert("")</script><style>body{ color: red; }</style>';
 		$expected = '';
@@ -25,6 +32,13 @@ class AMP_KSES_Test extends WP_UnitTestCase {
 	function test_strip_mixed_tags() {
 		$source = '<input type="text" /><p>Text</p><script>alert("")</script><style>body{ color: red; }</style>';
 		$expected = '<p>Text</p>';
+		$content = AMP_KSES::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_blacklisted_attributes() {
+		$source = '<img src="/path/to/file.jpg" style="border: 1px solid red;" />';
+		$expected = '<img src="/path/to/file.jpg" />';
 		$content = AMP_KSES::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}


### PR DESCRIPTION
kses does not strip content inside blacklisted tags.

So `<script>alert()</script>` is left as `alert()`

Use some regex to to clean those ourselves before running through kses.

Fixes #54 