### PR TITLE
Prefix all HTML class names with `amp-wp-`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ For the meta section of the template (i.e. author, date, taxonomies, etc.), you 
 Create a folder in your theme called `amp` and add a file called `meta-author.php` with the following:
 
 ```php
-<li class="byline">
+<li class="xyz-byline">
 	<span>Anonymous</span>
 </li>
 ```
@@ -160,7 +160,7 @@ function xyz_amp_set_custom_tax_meta_template( $file, $type, $post ) {
 In `t/meta-custom-tax.php`, you can add something like the following to replace the default category and tags with your custom `author` taxonomy:
 
 ```php
-<li class="tax-authors">
+<li class="xyz-tax-authors">
 	<?php echo get_the_term_list( $this->get( 'post_id' ), 'xyz-author', '', ', ' ); ?>
 </li>
 ```
@@ -222,7 +222,7 @@ add_action( 'amp_post_template_css', 'xyz_amp_my_additional_css_styles' );
 function xyz_amp_my_additional_css_styles( $amp_template ) {
 	// only CSS here please...
 	?>
-	.byline amp-img {
+	.amp-wp-byline amp-img {
 		border-radius: 0; /* we don't want round avatars! */
 	}
 	.my-custom-class {

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,10 @@ You can find details about customization options at https://github.com/Automatti
 
 == Changelog ==
 
+= 0.4 =
+
+* Breaking change: class names for elements in the default template were prefixed with `amp-wp-`. Any styles targeting these classes should be updated.
+
 = 0.3 (Feb 18, 2016) =
 
 * Fetch dimensions for hotlinked images.

--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -1,9 +1,9 @@
 <?php $post_author = $this->get( 'post_author' ); ?>
-<li class="byline">
+<li class="amp-wp-byline">
 	<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
 	<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array(
 		'size' => 24,
 	) ) ); ?>" width="24" height="24" layout="fixed"></amp-img>
 	<?php endif; ?>
-	<span class="author"><?php echo esc_html( $post_author->display_name ); ?></span>
+	<span class="amp-wp-author"><?php echo esc_html( $post_author->display_name ); ?></span>
 </li>

--- a/templates/meta-taxonomy.php
+++ b/templates/meta-taxonomy.php
@@ -1,6 +1,6 @@
 <?php $categories = get_the_category_list( _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ) ); ?>
 <?php if ( $categories ) : ?>
-	<li class="tax-category">
+	<li class="amp-wp-tax-category">
 		<span class="screen-reader-text">Categories:</span>
 		<?php echo $categories; ?>
 	</li>
@@ -8,7 +8,7 @@
 
 <?php $tags = get_the_tag_list( '', _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ) ); ?>
 <?php if ( $tags ) : ?>
-	<li class="tax-tag">
+	<li class="amp-wp-tax-tag">
 		<span class="screen-reader-text">Tags:</span>
 		<?php echo $tags; ?>
 	</li>

--- a/templates/meta-time.php
+++ b/templates/meta-time.php
@@ -1,4 +1,4 @@
-<li class="posted-on">
+<li class="amp-wp-posted-on">
 	<time datetime="<?php echo esc_attr( date( 'c', $this->get( 'post_publish_timestamp' ) ) ); ?>">
 		<?php
 		echo esc_html(

--- a/templates/single.php
+++ b/templates/single.php
@@ -12,20 +12,20 @@
 	</style>
 </head>
 <body>
-<nav class="title-bar">
+<nav class="amp-wp-title-bar">
 	<div>
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
-				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="site-icon"></amp-img>
+				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon"></amp-img>
 			<?php endif; ?>
 			<?php echo esc_html( $this->get( 'blog_name' ) ); ?>
 		</a>
 	</div>
 </nav>
-<div class="content">
-	<h1 class="title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
-	<ul class="meta">
+<div class="amp-wp-content">
+	<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
+	<ul class="amp-wp-meta">
 		<?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', array( 'meta-author', 'meta-time', 'meta-taxonomy' ) ) ); ?>
 	</ul>
 	<?php echo $this->get( 'post_amp_content' ); // amphtml content; no kses ?>

--- a/templates/style.php
+++ b/templates/style.php
@@ -15,7 +15,7 @@ amp-img.aligncenter { display: block; margin-left: auto; margin-right: auto; }
 }
 
 /* Generic WP.com reader style */
-.content, .title-bar div {
+.amp-wp-content, .amp-wp-title-bar div {
 	<?php $content_max_width = absint( $this->get( 'content_max_width' ) ); ?>
 	<?php if ( $content_max_width > 0 ) : ?>
 	max-width: <?php echo sprintf( '%dpx', $content_max_width ); ?>;
@@ -32,7 +32,7 @@ body {
 	padding-bottom: 100px;
 }
 
-.content {
+.amp-wp-content {
 	padding: 16px;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
@@ -40,7 +40,7 @@ body {
 	color: #3d596d;
 }
 
-.title {
+.amp-wp-title {
 	margin: 36px 0 0 0;
 	font-size: 36px;
 	line-height: 1.258;
@@ -48,7 +48,7 @@ body {
 	color: #2e4453;
 }
 
-.meta {
+.amp-wp-meta {
 	margin-bottom: 16px;
 }
 
@@ -72,8 +72,8 @@ a:focus {
 
 
 /* Open Sans */
-.meta,
-nav.title-bar,
+.amp-wp-meta,
+nav.amp-wp-title-bar,
 .wp-caption-text {
 	font-family: "Open Sans", sans-serif;
 	font-size: 15px;
@@ -81,12 +81,12 @@ nav.title-bar,
 
 
 /* Meta */
-ul.meta {
+ul.amp-wp-meta {
 	padding: 24px 0 0 0;
 	margin: 0 0 24px 0;
 }
 
-ul.meta li {
+ul.amp-wp-meta li {
 	list-style: none;
 	display: inline-block;
 	margin: 0;
@@ -97,21 +97,21 @@ ul.meta li {
 	max-width: 300px;
 }
 
-ul.meta li:before {
+ul.amp-wp-meta li:before {
 	content: "\2022";
 	margin: 0 8px;
 }
 
-ul.meta li:first-child:before {
+ul.amp-wp-meta li:first-child:before {
 	display: none;
 }
 
-.meta,
-.meta a {
+.amp-wp-meta,
+.amp-wp-meta a {
 	color: #4f748e;
 }
 
-.meta .screen-reader-text {
+.amp-wp-meta .screen-reader-text {
 	/* from twentyfifteen */
 	clip: rect(1px, 1px, 1px, 1px);
 	height: 1px;
@@ -120,7 +120,7 @@ ul.meta li:first-child:before {
 	width: 1px;
 }
 
-.byline amp-img {
+.amp-wp-byline amp-img {
 	border-radius: 50%;
 	border: 0;
 	background: #f3f6f8;
@@ -131,22 +131,22 @@ ul.meta li:first-child:before {
 
 
 /* Titlebar */
-nav.title-bar {
+nav.amp-wp-title-bar {
 	background: #0a89c0;
 	padding: 0 16px;
 }
 
-nav.title-bar div {
+nav.amp-wp-title-bar div {
 	line-height: 54px;
 	color: #fff;
 }
 
-nav.title-bar a {
+nav.amp-wp-title-bar a {
 	color: #fff;
 	text-decoration: none;
 }
 
-nav.title-bar .site-icon {
+nav.amp-wp-title-bar .amp-wp-site-icon {
 	/** site icon is 32px **/
 	float: left;
 	margin: 11px 8px 0 0;


### PR DESCRIPTION
To avoid conflicts with existing generic classes (like `title`) used in content.

See https://wordpress.org/support/topic/not-working-please-help-9