### PR TITLE
Remove extract_from_filename for dimensions

### DIFF
--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -14,27 +14,7 @@ class AMP_Image_Dimension_Extractor {
 	private static function register_callbacks() {
 		self::$callbacks_registered = true;
 
-		add_filter( 'amp_extract_image_dimensions', array( __CLASS__, 'extract_from_filename' ), 10, 2 );
 		add_filter( 'amp_extract_image_dimensions', array( __CLASS__, 'extract_from_attachment_metadata' ), 10, 2 );
-	}
-
-	public static function extract_from_filename( $dimensions, $url ) {
-		if ( $dimensions ) {
-			return $dimensions;
-		}
-
-		$path = parse_url( $url, PHP_URL_PATH );
-		$filename = basename( $path );
-		if ( ! $filename ) {
-			return false;
-		}
-
-		$result = preg_match( '~-(\d+)x(\d+)\.(jpg|jpeg|png)$~i', $filename, $matches );
-		if ( ! $result ) {
-			return false;
-		}
-
-		return array( $matches[1], $matches[2] );
 	}
 
 	public static function extract_from_attachment_metadata( $dimensions, $url ) {

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -1,49 +1,5 @@
 <?php
 
-class AMP_Image_Dimension_Extractor__From_Filename__Test extends WP_UnitTestCase {
-	public function get_data() {
-		return array(
-			'no_filename' => array(
-				'https://example.com/path/to/folder/',
-				false
-			),
-			'no_dimensions_in_file' => array(
-				'https://example.com/path/image.jpg',
-				false
-			),
-			'dimensions_with_wrong_ext' => array(
-				'https://example.com/path/image-100x100.txt',
-				false,
-			),
-			'valid_dimensions' => array(
-				'https://example.com/path/image-100x100.jpg',
-				array( 100, 100 ),
-			),
-			'valid_dimensions_uppercase_ext' => array(
-				'https://example.com/path/image-100x100.PNG',
-				array( 100, 100 ),
-			),
-		);
-	}
-
-	/**
-	 * @dataProvider get_data
-	 */
-	function test__no_dimensions_provided( $source_url, $expected ) {
-		$dimensions = AMP_Image_Dimension_Extractor::extract_from_filename( false, $source_url );
-		$this->assertEquals( $expected, $dimensions );
-	}
-
-	function test__dimensions_already_passed_in() {
-		$source_dimensions = array( 1, 1 );
-		$source_url = '';
-		$expected = array( 1, 1 );
-
-		$dimensions = AMP_Image_Dimension_Extractor::extract_from_filename( $source_dimensions, $source_url );
-		$this->assertEquals( $expected, $dimensions );
-	}
-}
-
 class AMP_Image_Dimension_Extractor__From_Metadata__Test extends WP_UnitTestCase {
 	private $_attachment_id = null;
 


### PR DESCRIPTION
It's a good idea in theory, but not always accurate (e.g. image could be
resized after being named with dimensions), which can lead to warped
images.