### PR TITLE
Update `remove_filter()` call to match its `add_filter()` call

### DIFF
--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -65,7 +65,7 @@ function wpcom_amp_extract_image_dimensions_add_custom_callbacks() {
 	// This doesn't work well on WP.com and doesn't scale well for VIP sites (see https://github.com/Automattic/amp-wp/issues/207)
 	remove_filter( 'amp_extract_image_dimensions', array( 'AMP_Image_Dimension_Extractor', 'extract_from_attachment_metadata' ) );
 	// The wpcom override obviates this one, so take it out.
-	remove_filter( 'amp_extract_image_dimensions', array( 'AMP_Image_Dimension_Extractor', 'extract_by_downloading_image' ), 100 );
+	remove_filter( 'amp_extract_image_dimensions', array( 'AMP_Image_Dimension_Extractor', 'extract_by_downloading_image' ), 999, 2 );
 }
 
 function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions, $url ) {


### PR DESCRIPTION
Currently this `remove_filter()` instance doesn't work due to the mismatch. If `fopen()` doesn't enable the `https` wrapper, warnings result because the unsupported image extraction still runs:

> PHP Warning:  fopen(): https:// wrapper is disabled in the server configuration by allow_url_fopen=0 in /.../wp-content/plugins/amp/includes/lib/class-fastimage.php on line 31

See https://github.com/ethitter/amp-wp/blob/2de5eb39b92bfc43b342ce87d278beb1784bed45/includes/utils/class-amp-image-dimension-extractor.php#L51.