### PR TITLE
Removing 'on' attribute from blacklist for image and button tags.

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -39,7 +39,14 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 
 				// on* attributes (like onclick) are a special case
 				if ( 0 === stripos( $attribute_name, 'on' ) ) {
-					$node->removeAttribute( $attribute_name );
+					switch ($node->tagName) {
+						case 'button':
+						case 'img':
+						case 'amp-img':
+							break;
+						default;
+							$node->removeAttribute( $attribute_name );
+					}
 					continue;
 				} elseif ( 'href' === $attribute_name ) {
 					$protocol = strtok( $attribute->value, ':' );

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -38,15 +38,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				// on* attributes (like onclick) are a special case
-				if ( 0 === stripos( $attribute_name, 'on' ) ) {
-					switch ($node->tagName) {
-						case 'button':
-						case 'img':
-						case 'amp-img':
-							break;
-						default;
-							$node->removeAttribute( $attribute_name );
-					}
+				if ( 0 === stripos( $attribute_name, 'on' ) && $attribute_name != 'on' ) {
+					$node->removeAttribute( $attribute_name );
 					continue;
 				} elseif ( 'href' === $attribute_name ) {
 					$protocol = strtok( $attribute->value, ':' );

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -73,6 +73,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				case 'class':
 				case 'srcset':
 				case 'sizes':
+				case 'on':
 					$out[ $name ] = $value;
 					break;
 				default;


### PR DESCRIPTION
Removing 'on' attribute from blacklist for image and button tags.
Needed to get example in amp-lightbox to work.
https://www.ampproject.org/docs/reference/extended/amp-lightbox.html