### PR TITLE
fix replace_node_with_children

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -37,9 +37,11 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		// Some nodes may contain valid content but are themselves invalid.
 		// Remove the node but preserve the children.
  		if ( 'font' === $node_name ) {
-			$this->replace_node_with_children( $node );
+			$this->replace_node_with_children( $node, $bad_attributes, $bad_protocols );
+			return;
 		} elseif ( 'a' === $node_name && false === $this->validate_a_node( $node ) ) {
-			$this->replace_node_with_children( $node );
+			$this->replace_node_with_children( $node, $bad_attributes, $bad_protocols );
+			return;
 		}
 
 		if ( $node->hasAttributes() ) {
@@ -153,12 +155,13 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		return true;
 	}
 
-	private function replace_node_with_children( $node ) {
+	private function replace_node_with_children( $node, $bad_attributes, $bad_protocols ) {
 		// If the node has children and also has a parent node,
 		// clone and re-add all the children just before current node.
 		if ( $node->hasChildNodes() && $node->parentNode ) {
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child = $child_node->cloneNode( true );
+				$this->strip_attributes_recursive( $new_child, $bad_attributes, $bad_protocols );
 				$node->parentNode->insertBefore( $new_child, $node );
 			}
 		}

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -128,6 +128,16 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a name="section2"></a>',
 			),
 
+			'a_empty' => array(
+				'<a>Hello World</a>',
+				'Hello World',
+			),
+
+			'a_empty_with_children_with_restricted_attributes' => array(
+				'<a><span style="color: red;">Red</span>&amp;<span style="color: blue;">Orange</span></a>',
+				'<span>Red</span>&amp;<span>Orange</span>'
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',


### PR DESCRIPTION
Continued from #449 by @Maxime2

> We need to sanitize children of removed node as if there are more than one those starting from second would be missed in sanitisation in parent's foreach loop.

Includes some tests.