### PR TITLE
check for get_site_icon_url() on < 4.3

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -37,12 +37,14 @@ class AMP_Post_Template {
 			'home_url' => home_url(),
 			'blog_name' => get_bloginfo( 'name' ),
 
-			'site_icon_url' => get_site_icon_url( self::SITE_ICON_SIZE ),
 			'placeholder_image_url' => amp_get_asset_url( 'images/placeholder-icon.png' ),
 
 			'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',
 			'amp_component_scripts' => array(),
 		);
+
+		if(function_exists("get_site_icon_url"))
+			$this->data['site_icon_url'] = get_site_icon_url( self::SITE_ICON_SIZE );
 
 		$this->build_post_content();
 		$this->build_post_data();


### PR DESCRIPTION
`get_site_icon_url()` was added in 4.3. For older WP compatibility this only sets the data array where the function is available and still allows the hook to operate as normal. Without this on < 4.3 Wordpress will fatal error on a clean install & activation.

https://developer.wordpress.org/reference/functions/get_site_icon_url/