### PR TITLE
Add amp-youtube handler

### DIFF
--- a/class-amp-content.php
+++ b/class-amp-content.php
@@ -20,7 +20,7 @@ class AMP_Content {
 	public function transform() {
 		$content = $this->original_content;
 
-		$twitter = new AMP_Twitter;
+		$twitter = new AMP_Twitter_Embed_Handler;
 		$content = apply_filters( 'the_content', $content );
 		$this->add_scripts( $twitter->get_scripts() );
 

--- a/class-amp-content.php
+++ b/class-amp-content.php
@@ -7,6 +7,7 @@ require_once( dirname( __FILE__ ) . '/class-amp-video.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-audio.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-embed-handler.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-twitter-embed.php' );
+require_once( dirname( __FILE__ ) . '/class-amp-youtube-embed.php' );
 
 class AMP_Content {
 	private $original_content;
@@ -20,9 +21,11 @@ class AMP_Content {
 	public function transform() {
 		$content = $this->original_content;
 
-		$twitter = new AMP_Twitter_Embed_Handler;
+		$twitter_embed = new AMP_Twitter_Embed_Handler;
+		$youtube_embed = new AMP_YouTube_Embed_Handler;
 		$content = apply_filters( 'the_content', $content );
-		$this->add_scripts( $twitter->get_scripts() );
+		$this->add_scripts( $twitter_embed->get_scripts() );
+		$this->add_scripts( $youtube_embed->get_scripts() );
 
 		$content = AMP_Sanitizer::strip( $content );
 

--- a/class-amp-twitter-embed.php
+++ b/class-amp-twitter-embed.php
@@ -59,8 +59,14 @@ class AMP_Twitter_Embed_Handler extends AMP_Embed_Handler {
 	}
 
 	function oembed( $matches, $attr, $url, $rawattr ) {
+		$id = false;
+
 		if ( isset( $matches[5] ) && intval( $matches[5] ) ) {
 			$id = intval( $matches[5] );
+		}
+
+		if ( ! $id ) {
+			return '';
 		}
 
 		return $this->shortcode( array( 'tweet' => $id ) );

--- a/class-amp-twitter-embed.php
+++ b/class-amp-twitter-embed.php
@@ -3,7 +3,7 @@
 require_once( dirname( __FILE__ ) . '/class-amp-embed-handler.php' );
 
 // Much of this class is borrowed from Jetpack embeds
-class AMP_Twitter extends AMP_Embed_Handler {
+class AMP_Twitter_Embed_Handler extends AMP_Embed_Handler {
 	const URL_PATTERN = '#http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)#i';
 	const DEFAULT_WIDTH = 600;
 	const DEFAULT_HEIGHT = 400;

--- a/class-amp-twitter-embed.php
+++ b/class-amp-twitter-embed.php
@@ -14,10 +14,10 @@ class AMP_Twitter_Embed_Handler extends AMP_Embed_Handler {
 	private $args;
 
 	function __construct( $args = array() ) {
-		$this->args = shortcode_atts( array(
+		$this->args = wp_parse_args( $args, array(
 			'width' => self::DEFAULT_WIDTH,
 			'height' => self::DEFAULT_HEIGHT,
-		), $args );
+		) );
 
 		add_shortcode( 'tweet', array( $this, 'shortcode' ) );
 		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
@@ -32,9 +32,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Embed_Handler {
 	}
 
 	function shortcode( $attr ) {
-		$attr = shortcode_atts( array(
-			'tweet' => '',
-		), $attr );
+		$attr = wp_parse_args( $attr, array(
+			'tweet' => false,
+		) );
 
 		$id = false;
 		if ( intval( $attr['tweet'] ) ) {

--- a/class-amp-youtube-embed.php
+++ b/class-amp-youtube-embed.php
@@ -1,0 +1,110 @@
+<?php
+
+require_once( dirname( __FILE__ ) . '/class-amp-embed-handler.php' );
+
+// Much of this class is borrowed from Jetpack embeds
+class AMP_YouTube_Embed_Handler extends AMP_Embed_Handler {
+	const SHORT_URL_HOST = 'youtu.be';
+	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|playlist|watch[/\#?])|youtu\.be/).*#i';
+	const DEFAULT_WIDTH = 600;
+	const DEFAULT_HEIGHT = 480;
+
+	private static $script_slug = 'amp-youtube';
+	private static $script_src = 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js';
+
+	private $args;
+
+	function __construct( $args = array() ) {
+		$this->args = wp_parse_args( $args, array(
+			'width' => self::DEFAULT_WIDTH,
+			'height' => self::DEFAULT_HEIGHT,
+		) );
+
+		wp_embed_register_handler( 'amp-youtube', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+		add_shortcode( 'youtube', array( $this, 'shortcode' ) );
+	}
+
+	public function get_scripts() {
+		if ( ! $this->did_convert_elements ) {
+			return array();
+		}
+
+		return array( self::$script_slug => self::$script_src );
+	}
+
+	public function shortcode( $attr ) {
+		$url = false;
+		$video_id = false;
+		if ( isset( $attr[0] ) ) {
+			$url = ltrim( $attr[0] , '=' );
+		} elseif ( function_exists ( 'shortcode_new_to_old_params' ) ) {
+			$url = shortcode_new_to_old_params( $atts );
+		}
+
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		$video_id = $this->get_video_id_from_url( $url );
+
+		return $this->render( array(
+			'url' => $url,
+			'video_id' => $video_id,
+		) );
+	}
+
+	public function oembed( $matches, $attr, $url, $rawattr ) {
+		return $this->shortcode( array( $url ) );
+	}
+
+	public function render( $args ) {
+		$this->did_convert_elements = true;
+
+		$args = wp_parse_args( $args, array(
+			'video_id' => false,
+		) );
+
+		if ( empty( $args['video_id'] ) ) {
+			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => $args['url'], 'class' => 'amp-wp-fallback' ), $args['url'] );
+		}
+
+		return AMP_HTML_Utils::build_tag(
+			'amp-youtube',
+			wp_parse_args( array(
+				'data-videoid' => $args['video_id'],
+				'layout' => 'responsive',
+			), $this->args )
+		);
+	}
+
+	private function get_video_id_from_url( $url ) {
+		$video_id = false;
+		$parsed_url = parse_url( $url );
+
+		if ( self::SHORT_URL_HOST === substr( $parsed_url['host'], -strlen( self::SHORT_URL_HOST ) ) ) {
+			// youtu.be/{id}
+			$parts = explode( '/', $parsed_url['path'], 1 );
+			if ( ! empty( $parts ) ) {
+				$video_id = $parts[0];
+			}
+		} else {
+			// ?v={id} or ?list={id}
+			parse_str( $parsed_url['query'], $query_args );
+
+			if ( isset( $query_args['v'] ) ) {
+				$video_id = $query_args['v'];
+			}
+		}
+
+		if ( empty( $video_id ) ) {
+			// /(v|e|embed)/{id}
+			$parts = explode( '/', $parsed_url['path'], 1 );
+
+			if ( in_array( $parts[0], array( 'v', 'e', 'embed' ) ) ) {
+				$video_id = $parts[1];
+			}
+		}
+
+		return $video_id;
+	}
+}


### PR DESCRIPTION
Converts YouTube URLs and YouTube shortcodes to proper `amp-youtube` element.

There is a bit of weirdness in how we're handling these. Will need to look at how to make these easier to extend (e.g. your own shortcodes) and customize in future PRs.

Fixes #5 and #55 