### PR TITLE
Handle additional validation errors

### DIFF
--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -31,15 +31,28 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-audio', $new_attributes );
 
-			// TODO: limit child nodes too (only allowed: `source`; move rest to div+fallback)
 			// TODO: `source` does not have closing tag, and DOMDocument doesn't handle it well.
-			// TODO: add a filter to kill the audio if the src or any children are not https
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child_node = $child_node->cloneNode( true );
-				$new_node->appendChild( $new_child_node );
+				$old_child_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $new_child_node );
+				$new_child_attributes = $this->filter_attributes( $old_child_attributes );
+
+				// Only append source tags with a valid src attribute
+				if ( ! empty( $new_child_attributes['src'] ) && 'source' === $new_child_node->tagName ) {
+					$new_node->appendChild( $new_child_node );
+				}
 			}
 
-			$node->parentNode->replaceChild( $new_node, $node );
+			// If the node has at least one valid source, replace the old node with it.
+			// Otherwise, just remove the node.
+			//
+			// TODO: Add a fallback handler.
+			// See: https://github.com/ampproject/amphtml/issues/2261
+			if ( 0 === $new_node->childNodes->length && empty( $new_attributes['src'] ) ) {
+				$node->parentNode->removeChild( $node );
+			} else {
+				$node->parentNode->replaceChild( $new_node, $node );
+			}
 
 			$this->did_convert_elements = true;
 		}
@@ -51,6 +64,8 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
+					$out[ $name ] = $this->validate_src_attribute( $value );
+					break;
 				case 'width':
 				case 'height':
 				case 'class':

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -64,7 +64,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
-					$out[ $name ] = $this->validate_src_attribute( $value );
+					$out[ $name ] = $this->maybe_enforce_https_src( $value );
 					break;
 				case 'width':
 				case 'height':

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -33,6 +33,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 
 			// TODO: limit child nodes too (only allowed: `source`; move rest to div+fallback)
 			// TODO: `source` does not have closing tag, and DOMDocument doesn't handle it well.
+			// TODO: add a filter to kill the audio if the src or any children are not https
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child_node = $child_node->cloneNode( true );
 				$new_node->appendChild( $new_child_node );

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -63,7 +63,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @param boolean $force_https
 	 * @return string
 	 */
-	public function validate_src_attribute( $src, $force_https = false ) {
+	public function maybe_enforce_https_src( $src, $force_https = false ) {
 		$protocol = strtok( $src, ':' );
 		if ( 'https' !== $protocol ) {
 			// Check if https is required

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -67,11 +67,11 @@ abstract class AMP_Base_Sanitizer {
 		$protocol = strtok( $src, ':' );
 		if ( 'https' !== $protocol ) {
 			// Check if https is required
-			$https_required = apply_filters( 'amp_require_https_src', false );
-			if ( true === $https_required ) {
+			if ( isset( $this->args['require_https_src'] ) && true === $this->args['require_https_src'] ) {
 				// Remove the src. Let the implementing class decide what do from here.
 				$src = '';
-			} elseif ( false === $https_required && true === $force_https ) {
+			} elseif ( ( ! isset( $this->args['require_https_src'] ) || false === $this->args['require_https_src'] )
+				&& true === $force_https ) {
 				// Don't remove the src, but force https instead
 				$src = set_url_scheme( $src, 'https' );
 			}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -54,4 +54,29 @@ abstract class AMP_Base_Sanitizer {
 			$attributes[ $key ] = $value;
 		}
 	}
+
+	/**
+	 * Decide if we should remove a src attribute if https is required.
+	 * If not required, the implementing class may want to try and force https instead.
+	 *
+	 * @param string $src
+	 * @param boolean $force_https
+	 * @return string
+	 */
+	public function validate_src_attribute( $src, $force_https = false ) {
+		$protocol = strtok( $src, ':' );
+		if ( 'https' !== $protocol ) {
+			// Check if https is required
+			$https_required = apply_filters( 'amp_require_https_src', false );
+			if ( true === $https_required ) {
+				// Remove the src. Let the implementing class decide what do from here.
+				$src = '';
+			} elseif ( false === $https_required && true === $force_https ) {
+				// Don't remove the src, but force https instead
+				$src = set_url_scheme( $src, 'https' );
+			}
+		}
+
+		return $src;
+	}
 }

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -106,13 +106,13 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function get_blacklisted_protocols() {
-		return array(
+		return apply_filters( 'amp_blacklisted_protocols', array(
 			'javascript',
-		);
+		) );
 	}
 
 	private function get_blacklisted_tags() {
-		return array(
+		return apply_filters( 'amp_blacklisted_tags', array(
 			'script',
 			'noscript',
 			'style',
@@ -141,14 +141,14 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			//'video',
 			//'audio',
 			//'iframe',
-		);
+		) );
 	}
 
 	private function get_blacklisted_attributes() {
-		return array(
+		return apply_filters( 'amp_blacklisted_attributes', array(
 			'style',
 			'srcset',
 			'size',
-		);
+		) );
 	}
 }

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -11,6 +11,12 @@ require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php' )
 class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	const PATTERN_REL_WP_ATTACHMENT = '#wp-att-([\d]+)#';
 
+	protected $DEFAULT_ARGS = array(
+		'add_blacklisted_protocols' => array(),
+		'add_blacklisted_tags' => array(),
+		'add_blacklisted_attributes' => array(),
+	);
+
 	public function sanitize() {
 		$blacklisted_tags = $this->get_blacklisted_tags();
 		$blacklisted_attributes = $this->get_blacklisted_attributes();
@@ -148,14 +154,24 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		}
 	}
 
+	private function merge_defaults_with_args( $key, $values ) {
+		// Merge default values with user specified args
+		if ( ! empty( $this->args[ $key ] )
+			&& is_array( $this->args[ $key ] ) ) {
+			$values = array_merge( $values, $this->args[ $key ] );
+		}
+
+		return $values;
+	}
+
 	private function get_blacklisted_protocols() {
-		return apply_filters( 'amp_blacklisted_protocols', array(
+		return $this->merge_defaults_with_args( 'add_blacklisted_protocols', array(
 			'javascript',
 		) );
 	}
 
 	private function get_blacklisted_tags() {
-		return apply_filters( 'amp_blacklisted_tags', array(
+		return $this->merge_defaults_with_args( 'add_blacklisted_tags', array(
 			'script',
 			'noscript',
 			'style',
@@ -186,7 +202,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function get_blacklisted_attributes() {
-		return apply_filters( 'amp_blacklisted_attributes', array(
+		return $this->merge_defaults_with_args( 'add_blacklisted_attributes', array(
 			'style',
 			'srcset',
 			'size',

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -42,7 +42,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 					$node->removeAttribute( $attribute_name );
 					continue;
 				} elseif ( 'href' === $attribute_name && 'a' !== $node_name ) {
-					if ( false === $this->is_valid_href( $attribute->value ) ) {
+					$protocol = strtok( $attribute->value, ':' );
+					if ( in_array( $protocol, $bad_protocols ) ) {
 						$node->removeAttribute( $attribute_name );
 						continue;
 					}
@@ -80,7 +81,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function sanitize_a_attribute( $node, $attribute ) {
-		// TODO: how to keep the text if the URL is invalid
 		$attribute_name = strtolower( $attribute->name );
 
 		if ( 'rel' === $attribute_name ) {
@@ -104,20 +104,15 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( $attribute_name );
 			}
 		} elseif ( 'href' === $attribute_name ) {
-			return false;
+			$valid_protocols = array( 'http', 'https' );
+			$protocol = strtok( $attribute->value, ':' );
+			if ( false === filter_var( $attribute->value, FILTER_VALIDATE_URL )
+				|| ! in_array( $protocol, $valid_protocols ) ) {
+				return false;
+			}
 		}
 
 		return true;
-	}
-
-	private function is_valid_href( $href ) {
-		$protocol = strtok( $href, ':' );
-		if ( in_array( $protocol, $bad_protocols )
-			|| false === filter_var( $href, FILTER_VALIDATE_URL ) ) {
-			return false;
-		} else {
-			return true;
-		}
 	}
 
 	private function replace_node_with_children( $node ) {

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -92,9 +92,15 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		} elseif ( 'rev' === $attribute_name ) {
 			// rev removed from HTML5 spec, which was used by Jetpack Markdown.
 			$node->removeAttribute( $attribute_name );
-		} elseif ( 'target' === $attribute_name && '_new' === $attribute->value ) {
-			// _new is not allowed; swap with _blank
-			$node->setAttribute( $attribute_name, '_blank' );
+		} elseif ( 'target' === $attribute_name ) {
+			// _blank is the only allowed value and it must be lowercase.
+			// replace _new with _blank and others should simply be removed.
+			$old_value = strtolower( $attribute->value );
+			if ( '_blank' === $old_value || '_new' === $old_value ) {
+				$node->setAttribute( $attribute_name, '_blank' );
+			} else {
+				$node->removeAttribute( $attribute_name );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -131,8 +131,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'font', // TODO: figure out if this needs to be removed but keeping the enclosed text
 			'picture',
 
-			// Sanitizers run after embed handlers,
-			// so if anything wasn't matched, it needs to be removed.
+			// Sanitizers run after embed handlers, so if anything wasn't matched, it needs to be removed.
 			'embed',
 			'embedvideo',
 

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -115,9 +115,15 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( $attribute_name );
 			}
 		} elseif ( 'href' === $attribute_name ) {
+			// If the href starts with a '/', append the home_url to it for validation purposes.
+			$href = $attribute->value;
+			if ( 0 === stripos( $attribute->value, '/' ) ) {
+				$href = untrailingslashit( get_home_url() ) . $href;
+			}
+
 			$valid_protocols = array( 'http', 'https', 'mailto', 'sms', 'tel', 'viber', 'whatsapp' );
-			$protocol = strtok( $attribute->value, ':' );
-			if ( false === filter_var( $attribute->value, FILTER_VALIDATE_URL )
+			$protocol = strtok( $href, ':' );
+			if ( false === filter_var( $href, FILTER_VALIDATE_URL )
 				|| ! in_array( $protocol, $valid_protocols ) ) {
 				return false;
 			}

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -48,12 +48,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				if ( 0 === stripos( $attribute_name, 'on' ) && $attribute_name != 'on' ) {
 					$node->removeAttribute( $attribute_name );
 					continue;
-				} elseif ( 'href' === $attribute_name && 'a' !== $node_name ) {
-					$protocol = strtok( $attribute->value, ':' );
-					if ( in_array( $protocol, $bad_protocols ) ) {
-						$node->removeAttribute( $attribute_name );
-						continue;
-					}
 				} elseif ( 'a' === $node_name ) {
 					// Sanitize the tag, but remove it entirely if the href is invalid.
 					// Children will be preserved as part of the parent.

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -216,7 +216,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_attributes() {
 		return $this->merge_defaults_with_args( 'add_blacklisted_attributes', array(
 			'style',
-			'srcset',
 			'size',
 		) );
 	}

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -121,7 +121,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 
 		// If no href is set and this isn't an anchor, it's invalid
 		if ( empty( $href ) ) {
-			if ( ! empty( $node->getAttribute( 'name' ) ) ) {
+			$name_attr = $node->getAttribute( 'name' );
+			if ( ! empty( $name_attr ) ) {
 				// No further validation is required
 				return true;
 			} else {

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -48,7 +48,10 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 						continue;
 					}
 				} elseif ( 'a' === $node_name ) {
-					$this->sanitize_a_attribute( $node, $attribute );
+					$result = $this->sanitize_a_attribute( $node, $attribute );
+					if ( false === $result ) {
+						// TODO: remove the tag, but keep the contents of the node
+					}
 				}
 			}
 		}
@@ -103,6 +106,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( $attribute_name );
 			}
 		}
+
+		return true;
 	}
 
 	private function get_blacklisted_protocols() {

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -79,6 +79,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function sanitize_a_attribute( $node, $attribute ) {
+		// TODO: how to keep the text if the URL is invalid
 		$attribute_name = strtolower( $attribute->name );
 
 		if ( 'rel' === $attribute_name ) {
@@ -127,7 +128,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'select',
 			'option',
 			'link',
-			'font',
+			'font', // TODO: figure out if this needs to be removed but keeping the enclosed text
 			'picture',
 
 			// Sanitizers run after embed handlers,

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -127,6 +127,13 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'select',
 			'option',
 			'link',
+			'font',
+			'picture',
+
+			// Sanitizers run after embed handlers,
+			// so if anything wasn't matched, it needs to be removed.
+			'embed',
+			'embedvideo',
 
 			// These are converted into amp-* versions
 			//'img',
@@ -139,6 +146,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_attributes() {
 		return array(
 			'style',
+			'srcset',
+			'size',
 		);
 	}
 }

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -26,8 +26,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
+		$node_name = $node->nodeName;
+
 		if ( $node->hasAttributes() ) {
-			$node_name = $node->nodeName;
 			$length = $node->attributes->length;
 			for ( $i = $length - 1; $i >= 0; $i-- ) {
 				$attribute = $node->attributes->item( $i );
@@ -48,11 +49,19 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 						continue;
 					}
 				} elseif ( 'a' === $node_name ) {
+					// Sanitize the tag, but remove it entirely if the href is invalid.
+					// Children will be preserved as part of the parent.
 					if ( false === $this->sanitize_a_attribute( $node, $attribute ) ) {
 						$this->replace_node_with_children( $node );
 					}
 				}
 			}
+		}
+
+		// Some nodes may contain valid content but are themselves invalid.
+		// Remove the node but preserve the children.
+ 		if ( 'font' === $node_name ) {
+			$this->replace_node_with_children( $node );
 		}
 
 		foreach ( $node->childNodes as $child_node ) {
@@ -154,7 +163,6 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'select',
 			'option',
 			'link',
-			'font', // TODO: figure out if this needs to be removed but keeping the enclosed text
 			'picture',
 
 			// Sanitizers run after embed handlers, so if anything wasn't matched, it needs to be removed.

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -121,6 +121,11 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( $attribute_name );
 			}
 		} elseif ( 'href' === $attribute_name ) {
+			// If this is an anchor link, just return true
+			if ( 0 === strpos( $attribute->value, '#' ) ) {
+				return true;
+			}
+
 			// If the href starts with a '/', append the home_url to it for validation purposes.
 			$href = $attribute->value;
 			if ( 0 === stripos( $attribute->value, '/' ) ) {

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -115,7 +115,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( $attribute_name );
 			}
 		} elseif ( 'href' === $attribute_name ) {
-			$valid_protocols = array( 'http', 'https' );
+			$valid_protocols = array( 'http', 'https', 'mailto', 'sms', 'tel', 'viber', 'whatsapp' );
 			$protocol = strtok( $attribute->value, ':' );
 			if ( false === filter_var( $attribute->value, FILTER_VALIDATE_URL )
 				|| ! in_array( $protocol, $valid_protocols ) ) {

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -37,16 +37,20 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
-			if ( ! array_key_exists( 'src', $old_attributes ) ) {
-				$node->parentNode->removeChild( $node );
-				continue;
-			}
-
-			// TODO: add a filter to kill the iframe if not https
-
 			$this->did_convert_elements = true;
 
 			$new_attributes = $this->filter_attributes( $old_attributes );
+
+			// If the src doesn't exist, remove the node.
+			// This means that it never existed or was invalidated
+			// while filtering attributes above.
+			//
+			// TODO: add a filter to allow for a fallback element in this instance.
+			// See: https://github.com/ampproject/amphtml/issues/2261
+			if ( empty( $new_attributes['src'] ) ) {
+				$node->parentNode->removeChild( $node );
+				continue;
+			}
 
 			if ( ! isset( $new_attributes['height'] ) ) {
 				unset( $new_attributes['width'] );
@@ -93,7 +97,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 
 				case 'src':
-					$out[ $name ] = set_url_scheme( $value, 'https' );
+					$out[ $name ] = $this->validate_src_attribute( $value, true );
 					break;
 
 				case 'width':

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -42,6 +42,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			// TODO: add a filter to kill the iframe if not https
+
 			$this->did_convert_elements = true;
 
 			$new_attributes = $this->filter_attributes( $old_attributes );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -97,7 +97,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 
 				case 'src':
-					$out[ $name ] = $this->validate_src_attribute( $value, true );
+					$out[ $name ] = $this->maybe_enforce_https_src( $value, true );
 					break;
 
 				case 'width':

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -37,8 +37,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
-			$this->did_convert_elements = true;
-
 			$new_attributes = $this->filter_attributes( $old_attributes );
 
 			// If the src doesn't exist, remove the node.
@@ -51,6 +49,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$node->parentNode->removeChild( $node );
 				continue;
 			}
+
+			$this->did_convert_elements = true;
 
 			if ( ! isset( $new_attributes['height'] ) ) {
 				unset( $new_attributes['width'] );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -61,7 +61,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
-					$out[ $name ] = $this->validate_src_attribute( $value );
+					$out[ $name ] = $this->maybe_enforce_https_src( $value );
 					break;
 				case 'poster':
 				case 'width':

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -32,6 +32,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 			// TODO: limit child nodes too (only allowed: `source`; move rest to div+fallback)
 			// TODO: `source` does not have closing tag, and DOMDocument doesn't handle it well.
+			// TODO: add a filter to kill the video if the src or any children are not https
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child_node = $child_node->cloneNode( true );
 				$new_node->appendChild( $new_child_node );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -30,15 +30,28 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-video', $new_attributes );
 
-			// TODO: limit child nodes too (only allowed: `source`; move rest to div+fallback)
 			// TODO: `source` does not have closing tag, and DOMDocument doesn't handle it well.
-			// TODO: add a filter to kill the video if the src or any children are not https
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child_node = $child_node->cloneNode( true );
-				$new_node->appendChild( $new_child_node );
+				$old_child_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $new_child_node );
+				$new_child_attributes = $this->filter_attributes( $old_child_attributes );
+
+				// Only append source tags with a valid src attribute
+				if ( ! empty( $new_child_attributes['src'] ) && 'source' === $new_child_node->tagName ) {
+					$new_node->appendChild( $new_child_node );
+				}
 			}
 
-			$node->parentNode->replaceChild( $new_node, $node );
+			// If the node has at least one valid source, replace the old node with it.
+			// Otherwise, just remove the node.
+			//
+			// TODO: Add a fallback handler.
+			// See: https://github.com/ampproject/amphtml/issues/2261
+			if ( 0 === $new_node->childNodes->length && empty( $new_attributes['src'] ) ) {
+				$node->parentNode->removeChild( $node );
+			} else {
+				$node->parentNode->replaceChild( $new_node, $node );
+			}
 		}
 	}
 
@@ -48,6 +61,8 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
+					$out[ $name ] = $this->validate_src_attribute( $value );
+					break;
 				case 'poster':
 				case 'width':
 				case 'height':

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -64,6 +64,11 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 </audio>',
 				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio><amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio><amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"></source></amp-audio>'
 			),
+
+			'https_not_required' => array(
+				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
+				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"></amp-audio>',
+			),
 		);
 	}
 
@@ -74,6 +79,20 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
 		$sanitizer->sanitize();
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEquals( $expected, $content );
+	}
+
+	public function test__https_required() {
+		$source = '<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>';
+		$expected = '';
+
+		add_filter( 'amp_require_https_src', '__return_true' );
+
+		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Audio_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
 	}

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -87,10 +87,10 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$source = '<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>';
 		$expected = '';
 
-		add_filter( 'amp_require_https_src', '__return_true' );
-
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Audio_Sanitizer( $dom );
+		$sanitizer = new AMP_Audio_Sanitizer( $dom, array(
+			'require_https_src' => true,
+		) );
 		$sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -98,6 +98,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com">Link</a>',
 			),
 
+			'a_with_invalid_href' => array(
+				'<a href="mailto:email@domain.com">Link</a>',
+				'Link',
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -123,6 +123,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="#section2">Home</a>',
 			),
 
+			'a_is_anchor' => array(
+				'<a name="section2"></a>',
+				'<a name="section2"></a>',
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -108,11 +108,6 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com">Link</a>',
 			),
 
-			'a_with_href_mailto' => array(
-				'<a href="mailto:email@domain.com">Link</a>',
-				'Link',
-			),
-
 			'a_with_href_invalid' => array(
 				'<a href="some random text">Link</a>',
 				'Link',

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -87,6 +87,16 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com" target="_new">Link</a>',
 				'<a href="http://example.com" target="_blank">Link</a>',
 			),
+
+			'a_with_target_uppercase_blank' => array(
+				'<a href="http://example.com" target="_BLANK">Link</a>',
+				'<a href="http://example.com" target="_blank">Link</a>',
+			),
+
+			'a_with_invalid_target' => array(
+				'<a href="http://example.com" target="_parent">Link</a>',
+				'<a href="http://example.com">Link</a>',
+			),
 		);
 	}
 

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -98,8 +98,13 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com">Link</a>',
 			),
 
-			'a_with_invalid_href' => array(
+			'a_with_mailto_href' => array(
 				'<a href="mailto:email@domain.com">Link</a>',
+				'Link',
+			),
+
+			'a_with_invalid_href' => array(
+				'<a href="some random text">Link</a>',
 				'Link',
 			),
 

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -97,6 +97,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com" target="_parent">Link</a>',
 				'<a href="http://example.com">Link</a>',
 			),
+
+			'h1_with_size' => array(
+				'<h1 size="1">Headline</h1>',
+				'<h1>Headline</h1>',
+			),
 		);
 	}
 

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -118,6 +118,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="/home">Home</a>',
 			),
 
+			'a_with_anchor' => array(
+				'<a href="#section2">Home</a>',
+				'<a href="#section2">Home</a>',
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -113,6 +113,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'Link',
 			),
 
+			'a_with_href_relative' => array(
+				'<a href="/home">Home</a>',
+				'<a href="/home">Home</a>',
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -50,7 +50,7 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 
 			'javascript_protocol' => array(
 				'<a href="javascript:alert(\'Hello\');">Click</a>',
-				'<a>Click</a>'
+				'Click'
 			),
 
 			'attribute_recursive' => array(

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -13,6 +13,11 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
 			),
 
+			'force_https' => array(
+				'<iframe src="http://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
+				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
+			),
+
 			'iframe_without_dimensions' => array(
 				'<iframe src="https://example.com/video/132886713"></iframe>',
 				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
@@ -110,6 +115,20 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
 		$sanitizer->sanitize();
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEquals( $expected, $content );
+	}
+
+	public function test__https_required() {
+		$source = '<iframe src="http://example.com/embed/132886713"></iframe>';
+		$expected = '';
+
+		add_filter( 'amp_require_https_src', '__return_true' );
+
+		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
 	}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -123,10 +123,11 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$source = '<iframe src="http://example.com/embed/132886713"></iframe>';
 		$expected = '';
 
-		add_filter( 'amp_require_https_src', '__return_true' );
-
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
+		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array(
+			'add_placeholder' => true,
+			'require_https_src' => true,
+		) );
 		$sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -88,10 +88,10 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$source = '<video width="300" height="300" src="http://example.com/video.mp4"></video>';
 		$expected = '';
 
-		add_filter( 'amp_require_https_src', '__return_true' );
-
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer = new AMP_Video_Sanitizer( $dom, array(
+			'require_https_src' => true,
+		) );
 		$sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -64,6 +64,11 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 <video src="https://example.com/video2.ogv" width="300" height="480"></video>
 <video src="https://example.com/video3.webm" height="100" width="200"></video>',
 				'<amp-video src="https://example.com/video1.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://example.com/video2.ogv" width="300" height="480" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://example.com/video3.webm" height="100" width="200" sizes="(min-width: 200px) 200px, 100vw" class="amp-wp-enforced-sizes"></amp-video>'
+			),
+
+			'https_not_required' => array(
+				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
+				'<amp-video width="300" height="300" src="http://example.com/video.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			)
 		);
 	}
@@ -75,6 +80,20 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
 		$sanitizer->sanitize();
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEquals( $expected, $content );
+	}
+
+	public function test__https_required() {
+		$source = '<video width="300" height="300" src="http://example.com/video.mp4"></video>';
+		$expected = '';
+
+		add_filter( 'amp_require_https_src', '__return_true' );
+
+		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
 	}


### PR DESCRIPTION
- Removes `<a>` tags that have invalid href attributes, but preserves child elements.
- Removes `<font>` tags, which aren't allowed, but preserves child elements.
- Slightly improved handling of `target` attributes which must be lowercase for validation.
- Removes embeds during sanitization that weren't converted during embed handling.