### PR TITLE
Move `style` tag out of style file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,9 +200,9 @@ function xyz_amp_my_additional_css_styles( $amp_template ) {
 If you'd prefer to use your own styles, you can either:
 
 - Create a folder in your theme called `amp` and add a file called `style.php` with your custom CSS.
-- Specify a custom template using the `amp_post_template_file` filter for `'style' === $type`.
+- Specify a custom template using the `amp_post_template_file` filter for `'style' === $type`. See the "Override" examples in the "Meta" section for examples.
 
-See the "Override" examples in the "Meta" section for examples.
+Note: the file should only include CSS, not the `<style>` opening and closing tag.
 
 #### Head and Footer
 
@@ -257,6 +257,12 @@ do_action( 'amp_post_template_head', $this );
 
 ```
 do_action( 'amp_post_template_footer', $this );
+```
+
+* Within your `amp-custom` `style` tags, you must trigger the `amp_post_template_css` action: 
+
+```php
+do_action( 'amp_post_template_css', $this );
 ```
 
 * You must include [all required mark-up](https://www.ampproject.org/docs/get_started/create/basic_markup.html) that isn't already output via the `amp_post_template_head` action.

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,10 @@ You can find details about customization options at https://github.com/Automatti
 
 == Changelog ==
 
+= 0.3 =
+
+* Breaking change: style.css no longer contains the `<style> tag. If you have a custom stylesheet, you need to update it to remove the tag.
+
 = 0.2 (Jan 28, 2016) =
 
 * Lots and lots and lots of compatibility and validation fixes

--- a/templates/single.php
+++ b/templates/single.php
@@ -6,7 +6,11 @@
 	<link href="https://fonts.googleapis.com/css?family=Merriweather:400,400italic,700,700italic|Open+Sans:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 	<style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+
+	<style amp-custom>
 	<?php $this->load_parts( array( 'style' ) ); ?>
+	<?php do_action( 'amp_post_template_css', $this ); ?>
+	</style>
 </head>
 <body>
 <nav class="title-bar">

--- a/templates/style.php
+++ b/templates/style.php
@@ -1,4 +1,3 @@
-<style amp-custom>
 /* Generic WP styling */
 amp-img.alignright { float: right; margin: 0 0 1em 1em; }
 amp-img.alignleft { float: left; margin: 0 1em 1em 0; }
@@ -196,6 +195,3 @@ amp-vine {
 	background-size: 48px 48px;
 	min-height: 48px;
 }
-
-<?php do_action( 'amp_post_template_css', $this ); ?>
-</style>


### PR DESCRIPTION
To ensure wider compatibility. If you replace the stylesheet, you shouldn't have to add the action. This way, plugins and such can still work nicely with folks with custom stylesheets.