### PR TITLE
Removed the tag "button" from the arrary returned by get_blacklisted_…

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -103,7 +103,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'applet',
 			'form',
 			'input',
-			'button',
 			'textarea',
 			'select',
 			'option',


### PR DESCRIPTION
Removed the tag "button" from the arrary returned by get_blacklisted_tags().

The button tag is allowed per https://www.ampproject.org/docs/reference/spec.html