### PR TITLE
Allow filtering of title bar

### DIFF
--- a/templates/single.php
+++ b/templates/single.php
@@ -14,11 +14,13 @@
 <nav class="amp-wp-title-bar">
 	<div>
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
+			<?php if ( apply_filters( 'amp_post_template_title_bar', true ) ) : ?>
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
 				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon"></amp-img>
 			<?php endif; ?>
 			<?php echo esc_html( $this->get( 'blog_name' ) ); ?>
+			<?php endif; ?>
 		</a>
 	</div>
 </nav>


### PR DESCRIPTION
In the new version of my Yoast SEO glue plugin I'm allowing people to change some colors etc for their AMP output. For a lot of reasons I'd like to stay as close as possible to the default template, however, I'd like to be able to change the title bar. A filter seems more appropriate for this then creating my own template file, so I was wondering if you'd consider this change: no change in functionality for the AMP plugin, but the option to replace the title bar content with simply a larger image and no blog name.