### PR TITLE
Bugfix for iframe / blacklist sanitizer

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -25,7 +25,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		if ( $node->hasAttributes() ) {
-			foreach ( $node->attributes as $attribute ) {
+			$length = $node->attributes->length;
+			for( $i = $length - 1; $i >= 0; $i--) {
+				$attribute = $node->attributes->item($i);
 				$attribute_name = strtolower( $attribute->name );
 				if ( in_array( $attribute_name, $bad_attributes ) ) {
 					$node->removeAttribute( $attribute_name );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -62,7 +62,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			if ( 'p' === strtolower( $parent_node->tagName ) ) {
 				// AMP does not like iframes in p tags
 				$parent_node->removeChild( $node );
-				$parent_node->parentNode->appendChild( $new_node );
+				$parent_node->parentNode->insertBefore( $new_node , $parent_node->nextSibling);
+				if( $parent_node->childNodes->length == 0 && empty( $parent_node->textContent ) ) {
+					$parent_node->parentNode->removeChild( $parent_node );
+				}
 			} else {
 				$parent_node->replaceChild( $new_node, $node );
 			}

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -40,10 +40,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$node->parentNode->removeChild( $node );
 				continue;
 			}
-			else if ( substr ( trim ( $old_attributes['src'] ), 0, 5 ) !== "https" ) {
-				$node->parentNode->removeChild( $node );
-				continue;
-			}
 
 			$this->did_convert_elements = true;
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -40,6 +40,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$node->parentNode->removeChild( $node );
 				continue;
 			}
+			else if ( substr ( trim ( $old_attributes['src'] ), 0, 5 ) !== "https" ) {
+				$node->parentNode->removeChild( $node );
+				continue;
+			}
 
 			$this->did_convert_elements = true;
 
@@ -57,7 +61,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$parent_node = $node->parentNode;
 			if ( 'p' === strtolower( $parent_node->tagName ) ) {
 				// AMP does not like iframes in p tags
-				$parent_node->parentNode->replaceChild( $new_node, $parent_node );
+				$parent_node->removeChild( $node );
+				$parent_node->parentNode->appendChild( $new_node );
 			} else {
 				$parent_node->replaceChild( $new_node, $node );
 			}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -57,6 +57,14 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>',
 				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
 			),
+			'iframes_in_p_tag' => array(
+				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
+				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
+			),
+			'iframes_and_contents_in_p_tag' => array(
+				'<p>contents<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
+				'<p>contents</p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="wp-amp-enforced-sizes"></amp-iframe>',
+			),
 		);
 	}
 


### PR DESCRIPTION
Hi, these are  bug fixes for iframe / blacklist sanitizer.
Please review and marge.

**fix for iframe sanitizer**
There is a bug when several iframe tags in p tag.
`<p><iframe></iframe><iframe></iframe></p>`
In this case, as it is replacing parent p tag with the new amp-iframe tag,  it will crash by referring invalid node in the next loop. 
I changed to append amp-iframe after p tag, and remove p tag only when there is nothing in it.

**fix for blocklist sanitizer**
Currently the only first blacklist attribute is removed as it is removing the attribute in foreach loop.
 This is a minor as the blacklist attribute is only "style" for now.

Regards