### PR TITLE
img converter should handle GIF urls with query

### DIFF
--- a/class-amp-converter.php
+++ b/class-amp-converter.php
@@ -29,7 +29,8 @@ abstract class AMP_Converter {
 		return AMP_HTML_Utils::build_attributes_string( $attributes );
 	}
 
-	protected function file_has_extension( $file, $ext ) {
-		return $ext === substr( $file, -strlen( $ext ) );
+	protected function url_has_extension( $url, $ext ) {
+		$path = parse_url( $url, PHP_URL_PATH );
+		return $ext === substr( $path, -strlen( $ext ) );
 	}
 }

--- a/class-amp-img.php
+++ b/class-amp-img.php
@@ -43,7 +43,7 @@ class AMP_Img_Converter extends AMP_Converter {
 					unset( $attributes['layout'] );
 				}
 
-				if ( $this->file_has_extension( $attributes['src'], self::$anim_extension ) ) {
+				if ( $this->url_has_extension( $attributes['src'], self::$anim_extension ) ) {
 					$this->did_convert_elements = true;
 					$new_img .= sprintf( '<amp-anim %s></amp-anim>', $this->build_attributes_string( $attributes ) );
 				} else {

--- a/tests/test-amp-img-converter.php
+++ b/tests/test-amp-img-converter.php
@@ -64,6 +64,15 @@ class AMP_Img_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $scripts );
 	}
 
+	function test_gif_image_url_with_querystring() {
+		$content = '<img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />';
+		$expected = '<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!"></amp-anim>';
+
+		$converter = new AMP_Img_Converter( $content );
+		$converted = $converter->convert();
+		$this->assertEquals( $expected, $converted );
+	}
+
 	function test_multiple_same_image() {
 		$content = '
 <img src="http://placehold.it/350x150" />


### PR DESCRIPTION
Parse the URL path and use that to check instead of just checking the end of the URL.

h/t @j3j5 (see https://github.com/Automattic/amp-wp/commit/73f4cd55e17f21f6f9970770a11f77b271eb58e0#commitcomment-15264564)
