### PR TITLE
Use https:// URL for amp-iframe src instead of protocol relative URL

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -91,7 +91,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 
 				case 'src':
-					$out[ $name ] = preg_replace('/^\/\//', 'https://', $value);
+					$out[ $name ] = set_url_scheme( $value, 'https' );
 					break;
 
 				case 'width':

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -83,12 +83,15 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
-				case 'src':
 				case 'sandbox':
 				case 'height':
 				case 'class':
 				case 'sizes':
 					$out[ $name ] = $value;
+					break;
+
+				case 'src':
+					$out[ $name ] = preg_replace('/^\/\//', 'https://', $value);
 					break;
 
 				case 'width':

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -58,6 +58,11 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com/iframe" width="500" height="281" sizes="(min-width: 500px) 500px, 100vw" sandbox="allow-scripts allow-same-origin" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
+			'iframe_with_protocol_relative_url' => array(
+				'<iframe src="//example.com/video/132886713"></iframe>',
+				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+			),
+
 			'multiple_same_iframe' => array(
 				'
 <iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>


### PR DESCRIPTION
amp-iframe rejects a src with a protocol relative URL: `Invalid <amp-iframe> src. Must start with https://.`

This PR uses an https:// URL where the original src is protocol relative.