### PR TITLE
Consistency for html class naming

### DIFF
--- a/includes/embeds/class-amp-instagram-embed.php
+++ b/includes/embeds/class-amp-instagram-embed.php
@@ -59,7 +59,7 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 		) );
 
 		if ( empty( $args['instagram_id'] ) ) {
-			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-fallback' ), esc_html( $args['url'] ) );
+			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-embed-fallback' ), esc_html( $args['url'] ) );
 		}
 
 		$this->did_convert_elements = true;

--- a/includes/embeds/class-amp-vine-embed.php
+++ b/includes/embeds/class-amp-vine-embed.php
@@ -38,7 +38,7 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 		) );
 
 		if ( empty( $args['vine_id'] ) ) {
-			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-fallback' ), esc_html( $args['url'] ) );
+			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-embed-fallback' ), esc_html( $args['url'] ) );
 		}
 
 		$this->did_convert_elements = true;

--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -59,7 +59,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 		) );
 
 		if ( empty( $args['video_id'] ) ) {
-			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-fallback' ), esc_html( $args['url'] ) );
+			return AMP_HTML_Utils::build_tag( 'a', array( 'href' => esc_url( $args['url'] ), 'class' => 'amp-wp-embed-fallback' ), esc_html( $args['url'] ) );
 		}
 
 		$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -42,7 +42,7 @@ abstract class AMP_Base_Sanitizer {
 
 		$attributes['sizes'] = sprintf( '(min-width: %1$dpx) %1$dpx, 100vw', absint( $max_width ) );
 
-		$class = 'wp-amp-enforced-sizes';
+		$class = 'amp-wp-enforced-sizes';
 		if ( isset( $attributes['class'] ) ) {
 			$attributes['class'] .= ' ' . $class;
 		} else {

--- a/templates/amp-index.php
+++ b/templates/amp-index.php
@@ -24,7 +24,7 @@ $content_max_width = $amp_post->get_content_max_width();
 	.wp-caption.alignleft { margin-right: 1em; }
 	.wp-caption.alignright { margin-left: 1em; }
 
-	.wp-amp-enforced-sizes {
+	.amp-wp-enforced-sizes {
 		/** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
 		max-width: 100%;
 	}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -10,17 +10,17 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 			'simple_iframe' => array(
 				'<iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
-				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" frameborder="0" class="iframe-class wp-amp-enforced-sizes" allowfullscreen="true" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
+				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="true" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
 			),
 
 			'simple_iframe_with_sandbox' => array(
 				'<iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-same-origin"></iframe>',
-				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
+				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'iframe_with_blacklisted_attribute' => array(
 				'<iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" scrolling="auto"></iframe>',
-				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
+				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'iframe_with_sizes_attribute' => array(
@@ -35,9 +35,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 <iframe src="https://player.vimeo.com/video/132886713" width="500" height="281"></iframe>
 				',
 				'
-<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
-<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
-<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
 				',
 			),
 
@@ -48,14 +48,14 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 <iframe src="https://player.vimeo.com/video/11111" width="700" height="601"></iframe>
 				',
 				'
-<amp-iframe src="https://player.vimeo.com/video/12345" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
-<amp-iframe src="https://player.vimeo.com/video/67890" width="280" height="501" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 280px) 280px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
-<amp-iframe src="https://player.vimeo.com/video/11111" width="700" height="601" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 700px) 700px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/12345" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/67890" width="280" height="501" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 280px) 280px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
+<amp-iframe src="https://player.vimeo.com/video/11111" width="700" height="601" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 700px) 700px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>
 				',
 			),
 			'iframe_in_p_tag' => array(
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>',
-				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
+				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 		);
 	}
@@ -97,7 +97,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 	public function test__args__placeholder() {
 		$source = '<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe>';
-		$expected = '<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"><div layout="fill" placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe>';
+		$expected = '<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"><div layout="fill" placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array(

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -15,17 +15,17 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_self_closing_tag' => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="wp-amp-enforced-sizes"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-img>',
 			),
 
 			'image_with_no_end_tag' => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!">',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="wp-amp-enforced-sizes"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-img>',
 			),
 
 			'image_with_end_tag' => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></img>',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="wp-amp-enforced-sizes"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-img>',
 			),
 
 			'image_with_blacklisted_attribute' => array(
@@ -40,12 +40,12 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'gif_image_conversion' => array(
 				'<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="wp-amp-enforced-sizes"></amp-anim>',
+				'<amp-anim src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-anim>',
 			),
 
 			'gif_image_url_with_querystring' => array(
 				'<img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="wp-amp-enforced-sizes"></amp-anim>',
+				'<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-anim>',
 			),
 
 			'multiple_same_image' => array(

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -10,22 +10,22 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'simple_video' => array(
 				'<video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="wp-amp-enforced-sizes"></amp-video>',
+				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'autoplay_attribute' => array(
 				'<video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" autoplay></video>',
-				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" autoplay="desktop tablet mobile" sizes="(min-width: 300px) 300px, 100vw" class="wp-amp-enforced-sizes"></amp-video>',
+				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" autoplay="desktop tablet mobile" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'video_with_whitelisted_attributes' => array(
 				'<video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" controls loop muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" controls="true" loop="true" sizes="(min-width: 300px) 300px, 100vw" class="wp-amp-enforced-sizes"></amp-video>',
+				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" controls="true" loop="true" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'video_with_blacklisted_attribute' => array(
 				'<video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" style="border-color: red;"></video>',
-				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="wp-amp-enforced-sizes"></amp-video>',
+				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'video_with_sizes_attribute' => array(
@@ -38,7 +38,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	<source src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" type="video/mp4" />
 	<source src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" type="video/ogg" />
 </video>',
-				'<amp-video width="480" height="300" poster="https://archive.org/download/WebmVp8Vorbis/webmvp8.gif" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"><source src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" type="video/mp4"></source><source src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" type="video/ogg"></source></amp-video>'
+				'<amp-video width="480" height="300" poster="https://archive.org/download/WebmVp8Vorbis/webmvp8.gif" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"><source src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" type="video/mp4"></source><source src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" type="video/ogg"></source></amp-video>'
 			),
 
 			'multiple_same_video' => array(
@@ -46,14 +46,14 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 <video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300"></video>
 <video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300"></video>
 <video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300"></video>',
-				'<amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"></amp-video>'
+				'<amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video>'
 			),
 
 			'multiple_different_videos' => array(
 				'<video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300"></video>
 <video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" width="300" height="480"></video>
 <video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.webm" height="100" width="200"></video>',
-				'<amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="wp-amp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" width="300" height="480" sizes="(min-width: 300px) 300px, 100vw" class="wp-amp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.webm" height="100" width="200" sizes="(min-width: 200px) 200px, 100vw" class="wp-amp-enforced-sizes"></amp-video>'
+				'<amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv" width="300" height="480" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://archive.org/download/WebmVp8Vorbis/webmvp8.webm" height="100" width="200" sizes="(min-width: 200px) 200px, 100vw" class="amp-wp-enforced-sizes"></amp-video>'
 			)
 		);
 	}

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -49,7 +49,7 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 					'width' => 200,
 					'height' => 100,
 					'sizes' => '(min-width: 200px) 200px, 100vw',
-					'class' => 'wp-amp-enforced-sizes'
+					'class' => 'amp-wp-enforced-sizes'
 				),
 			),
 
@@ -63,7 +63,7 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 					'width' => 200,
 					'height' => 100,
 					'sizes' => '(min-width: 200px) 200px, 100vw',
-					'class' => 'my-class wp-amp-enforced-sizes'
+					'class' => 'my-class amp-wp-enforced-sizes'
 				),
 			),
 
@@ -76,7 +76,7 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 					'width' => 250,
 					'height' => 100,
 					'sizes' => '(min-width: 250px) 250px, 100vw',
-					'class' => 'wp-amp-enforced-sizes'
+					'class' => 'amp-wp-enforced-sizes'
 				),
 				array(
 					'content_max_width' => 500,
@@ -92,7 +92,7 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 					'width' => 800,
 					'height' => 350,
 					'sizes' => '(min-width: 675px) 675px, 100vw',
-					'class' => 'wp-amp-enforced-sizes'
+					'class' => 'amp-wp-enforced-sizes'
 				),
 				array(
 					'content_max_width' => 675,


### PR DESCRIPTION
Should all start with `amp-wp-`. This level of specificity is probably not needed, but doesn't hurt.