### PR TITLE
Handle empty width and height attributes

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -1,6 +1,8 @@
 <?php
 
 abstract class AMP_Base_Sanitizer {
+	const FALLBACK_HEIGHT = 400;
+
 	protected $DEFAULT_ARGS = array();
 
 	protected $dom;
@@ -20,6 +22,19 @@ abstract class AMP_Base_Sanitizer {
 
 	protected function get_body_node() {
 		return $this->dom->getElementsByTagName( 'body' )->item( 0 );
+	}
+
+	public function enforce_fixed_height( $attributes ) {
+		if ( empty( $attributes['height'] ) ) {
+			unset( $attributes['width'] );
+			$attributes['height'] = self::FALLBACK_HEIGHT;
+		}
+
+		if ( empty( $attributes['width'] ) ) {
+			$attributes['layout'] = 'fixed-height';
+		}
+
+		return $attributes;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -52,14 +52,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 			$this->did_convert_elements = true;
 
-			if ( ! isset( $new_attributes['height'] ) ) {
-				unset( $new_attributes['width'] );
-				$new_attributes['height'] = self::FALLBACK_HEIGHT;
-			}
-
-			if ( ! isset( $new_attributes['width'] ) ) {
-				$new_attributes['layout'] = 'fixed-height';
-			}
+			$new_attributes = $this->enforce_fixed_height( $new_attributes );
 			$new_attributes = $this->enforce_sizes_attribute( $new_attributes );
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-iframe', $new_attributes );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -22,10 +22,8 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
 			$new_attributes = $this->filter_attributes( $old_attributes );
-			if ( ! isset( $new_attributes['width'], $new_attributes['height'] ) ) {
-				$new_attributes['height'] = self::FALLBACK_HEIGHT;
-				$new_attributes['layout'] = 'fixed-height';
-			}
+
+			$new_attributes = $this->enforce_fixed_height( $new_attributes );
 			$new_attributes = $this->enforce_sizes_attribute( $new_attributes );
 
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, 'amp-video', $new_attributes );

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -5,6 +5,7 @@ class AMP_Stub_Sanitizer extends AMP_Base_Sanitizer {
 		return $this->dom;
 	}
 }
+
 class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase {
 	public function get_data() {
 		return array(
@@ -107,6 +108,72 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 	public function test_enforce_sizes_attribute( $source_attributes, $expected_attributes, $args = array() ) {
 		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
 		$returned_attributes = $sanitizer->enforce_sizes_attribute( $source_attributes );
+
+		$this->assertEquals( $expected_attributes, $returned_attributes );
+	}
+}
+
+class AMP_Base_Sanitizer__Enforce_Fixed_Height__Test extends WP_UnitTestCase {
+	public function get_data() {
+		return array(
+			'both_dimensions_included' => array(
+				array(
+					'width' => 100,
+					'height' => 100,
+				),
+				array(
+					'width' => 100,
+					'height' => 100,
+				),
+			),
+
+			'both_dimensions_missing' => array(
+				array(),
+				array(
+					'height' => 400,
+					'layout' => 'fixed-height',
+				),
+			),
+
+			'both_dimensions_empty' => array(
+				array(
+					'width' => '',
+					'height' => '',
+				),
+				array(
+					'height' => 400,
+					'layout' => 'fixed-height',
+				),
+			),
+
+			'no_width' => array(
+				array(
+					'height' => 100,
+				),
+				array(
+					'height' => 100,
+					'layout' => 'fixed-height',
+				),
+			),
+
+			'no_height' => array(
+				array(
+					'width' => 200,
+				),
+				array(
+					'height' => 400,
+					'layout' => 'fixed-height',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_data
+	 */
+	public function test_enforce_fixed_height( $source_attributes, $expected_attributes, $args = array() ) {
+		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
+		$returned_attributes = $sanitizer->enforce_fixed_height( $source_attributes );
 
 		$this->assertEquals( $expected_attributes, $returned_attributes );
 	}


### PR DESCRIPTION
We were only checking if the width and height attributes were set but
ended up ignoring cases like `width=""`, which were leading to broken
embeds.

Fixes #371