### PR TITLE
Invalid amphtml by using plain permalink structure

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -4,7 +4,7 @@ function amp_get_permalink( $post_id ) {
 	if ( '' != get_option( 'permalink_structure' ) ) {
 		$amp_url = trailingslashit( get_permalink( $post_id ) ) . user_trailingslashit( AMP_QUERY_VAR, 'single_amp' );
 	} else {
-		$amp_url = add_query_arg( AMP_QUERY_VAR, absint( $post_id ), home_url() );
+		$amp_url = add_query_arg( AMP_QUERY_VAR, 1, get_permalink( $post_id ) );
 	}
 
 	return apply_filters( 'amp_get_permalink', $amp_url, $post_id );


### PR DESCRIPTION
I was faced with an invalid amp url by using plain permalink structure. In this case, `amphtml` is like this:

```
<link rel="amphtml" href="http://192.168.99.100?amp=123" />
```

This url just redirect to homepage.

I fixed it by appending `?amp=1` behind it's permalink.

```
<link rel="amphtml" href="http://192.168.99.100/?p=123&#038;amp=1" />
```