### PR TITLE
Switching from template_redirect to template_include

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -100,7 +100,7 @@ function amp_add_post_template_actions() {
 }
 
 function amp_prepare_render() {
-	add_action( 'template_redirect', 'amp_render' );
+	add_action( 'template_include', 'amp_render' );
 }
 
 function amp_render() {


### PR DESCRIPTION
This pull request converts from using `template_include` to using `template_redirect` for reasons explained in issue #412 