### PR TITLE
Add `amp_is_enabled` to globally disable plugin

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -27,6 +27,10 @@ function amp_deactivate(){
 
 add_action( 'init', 'amp_init' );
 function amp_init() {
+	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
+		return;
+	}
+
 	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
 	add_post_type_support( 'post', AMP_QUERY_VAR );
 


### PR DESCRIPTION
Useful if the plugin is network activated and you want to turn it off on select sites.

```
add_filter( 'amp_is_enabled', '__return_false' );
```