### PR TITLE
Ensure that `amp` query var has an explicit value.

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -42,11 +42,21 @@ function amp_init() {
 	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
 	add_post_type_support( 'post', AMP_QUERY_VAR );
 
+	add_filter( 'request', 'amp_force_query_var_value' );
 	add_action( 'wp', 'amp_maybe_add_actions' );
 
 	if ( class_exists( 'Jetpack' ) && ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		require_once( AMP__DIR__ . '/jetpack-helper.php' );
 	}
+}
+
+// Make sure the `amp` query var has an explicit value.
+// Avoids issues when filtering the deprecated `query_string` hook.
+function amp_force_query_var_value( $query_vars ) {
+	if ( isset( $query_vars[ AMP_QUERY_VAR ] ) && '' === $query_vars[ AMP_QUERY_VAR ] ) {
+		$query_vars[ AMP_QUERY_VAR ] = 1;
+	}
+	return $query_vars;
 }
 
 function amp_maybe_add_actions() {


### PR DESCRIPTION
Avoids issues when filtering the deprecated `query_string` hook, which
ends up stripping out the `amp` query var.

h/t @mkuplens

Fixes #391