### PR TITLE
Ditch LIBXML_NOEMPTYTAG

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -25,8 +25,14 @@ class AMP_DOM_Utils {
 		// Only want children of the body tag, since we have a subset of HTML.
 		$out = '';
 		$body = $dom->getElementsByTagName( 'body' )->item( 0 );
+
+		// AMP elements always need closing tags.
+		// To force them, we can't use saveHTML (node support is 5.3+) and LIBXML_NOEMPTYTAG results in issues with self-closing tags like `br` and `hr`.
+		// So, we're manually forcing closing tags.
+		self::recursive_force_closing_tags( $dom, $body );
+
 		foreach ( $body->childNodes as $node ) {
-			$out .= $dom->saveXML( $node, LIBXML_NOEMPTYTAG );
+			$out .= $dom->saveXML( $node );
 		}
 		return $out;
 	}
@@ -52,6 +58,43 @@ class AMP_DOM_Utils {
 	}
 
 	public static function is_node_empty( $node ) {
-		return 0 === $node->childNodes->length && empty( $node->textContent );
+		return false === $node->hasChildNodes()
+			&& empty( $node->textContent );
+	}
+
+	public static function recursive_force_closing_tags( $dom, $node ) {
+		if ( XML_ELEMENT_NODE !== $node->nodeType ) {
+			return;
+		}
+
+		if ( self::is_self_closing_tag( $node->nodeName ) ) {
+			return;
+		}
+
+		if ( self::is_node_empty( $node ) ) {
+			$text_node = $dom->createTextNode( '' );
+			$node->appendChild( $text_node );
+			return;
+		}
+
+		$num_children = $node->childNodes->length;
+		for ( $i = $num_children - 1; $i >= 0; $i-- ) {
+			$child = $node->childNodes->item( $i );
+			self::recursive_force_closing_tags( $dom, $child );
+		}
+	}
+
+	private static function is_self_closing_tag( $tag ) {
+		// This function is called a lot; the static var prevents having to re-create the array every time.
+		static $self_closing_tags;
+		if ( ! isset( $self_closing_tags ) ) {
+			// https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
+			// Not all are valid AMP, but we include them for completeness.
+			$self_closing_tags = array(
+				'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'embed', 'frame', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+			);
+		}
+
+		return in_array( $tag, $self_closing_tags );
 	}
 }

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -42,7 +42,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'<audio width="400" height="300">
 	<source src="https://example.com/foo.wav" type="audio/wav">
 </audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio>'
+				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio>'
 			),
 
 
@@ -56,7 +56,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 <audio width="400" height="300">
 	<source src="https://example.com/foo.wav" type="audio/wav">
 </audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio>',
+				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio>',
 			),
 
 			'multiple_different_audio' => array(
@@ -67,7 +67,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 <audio height="500" width="300">
 	<source src="https://example.com/foo2.wav" type="audio/wav">
 </audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></source></amp-audio><amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio><amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"></source></amp-audio>'
+				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio><amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio><amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"/></amp-audio>'
 			),
 
 			'https_not_required' => array(

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -25,7 +25,7 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 
 			'whitelisted_tag_only' => array(
 				'<p>Text</p><img src="/path/to/file.jpg" />',
-				'<p>Text</p><img src="/path/to/file.jpg"></img>' // LIBXML_NOEMPTYTAG
+				'<p>Text</p><img src="/path/to/file.jpg"/>' // LIBXML_NOEMPTYTAG
 			),
 
 			'blacklisted_attributes' => array(

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -53,7 +53,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	<source src="https://example.com/video.mp4" type="video/mp4" />
 	<source src="https://example.com/video.ogv" type="video/ogg" />
 </video>',
-				'<amp-video width="480" height="300" poster="https://example.com/video-image.gif" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"><source src="https://example.com/video.mp4" type="video/mp4"></source><source src="https://example.com/video.ogv" type="video/ogg"></source></amp-video>'
+				'<amp-video width="480" height="300" poster="https://example.com/video-image.gif" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"><source src="https://example.com/video.mp4" type="video/mp4"/><source src="https://example.com/video.ogv" type="video/ogg"/></amp-video>'
 			),
 
 			'multiple_same_video' => array(


### PR DESCRIPTION
LIBXML_NOEMPTYTAG results in issues with self-closing tags like `br` and `hr`.

Instead manually force recursive noded by adding an empty TextNode to elements that have no children and are not self-closing.