### PR TITLE
human_time_diff produces wrong results in templates/meta-time.php 

### DIFF
--- a/templates/meta-time.php
+++ b/templates/meta-time.php
@@ -4,7 +4,7 @@
 		echo esc_html(
 			sprintf(
 				_x( '%s ago', '%s = human-readable time difference', 'amp' ),
-				human_time_diff( $this->get( 'post_publish_timestamp' ) )
+				human_time_diff( $this->get( 'post_publish_timestamp' ), current_time( 'timestamp' ) )
 			)
 		);
 		?>


### PR DESCRIPTION
post_publish_timestamp is calculated using get_the_time (which produces timezone offset timestamp), however, human_time_diff's second argument defaults to `time()` which is UTC, resulting in a wrong difference. 

To fix that we need to pass `current_time('timestamp')` as the second argument for human_time_diff

