### PR TITLE
Reactivate Photon

### DIFF
--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -9,19 +9,7 @@ add_action( 'pre_amp_render', 'amp_jetpack_mods' );
  *
  **/
 function amp_jetpack_mods() {
-	amp_jetpack_disable_photon();
 	amp_jetpack_disable_related_posts();
-}
-
-/**
- * Disables Photon for all images.
- *
- * Photon currently strips the height/width attr from the img tag, which nojoys AMP.
- * For now, let's just disable Photon pending longterm fix.
- *
- **/
-function amp_jetpack_disable_photon() {
-	add_filter( 'jetpack_photon_skip_image', '__return_true' );
 }
 
 /**


### PR DESCRIPTION
Photon in JP 3.8.2 resolved any issues with AMP previously. I'd suggest we just activate it. I've had second-thoughts on the version check—this is in dev and not released, I think it is fine to assume current version of other plugins, at least at time of release.

Fixes #102 