### PR TITLE
Google has requested we move the amphtml link rel higher up on the page.

### DIFF
--- a/includes/amp-frontend-actions.php
+++ b/includes/amp-frontend-actions.php
@@ -1,7 +1,7 @@
 <?php
 // Callbacks for adding AMP-related things to the main theme
 
-add_action( 'wp_head', 'amp_frontend_add_canonical' );
+add_action( 'wp_head', 'amp_frontend_add_canonical', 1 );
 
 function amp_frontend_add_canonical() {
 	if ( false === apply_filters( 'amp_frontend_show_canonical', true ) ) {


### PR DESCRIPTION
From Adam Greenberg @ Google: "Even though the page has a rel=amphtml tag when I fetch the page, it looks like Google's view of the page doesn't have any rel=amphtml tag present which makes it seem like they are cloaking in a way .  It might have to do with where they are putting their rel=amphtml tag.  **They should try to have it at the beginning of the header section**."

This pull request moves the rel="amphtml" tag near the top of the header section.