### PR TITLE
Allow easier setting of amp-analytics tags

### DIFF
--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -59,14 +59,14 @@ function amp_post_template_add_analytics_data( $amp_template ) {
 	}
 
 	foreach ( $analytics_entries as $id => $analytics_entry ) {
-		if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['script_data'] ) ) {
+		if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['config_data'] ) ) {
 			_doing_it_wrong( __FUNCTION__, sprintf( __( 'Analytics entry for %s is missing one of the following keys: `type`, `attributes`, or `data`', 'amp' ), esc_html( $id ) ) );
 			continue;
 		}
 
 		$script_element = AMP_HTML_Utils::build_tag( 'script', array(
 			'type' => 'application/json',
-		), json_encode( $analytics_entry['script_data'] ) );
+		), json_encode( $analytics_entry['config_data'] ) );
 
 		$amp_analytics_attr = array_merge( array(
 			'id' => $id,

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -42,3 +42,37 @@ function amp_post_template_add_schemaorg_metadata( $amp_template ) {
 	<script type="application/ld+json"><?php echo json_encode( $metadata ); ?></script>
 	<?php
 }
+
+add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
+function amp_post_template_add_analytics_script( $data ) {
+	if ( ! empty( $data['amp_analytics'] ) ) {
+		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';
+	}
+	return $data;
+}
+
+add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
+function amp_post_template_add_analytics_data( $amp_template ) {
+	$analytics_entries = $amp_template->get( 'amp_analytics' );
+	if ( empty( $analytics_entries ) ) {
+		return;
+	}
+
+	foreach ( $analytics_entries as $id => $analytics_entry ) {
+		if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['script_data'] ) ) {
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'Analytics entry for %s is missing one of the following keys: `type`, `attributes`, and `data` keys.', 'amp' ), esc_html( $id ) ) );
+			continue;
+		}
+
+		$script_element = AMP_HTML_Utils::build_tag( 'script', array(
+			'type' => 'application/json',
+		), json_encode( $analytics_entry['script_data'] ) );
+
+		$amp_analytics_attr = array_merge( array(
+			'id' => $id,
+			'type' => $analytics_entry['type'],
+		), $analytics_entry['attributes'] );
+
+		echo AMP_HTML_Utils::build_tag( 'amp-analytics', $amp_analytics_attr, $script_element );
+	}
+}

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -60,7 +60,7 @@ function amp_post_template_add_analytics_data( $amp_template ) {
 
 	foreach ( $analytics_entries as $id => $analytics_entry ) {
 		if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['script_data'] ) ) {
-			_doing_it_wrong( __FUNCTION__, sprintf( __( 'Analytics entry for %s is missing one of the following keys: `type`, `attributes`, and `data` keys.', 'amp' ), esc_html( $id ) ) );
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'Analytics entry for %s is missing one of the following keys: `type`, `attributes`, or `data`', 'amp' ), esc_html( $id ) ) );
 			continue;
 		}
 

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -50,6 +50,8 @@ class AMP_Post_Template {
 
 			'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',
 			'amp_component_scripts' => array(),
+
+			'amp_analytics' => apply_filters( 'amp_post_template_analytics', array() ),
 		);
 
 		$this->build_post_content();

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
+
 require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
 
 require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-blacklist-sanitizer.php' );

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -51,7 +51,17 @@ class AMP_Post_Template {
 			'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',
 			'amp_component_scripts' => array(),
 
-			'amp_analytics' => apply_filters( 'amp_post_template_analytics', array() ),
+			/**
+			 * Add amp-analytics tags.
+			 *
+			 * This filter allows you to easily insert any amp-analytics tags without needing much heavy lifting.
+			 *
+			 * @since 0.4
+			 *.
+			 * @param	array	$analytics	An associative array of the analytics entries we want to output. Each array entry must have a unique key, and the value should be an array with the following keys: `type`, `attributes`, `script_data`. See readme for more details.
+			 * @param	object	$post	The current post.
+			 */
+			'amp_analytics' => apply_filters( 'amp_post_template_analytics', array(), $this->post ),
 		);
 
 		$this->build_post_content();

--- a/readme.md
+++ b/readme.md
@@ -246,23 +246,12 @@ Note: the file should only include CSS, not the `<style>` opening and closing ta
 If you want to add stuff to the head or footer of the default AMP template, use the `amp_post_template_head` and `amp_post_template_footer` actions.
 
 ```php
-add_action( 'amp_post_template_footer', 'xyz_amp_add_analytics' );
+add_action( 'amp_post_template_footer', 'xyz_amp_add_pixel' );
 
 function xyz_amp_add_analytics( $amp_template ) {
 	$post_id = $amp_template->get( 'post_id' );
-	// see https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md for more on amp-analytics
 	?>
-	<amp-analytics>
-		<script type="application/json">
-		{
-			"requests": {
-				"pageview": "https://example.com/analytics?url=${canonicalUrl}&title=${title}&acct=${account}",
-				"event": "https://example.com/analytics?eid=${eventId}&elab=${eventLabel}&acct=${account}"
-			}
-			// ...
-		}
-		</script>
-	</amp-analytics>
+	<amp-pixel src="https://example.com/hi.gif?x=RANDOM"></amp-pixel>
 	<?php
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -462,6 +462,57 @@ function xyz_amp_add_ad_sanitizer( $sanitizer_classes, $post ) {
 }
 ```
 
+## Analytics
+
+To output proper analytics tags, you can use the `amp_post_template_analytics` filter:
+
+```
+add_filter( 'amp_post_template_analytics', 'xyz_amp_add_custom_analytics' );
+function xyz_amp_add_custom_analytics( $analytics ) {
+	if ( ! is_array( $analytics ) ) {
+		$analytics = array();
+	}
+
+	// https://developers.google.com/analytics/devguides/collection/amp-analytics/
+	$analytics['xyz-googleanalytics'] = array(
+		'type' => 'googleanalytics',
+		'attributes' => array(
+			// 'data-credentials' => 'include',
+		),
+		'config_data' => array(
+			'vars' => array(
+				'account' => "UA-XXXXX-Y"
+			),
+			'triggers' => array(
+				'trackPageview' => array(
+					'on' => 'visible',
+					'request' => 'pageview',
+				),
+			),
+		),
+	);
+
+	// https://www.parsely.com/docs/integration/tracking/google-amp.html
+	$analytics['xyz-parsely'] = array(
+		'type' => 'parsely',
+		'attributes' => array(),
+		'config_data' => array(
+			'vars' => array(
+				'apikey' => 'YOUR APIKEY GOES HERE',
+			)
+		),
+	);
+
+	return $analytics;
+}
+```
+
+Each analytics entry must include a unique array key and the following attributes:
+
+- `type`: `(string)` one of the [valid vendors](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md#analytics-vendors) for amp-analytics.
+- `attributes`: `(array)` any [additional valid  attributes](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md#attributes) to add to the `amp-analytics` element.
+- `config_data`: `(array)` the [config data](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md#configuration) to include in the `amp-analytics` script tag. This is `json_encode`-d on output.
+
 ## Custom Post Type Support
 
 By default, the plugin only creates AMP content for posts. You can add support for other post_types like so (assume our post_type slug is `xyz-review`):


### PR DESCRIPTION
To avoid lots of duplicate code needed by each vendor. Hook into the filter and add entries as needed.