### PR TITLE
Don't cast Tweet IDs as ints

### DIFF
--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -32,13 +32,17 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			'tweet' => false,
 		) );
 
+		if ( empty( $attr['tweet'] ) && ! empty( $attr[0] ) ) {
+			$attr['tweet'] = $attr[0];
+		}
+
 		$id = false;
-		if ( intval( $attr['tweet'] ) ) {
-			$id = intval( $attr['tweet'] );
+		if ( is_numeric( $attr['tweet'] ) ) {
+			$id = $attr['tweet'];
 		} else {
 			preg_match( self::URL_PATTERN, $attr['tweet'], $matches );
 			if ( isset( $matches[5] ) && intval( $matches[5] ) ) {
-				$id = intval( $matches[5] );
+				$id = $matches[5];
 			}
 
 			if ( empty( $id ) ) {
@@ -63,7 +67,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		$id = false;
 
 		if ( isset( $matches[5] ) && intval( $matches[5] ) ) {
-			$id = intval( $matches[5] );
+			$id = $matches[5];
 		}
 
 		if ( ! $id ) {

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -7,10 +7,35 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL
 			),
-			'simple_url' => array(
+			'url_simple' => array(
 				'https://twitter.com/altjoen/status/118252236836061184' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL
-			)
+			),
+			'url_with_big_tweet_id' => array(
+				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
+				'<p><amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL
+			),
+
+			'shortcode_without_id' => array(
+				'[tweet]' . PHP_EOL,
+				'' . PHP_EOL,
+			),
+			'shortcode_simple' => array(
+				'[tweet 118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_tweet_attribute' => array(
+				'[tweet tweet=118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_big_tweet_id' => array(
+				'[tweet 705219971425574912]' . PHP_EOL,
+				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
+			'shortcode_with_non_numeric_tweet_id' => array(
+				'[tweet abcd]' . PHP_EOL,
+				'' . PHP_EOL
+			),
 		);
 	}
 

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -32,6 +32,10 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'[tweet 705219971425574912]' . PHP_EOL,
 				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
 			),
+			'shortcode_with_url' => array(
+				'[tweet https://twitter.com/altjoen/status/118252236836061184]' . PHP_EOL,
+				'<amp-twitter data-tweetid="118252236836061184" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL
+			),
 			'shortcode_with_non_numeric_tweet_id' => array(
 				'[tweet abcd]' . PHP_EOL,
 				'' . PHP_EOL


### PR DESCRIPTION
Breaks on 32-bit systems since `intval` casts to the max int.

Fixes #334