### PR TITLE
Use explicit is_array checks

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -202,7 +202,7 @@ class AMP_Post_Template {
 
 		$post_image_src = wp_get_attachment_image_src( $post_image_id, 'full' );
 
-		if ( $post_image_src ) {
+		if ( is_array( $post_image_src ) ) {
 			$post_image_meta = array(
 				'@type' => 'ImageObject',
 				'url' => $post_image_src[0],

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -33,7 +33,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$new_attributes = $this->filter_attributes( $old_attributes );
 			if ( ! isset( $new_attributes['width'] ) || ! isset( $new_attributes['height'] ) ) {
 				$dimensions = AMP_Image_Dimension_Extractor::extract( $new_attributes['src'] );
-				if ( $dimensions ) {
+				if ( is_array( $dimensions ) ) {
 					$new_attributes['width'] = $dimensions[0];
 					$new_attributes['height'] = $dimensions[1];
 				}

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -18,7 +18,7 @@ class AMP_Image_Dimension_Extractor {
 	}
 
 	public static function extract_from_attachment_metadata( $dimensions, $url ) {
-		if ( $dimensions ) {
+		if ( is_array( $dimensions ) ) {
 			return $dimensions;
 		}
 

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -71,7 +71,7 @@ function jetpack_amp_disable_the_content_filters( $post_id ) {
 }
 
 add_action( 'amp_post_template_head', 'jetpack_amp_add_og_tags' );
-	
+
 function jetpack_amp_add_og_tags( $amp_template ) {
 	if ( function_exists( 'jetpack_og_tags' ) ) {
 		jetpack_og_tags();
@@ -115,7 +115,7 @@ function wpcom_amp_add_blavatar( $metadata, $post ) {
 // If images are being served from Photon or WP.com files, try extracting the size using querystring.
 add_action( 'amp_extract_image_dimensions', 'wpcom_amp_extract_image_dimensions_from_querystring', 9, 2 ); // Hook in before the default extractors
 function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions, $url ) {
-	if ( $dimensions ) {
+	if ( is_array( $dimensions ) ) {
 		return $dimensions;
 	}
 
@@ -138,7 +138,7 @@ function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions, $url 
 // Uses a special wpcom lib (wpcom_getimagesize) to extract dimensions as a last resort if we weren't able to figure them out.
 add_action( 'amp_extract_image_dimensions', 'wpcom_amp_extract_image_dimensions_from_getimagesize', 100, 2 ); // Our last resort
 function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions, $url ) {
-	if ( $dimensions ) {
+	if ( is_array( $dimensions ) ) {
 		return $dimensions;
 	}
 
@@ -148,9 +148,9 @@ function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions, $url
 
 	require_lib( 'wpcom/imagesize' );
 	$size = wpcom_getimagesize( $url );
-	if ( $size ) {
-		return array( $size[0], $size[1] );
+	if ( ! is_array( $size ) ) {
+		return false;
 	}
 
-	return false;
+	return array( $size[0], $size[1] );
 }


### PR DESCRIPTION
We were previously just doing a boolean check which isn't ideal for all situations. `is_array` protects us better.