### PR TITLE
Fix validation errors with gallery

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -126,7 +126,12 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-carousel',
-			wp_parse_args( array(), $this->args ),
+			array(
+				'width' => $this->args['width'],
+				'height' => $this->args['height'],
+				'type' => 'slides',
+				'layout' => 'responsive',
+			),
 			implode( PHP_EOL, $images )
 		);
 	}


### PR DESCRIPTION
Don't output args as-is. Make them explicit (so we don't end up outputting `content_max_width`).