### PR TITLE
Use an override-able constant for the rewrite endpoint.

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -11,7 +11,10 @@
  * License: GPLv2 or later
  */
 
-define( 'AMP_QUERY_VAR', 'amp' );
+// Let users define their own feed slug
+if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+	define( 'AMP_QUERY_VAR', 'amp' );
+}
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );

--- a/amp.php
+++ b/amp.php
@@ -11,11 +11,6 @@
  * License: GPLv2 or later
  */
 
-// Let users define their own feed slug
-if ( ! defined( 'AMP_QUERY_VAR' ) ) {
-	define( 'AMP_QUERY_VAR', 'amp' );
-}
-
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
 
@@ -37,6 +32,8 @@ function amp_init() {
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
 		return;
 	}
+
+	define( 'AMP_QUERY_VAR', apply_filters('amp_query_var', 'amp' ) );
 
 	do_action( 'amp_init' );
 

--- a/amp.php
+++ b/amp.php
@@ -33,7 +33,7 @@ function amp_init() {
 		return;
 	}
 
-	define( 'AMP_QUERY_VAR', apply_filters('amp_query_var', 'amp' ) );
+	define( 'AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp' ) );
 
 	do_action( 'amp_init' );
 

--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,18 @@ function xyz_amp_add_analytics( $amp_template ) {
 }
 ```
 
+#### AMP Endpoint
+
+If you don't want to use the default `/amp` endpoint, use the `amp_query_var` filter to change it to anything else.
+
+```php
+add_filter( 'amp_query_var' , 'xyz_amp_change_endpoint' );
+
+function xyz_amp_change_endpoint( $amp_endpoint ) {
+	return 'foo';
+}
+```
+
 ### Custom Template
 
 If you want complete control over the look and feel of your AMP content, you can override the default template using the `amp_post_template_file` filter and pass it the path to a custom template:


### PR DESCRIPTION
If the users want to change the endpoint on the theme, they can simply define their own endpoint.

I decided to check if the constant is defined, to be consistent on how the Facebook Instant Articles plugin is programmed. 

Another option would be to filter the value below.