### PR TITLE
Always override sizes attribute

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -31,10 +31,6 @@ abstract class AMP_Base_Sanitizer {
 	 * See https://github.com/Automattic/amp-wp/issues/101
 	 */
 	public function enforce_sizes_attribute( $attributes ) {
-		if ( isset( $attributes['sizes'] ) ) {
-			return $attributes;
-		}
-
 		if ( ! isset( $attributes['width'], $attributes['height'] ) ) {
 			return $attributes;
 		}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -28,9 +28,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://player.vimeo.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
-			'iframe_with_sizes_attribute' => array(
+			'iframe_with_sizes_attribute_is_overridden' => array(
 				'<iframe src="https://example.com/iframe" width="500" height="281" sizes="(min-width: 100px) 300px, 90vw"></iframe>',
-				'<amp-iframe src="https://example.com/iframe" width="500" height="281" sizes="(min-width: 100px) 300px, 90vw" sandbox="allow-scripts allow-same-origin"></amp-iframe>',
+				'<amp-iframe src="https://example.com/iframe" width="500" height="281" sizes="(min-width: 500px) 500px, 100vw" sandbox="allow-scripts allow-same-origin" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'multiple_same_iframe' => array(

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -33,9 +33,9 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="http://placehold.it/350x150"></amp-img>',
 			),
 
-			'image_with_sizes_attribute' => array(
+			'image_with_sizes_attribute_is_overriden' => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" sizes="(min-width: 100px) 300px, 90vw" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" sizes="(min-width: 100px) 300px, 90vw"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-img>',
 			),
 
 			'gif_image_conversion' => array(

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -33,9 +33,9 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<amp-video width="300" height="300" src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
-			'video_with_sizes_attribute' => array(
+			'video_with_sizes_attribute_is_overridden' => array(
 				'<video width="300" height="200" src="https://example.com/file.mp4" sizes="(min-width: 100px) 200px, 90vw"></video>',
-				'<amp-video width="300" height="200" src="https://example.com/file.mp4" sizes="(min-width: 100px) 200px, 90vw"></amp-video>',
+				'<amp-video width="300" height="200" src="https://example.com/file.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'video_with_children' => array(


### PR DESCRIPTION
Images larger than the content well end up overflowing and enforcing our
own sizes attribute helps prevent that.

Fixes #158