### PR TITLE
Adding backwards compatibility for older versions of WordPress

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -37,7 +37,7 @@ class AMP_Post_Template {
 			'home_url' => home_url(),
 			'blog_name' => get_bloginfo( 'name' ),
 
-			'site_icon_url' => get_site_icon_url( self::SITE_ICON_SIZE ),
+			'site_icon_url' => function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '',
 			'placeholder_image_url' => amp_get_asset_url( 'images/placeholder-icon.png' ),
 
 			'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -37,7 +37,7 @@ class AMP_Post_Template {
 			'home_url' => home_url(),
 			'blog_name' => get_bloginfo( 'name' ),
 
-			'site_icon_url' => function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '',
+			'site_icon_url' => apply_filters( 'amp_site_icon_url', function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '' ),
 			'placeholder_image_url' => amp_get_asset_url( 'images/placeholder-icon.png' ),
 
 			'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',

--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -1,7 +1,9 @@
 <?php $post_author = $this->get( 'post_author' ); ?>
 <li class="byline">
+	<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
 	<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array(
 		'size' => 24,
 	) ) ); ?>" width="24" height="24" layout="fixed"></amp-img>
+	<?php endif; ?>
 	<span class="author"><?php echo esc_html( $post_author->display_name ); ?></span>
 </li>

--- a/templates/single.php
+++ b/templates/single.php
@@ -16,7 +16,7 @@
 <nav class="title-bar">
 	<div>
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
-			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
+			<?php $site_icon_url = apply_filters( 'amp_site_icon_url', $this->get( 'site_icon_url' ) ); ?>
 			<?php if ( $site_icon_url ) : ?>
 				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="site-icon"></amp-img>
 			<?php else : ?>

--- a/templates/single.php
+++ b/templates/single.php
@@ -16,7 +16,7 @@
 <nav class="title-bar">
 	<div>
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
-			<?php $site_icon_url = apply_filters( 'amp_site_icon_url', $this->get( 'site_icon_url' ) ); ?>
+			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
 				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="site-icon"></amp-img>
 			<?php else : ?>


### PR DESCRIPTION
Upon testing this plugin on version 4.1.6, I discovered that two functions were in use that caused fatal errors:

`get_site_icon_url`: only exists since 4.3
`get_avatar_url`: only exists since 4.2

The site icon already has a nice SVG default and I've made it filterable to allow you to provide your own in absence of the core function.

There isn't really a great fallback for the avatar URL, but simply removing it does not significantly degrade the experience.

Both of these seem like small compromises to allow wider usage of AMP on older installs.