### PR TITLE
Add full post to amp_skip_post filter

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -16,7 +16,7 @@ function post_supports_amp( $post ) {
 		return false;
 	}
 
-	if ( true === apply_filters( 'amp_skip_post', false, $post->ID ) ) {
+	if ( true === apply_filters( 'amp_skip_post', false, $post->ID, $post ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
As so many of the sites that will want to take advantage of this are quite large getting the necessary data from the post_id alone is inefficient, particularly where the post object has already been created. This exposes the full post object to the amp_skip_post filter to prevent unneeded retrieval of the common data.