### PR TITLE
Blacklists rev attribute

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -55,7 +55,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 					} elseif ( $old_value !== $new_value ) {
 						$node->setAttribute( $attribute_name, $new_value );
 					}
-
+				} elseif ( 'a' === $node_name && 'rev' === $attribute_name ) {
+					// rev removed from HTML5 spec, which was used by Jetpack Markdown.
+					$node->removeAttribute( $attribute_name );
 				}
 			}
 		}

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -76,7 +76,12 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 			'a_with_attachment_rel_plus_another_valid_value' => array(
 				'<a href="http://example.com" rel="attachment wp-att-1686">Link</a>',
 				'<a href="http://example.com" rel="attachment">Link</a>',
-			)
+			),
+
+			'a_with_rev' => array(
+				'<a href="http://example.com" rev="footnote">Link</a>',
+				'<a href="http://example.com">Link</a>',
+			),
 		);
 	}
 


### PR DESCRIPTION
Per the validator, `rev` is not a valid attribute. I don't see reference to this in the docs. As seen by using Jetpack's Markdown to create a footnote, which creates a link like `<a href="#fnref-3468-1" rev="footnote">↩</a>`