### PR TITLE
Fix active_callback for AMP panel

### DIFF
--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -141,7 +141,7 @@ class AMP_Template_Customizer {
 		$this->wp_customize->add_panel( $this->panel_id, array(
 			'type'            => 'amp',
 			'title'           => __( 'AMP', 'amp' ),
-			'active_callback' => 'is_amp_endpoint'
+			'active_callback' => array( __CLASS__, 'is_amp_customizer' ),
 		) );
 	}
 
@@ -224,7 +224,7 @@ class AMP_Template_Customizer {
 		return $devices;
 	}
 
-	private static function is_amp_customizer() {
+	public static function is_amp_customizer() {
 		return ! empty( $_REQUEST['amp'] );
 	}
 }


### PR DESCRIPTION
When not using pretty permalinks, `is_amp_endpoint` is true
both when viewing an AMP post and in the
customizer (since the `amp` param is in the URL)

When you have pretty permalinks, no `amp` param in the URL, so
`is_amp_endpoint` fails.

Update the active_callback to work in both contexts