### PR TITLE
Use url pattern to parse instagram embed

### DIFF
--- a/includes/embeds/class-amp-instagram-embed.php
+++ b/includes/embeds/class-amp-instagram-embed.php
@@ -79,15 +79,12 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	private function get_instagram_id_from_url( $url ) {
-		$url_path = parse_url( $url, PHP_URL_PATH );
+		$found = preg_match( self::URL_PATTERN, $url, $matches );
 
-		// /p/{id} on both, short url and normal urls
-		$instagram_id = mb_substr( $url_path, 3 );
-
-		if( ! empty( $instagram_id ) ) {
-			return $instagram_id;
+		if ( ! $found ) {
+			return false;
 		}
 
-		return false;
+		return end( $matches );
 	}
 }

--- a/tests/test-amp-instagram-embed.php
+++ b/tests/test-amp-instagram-embed.php
@@ -11,10 +11,26 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL
 			),
+
 			'short_url' => array(
 				'https://instagr.am/p/7-l0z_p4A4' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL
-			)
+			),
+
+			'shortcode_simple' => array(
+				'[instagram url=https://www.instagram.com/p/BIyO4vXjE6b]' . PHP_EOL,
+				'<amp-instagram data-shortcode="BIyO4vXjE6b" layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL
+			),
+
+			'shortcode_url_with_query' => array(
+				'[instagram url=https://www.instagram.com/p/BIyO4vXjE6b/?taken-by=natgeo]' . PHP_EOL,
+				'<amp-instagram data-shortcode="BIyO4vXjE6b" layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL
+			),
+
+			'shortcode_with_short_url' => array(
+				'[instagram url=https://instagr.am/p/7-l0z_p4A4]' . PHP_EOL,
+				'<amp-instagram data-shortcode="7-l0z_p4A4" layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL
+			),
 		);
 	}
 


### PR DESCRIPTION
Instead of naive trims. This way we can better support URLs with query
strings and trailing slashes.

h/t @jlapitan for finding and reporting the issue.

Fixes #428 