### PR TITLE
Do not enable AMP on feeds

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -50,7 +50,7 @@ function amp_init() {
 }
 
 function amp_maybe_add_actions() {
-	if ( ! is_singular() ) {
+	if ( ! is_singular() || is_feed() ) {
 		return;
 	}
 


### PR DESCRIPTION
Verify that the `$post->post_type` variable is set before using it.

`Trying to get property of non-object in /srv/www/master/html/wp-content/plugins/amp/includes/amp-helper-functions.php on line 15`
`PHP Notice:  Trying to get property of non-object in /srv/www/html/wp-includes/query.php on line 4653" while reading response header from upstream, client: 62.210.215.114, server:, request: "GET /XXXXX/feed/ HTTP/1.1",`

Seems to occur when viewing the `/feed/`of a post.

EDIT TO THE ORIGINAL:
AMP checks to confirm `is_singular` before loading; however, `example.tld/2016/02/example/feed/` feeds (comment feeds) pass `is_singular`. Adding a `is_feed` check will stop it.