### PR TITLE
Add ability to go canonical AMP (AMP-only)

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -17,9 +17,6 @@ define( 'AMP__DIR__', dirname( __FILE__ ) );
 require_once( AMP__DIR__ . '/includes/amp-helper-functions.php' );
 require_once( AMP__DIR__ . '/options.php' );
 
-// Determine if we want to treat the whole page as AMP
-define( 'AMP_CANONICAL', get_option( 'amp_canonical', 0 ) );
-
 register_activation_hook( __FILE__, 'amp_activate' );
 function amp_activate(){
 	amp_init();
@@ -43,7 +40,8 @@ function amp_init() {
 
 	load_plugin_textdomain( 'amp', false, plugin_basename( AMP__DIR__ ) . '/languages' );
 
-	if( !AMP_CANONICAL ) {
+	// Add rewrite endpoints if we either don't want canonical AMP, or if the theme doesn't support it
+	if( ! get_option( 'amp_canonical') || ! get_theme_support('amp') ) {
 		add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
 		add_post_type_support( 'post', AMP_QUERY_VAR );
 	}
@@ -88,7 +86,7 @@ function amp_maybe_add_actions() {
 
 	if ( $is_amp_endpoint ) {
 		amp_prepare_render();
-	} else if(AMP_CANONICAL && $supports) {
+	} else if( get_option( 'amp_canonical') && $supports && get_theme_support('amp') ) {
 		amp_render_canonical();
 	} else {
 		amp_add_frontend_actions();
@@ -128,6 +126,6 @@ function amp_render_canonical() {
 }
 
 // load high priority filters for canonical AMP
-if( AMP_CANONICAL ) {
+if( get_option( 'amp_canonical') ) {
 	require_once( AMP__DIR__ . '/includes/amp-canonical-filters.php' );
 }

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -2,6 +2,7 @@
 
 require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
 require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-string-utils.php' );
 
 require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
 

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -19,7 +19,7 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
 
-function build_post_content() {
+function amp_canonical_retrieve_content() {
 
 	$post = get_post();
 
@@ -56,7 +56,7 @@ function build_post_content() {
 }
 
 // Generate the AMP post content early on (runs the_content filters but skips our filter below)
-$GLOBALS['amp_content'] = build_post_content();
+$GLOBALS['amp_content'] = amp_canonical_retrieve_content();
 
 // "the_content" filter was already invoked now, so attempt remove all filters
 remove_all_filters('the_content');

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -57,13 +57,17 @@ function build_post_content() {
 // Generate the AMP post content early on (runs the_content filters but skips our filter below)
 $GLOBALS['amp_content'] = build_post_content();
 
+// "the_content" filter was already invoked now, so attempt remove all filters
+remove_all_filters('the_content');
+
 // Callbacks for adding AMP-related things to the main theme when used as canonical
 add_action( 'wp_head', 'amp_canonical_add_scripts' );
 add_action( 'wp_head', 'amp_canonical_add_boilerplate_css' );
 add_action( 'wp_footer', 'amp_deregister_scripts' );
 
-// the final filter that replaces the content
-add_filter( 'the_content', 'amp_the_content_filter' );
+// the final filter that replaces the content, run at the very end just to
+// make sure that no content filters run after it
+add_filter( 'the_content', 'amp_the_content_filter', PHP_INT_MAX);
 
 function amp_the_content_filter($content) {
 	if(isset($GLOBALS['amp_content'])) {

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -22,7 +22,7 @@ function build_post_content() {
 
 	$post = get_post();
 
-	$content_max_width = 600;
+	$content_max_width = 1200;
 	if ( isset( $GLOBALS['content_width'] ) && $GLOBALS['content_width'] > 0 ) {
 		$content_max_width = $GLOBALS['content_width'];
 	}

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -65,14 +65,6 @@ add_action( 'wp_footer', 'amp_deregister_scripts' );
 // the final filter that replaces the content
 add_filter( 'the_content', 'amp_the_content_filter' );
 
-// we need to replace thumbnail img tags (and probably a few other functions I've missed)
-add_filter( 'post_thumbnail_html', 'amp_thumbnail_filter' );
-
-function amp_thumbnail_filter( $thumbnail ) {
-	echo "WARK";
-	return $thumbnail;
-}
-
 function amp_the_content_filter($content) {
 	if(isset($GLOBALS['amp_content'])) {
 		return $GLOBALS['amp_content']->get_amp_content();

--- a/includes/amp-canonical-actions.php
+++ b/includes/amp-canonical-actions.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
+
+require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
+
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-blacklist-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-img-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-video-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-iframe-sanitizer.php' );
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-audio-sanitizer.php' );
+
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-twitter-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-youtube-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-gallery-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
+
+function build_post_content() {
+
+	$post = get_post();
+
+	$content_max_width = 600;
+	if ( isset( $GLOBALS['content_width'] ) && $GLOBALS['content_width'] > 0 ) {
+		$content_max_width = $GLOBALS['content_width'];
+	}
+
+	$amp_content = new AMP_Content( $post->post_content,
+		array(
+			'AMP_Twitter_Embed_Handler' => array(),
+			'AMP_YouTube_Embed_Handler' => array(),
+			'AMP_Instagram_Embed_Handler' => array(),
+			'AMP_Vine_Embed_Handler' => array(),
+			'AMP_Facebook_Embed_Handler' => array(),
+			'AMP_Gallery_Embed_Handler' => array(),
+		),
+		array(
+			 'AMP_Blacklist_Sanitizer' => array(),
+			 'AMP_Img_Sanitizer' => array(),
+			 'AMP_Video_Sanitizer' => array(),
+			 'AMP_Audio_Sanitizer' => array(),
+			 'AMP_Iframe_Sanitizer' => array(
+				 'add_placeholder' => true,
+			 ),
+		),
+		array(
+			'content_max_width' => $content_max_width,
+		)
+	);
+
+	return $amp_content;
+
+}
+
+// Generate the AMP post content early on (runs the_content filters but skips our filter below)
+$GLOBALS['amp_content'] = build_post_content();
+
+// Callbacks for adding AMP-related things to the main theme when used as canonical
+add_action( 'wp_head', 'amp_canonical_add_scripts' );
+add_action( 'wp_head', 'amp_canonical_add_boilerplate_css' );
+add_action( 'wp_footer', 'amp_deregister_scripts' );
+
+// the final filter that replaces the content
+add_filter( 'the_content', 'amp_the_content_filter' );
+
+// we need to replace thumbnail img tags (and probably a few other functions I've missed)
+add_filter( 'post_thumbnail_html', 'amp_thumbnail_filter' );
+
+function amp_thumbnail_filter( $thumbnail ) {
+	echo "WARK";
+	return $thumbnail;
+}
+
+function amp_the_content_filter($content) {
+	if(isset($GLOBALS['amp_content'])) {
+		return $GLOBALS['amp_content']->get_amp_content();
+	} else {
+		return $content;
+	}
+}
+
+function amp_deregister_scripts() {
+  wp_deregister_script( 'wp-embed' );
+}
+
+function amp_canonical_add_boilerplate_css() {
+	?>
+	<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+	<?php
+}
+
+function amp_canonical_add_scripts() {
+
+	$amp_runtime_script = 'https://cdn.ampproject.org/v0.js';
+
+	// Always include AMP form & analytics, as almost every template has search form somewhere and is tracking page views
+	$scripts = array_merge(
+		array('amp-form' => 'https://cdn.ampproject.org/v0/amp-form-0.1.js'),
+		array('amp-analytics' => 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js'),
+		$GLOBALS['amp_content']->get_amp_scripts()
+	);
+
+	foreach ( $scripts as $element => $script ) : ?>
+		<script custom-element="<?php echo esc_attr( $element ); ?>" src="<?php echo esc_url( $script ); ?>" async></script>
+	<?php endforeach; ?>
+	<script src="<?php echo esc_url( $amp_runtime_script ); ?>" async></script>
+	<?php
+
+}

--- a/includes/amp-canonical-filters.php
+++ b/includes/amp-canonical-filters.php
@@ -1,19 +1,10 @@
 <?php
 
 // before Jetpack ever gets loaded, we need to remove a link rel prefetch for canonical AMP support
-// Remove the videopress shortcode as it adds a link rel prefetch that doesn't validate in AMP
-function amp_remove_shortcode( $shortcodes ) {
-
-	$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
-
-	$shortcodes_to_unload = array( 'videopress.php' );
-
-	foreach ( $shortcodes_to_unload as $shortcode ) {
-			if ( $key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes ) ) {
-					unset( $shortcodes[$key] );
-			}
-	}
-
-	return $shortcodes;
+// TODO: These will be allowed in the AMP validator in the future, so remove as soon as it works.
+function amp_canonical_disable_jetpack_dns_fetch() {
+    if ( class_exists( 'Jetpack' ) ) {
+        remove_action( 'wp_head', array( 'Jetpack', 'dns_prefetch' ) ); 
+    }
 }
-add_filter( 'jetpack_shortcodes_to_include', 'amp_remove_shortcode' );
+add_action( 'wp_head', 'amp_canonical_disable_jetpack_dns_fetch', 0 ); // Hook early so we can unhook Jetpack

--- a/includes/amp-canonical-filters.php
+++ b/includes/amp-canonical-filters.php
@@ -1,0 +1,19 @@
+<?php
+
+// before Jetpack ever gets loaded, we need to remove a link rel prefetch for canonical AMP support
+// Remove the videopress shortcode as it adds a link rel prefetch that doesn't validate in AMP
+function amp_remove_shortcode( $shortcodes ) {
+
+	$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
+
+	$shortcodes_to_unload = array( 'videopress.php' );
+
+	foreach ( $shortcodes_to_unload as $shortcode ) {
+			if ( $key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes ) ) {
+					unset( $shortcodes[$key] );
+			}
+	}
+
+	return $shortcodes;
+}
+add_filter( 'jetpack_shortcodes_to_include', 'amp_remove_shortcode' );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -18,7 +18,7 @@ function amp_get_permalink( $post_id ) {
 
 function post_supports_amp( $post ) {
 	// Because `add_rewrite_endpoint` doesn't let us target specific post_types :(
-	if (!AMP_CANONICAL && !post_type_supports( $post->post_type, AMP_QUERY_VAR ) ) {
+	if (! get_option( 'amp_canonical') && ! post_type_supports( $post->post_type, AMP_QUERY_VAR ) ) {
 		return false;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -12,7 +12,7 @@ function amp_get_permalink( $post_id ) {
 
 function post_supports_amp( $post ) {
 	// Because `add_rewrite_endpoint` doesn't let us target specific post_types :(
-	if ( ! post_type_supports( $post->post_type, AMP_QUERY_VAR ) ) {
+	if (!AMP_CANONICAL && !post_type_supports( $post->post_type, AMP_QUERY_VAR ) ) {
 		return false;
 	}
 

--- a/options.php
+++ b/options.php
@@ -1,0 +1,73 @@
+<?php
+
+add_action( 'admin_init', 'amp_register_settings' );
+add_action( 'admin_menu', 'amp_custom_admin_menu' );
+
+/**
+ * Register the settings
+ */
+function amp_register_settings() {
+     register_setting(
+          'amp_options',  // settings section
+          'amp_canonical' // setting name
+     );
+}
+
+/**
+ * Add the options page
+ */
+function amp_custom_admin_menu() {
+    add_options_page(
+        'AMP',
+        'AMP',
+        'manage_options',
+        'amp-plugin',
+        'amp_options_page'
+    );
+}
+
+
+/**
+ * Build the options page
+ */
+function amp_options_page() {
+     if ( ! isset( $_REQUEST['settings-updated'] ) )
+          $_REQUEST['settings-updated'] = false; ?>
+
+     <div class="wrap">
+
+          <?php if ( false !== $_REQUEST['settings-updated'] ) : ?>
+               <div class="updated fade"><p><strong><?php _e( 'AMP Options saved!', 'amp' ); ?></strong></p></div>
+          <?php endif; ?>
+
+          <h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
+
+          <div id="poststuff">
+               <div id="post-body">
+                    <div id="post-body-content">
+                         <form method="post" action="options.php">
+                              <?php settings_fields( 'amp_options' ); ?>
+                              <?php $amp_canonical = get_option( 'amp_canonical' ); ?>
+                              <table class="form-table">
+                                   <tr valign="top"><th scope="row"><?php _e( 'Make the whole site AMP?', 'amp' ); ?></th>
+                                        <td>
+                                             <select name="amp_canonical" id="amp_canonical">
+                                                  <?php $selected = intval($amp_canonical); ?>
+                                                  <option value="1" <?php selected( $selected, 1 ); ?> >Yes, enable for all posts!</option>
+                                                  <option value="0" <?php selected( $selected, 0 ); ?> >No, generate separate pages</option>
+                                             </select><br />
+                                             <label class="description" for="amp_canonical"><?php _e( 'Toggles whether the plugin generates paired AMP pages or reuses the current theme.', 'amp' ); ?></label>
+                                        </td>
+                                   </tr>
+                              </table>
+
+                              <p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes"></p>
+                         </form>
+                    </div> <!-- end post-body-content -->
+               </div> <!-- end post-body -->
+          </div> <!-- end poststuff -->
+     </div>
+     <?php
+}
+
+?>

--- a/options.php
+++ b/options.php
@@ -49,14 +49,19 @@ function amp_options_page() {
                               <?php settings_fields( 'amp_options' ); ?>
                               <?php $amp_canonical = get_option( 'amp_canonical' ); ?>
                               <table class="form-table">
-                                   <tr valign="top"><th scope="row"><?php _e( 'Make the whole site AMP?', 'amp' ); ?></th>
+                                   <tr valign="top"><th scope="row"><?php _e( 'AMP Generation Mode (Beta)', 'amp' ); ?></th>
                                         <td>
-                                             <select name="amp_canonical" id="amp_canonical">
-                                                  <?php $selected = intval($amp_canonical); ?>
-                                                  <option value="1" <?php selected( $selected, 1 ); ?> >Yes, enable for all posts!</option>
-                                                  <option value="0" <?php selected( $selected, 0 ); ?> >No, generate separate pages</option>
-                                             </select><br />
-                                             <label class="description" for="amp_canonical"><?php _e( 'Toggles whether the plugin generates paired AMP pages or reuses the current theme.', 'amp' ); ?></label>
+                                          <?php $selected = intval($amp_canonical); ?>
+                                          <fieldset>
+                                            <legend class="screen-reader-text"><span><?php _e( 'Mode', 'amp' ); ?></span></legend>
+                                            <p>
+                                              <label><input name="amp_canonical" type="radio" value="1" <?php checked( $selected, 1 ); ?> > Standalone</label>
+                                              <br>
+                                              <label><input name="amp_canonical" type="radio" value="0" <?php checked( $selected, 0 ); ?> > Paired</label>
+                                            </p>
+                                            <p><?php _e( 'Toggles whether the plugin generates paired AMP pages, or makes the whole site use AMP (similar to any JS library).', 'amp' ); ?></p>
+                                            <p class="description"><?php _e( 'Note: Standalone mode is experimental and requires a supporting theme and widgets. Currently only applies to single posts.', 'amp' ); ?> <a href="https://github.com/Automattic/amp-wp#standalone-mode"><?php _e( 'Learn more.', 'amp' ); ?></a></p>
+                                          </fieldset>
                                         </td>
                                    </tr>
                               </table>

--- a/readme.md
+++ b/readme.md
@@ -569,6 +569,105 @@ function xyz_amp_set_review_template( $file, $type, $post ) {
 
 We may provide better ways to handle this in the future.
 
+## Standalone mode
+
+In Settings -> AMP, you'll find the option to change the **AMP Generation Mode**
+to "Standalone".
+
+This will cause the whole site to turn into AMP – that is, there won't be a
+"normal" version of your site, and an "AMP" version, but just one, single
+AMP-enabled experience.
+
+This mode is experimental, and requires the theme and any potential rendered
+widgets to specifically add support.
+
+### How do I enable canonical AMP support for my theme or widget?
+
+Here's how a theme would conform:
+
+#### 1. Add `amp` theme support
+
+The theme must signal that it supports AMP in order for the plugin to enable canonical AMP mode, like so:
+
+```
+add_theme_support( 'amp' );
+```
+
+#### 2. Inline stylesheet
+
+Something like:
+
+```
+function add_inline_stylesheet() {
+	if( get_option( 'amp_canonical') ) {
+		$css = file_get_contents(get_stylesheet_uri());
+		?>
+		<style amp-custom><?= $css; ?></style>
+		<?php
+	}
+}
+
+add_action( 'wp_head', 'add_inline_stylesheet' );
+```
+
+#### 3. Provide valid header bits
+
+Include the flash in the html tag (doesn't hurt even without AMP), make sure that the charset is lowercase and that the correct viewport is set.
+
+```
+<html ⚡ <?php language_attributes(); ?>>
+	<head>
+		<meta charset="<?= strtolower(get_bloginfo( 'charset', 'display' )); ?>">
+		<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+```
+
+#### 4. Embed AMP analytics
+
+Use AMP analytics instead of other analytics solutions based on the AMP_CANONICAL check:
+
+```
+if ( get_option( 'amp_canonical') ) {
+?>
+<amp-analytics type="googleanalytics" id="analytics-ga">
+  <script type="application/json">
+  {
+    "vars": {
+      "account": "UA-2427667-1"
+    },
+    "triggers": {
+      "trackPageview": {
+        "on": "visible",
+        "request": "pageview"
+      }
+    }
+  }
+  </script>
+</amp-analytics>
+<?php
+}
+```
+
+#### 5. Optional: Add AMP-specific styles
+
+Currently, stolen from the styles in the default template. These are not required but helpful:
+
+```
+.amp-wp-enforced-sizes {
+	/** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
+	max-width: 100%;
+}
+
+.amp-wp-unknown-size img {
+	/** Worst case scenario when we can't figure out dimensions for an image. **/
+	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/
+	object-fit: contain;
+}
+
+amp-carousel > amp-img > img {
+	object-fit: contain;
+}
+```
+
 ## Plugin integrations
 
 ### Jetpack


### PR DESCRIPTION
This directly addresses #394 and adds the following:
1. Configuration page under Settings with one setting (_Canonical AMP_), off by default right now
2. A WP option called `amp_canonical` that the plugin, plus any other plugins and themes can use to do certain things differently when signalled the blog is in "full AMP mode".
3. A theme support flag called `amp` that the theme can use to signal it supports AMP. 
4. Renders the post content of all posts (only single posts right now) as AMP and does a few tricks to make WP behave nicely.

Importantly, this PR does not address the actual used theme – it's still the theme's responsibility right now to make sure no external JS or CSS is loaded.
## Where can I see a demo?

Glad you're asking. A live example of a canonical AMP blog + theme using this plugin can be found here: [https://paulbakaus.com](https://paulbakaus.com)
## How do I make my theme validate?

Here's how a theme would conform:
### 1. Add `amp` theme support

The theme must signal that it supports AMP in order for the plugin to enable canonical AMP mode, like so:

```
add_theme_support( 'amp' );
```
### 2. Inline stylesheet

Something like:

```
function add_inline_stylesheet() {
    if( get_option( 'amp_canonical') ) {
        $css = file_get_contents(get_stylesheet_uri());
        ?>
        <style amp-custom><?= $css; ?></style>
        <?php
    }
}

add_action( 'wp_head', 'add_inline_stylesheet' );
```
### 3. Provide valid header bits

Include the flash in the html tag (doesn't hurt even without AMP), make sure that the charset is lowercase and that the correct viewport is set.

```
<html ⚡ <?php language_attributes(); ?>>
    <head>
        <meta charset="<?= strtolower(get_bloginfo( 'charset', 'display' )); ?>">
        <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
```
### 4. Embed AMP analytics

Use AMP analytics instead of other analytics solutions based on the AMP_CANONICAL check:

```
if ( get_option( 'amp_canonical') ) {
?>
<amp-analytics type="googleanalytics" id="analytics-ga">
  <script type="application/json">
  {
    "vars": {
      "account": "UA-2427667-1"
    },
    "triggers": {
      "trackPageview": {
        "on": "visible",
        "request": "pageview"
      }
    }
  }
  </script>
</amp-analytics>
<?php
}
```
### 5. Optional: Add AMP-specific styles

Currently, stolen from the styles in the default template. These are not required but helpful:

```
.amp-wp-enforced-sizes {
    /** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
    max-width: 100%;
}

.amp-wp-unknown-size img {
    /** Worst case scenario when we can't figure out dimensions for an image. **/
    /** Force the image into a box of fixed dimensions and use object-fit to scale. **/
    object-fit: contain;
}

amp-carousel > amp-img > img {
    object-fit: contain;
}
```

This is my first real attempt at writing Wordpress-compliant code and I haven't touched PHP for ages, so a lot of it is probably not compliant or can be done in better ways. Very much looking for feedback and somebody who can take it and polish it if needed.
