### PR TITLE
prevent images from clipping

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -120,6 +120,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					'src' => $image['url'],
 					'width' => $image['width'],
 					'height' => $image['height'],
+					'layout' => 'responsive',
 				)
 			);
 		}

--- a/templates/style.php
+++ b/templates/style.php
@@ -192,6 +192,10 @@ amp-vine {
 	background: #f3f6f8;
 }
 
+amp-carousel > amp-img > img {
+	object-fit: contain;
+}
+
 .amp-wp-iframe-placeholder {
 	background: #f3f6f8 url( <?php echo esc_url( $this->get( 'placeholder_image_url' ) ); ?> ) no-repeat center 40%;
 	background-size: 48px 48px;


### PR DESCRIPTION
images got clipped, when they were larger than, the carousel.

before:
![clipped](https://cloud.githubusercontent.com/assets/68937/13427510/cc8a402e-dfb4-11e5-9285-977f96f9d7ac.png)

after:
![all visible](https://cloud.githubusercontent.com/assets/68937/13427514/d74c93b8-dfb4-11e5-9893-5cd3dddda7f1.png)

see this bug here for reference: https://github.com/ampproject/amphtml/issues/1531
