### PR TITLE
`meta` is an allowed element

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -107,7 +107,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'select',
 			'option',
 			'link',
-			'meta',
 
 			// These are converted into amp-* versions
 			//'img',


### PR DESCRIPTION
It's necessary for schema.org markup.

Fixes #211