### PR TITLE
Blacklist Sanitizer: Use for loop for traversing child nodes

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -62,7 +62,10 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		foreach ( $node->childNodes as $child_node ) {
+		$length = $node->childNodes->length;
+		for ( $i = $length - 1; $i >= 0; $i-- ) {
+			$child_node = $node->childNodes->item( $i );
+
 			$this->strip_attributes_recursive( $child_node, $bad_attributes, $bad_protocols );
 		}
 	}

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -137,6 +137,12 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<font size="1">Headline</font>',
 				'Headline',
 			),
+
+			// font is removed so we should check that other elements are checked as well
+			'font_with_other_bad_elements' => array(
+				'<font size="1">Headline</font><span style="color: blue">Span</span>',
+				'Headline<span>Span</span>',
+			),
 		);
 	}
 


### PR DESCRIPTION
Because we now remove certain elements (like `font`), we need to use a
`for` loop instead of a `foreach` to make sure we traverse through every
single element. Otherwise we end up skipping some.