### PR TITLE
Sanitize width and height dimensions

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -2,6 +2,7 @@
 
 require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
 require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-string-utils.php' );
 
 require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
 

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -66,8 +66,12 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 				case 'src':
 					$out[ $name ] = $this->maybe_enforce_https_src( $value );
 					break;
+
 				case 'width':
 				case 'height':
+					$out[ $name ] = $this->sanitize_dimension( $value, $name );
+					break;
+
 				case 'class':
 					$out[ $name ] = $value;
 					break;

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -24,6 +24,29 @@ abstract class AMP_Base_Sanitizer {
 		return $this->dom->getElementsByTagName( 'body' )->item( 0 );
 	}
 
+	public function sanitize_dimension( $value, $dimension ) {
+		if ( empty( $value ) ) {
+			return $value;
+		}
+
+		if ( false !== filter_var( $value, FILTER_VALIDATE_INT ) ) {
+			return absint( $value );
+		}
+
+		if ( AMP_String_Utils::endswith( $value, 'px' ) ) {
+			return absint( $value );
+		}
+
+		if ( AMP_String_Utils::endswith( $value, '%' ) ) {
+			if ( 'width' === $dimension && isset( $this->args[ 'content_max_width'] ) ) {
+				$percentage = absint( $value ) / 100;
+				return round( $percentage * $this->args[ 'content_max_width'] );
+			}
+		}
+
+		return '';
+	}
+
 	public function enforce_fixed_height( $attributes ) {
 		if ( empty( $attributes['height'] ) ) {
 			unset( $attributes['width'] );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -83,7 +83,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'sandbox':
-				case 'height':
 				case 'class':
 				case 'sizes':
 					$out[ $name ] = $value;
@@ -94,11 +93,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 
 				case 'width':
-					if ( $value === '100%' ) {
-						continue;
-					}
-					$out[ $name ] = $value;
+				case 'height':
+					$out[ $name ] = $this->sanitize_dimension( $value, $name );
 					break;
+
 
 				case 'frameborder':
 					if ( '0' !== $value && '1' !== $value ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -81,14 +81,18 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			switch ( $name ) {
 				case 'src':
 				case 'alt':
-				case 'width':
-				case 'height':
 				case 'class':
 				case 'srcset':
 				case 'sizes':
 				case 'on':
 					$out[ $name ] = $value;
 					break;
+
+				case 'width':
+				case 'height':
+					$out[ $name ] = $this->sanitize_dimension( $value, $name );
+					break;
+
 				default;
 					break;
 			}

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -61,9 +61,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 				case 'src':
 					$out[ $name ] = $this->maybe_enforce_https_src( $value );
 					break;
-				case 'poster':
+
 				case 'width':
 				case 'height':
+					$out[ $name ] = $this->sanitize_dimension( $value, $name );
+					break;
+
+				case 'poster':
 				case 'class':
 				case 'sizes':
 					$out[ $name ] = $value;

--- a/includes/utils/class-amp-string-utils.php
+++ b/includes/utils/class-amp-string-utils.php
@@ -1,0 +1,9 @@
+<?php
+
+class AMP_String_Utils {
+	public static function endswith( $haystack, $needle ) {
+		return '' !== $haystack
+			&& '' !== $needle
+			&& $needle === substr( $haystack, -strlen( $needle ) );
+	}
+}

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -33,11 +33,6 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
 			),
 
-			'iframe_with_100_percent_width' => array(
-				'<iframe src="https://example.com/embed/132886713" width="100%" height="280"></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" height="280" sandbox="allow-scripts allow-same-origin" layout="fixed-height"></amp-iframe>',
-			),
-
 			'iframe_with_invalid_frameborder' => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="no"></iframe>',
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw" class="amp-wp-enforced-sizes"></amp-iframe>',

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -178,3 +178,73 @@ class AMP_Base_Sanitizer__Enforce_Fixed_Height__Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_attributes, $returned_attributes );
 	}
 }
+
+class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
+	public function get_data() {
+		return array(
+			'empty' => array(
+				array( '', 'width' ),
+				'',
+			),
+
+			'empty_space' => array(
+				array( ' ', 'width' ),
+				'',
+			),
+
+			'int' => array(
+				array( 123, 'width' ),
+				123,
+			),
+
+			'int_as_string' => array(
+				array( '123', 'width' ),
+				123,
+			),
+
+			'with_px' => array(
+				array( '567px', 'width' ),
+				567,
+			),
+
+			'100%_width__with_max' => array(
+				array( '100%', 'width' ),
+				600,
+				array( 'content_max_width' => 600 ),
+			),
+
+			'100%_width__no_max' => array(
+				array( '100%', 'width' ),
+				'',
+			),
+
+			'50%_width__with_max' => array(
+				array( '50%', 'width' ),
+				300,
+				array( 'content_max_width' => 600 ),
+			),
+
+			'%_height' => array(
+				array( '100%', 'height' ),
+				'',
+			),
+
+			'non_int' => array(
+				array( 'abcd', 'width' ),
+				'',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_data
+	 */
+	public function test_enforce_sizes_attribute( $source_params, $expected_value, $args = array() ) {
+		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
+		list( $value, $dimension ) = $source_params;
+
+		$actual_value = $sanitizer->sanitize_dimension( $value, $dimension );
+
+		$this->assertEquals( $expected_value, $actual_value );
+	}
+}


### PR DESCRIPTION
Leave integers as-is. If `px`, strip that out. If `%` and it's a width value try to adjust to
the `max_content_width`, if set.

Everything else should be converted to empty.

Fixes #374