### PR TITLE
kses/regex => DOMDocument for AMP_Sanitizer

### DIFF
--- a/class-amp-content.php
+++ b/class-amp-content.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once( dirname( __FILE__ ) . '/class-amp-kses.php' );
+require_once( dirname( __FILE__ ) . '/class-amp-sanitizer.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-img.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-iframe.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-video.php' );
@@ -20,10 +20,7 @@ class AMP_Content {
 
 		$content = apply_filters( 'the_content', $content );
 
-		// We run kses before AMP conversion due to a kses bug which doesn't allow hyphens (#34105-core).
-		// Our custom kses handler strips out all not-allowed stuff and leaves in stuff that will be converted (like iframe, img, audio, video).
-		// Technically, conversion should catch the tags so we shouldn't need to run it after anyway.
-		$content = AMP_KSES::strip( $content );
+		$content = AMP_Sanitizer::strip( $content );
 
 		// Convert HTML to AMP
 		// see https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#html-tags)

--- a/class-amp-sanitizer.php
+++ b/class-amp-sanitizer.php
@@ -1,6 +1,6 @@
 <?php
 
-class AMP_KSES {
+class AMP_Sanitizer {
 	private static $allowed_html;
 	private static $allowed_protocols;
 
@@ -153,4 +153,3 @@ class AMP_KSES {
 		);
 	}
 }
-

--- a/tests/test-amp-sanitizer.php
+++ b/tests/test-amp-sanitizer.php
@@ -1,59 +1,59 @@
 <?php
 
-class AMP_KSES_Test extends WP_UnitTestCase {
+class AMP_Sanitizer_Test extends WP_UnitTestCase {
 	function test_strip_empty() {
 		$source = '';
 		$expected = '';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_blacklisted_tags_with_innertext() {
 		$source = '<script>alert("")</script>';
 		$expected = '';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_blacklisted_tags_only() {
 		$source = '<input type="text" /><script>alert("")</script><style>body{ color: red; }</style>';
 		$expected = '';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_whitelisted_tags_only() {
 		$source = '<p>Text</p><img src="/path/to/file.jpg" />';
 		$expected = '<p>Text</p><img src="/path/to/file.jpg" />';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_mixed_tags() {
 		$source = '<input type="text" /><p>Text</p><script>alert("")</script><style>body{ color: red; }</style>';
 		$expected = '<p>Text</p>';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_blacklisted_attributes() {
 		$source = '<img src="/path/to/file.jpg" style="border: 1px solid red;" />';
 		$expected = '<img src="/path/to/file.jpg" />';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_on_attribute() {
 		$source = '<img src="/path/to/file.jpg" onclick="alert(e);" />';
 		$expected = '<img src="/path/to/file.jpg" />';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_javascript_protocol() {
 		$source = '<a href="javascript:alert(\'Hello\');">Click</a>';
 		$expected = '<a href="alert(\'Hello\');">Click</a>';
-		$content = AMP_KSES::strip( $source );
+		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 }

--- a/tests/test-amp-sanitizer.php
+++ b/tests/test-amp-sanitizer.php
@@ -24,7 +24,7 @@ class AMP_Sanitizer_Test extends WP_UnitTestCase {
 
 	function test_strip_whitelisted_tags_only() {
 		$source = '<p>Text</p><img src="/path/to/file.jpg" />';
-		$expected = '<p>Text</p><img src="/path/to/file.jpg" />';
+		$expected = '<p>Text</p><img src="/path/to/file.jpg"/>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
@@ -37,22 +37,29 @@ class AMP_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	function test_strip_blacklisted_attributes() {
-		$source = '<img src="/path/to/file.jpg" style="border: 1px solid red;" />';
-		$expected = '<img src="/path/to/file.jpg" />';
+		$source = '<img src="/path/to/file.jpg" style="border: 1px solid red;"/>';
+		$expected = '<img src="/path/to/file.jpg"/>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_on_attribute() {
 		$source = '<img src="/path/to/file.jpg" onclick="alert(e);" />';
-		$expected = '<img src="/path/to/file.jpg" />';
+		$expected = '<img src="/path/to/file.jpg"/>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_javascript_protocol() {
 		$source = '<a href="javascript:alert(\'Hello\');">Click</a>';
-		$expected = '<a href="alert(\'Hello\');">Click</a>';
+		$expected = '<a>Click</a>';
+		$content = AMP_Sanitizer::strip( $source );
+		$this->assertEquals( $expected, $content );
+	}
+
+	function test_strip_attribute_recursive() {
+		$source = '<div style="border: 1px solid red;"><img src="/path/to/file.jpg" onclick="alert(e);" />Hello World</div>';
+		$expected = '<div><img src="/path/to/file.jpg"/>Hello World</div>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}


### PR DESCRIPTION
Much more flexible and easier to work with, even if it may be a bit more verbose. It also let's us parse `amp-*` elements without issues (unlike kses).

Currently only used for `AMP_Sanitizer` but we'll probably roll this out across all Converters.