### PR TITLE
some more blacklisted attributes

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -138,6 +138,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_attributes() {
 		return array(
 			'style',
+			'noshade',
+			'align'
 		);
 	}
 }


### PR DESCRIPTION
_noshade_ is blacklisted for **hr** tags
_align_ is blacklisted in **p** tags

in alternative, you can add an apply_filters:

```
private function get_blacklisted_attributes() {
  $args = array('style');
  return apply_filters('amp_blacklisted_attributes', $args);
}
```
