### PR TITLE
rm `development` attr for amp runtime

### DIFF
--- a/template.php
+++ b/template.php
@@ -9,7 +9,7 @@
 	<?php foreach ( $amp_post->get_scripts() as $element => $script ) : ?>
 		<script custom-element="<?php echo esc_attr( $element ); ?>" src="<?php echo esc_url( $script ); ?>" async></script>
 	<?php endforeach; ?>
-	<script src="https://cdn.ampproject.org/v0.js" async <?php echo defined( 'AMP_DEV_MODE' ) && AMP_DEV_MODE ? 'development' : ''; ?>></script>
+	<script src="https://cdn.ampproject.org/v0.js" async></script>
 	<script type="application/ld+json"><?php echo json_encode( $amp_post->get_metadata() ); ?></script>
 	<?php do_action( 'amp_head', $amp_post ); ?>
 	<style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>


### PR DESCRIPTION
No longer supported. Fixes #86.