### PR TITLE
Update typography to match Calypso.

### DIFF
--- a/templates/single.php
+++ b/templates/single.php
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-	<link href="https://fonts.googleapis.com/css?family=Merriweather:400,400italic,700,700italic|Open+Sans:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+	<link href="https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160212" rel="stylesheet" type="text/css">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/single.php
+++ b/templates/single.php
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-	<link href="https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160212" rel="stylesheet" type="text/css">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/style.php
+++ b/templates/style.php
@@ -1,4 +1,43 @@
-@import "https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160212";
+/* Merriweather fonts */
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.svg#merriweatherregular') format('svg');
+	font-weight:400;
+	font-style:normal;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.svg#merriweatheritalic') format('svg');
+	font-weight:400;
+	font-style:italic;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.svg#merriweatherbold') format('svg');
+	font-weight:700;
+	font-style:normal;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.svg#merriweatherbold_italic') format('svg');
+	font-weight:700;
+	font-style:italic;
+}
 
 /* Generic WP styling */
 amp-img.alignright { float: right; margin: 0 0 1em 1em; }

--- a/templates/style.php
+++ b/templates/style.php
@@ -77,11 +77,11 @@ a:focus {
 }
 
 
-/* Open Sans */
+/* UI Fonts */
 .amp-wp-meta,
 nav.amp-wp-title-bar,
 .wp-caption-text {
-	font-family: "Open Sans", sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 	font-size: 15px;
 }
 

--- a/templates/style.php
+++ b/templates/style.php
@@ -1,3 +1,5 @@
+@import "https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160212";
+
 /* Generic WP styling */
 amp-img.alignright { float: right; margin: 0 0 1em 1em; }
 amp-img.alignleft { float: left; margin: 0 1em 1em 0; }


### PR DESCRIPTION
This PR makes two changes:

- Replaces the Google Fonts-hosted version of Merriweather with the one we host on WP.com (related: https://github.com/Automattic/wp-calypso/pull/2766)
- Replaces Open Sans with system UI fonts for interface text, and removes the link to Open Sans on Google Fonts. (related: https://github.com/Automattic/wp-calypso/pull/3016)

Before:
<img width="579" alt="screen shot 2016-03-03 at 8 32 22 pm" src="https://cloud.githubusercontent.com/assets/1396552/13515415/1cace57c-e17f-11e5-9f7d-3348ed5698c2.png">

After:
<img width="618" alt="screen shot 2016-03-03 at 8 31 09 pm" src="https://cloud.githubusercontent.com/assets/1396552/13515418/2037c798-e17f-11e5-9383-129c9805e29b.png">
