### PR TITLE
Swap validate_file with custom traversal checks

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -257,7 +257,11 @@ class AMP_Post_Template {
 	}
 
 	private function is_valid_template( $template ) {
-		if ( 0 !== validate_file( $template ) ) {
+		if ( false !== strpos( $template, '..' ) ) {
+			return false;
+		}
+
+		if ( false !== strpos( $template, './' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
`validate_file` only seems to work well with relative files and breaks absolute paths on windows (since they have colons in them).

Fixes #255