### PR TITLE
Fallback iframe+video to fixed-height

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -6,6 +6,7 @@ require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php' )
  * Converts <iframe> tags to <amp-iframe>
  */
 class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
+	const FALLBACK_HEIGHT = 400;
 	const SANDBOX_DEFAULTS = 'allow-scripts allow-same-origin';
 
 	public static $tag = 'iframe';
@@ -44,6 +45,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$this->did_convert_elements = true;
 
 			$new_attributes = $this->filter_attributes( $old_attributes );
+			if ( ! isset( $new_attributes['width'], $new_attributes['height'] ) ) {
+				$new_attributes['height'] = self::FALLBACK_HEIGHT;
+				$new_attributes['layout'] = 'fixed-height';
+			}
 			$new_attributes = $this->enforce_sizes_attribute( $new_attributes );
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-iframe', $new_attributes );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -6,6 +6,8 @@ require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php' )
  * Converts <video> tags to <amp-video>
  */
 class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
+	const FALLBACK_HEIGHT = 400;
+
 	public static $tag = 'video';
 
 	public function sanitize() {
@@ -20,6 +22,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
 			$new_attributes = $this->filter_attributes( $old_attributes );
+			if ( ! isset( $new_attributes['width'], $new_attributes['height'] ) ) {
+				$new_attributes['height'] = self::FALLBACK_HEIGHT;
+				$new_attributes['layout'] = 'fixed-height';
+			}
 			$new_attributes = $this->enforce_sizes_attribute( $new_attributes );
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-video', $new_attributes );
@@ -62,8 +68,6 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 			}
 		}
-
-		// TODO: default width/height
 
 		return $out;
 	}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -13,6 +13,11 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
 			),
 
+			'iframe_without_dimensions' => array(
+				'<iframe src="https://example.com/video/132886713"></iframe>',
+				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+			),
+
 			'simple_iframe_with_sandbox' => array(
 				'<iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-same-origin"></iframe>',
 				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -13,6 +13,11 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
+			'video_without_dimensions' => array(
+				'<video src="https://example.com/file.mp4"></video>',
+				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"></amp-video>',
+			),
+
 			'autoplay_attribute' => array(
 				'<video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" autoplay></video>',
 				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" autoplay="desktop tablet mobile" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',


### PR DESCRIPTION
If iframe or video don't have dimensions, let's fall back to a fixed
height and let them scale width-wise in the viewport. Both elements
scale pretty well when only provided a height. This also prevents
validation errors when outputting without any dimensions.