### PR TITLE
Add support for Archive / Authors / Tags and pagination

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -90,7 +90,7 @@ function amp_maybe_add_actions() {
 	if ( ( !is_home() && !is_singular() && !is_category() && !is_author()) && !is_tag() || is_feed() ) {
 		return;
 	}
-	
+
 	$is_amp_endpoint = is_amp_endpoint();
 
 	if ( !$is_amp_endpoint ) return;
@@ -179,7 +179,7 @@ function amp_rewrite_rules( $rules ) {
 
     $newrules = array();
 
-    $newrules["amp/"] = 'index.php?amp=1';
+    $newrules["^amp/?$"] = 'index.php?amp=1';
 
     foreach($rules as $key => $value) {
         if (preg_match('/^('.amp_get_category_base().'|'.amp_get_tag_base().'|author)\//',$key)) $newrules["amp/".$key] = $value.'&amp=1';

--- a/amp.php
+++ b/amp.php
@@ -98,10 +98,7 @@ function amp_maybe_add_actions() {
 		return;
 	}
 
-	add_filter('term_link', 'amp_term_link', 1, 3);
-	add_filter('author_link', 'amp_author_link', 1, 3);
-	add_filter('_get_page_link', 'amp__get_page_link', 1, 3);
-	add_filter('post_link', 'amp_post_link', 1, 3);
+	set_query_var('amp-object', get_queried_object());
 
 	if( get_queried_object() === NULL) {
 		set_query_var('amp-type', 'archive');
@@ -169,6 +166,11 @@ function amp_render() {
 		amp_add_post_template_actions();
 		$template = new AMP_Post_Template( $post_id );
 	}
+
+	add_filter('term_link', 'amp_term_link', 1, 3);
+	add_filter('author_link', 'amp_author_link', 1, 3);
+	add_filter('_get_page_link', 'amp__get_page_link', 1, 3);
+	add_filter('post_link', 'amp_post_link', 1, 3);
 
 	$template->load();
 	exit;

--- a/amp.php
+++ b/amp.php
@@ -41,8 +41,9 @@ function amp_init() {
 
 	load_plugin_textdomain( 'amp', false, plugin_basename( AMP__DIR__ ) . '/languages' );
 
-	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
+	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK | EP_PAGES );
 	add_post_type_support( 'post', AMP_QUERY_VAR );
+	add_post_type_support( 'page', AMP_QUERY_VAR );
 
 	add_action( 'wp', 'amp_maybe_add_actions' );
 

--- a/amp.php
+++ b/amp.php
@@ -2,9 +2,9 @@
 /**
  * Plugin Name: AMP
  * Description: Add AMP support to your WordPress site.
- * Plugin URI: https://github.com/automattic/amp-wp
- * Author: Automattic
- * Author URI: https://automattic.com
+ * Plugin URI: https://github.com/gabrielperez/amp-wp
+ * Author: gabrielperezs
+ * Author URI: https://www.guero.net
  * Version: 0.3.1
  * Text Domain: amp
  * Domain Path: /languages/

--- a/amp.php
+++ b/amp.php
@@ -93,7 +93,10 @@ function amp_maybe_add_actions() {
 
 	$is_amp_endpoint = is_amp_endpoint();
 
-	if ( !$is_amp_endpoint ) return;
+	if ( !$is_amp_endpoint )  {
+		amp_add_frontend_actions();
+		return;
+	}
 
 	add_filter('term_link', 'amp_term_link', 1, 3);
 	add_filter('author_link', 'amp_author_link', 1, 3);
@@ -128,11 +131,7 @@ function amp_maybe_add_actions() {
 
 	}
 
-	if ( $is_amp_endpoint ) {
-		amp_prepare_render();
-	} else {
-		amp_add_frontend_actions();
-	}
+	amp_prepare_render();
 }
 
 function amp_load_classes() {

--- a/amp.php
+++ b/amp.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: AMP
- * Description: Add AMP support to your WordPress site.
+ * Plugin Name: AMP fork
+ * Description: Add AMP support to your WordPress site. Fork: support pages, tags, authors..
  * Plugin URI: https://github.com/gabrielperez/amp-wp
  * Author: gabrielperezs
  * Author URI: https://www.guero.net

--- a/amp.php
+++ b/amp.php
@@ -62,7 +62,7 @@ function amp_term_link($termlink, $term, $taxonomy) {
 	if ($taxonomy == 'category') {
 		return str_replace('/category/','/amp/category/', $termlink);
 	}
-	elseif ($taxonomy == 'tag') {
+	elseif ($taxonomy == 'post_tag') {
 		return str_replace('/tag/','/amp/tag/', $termlink);
 	}
 	return $termlink;
@@ -73,7 +73,7 @@ function amp_author_link($link, $author_id, $author_nicename) {
 }
 
 function amp_maybe_add_actions() {
-	if ( ( !is_singular() && !is_category() && !is_author()) || is_feed() ) {
+	if ( ( !is_singular() && !is_category() && !is_author()) && !is_tag() || is_feed() ) {
 		return;
 	}
 

--- a/includes/amp-frontend-actions.php
+++ b/includes/amp-frontend-actions.php
@@ -8,6 +8,24 @@ function amp_frontend_add_canonical() {
 		return;
 	}
 
-	$amp_url = amp_get_permalink( get_queried_object_id() );
-	printf( '<link rel="amphtml" href="%s" />', esc_url( $amp_url ) );
+    if ( is_home() ) {
+        printf( '<link rel="amphtml" href="%s" />', esc_url( home_url().'/amp/' ) );
+    }
+    elseif( is_category() || is_tag() || is_author() ) {
+        $term = get_queried_object();
+        if ($term instanceof WP_Term) {
+            $amp_url = get_term_link( $term );
+            printf( '<link rel="amphtml" href="%s" />', esc_url( amp_term_link($amp_url, $term, $term->taxonomy ) ) );
+        }
+        elseif($term instanceof WP_User) {
+            $amp_url = get_author_posts_url( $term->ID );
+            amp_author_link($amp_url, $term->ID, $term );
+            printf( '<link rel="amphtml" href="%s" />', esc_url( amp_author_link($amp_url, $term->ID, $term ) ) );   
+        }
+    }
+    else {
+        $amp_url = amp_get_permalink( get_queried_object_id() );
+        printf( '<link rel="amphtml" href="%s" />', esc_url( $amp_url ) );
+    }
+
 }

--- a/includes/class-amp-archive-template.php
+++ b/includes/class-amp-archive-template.php
@@ -11,7 +11,7 @@ class AMP_Archive_Template extends AMP_Common_Template {
         parent::__construct( $post_id );
 
         $this->ID = $post_id;
-        $this->post = get_post( $post_id );
+        $this->post = get_query_var('amp-object');
 
         $content_max_width = self::CONTENT_MAX_WIDTH;
         if ( isset( $GLOBALS['content_width'] ) && $GLOBALS['content_width'] > 0 ) {
@@ -19,11 +19,21 @@ class AMP_Archive_Template extends AMP_Common_Template {
         }
         $content_max_width = apply_filters( 'amp_content_max_width', $content_max_width );
 
+        if( $this->post === NULL) {
+            $_canonical = get_term_link($post_id);
+        }
+        elseif ($this->post instanceof WP_Term) {
+            $_canonical = get_term_link($post_id);
+        }
+        elseif ($this->post instanceof WP_User) {
+            $_canonical = get_author_posts_url( $post_id );
+        }
+
         $this->data = array(
             'content_max_width' => $content_max_width,
 
             'document_title' => function_exists( 'wp_get_document_title' ) ? wp_get_document_title() : wp_title( '', false ), // back-compat with 4.3
-            'canonical_url' => get_permalink( $post_id ),
+            'canonical_url' => $_canonical,
             'home_url' => home_url(),
             'blog_name' => get_bloginfo( 'name' ),
 
@@ -43,8 +53,10 @@ class AMP_Archive_Template extends AMP_Common_Template {
              * @param   array   $analytics  An associative array of the analytics entries we want to output. Each array entry must have a unique key, and the value should be an array with the following keys: `type`, `attributes`, `script_data`. See readme for more details.
              * @param   object  $post   The current post.
              */
-            'amp_analytics' => apply_filters( 'amp_post_template_analytics', array(), $this->post ),
+            'amp_analytics' => apply_filters( 'amp_post_template_analytics', array(), $term ),
         );
+
+
     }
 
     public function have_posts() {

--- a/includes/class-amp-archive-template.php
+++ b/includes/class-amp-archive-template.php
@@ -89,6 +89,8 @@ class AMP_Archive_Template extends AMP_Common_Template {
 
     public function build_archive_data() {
 
+        $args = false;
+
         if ($this->original_object instanceof WP_Term) {
             $post_title = $this->original_object->name;
             $args = array(
@@ -101,8 +103,18 @@ class AMP_Archive_Template extends AMP_Common_Template {
                 ),
                 'posts_per_page' => 1
             );
-            $_posts = get_posts($args);
-            $this->post = array_shift($_posts);
+        }
+        elseif ($this->original_object instanceof WP_User) {
+            $post_title = $this->original_object->display_name;
+            $args = array(
+                'author' => $this->original_object->ID,
+                'posts_per_page' => 1
+            );
+        }
+
+        if ($args) {
+            $_posts = new WP_Query($args);
+            $this->post = array_shift($_posts->posts);
             $this->ID = $this->post->ID;
         }
 
@@ -110,7 +122,6 @@ class AMP_Archive_Template extends AMP_Common_Template {
         $post_modified_timestamp = get_post_modified_time( 'U', false, $this->post );
         $post_publish_timestamp = get_the_date( 'U', $this->ID );
         $post_modified_timestamp = get_post_modified_time( 'U', false, $this->post );
-        $post_author = get_userdata( $this->post->post_author );
 
         $this->add_data( array(
             'post' => $this->post,
@@ -118,7 +129,7 @@ class AMP_Archive_Template extends AMP_Common_Template {
             'post_title' => $post_title,
             'post_publish_timestamp' => $post_publish_timestamp,
             'post_modified_timestamp' => $post_modified_timestamp,
-            'post_author' => $post_author,
+            'post_author' => $this->post->post_author,
         ) );
 
         $metadata = array(
@@ -134,7 +145,7 @@ class AMP_Archive_Template extends AMP_Common_Template {
             'dateModified' => date( 'c', $post_modified_timestamp ),
             'author' => array(
                 '@type' => 'Person',
-                'name' => $post_author->display_name,
+                'name' => $this->post->post_author,
             ),
         );
 
@@ -153,6 +164,6 @@ class AMP_Archive_Template extends AMP_Common_Template {
             $metadata['image'] = $image_metadata;
         }
 
-        $this->add_data_by_key( 'metadata', apply_filters( 'amp_post_template_metadata', $metadata, $this->post ) );
+        $this->add_data_by_key( 'metadata', apply_filters( 'amp_archive_template_metadata', $metadata, $this->post ) );
     }
 }

--- a/includes/class-amp-archive-template.php
+++ b/includes/class-amp-archive-template.php
@@ -1,0 +1,73 @@
+<?php
+
+class AMP_Archive_Template extends AMP_Common_Template {
+    const SITE_ICON_SIZE = 32;
+    const CONTENT_MAX_WIDTH = 600;
+
+    public $template_dir;
+    public $data;
+
+    public function __construct( $post_id ) {
+        parent::__construct( $post_id );
+
+        $this->ID = $post_id;
+        $this->post = get_post( $post_id );
+
+        $content_max_width = self::CONTENT_MAX_WIDTH;
+        if ( isset( $GLOBALS['content_width'] ) && $GLOBALS['content_width'] > 0 ) {
+            $content_max_width = $GLOBALS['content_width'];
+        }
+        $content_max_width = apply_filters( 'amp_content_max_width', $content_max_width );
+
+        $this->data = array(
+            'content_max_width' => $content_max_width,
+
+            'document_title' => function_exists( 'wp_get_document_title' ) ? wp_get_document_title() : wp_title( '', false ), // back-compat with 4.3
+            'canonical_url' => get_permalink( $post_id ),
+            'home_url' => home_url(),
+            'blog_name' => get_bloginfo( 'name' ),
+
+            'site_icon_url' => apply_filters( 'amp_site_icon_url', function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '' ),
+            'placeholder_image_url' => amp_get_asset_url( 'images/placeholder-icon.png' ),
+
+            'amp_runtime_script' => 'https://cdn.ampproject.org/v0.js',
+            'amp_component_scripts' => array(),
+
+            /**
+             * Add amp-analytics tags.
+             *
+             * This filter allows you to easily insert any amp-analytics tags without needing much heavy lifting.
+             *
+             * @since 0.4
+             *.
+             * @param   array   $analytics  An associative array of the analytics entries we want to output. Each array entry must have a unique key, and the value should be an array with the following keys: `type`, `attributes`, `script_data`. See readme for more details.
+             * @param   object  $post   The current post.
+             */
+            'amp_analytics' => apply_filters( 'amp_post_template_analytics', array(), $this->post ),
+        );
+    }
+
+    public function have_posts() {
+        global $wp_query;
+        return $wp_query->have_posts();
+    }
+
+
+    public function the_post() {
+
+        global $wp_query;
+        $wp_query->the_post();
+
+        $this->ID = $wp_query->post->ID;
+        $this->post = $wp_query->post;
+
+        $this->build_post_content();
+        $this->build_post_data();
+
+        $this->data = apply_filters( 'amp_post_template_data', $this->data, $this->post );
+    }
+
+    public function load() {
+        $this->load_parts( array( 'archive' ) );
+    }
+}

--- a/includes/class-amp-common-template.php
+++ b/includes/class-amp-common-template.php
@@ -1,0 +1,230 @@
+<?php
+
+require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
+
+require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
+
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-blacklist-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-img-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-video-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-iframe-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-audio-sanitizer.php' );
+
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-twitter-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-youtube-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-gallery-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
+
+class AMP_Common_Template {
+    const SITE_ICON_SIZE = 32;
+    const CONTENT_MAX_WIDTH = 600;
+
+    public $template_dir;
+    public $data;
+
+    public function __construct( $post_id ) {
+        $this->template_dir = AMP__DIR__ . '/templates';
+    }
+
+    public function get( $property, $default = null ) {
+        if ( isset( $this->data[ $property ] ) ) {
+            return $this->data[ $property ];
+        } else {
+            _doing_it_wrong( __METHOD__, sprintf( __( 'Called for non-existant key ("%s").', 'amp' ), esc_html( $property ) ), '0.1' );
+        }
+
+        return $default;
+    }
+
+    public function load() {
+        $this->load_parts( array( 'single' ) );
+    }
+
+    public function load_parts( $templates ) {
+        foreach ( $templates as $template ) {
+            $file = $this->get_template_path( $template );
+            $this->verify_and_include( $file, $template );
+        }
+    }
+
+    public function get_template_path( $template ) {
+        return sprintf( '%s/%s.php', $this->template_dir, $template );
+    }
+
+    public function add_data( $data ) {
+        $this->data = array_merge( $this->data, $data );
+    }
+
+    public function add_data_by_key( $key, $value ) {
+        $this->data[ $key ] = $value;
+    }
+
+    public function merge_data_for_key( $key, $value ) {
+        if ( is_array( $this->data[ $key ] ) ) {
+            $this->data[ $key ] = array_merge( $this->data[ $key ], $value );
+        } else {
+            $this->add_data_by_key( $key, $value );
+        }
+    }
+
+    public function build_post_data() {
+        $post_title = get_the_title( $this->ID );
+        $post_publish_timestamp = get_the_date( 'U', $this->ID );
+        $post_modified_timestamp = get_post_modified_time( 'U', false, $this->post );
+        $post_author = get_userdata( $this->post->post_author );
+
+        $this->add_data( array(
+            'post' => $this->post,
+            'post_id' => $this->ID,
+            'post_title' => $post_title,
+            'post_publish_timestamp' => $post_publish_timestamp,
+            'post_modified_timestamp' => $post_modified_timestamp,
+            'post_author' => $post_author,
+        ) );
+
+        $metadata = array(
+            '@context' => 'http://schema.org',
+            '@type' => 'BlogPosting',
+            'mainEntityOfPage' => $this->get( 'canonical_url' ),
+            'publisher' => array(
+                '@type' => 'Organization',
+                'name' => $this->get( 'blog_name' ),
+            ),
+            'headline' => $post_title,
+            'datePublished' => date( 'c', $post_publish_timestamp ),
+            'dateModified' => date( 'c', $post_modified_timestamp ),
+            'author' => array(
+                '@type' => 'Person',
+                'name' => $post_author->display_name,
+            ),
+        );
+
+        $site_icon_url = $this->get( 'site_icon_url' );
+        if ( $site_icon_url ) {
+            $metadata['publisher']['logo'] = array(
+                '@type' => 'ImageObject',
+                'url' => $site_icon_url,
+                'height' => self::SITE_ICON_SIZE,
+                'width' => self::SITE_ICON_SIZE,
+            );
+        }
+
+        $image_metadata = $this->get_post_image_metadata();
+        if ( $image_metadata ) {
+            $metadata['image'] = $image_metadata;
+        }
+
+        $this->add_data_by_key( 'metadata', apply_filters( 'amp_post_template_metadata', $metadata, $this->post ) );
+    }
+
+    public function build_post_content() {
+        $amp_content = new AMP_Content( $this->post->post_content, $this->post->post_excerpt,
+            apply_filters( 'amp_content_embed_handlers', array(
+                'AMP_Twitter_Embed_Handler' => array(),
+                'AMP_YouTube_Embed_Handler' => array(),
+                'AMP_Instagram_Embed_Handler' => array(),
+                'AMP_Vine_Embed_Handler' => array(),
+                'AMP_Facebook_Embed_Handler' => array(),
+                'AMP_Gallery_Embed_Handler' => array(),
+            ), $this->post ),
+            apply_filters( 'amp_content_sanitizers', array(
+                 'AMP_Blacklist_Sanitizer' => array(),
+                 'AMP_Img_Sanitizer' => array(),
+                 'AMP_Video_Sanitizer' => array(),
+                 'AMP_Audio_Sanitizer' => array(),
+                 'AMP_Iframe_Sanitizer' => array(
+                     'add_placeholder' => true,
+                 ),
+            ), $this->post ),
+            array(
+                'content_max_width' => $this->get( 'content_max_width' ),
+            )
+        );
+
+        $this->add_data_by_key( 'post_amp_content', $amp_content->get_amp_content() );
+        $this->add_data_by_key( 'post_amp_excerpt', $amp_content->get_amp_excerpt() );
+        $this->merge_data_for_key( 'amp_component_scripts', $amp_content->get_amp_scripts() );
+    }
+
+    /**
+     * Grabs featured image or the first attached image for the post
+     *
+     * TODO: move to a utils class?
+     */
+    public function get_post_image_metadata() {
+        $post_image_meta = null;
+        $post_image_id = false;
+
+        if ( has_post_thumbnail( $this->ID ) ) {
+            $post_image_id = get_post_thumbnail_id( $this->ID );
+        } else {
+            $attached_image_ids = get_posts( array(
+                'post_parent' => $this->ID,
+                'post_type' => 'attachment',
+                'post_mime_type' => 'image',
+                'posts_per_page' => 1,
+                'orderby' => 'menu_order',
+                'order' => 'ASC',
+                'fields' => 'ids',
+                'suppress_filters' => false,
+            ) );
+
+            if ( ! empty( $attached_image_ids ) ) {
+                $post_image_id = array_shift( $attached_image_ids );
+            }
+        }
+
+        if ( ! $post_image_id ) {
+            return false;
+        }
+
+        $post_image_src = wp_get_attachment_image_src( $post_image_id, 'full' );
+
+        if ( is_array( $post_image_src ) ) {
+            $post_image_meta = array(
+                '@type' => 'ImageObject',
+                'url' => $post_image_src[0],
+                'width' => $post_image_src[1],
+                'height' => $post_image_src[2],
+            );
+        }
+
+        return $post_image_meta;
+    }
+
+    public function verify_and_include( $file, $template_type ) {
+        $located_file = $this->locate_template( $file );
+        if ( $located_file ) {
+            $file = $located_file;
+        }
+
+        $file = apply_filters( 'amp_post_template_file', $file, $template_type, $this->post );
+        if ( ! $this->is_valid_template( $file ) ) {
+            _doing_it_wrong( __METHOD__, sprintf( __( 'Path validation for template (%s) failed. Path cannot traverse and must be located in `%s`.', 'amp' ), esc_html( $file ), 'WP_CONTENT_DIR' ), '0.1' );
+            return;
+        }
+
+        include( $file );
+    }
+
+
+    public function locate_template( $file ) {
+        $search_file = sprintf( 'amp/%s', basename( $file ) );
+        return locate_template( array( $search_file ), false );
+    }
+
+    public function is_valid_template( $template ) {
+        if ( 0 !== validate_file( $template ) ) {
+            return false;
+        }
+
+        if ( ! file_exists( $template ) ) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/includes/class-amp-content.php
+++ b/includes/class-amp-content.php
@@ -6,14 +6,17 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-base-embed-handler.php' )
 
 class AMP_Content {
 	private $content;
+	private $excerpt;
 	private $amp_content = '';
+	private $amp_excerpt = '';
 	private $amp_scripts = array();
 	private $args = array();
 	private $embed_handler_classes = array();
 	private $sanitizer_classes = array();
 
-	public function __construct( $content, $embed_handler_classes, $sanitizer_classes, $args = array() ) {
+	public function __construct( $content, $excerpt, $embed_handler_classes, $sanitizer_classes, $args = array() ) {
 		$this->content = $content;
+		$this->excerpt = $excerpt;
 		$this->args = $args;
 		$this->embed_handler_classes = $embed_handler_classes;
 		$this->sanitizer_classes = $sanitizer_classes;
@@ -25,12 +28,22 @@ class AMP_Content {
 		return $this->amp_content;
 	}
 
+	public function get_amp_excerpt() {
+		return $this->amp_excerpt;
+	}
+
 	public function get_amp_scripts() {
 		return $this->amp_scripts;
 	}
 
 	private function transform() {
+
 		$content = $this->content;
+		$excerpt = $this->excerpt;
+
+		if (!$this->excerpt) {
+			$excerpt = wp_trim_words($this->content);
+		}
 
 		// First, embeds + the_content filter
 		$embed_handlers = $this->register_embed_handlers();
@@ -41,6 +54,20 @@ class AMP_Content {
 		$content = $this->sanitize( $content );
 
 		$this->amp_content = $content;
+
+		// excerpt
+
+		// First, embeds + the_content filter
+		$embed_handlers = $this->register_embed_handlers();
+		$excerpt = apply_filters( 'the_content', $excerpt );
+		$this->unregister_embed_handlers( $embed_handlers );
+
+		// Then, sanitize to strip and/or convert non-amp content
+		$excerpt = $this->sanitize( $excerpt );
+
+		$this->amp_excerpt = $excerpt;
+
+
 	}
 
 	private function add_scripts( $scripts ) {

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -1,23 +1,5 @@
 <?php
 
-require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
-require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
-
-require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
-
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-blacklist-sanitizer.php' );
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-img-sanitizer.php' );
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-video-sanitizer.php' );
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-iframe-sanitizer.php' );
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-audio-sanitizer.php' );
-
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-twitter-embed.php' );
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-youtube-embed.php' );
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-gallery-embed.php' );
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
-require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
-
 class AMP_Post_Template {
 	const SITE_ICON_SIZE = 32;
 	const CONTENT_MAX_WIDTH = 600;
@@ -26,6 +8,7 @@ class AMP_Post_Template {
 	private $data;
 
 	public function __construct( $post_id ) {
+
 		$this->template_dir = AMP__DIR__ . '/templates';
 
 		$this->ID = $post_id;
@@ -162,7 +145,7 @@ class AMP_Post_Template {
 	}
 
 	private function build_post_content() {
-		$amp_content = new AMP_Content( $this->post->post_content,
+		$amp_content = new AMP_Content( $this->post->post_content, $this->post->post_excerpt,
 			apply_filters( 'amp_content_embed_handlers', array(
 				'AMP_Twitter_Embed_Handler' => array(),
 				'AMP_YouTube_Embed_Handler' => array(),

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -120,6 +120,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					'src' => $image['url'],
 					'width' => $image['width'],
 					'height' => $image['height'],
+					'layout' => 'responsive',
 				)
 			);
 		}

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -32,13 +32,17 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			'tweet' => false,
 		) );
 
+		if ( empty( $attr['tweet'] ) && ! empty( $attr[0] ) ) {
+			$attr['tweet'] = $attr[0];
+		}
+
 		$id = false;
-		if ( intval( $attr['tweet'] ) ) {
-			$id = intval( $attr['tweet'] );
+		if ( is_numeric( $attr['tweet'] ) ) {
+			$id = $attr['tweet'];
 		} else {
 			preg_match( self::URL_PATTERN, $attr['tweet'], $matches );
 			if ( isset( $matches[5] ) && intval( $matches[5] ) ) {
-				$id = intval( $matches[5] );
+				$id = $matches[5];
 			}
 
 			if ( empty( $id ) ) {
@@ -63,7 +67,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		$id = false;
 
 		if ( isset( $matches[5] ) && intval( $matches[5] ) ) {
-			$id = intval( $matches[5] );
+			$id = $matches[5];
 		}
 
 		if ( ! $id ) {

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -58,7 +58,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 				case 'loop':
 				case 'muted':
 					if ( 'false' !== $value ) {
-						$out[ $name ] = 'true';
+						$out[ $name ] = '';
 					}
 					break;
 				case 'autoplay':

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -92,9 +92,14 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		} elseif ( 'rev' === $attribute_name ) {
 			// rev removed from HTML5 spec, which was used by Jetpack Markdown.
 			$node->removeAttribute( $attribute_name );
-		} elseif ( 'target' === $attribute_name && '_new' === $attribute->value ) {
-			// _new is not allowed; swap with _blank
-			$node->setAttribute( $attribute_name, '_blank' );
+		} elseif ( 'target' === $attribute_name ) {
+		       if ( '_blank' === $attribute->value || '_new' === $attribute->value ) {
+			       // _new is not allowed; swap with _blank
+			       $node->setAttribute( $attribute_name, '_blank' );
+		       } else {
+			       // only _blank is allowed
+			       $node->removeAttribute( $attribute_name );
+		       }
 		}
 	}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -58,7 +58,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 				case 'loop':
 				case 'muted':
 					if ( 'false' !== $value ) {
-						$out[ $name ] = 'true';
+						$out[ $name ] = '';
 					}
 					break;
 				case 'autoplay':

--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,8 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 
+Fork: support pages, tags, authors..
+
 == Description ==
 
 This plugin adds support for the [Accelerated Mobile Pages](https://www.ampproject.org) (AMP) Project, which is an an open source initiative that aims to provide mobile optimized content that can load instantly everywhere.
@@ -34,15 +36,34 @@ You can find details about customization options at https://github.com/Automatti
 
 == Changelog ==
 
+= 0.4 (??? ?, ????) =
+
+- Handle many more validation errors (props bcampeau and alleyinteractive).
+- Nav bar is now it's own template part (props jdevalk).
+- Fix: don't break really large Twitter IDs.
+
+= 0.3.2 (Mar 4, 2016) =
+
+* Jetpack Stats support.
+* Better version of Merriweather and use system fonts for sans-serif (props mattmiklic).
+* Move font to stylesheet so it can be more easily overridden (props mattmiklic).
+* Fix: Template loading issues on Windows. (Thanks to everyone who reported this, especially w33zy for pointing out the `validate_file` issue.)
+* Fix: don't run AMP on post comment feeds (props kraftbj).
+* Fix: un-break pagination when using a static home page with multiple pages.
+* Fix: force amp-iframe to use https to validate correctly (props mister-ben).
+* Fix: validation for `target` and `video`/`audio` attributes.
+* Fix: clipped images in galleries (thanks tobaco).
+
 = 0.3.1 (Feb 24, 2016) =
 
-* Fix AMP URLs for non-pretty permalinks.
+* Allow custom query var (props vaurdan).
+* Fix AMP URLs for non-pretty permalinks (props rakuishi).
 * Fix for password-protected posts.
 * Fix dimension extraction for schema-less or relative image URLs.
 * Better fallback for images with no dimensions.
-* Validation fixes for `a` tags.
+* Validation fixes for `a` tags (props kraftbj).
 * Updated AMP boilerplate.
-* Allow `on` tags for elements.
+* Allow `on` tags for elements (props Steven Evatt).
 * Prefixed class names.
 
 = 0.3 (Feb 18, 2016) =

--- a/templates/archive.php
+++ b/templates/archive.php
@@ -1,0 +1,41 @@
+<!doctype html>
+<html amp>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,400italic,700,700italic|Open+Sans:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <?php do_action( 'amp_post_template_head', $this ); ?>
+
+    <style amp-custom>
+    <?php $this->load_parts( array( 'style' ) ); ?>
+    <?php do_action( 'amp_post_template_css', $this ); ?>
+    </style>
+</head>
+<body>
+<nav class="amp-wp-title-bar">
+    <div>
+        <a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
+            <?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
+            <?php if ( $site_icon_url ) : ?>
+                <amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon"></amp-img>
+            <?php endif; ?>
+            <?php echo esc_html( $this->get( 'blog_name' ) ); ?>
+        </a>
+    </div>
+</nav>
+
+<?php if ($this->have_posts()): ?>
+    <?php while($this->have_posts()): $this->the_post(); ?>
+        <div class="amp-wp-content">
+            <h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
+            <ul class="amp-wp-meta">
+                <?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', array( 'meta-author', 'meta-time', 'meta-taxonomy' ) ) ); ?>
+            </ul>
+            <?php echo $this->get( 'post_amp_content' ); // amphtml content; no kses ?>
+        </div>
+    <?php endwhile; ?>
+<?php endif; ?>
+
+<?php do_action( 'amp_post_template_footer', $this ); ?>
+</body>
+</html>

--- a/templates/archive.php
+++ b/templates/archive.php
@@ -27,7 +27,7 @@
 <?php if ($this->have_posts()): ?>
     <?php while($this->have_posts()): $this->the_post(); ?>
         <div class="amp-wp-content">
-            <h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
+            <h1 class="amp-wp-title"><a href="<?php the_permalink(); ?>"><?php echo esc_html( $this->get( 'post_title' ) ); ?></a></h1>
             <ul class="amp-wp-meta">
                 <?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', array( 'meta-author', 'meta-time', 'meta-taxonomy' ) ) ); ?>
             </ul>

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -18,9 +18,14 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay="desktop tablet mobile"></amp-audio>',
 			),
 
-			'audio_with_whitelisted_attributes' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="false" muted></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" muted="true"></amp-audio>',
+			'audio_with_whitelisted_attributes__enabled' => array(
+				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="" muted=""></amp-audio>',
+			),
+
+			'audio_with_whitelisted_attributes__disabled' => array(
+				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test"></amp-audio>',
 			),
 
 			'audio_with_blacklisted_attribute' => array(

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -87,6 +87,21 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="http://example.com" target="_new">Link</a>',
 				'<a href="http://example.com" target="_blank">Link</a>',
 			),
+
+			'a_with_target_blank' => array(
+				'<a href="http://example.com" target="_blank">Link</a>',
+				'<a href="http://example.com" target="_blank">Link</a>',
+			),
+
+			'a_with_target_self' => array(
+				'<a href="http://example.com" target="_self">Link</a>',
+				'<a href="http://example.com">Link</a>',
+			),
+
+			'a_with_target_invalid' => array(
+				'<a href="http://example.com" target="boom">Link</a>',
+				'<a href="http://example.com">Link</a>',
+			),
 		);
 	}
 

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -7,10 +7,39 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL
 			),
-			'simple_url' => array(
+			'url_simple' => array(
 				'https://twitter.com/altjoen/status/118252236836061184' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL
-			)
+			),
+			'url_with_big_tweet_id' => array(
+				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
+				'<p><amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL
+			),
+
+			'shortcode_without_id' => array(
+				'[tweet]' . PHP_EOL,
+				'' . PHP_EOL,
+			),
+			'shortcode_simple' => array(
+				'[tweet 118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_tweet_attribute' => array(
+				'[tweet tweet=118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_big_tweet_id' => array(
+				'[tweet 705219971425574912]' . PHP_EOL,
+				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_url' => array(
+				'[tweet https://twitter.com/altjoen/status/118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_non_numeric_tweet_id' => array(
+				'[tweet abcd]' . PHP_EOL,
+				'' . PHP_EOL
+			),
 		);
 	}
 

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -23,9 +23,14 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="desktop tablet mobile" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
-			'video_with_whitelisted_attributes' => array(
-				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="true" loop="true" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
+			'video_with_whitelisted_attributes__enabled' => array(
+				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
+			),
+
+			'video_with_whitelisted_attributes__disabled' => array(
+				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
 			),
 
 			'video_with_blacklisted_attribute' => array(


### PR DESCRIPTION
Some URL structure examples:

Categories:
http://www.mysite.com/amp/category/linux/
http://www.mysite.com/amp/category/linux/page/2/

Tags:
http://www.mysite.com/amp/tag/linux/
http://www.mysite.com/amp/tag/linux/page/2/

Authors:
http://www.mysite.com/amp/author/gabriel/
http://www.mysite.com/amp/author/gabriel/page/2/

Posts:
http://www.mysite.com/my-nice-post-title/amp/

At the same time, make find and replace of the URL in the menu, the visitor can surf in the AMP version.

Also a new template for archive. And the object to handle. I think could be good to have a "common" class (abstract) and from this extends to archive, posts. In the future home-page, or other types.
