### PR TITLE
Deal with broken YouTube URLs w/ multiple ?s

### DIFF
--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -104,7 +104,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 			parse_str( $parsed_url['query'], $query_args );
 
 			if ( isset( $query_args['v'] ) ) {
-				$video_id = $query_args['v'];
+				$video_id = $this->sanitize_v_arg( $query_args['v'] );
 			}
 		}
 
@@ -118,5 +118,14 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		return $video_id;
+	}
+
+	private function sanitize_v_arg( $value ) {
+		// Deal with broken params like `?v=123?rel=0`
+		if ( false !== strpos( $value, '?' ) ) {
+			$value = strtok( $value, '?' );
+		}
+
+		return $value;
 	}
 }

--- a/tests/test-amp-youtube-embed.php
+++ b/tests/test-amp-youtube-embed.php
@@ -7,14 +7,32 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL
 			),
-			'simple_url' => array(
+
+			'url_simple' => array(
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL
 			),
-			'short_url' => array(
+
+			'url_short' => array(
 				'https://youtu.be/kfVsfOSbJY0' . PHP_EOL,
-				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL
-			)
+				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
+			),
+
+			'url_with_querystring' => array(
+				'http://www.youtube.com/watch?v=kfVsfOSbJY0&hl=en&fs=1&w=425&h=349' . PHP_EOL,
+				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
+			),
+
+			// Several reports of invalid URLs that have multiple `?` in the URL.
+			'url_with_querystring_and_extra_?' => array(
+				'http://www.youtube.com/watch?v=kfVsfOSbJY0?hl=en&fs=1&w=425&h=349' . PHP_EOL,
+				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
+			),
+
+			'shortcode_unnamed_attr_as_url' => array(
+				'[youtube http://www.youtube.com/watch?v=kfVsfOSbJY0]' . PHP_EOL,
+				'<amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube>' . PHP_EOL
+			),
 		);
 	}
 


### PR DESCRIPTION
When we try to parse out the YouTube video from a URL, we rely on
parse_str, which correctly parses `?v=123?rel=0` as `'v' =>
'123?rel=0'`. However, there are many incidences of these broken URLs in
the wild which is resulting in broken embeds on AMP pages. This strips
off any excess `?` bits from a video ID if found.

Fixes #444