### PR TITLE
Add filter (`amp_skip_post`) to skip posts

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -49,7 +49,12 @@ function amp_add_actions() {
 }
 
 function amp_template_redirect() {
-	amp_render( get_queried_object_id() );
+	$post_id = get_queried_object_id();
+	if ( true === apply_filters( 'amp_skip_post', false, $post_id ) ) {
+		return;
+	}
+
+	amp_render( $post_id );
 	exit;
 }
 
@@ -77,4 +82,3 @@ function amp_render( $post_id ) {
 	$amp_post = new AMP_Post( $post_id );
 	include( dirname( __FILE__ ) . '/template.php' );
 }
-


### PR DESCRIPTION
Usage:

```
add_filter( 'amp_skip_post', 'my_skip_some_amp_posts', 10, 2 ); 
function my_skip_some_amp_posts( $skip, $post_id ) {
    if ( 1234 == $post_id ) {
        $skip = true;
    }
    return $skip;
}
```

Fixes #56