### PR TITLE
Convert [gallery] to amp-carousel

### DIFF
--- a/class-amp-content.php
+++ b/class-amp-content.php
@@ -8,6 +8,7 @@ require_once( dirname( __FILE__ ) . '/class-amp-audio.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-embed-handler.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-twitter-embed.php' );
 require_once( dirname( __FILE__ ) . '/class-amp-youtube-embed.php' );
+require_once( dirname( __FILE__ ) . '/class-amp-gallery-embed.php' );
 
 class AMP_Content {
 	private $original_content;
@@ -23,9 +24,11 @@ class AMP_Content {
 
 		$twitter_embed = new AMP_Twitter_Embed_Handler;
 		$youtube_embed = new AMP_YouTube_Embed_Handler;
+		$gallery_embed = new AMP_Gallery_Embed_Handler;
 		$content = apply_filters( 'the_content', $content );
 		$this->add_scripts( $twitter_embed->get_scripts() );
 		$this->add_scripts( $youtube_embed->get_scripts() );
+		$this->add_scripts( $gallery_embed->get_scripts() );
 
 		$content = AMP_Sanitizer::strip( $content );
 

--- a/class-amp-gallery-embed.php
+++ b/class-amp-gallery-embed.php
@@ -1,0 +1,140 @@
+<?php
+
+require_once( dirname( __FILE__ ) . '/class-amp-embed-handler.php' );
+
+class AMP_Gallery_Embed_Handler extends AMP_Embed_Handler {
+	const DEFAULT_WIDTH = 600;
+	const DEFAULT_HEIGHT = 480;
+
+	private static $script_slug = 'amp-carousel';
+	private static $script_src = 'https://cdn.ampproject.org/v0/amp-carousel-0.1.js';
+
+	private $args;
+
+	function __construct( $args = array() ) {
+		$this->args = wp_parse_args( $args, array(
+			'width' => self::DEFAULT_WIDTH,
+			'height' => self::DEFAULT_HEIGHT,
+			'type' => 'slides',
+		) );
+
+		add_shortcode( 'gallery', array( $this, 'shortcode' ) );
+	}
+
+	public function get_scripts() {
+		if ( ! $this->did_convert_elements ) {
+			return array();
+		}
+
+		return array( self::$script_slug => self::$script_src );
+	}
+
+	public function shortcode( $attr ) {
+		$post = get_post();
+
+		if ( ! empty( $attr['ids'] ) ) {
+			// 'ids' is explicitly ordered, unless you specify otherwise.
+			if ( empty( $attr['orderby'] ) ) {
+				$attr['orderby'] = 'post__in';
+			}
+			$attr['include'] = $attr['ids'];
+		}
+
+		$atts = shortcode_atts( array(
+			'order'      => 'ASC',
+			'orderby'    => 'menu_order ID',
+			'id'         => $post ? $post->ID : 0,
+			'include'    => '',
+			'exclude'    => '',
+			'size'       => array( $this->args['width'], $this->args['height'] )
+		), $attr, 'gallery' );
+
+		$id = intval( $atts['id'] );
+
+		if ( ! empty( $atts['include'] ) ) {
+			$attachments = get_posts( array(
+				'include' => $atts['include'],
+				'post_status' => 'inherit',
+				'post_type' => 'attachment',
+				'post_mime_type' => 'image',
+				'order' => $atts['order'],
+				'orderby' => $atts['orderby'],
+				'fields' => 'ids',
+			) );
+		} elseif ( ! empty( $atts['exclude'] ) ) {
+			$attachments = get_children( array(
+				'post_parent' => $id,
+				'exclude' => $atts['exclude'],
+				'post_status' => 'inherit',
+				'post_type' => 'attachment',
+				'post_mime_type' => 'image',
+				'order' => $atts['order'],
+				'orderby' => $atts['orderby'],
+				'fields' => 'ids',
+			) );
+		} else {
+			$attachments = get_children( array(
+				'post_parent' => $id,
+				'post_status' => 'inherit',
+				'post_type' => 'attachment',
+				'post_mime_type' => 'image',
+				'order' => $atts['order'],
+				'orderby' => $atts['orderby'],
+				'fields' => 'ids',
+			) );
+		}
+
+		if ( empty( $attachments ) ) {
+			return '';
+		}
+
+		$urls = array();
+		foreach ( $attachments as $attachment_id ) {
+			list( $url, $width, $height ) = wp_get_attachment_image_src( $attachment_id, $atts['size'], true );
+
+			if ( ! $url ) {
+				continue;
+			}
+
+			$urls[] = array(
+				'url' => $url,
+				'width' => $width,
+				'height' => $height,
+			);
+		}
+
+		return $this->render( array(
+			'images' => $urls,
+		) );
+	}
+
+	public function render( $args ) {
+		$this->did_convert_elements = true;
+
+		$args = wp_parse_args( $args, array(
+			'images' => false,
+		) );
+
+		if ( empty( $args['images'] ) ) {
+			return '';
+		}
+
+		$images = array();
+		foreach ( $args['images'] as $image ) {
+			$images[] = AMP_HTML_Utils::build_tag(
+				'amp-img',
+				array(
+					'src' => $image['url'],
+					'width' => $image['width'],
+					'height' => $image['height'],
+				)
+			);
+		}
+
+		return AMP_HTML_Utils::build_tag(
+			'amp-carousel',
+			wp_parse_args( array(), $this->args ),
+			implode( PHP_EOL, $images )
+		);
+	}
+}

--- a/class-amp-sanitizer.php
+++ b/class-amp-sanitizer.php
@@ -39,7 +39,7 @@ class AMP_Sanitizer {
 		// Only want children of the body tag, since we have a subset of HTML.
 		$out = '';
 		foreach ( $body->childNodes as $node ) {
-			$out .= $dom->saveXML( $node );
+			$out .= $dom->saveXML( $node, LIBXML_NOEMPTYTAG );
 		}
 		return $out;
 	}

--- a/template.php
+++ b/template.php
@@ -155,6 +155,11 @@
 	blockquote p:last-child {
 		margin-bottom: 0;
 	}
+
+	/* Other Elements */
+	amp-carousel {
+		background: #000;
+	}
 	</style>
 </head>
 <body>

--- a/tests/test-amp-sanitizer.php
+++ b/tests/test-amp-sanitizer.php
@@ -24,7 +24,7 @@ class AMP_Sanitizer_Test extends WP_UnitTestCase {
 
 	function test_strip_whitelisted_tags_only() {
 		$source = '<p>Text</p><img src="/path/to/file.jpg" />';
-		$expected = '<p>Text</p><img src="/path/to/file.jpg"/>';
+		$expected = '<p>Text</p><img src="/path/to/file.jpg"></img>'; // LIBXML_NOEMPTYTAG
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
@@ -37,15 +37,15 @@ class AMP_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	function test_strip_blacklisted_attributes() {
-		$source = '<img src="/path/to/file.jpg" style="border: 1px solid red;"/>';
-		$expected = '<img src="/path/to/file.jpg"/>';
+		$source = '<a href="/path/to/file.jpg" style="border: 1px solid red;">Link</a>';
+		$expected = '<a href="/path/to/file.jpg">Link</a>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
 
 	function test_strip_on_attribute() {
-		$source = '<img src="/path/to/file.jpg" onclick="alert(e);" />';
-		$expected = '<img src="/path/to/file.jpg"/>';
+		$source = '<a href="/path/to/file.jpg" onclick="alert(e);">Link</a>';
+		$expected = '<a href="/path/to/file.jpg">Link</a>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}
@@ -58,8 +58,8 @@ class AMP_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	function test_strip_attribute_recursive() {
-		$source = '<div style="border: 1px solid red;"><img src="/path/to/file.jpg" onclick="alert(e);" />Hello World</div>';
-		$expected = '<div><img src="/path/to/file.jpg"/>Hello World</div>';
+		$source = '<div style="border: 1px solid red;"><a href="/path/to/file.jpg" onclick="alert(e);">Hello World</a></div>';
+		$expected = '<div><a href="/path/to/file.jpg">Hello World</a></div>';
 		$content = AMP_Sanitizer::strip( $source );
 		$this->assertEquals( $expected, $content );
 	}


### PR DESCRIPTION
The `amp-carousel` implementation is a bit rough bit it's the best we have for now for a gallery / slideshow view. The alternative would be to just display the large-ish versions of the images and maybe wire up to `amp-lightbox` (although, that doesn't allow swiping between images).

Letting this soak for a bit before deciding what the best course is.