### PR TITLE
Add amp-facebook support

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -13,6 +13,7 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-youtube-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-gallery-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
 
 class AMP_Post_Template {
 	const SITE_ICON_SIZE = 32;
@@ -148,6 +149,7 @@ class AMP_Post_Template {
 				'AMP_YouTube_Embed_Handler' => array(),
 				'AMP_Instagram_Embed_Handler' => array(),
 				'AMP_Vine_Embed_Handler' => array(),
+				'AMP_Facebook_Embed_Handler' => array(),
 				'AMP_Gallery_Embed_Handler' => array(),
 			), $this->post ),
 			apply_filters( 'amp_content_sanitizers', array(

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-base-embed-handler.php' );
+
+class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
+	const URL_PATTERN = '#https?://(www\.)?facebook\.com/.*#i';
+
+	protected $DEFAULT_WIDTH = 600;
+	protected $DEFAULT_HEIGHT = 400;
+
+	private static $script_slug = 'amp-facebook';
+	private static $script_src = 'https://cdn.ampproject.org/v0/amp-facebook-0.1.js';
+
+	public function register_embed() {
+		wp_embed_register_handler( 'amp-facebook', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+	}
+
+	public function unregister_embed() {
+		wp_embed_unregister_handler( 'amp-facebook', -1 );
+	}
+
+	public function get_scripts() {
+		if ( ! $this->did_convert_elements ) {
+			return array();
+		}
+
+		return array( self::$script_slug => self::$script_src );
+	}
+
+	public function oembed( $matches, $attr, $url, $rawattr ) {
+		return $this->render( array( 'url' => $url ) );
+	}
+
+	public function render( $args ) {
+		$args = wp_parse_args( $args, array(
+			'url' => false,
+		) );
+
+		if ( empty( $args['url'] ) ) {
+			return '';
+		}
+
+		$this->did_convert_elements = true;
+
+		return AMP_HTML_Utils::build_tag(
+			'amp-facebook',
+			array(
+				'data-href' => $args['url'],
+				'layout' => 'responsive',
+				'width' => $this->args['width'],
+				'height' => $this->args['height'],
+			)
+		);
+	}
+}

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -1,0 +1,74 @@
+<?php
+
+class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
+	public function get_conversion_data() {
+		return array(
+			'no_embed' => array(
+				'<p>Hello world.</p>',
+				'<p>Hello world.</p>' . PHP_EOL
+			),
+			'simple_url_https' => array(
+				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
+				'<p><amp-facebook data-href="https://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+			'simple_url_http' => array(
+				'http://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
+				'<p><amp-facebook data-href="http://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+			'no_dubdubdub' => array(
+				'https://facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
+				'<p><amp-facebook data-href="https://facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+			'notes_url' => array(
+				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
+				'<p><amp-facebook data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+			'photo_url' => array(
+				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
+				'<p><amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+			'notes_url' => array(
+				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
+				'<p><amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL
+			),
+
+
+		);
+	}
+
+	/**
+	 * @dataProvider get_conversion_data
+	 */
+	public function test__conversion( $source, $expected ) {
+		$embed = new AMP_Facebook_Embed_Handler();
+		$embed->register_embed();
+		$filtered_content = apply_filters( 'the_content', $source );
+
+		$this->assertEquals( $expected, $filtered_content );
+	}
+
+	public function get_scripts_data() {
+		return array(
+			'not_converted' => array(
+				'<p>Hello World.</p>',
+				array()
+			),
+			'converted' => array(
+				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
+				array( 'amp-facebook' => 'https://cdn.ampproject.org/v0/amp-facebook-0.1.js' )
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_scripts_data
+	 */
+	public function test__get_scripts( $source, $expected ) {
+		$embed = new AMP_Facebook_Embed_Handler();
+		$embed->register_embed();
+		apply_filters( 'the_content', $source );
+		$scripts = $embed->get_scripts();
+
+		$this->assertEquals( $expected, $scripts );
+	}
+}


### PR DESCRIPTION
Any `facebook.com/*` URL gets converted to an amp-facebook element.

Fixes #139 