### PR TITLE
Preserve Inline Styles

### DIFF
--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -46,18 +46,13 @@ function amp_post_template_add_schemaorg_metadata( $amp_template ) {
 add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 function amp_post_template_add_styles( $amp_template ) {
 	$styles = $amp_template->get( 'post_amp_styles' );
-	if ( ! empty( $styles ) ) : ?>
-
-/* Inline styles */
-<?php
-	foreach ( $styles as $selector => $declarations ) :
-		$declarations = implode( ";\n\t", $declarations ) . ";\n"; ?>
-<?php echo $selector; ?> {
-	<?php echo $declarations; ?>
-}
-
-<?php endforeach;
-	endif;
+	if ( ! empty( $styles ) ) {
+		echo '/* Inline styles */' . PHP_EOL;
+		foreach ( $styles as $selector => $declarations ) {
+			$declarations = implode( ";", $declarations ) . ";";
+			printf( '%1$s{%2$s}', $selector, $declarations );
+		}
+	}
 }
 
 add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -45,7 +45,19 @@ function amp_post_template_add_schemaorg_metadata( $amp_template ) {
 
 add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 function amp_post_template_add_styles( $amp_template ) {
-	echo $amp_template->get( 'post_amp_styles' );
+	$styles = $amp_template->get( 'post_amp_styles' );
+	if ( ! empty( $styles ) ) : ?>
+
+/* Inline styles */
+<?php
+	foreach ( $styles as $selector => $declarations ) :
+		$declarations = implode( ";\n\t", $declarations ) . ";\n"; ?>
+<?php echo $selector; ?> {
+	<?php echo $declarations; ?>
+}
+
+<?php endforeach;
+	endif;
 }
 
 add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -43,6 +43,11 @@ function amp_post_template_add_schemaorg_metadata( $amp_template ) {
 	<?php
 }
 
+add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
+function amp_post_template_add_styles( $amp_template ) {
+	echo $amp_template->get( 'post_amp_styles' );
+}
+
 add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 function amp_post_template_add_analytics_script( $data ) {
 	if ( ! empty( $data['amp_analytics'] ) ) {

--- a/includes/class-amp-content.php
+++ b/includes/class-amp-content.php
@@ -8,6 +8,7 @@ class AMP_Content {
 	private $content;
 	private $amp_content = '';
 	private $amp_scripts = array();
+	private $amp_styles = '';
 	private $args = array();
 	private $embed_handler_classes = array();
 	private $sanitizer_classes = array();
@@ -29,6 +30,10 @@ class AMP_Content {
 		return $this->amp_scripts;
 	}
 
+	public function get_amp_styles() {
+		return $this->amp_styles;
+	}
+
 	private function transform() {
 		$content = $this->content;
 
@@ -45,6 +50,10 @@ class AMP_Content {
 
 	private function add_scripts( $scripts ) {
 		$this->amp_scripts = array_merge( $this->amp_scripts, $scripts );
+	}
+
+	private function add_styles( $styles ) {
+		$this->amp_styles .= $styles;
 	}
 
 	private function register_embed_handlers() {
@@ -85,6 +94,7 @@ class AMP_Content {
 
 			$sanitizer->sanitize();
 			$this->add_scripts( $sanitizer->get_scripts() );
+			$this->add_styles( $sanitizer->get_styles() );
 		}
 
 		return AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/includes/class-amp-content.php
+++ b/includes/class-amp-content.php
@@ -8,7 +8,7 @@ class AMP_Content {
 	private $content;
 	private $amp_content = '';
 	private $amp_scripts = array();
-	private $amp_styles = '';
+	private $amp_styles = array();
 	private $args = array();
 	private $embed_handler_classes = array();
 	private $sanitizer_classes = array();
@@ -53,7 +53,7 @@ class AMP_Content {
 	}
 
 	private function add_styles( $styles ) {
-		$this->amp_styles .= $styles;
+		$this->amp_styles = array_merge( $this->amp_styles, $styles );
 	}
 
 	private function register_embed_handlers() {

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -203,6 +203,7 @@ class AMP_Post_Template {
 
 		$this->add_data_by_key( 'post_amp_content', $amp_content->get_amp_content() );
 		$this->merge_data_for_key( 'amp_component_scripts', $amp_content->get_amp_scripts() );
+		$this->add_data_by_key( 'post_amp_styles', $amp_content->get_amp_styles() );
 	}
 
 	private function build_customizer_settings() {

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -6,6 +6,7 @@ require_once( AMP__DIR__ . '/includes/utils/class-amp-string-utils.php' );
 
 require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
 
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-style-sanitizer.php' );
 require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-blacklist-sanitizer.php' );
 require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-img-sanitizer.php' );
 require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-video-sanitizer.php' );
@@ -186,6 +187,7 @@ class AMP_Post_Template {
 				'AMP_Gallery_Embed_Handler' => array(),
 			), $this->post ),
 			apply_filters( 'amp_content_sanitizers', array(
+				 'AMP_Style_Sanitizer' => array(),
 				 'AMP_Blacklist_Sanitizer' => array(),
 				 'AMP_Img_Sanitizer' => array(),
 				 'AMP_Video_Sanitizer' => array(),

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -20,6 +20,10 @@ abstract class AMP_Base_Sanitizer {
 		return array();
 	}
 
+	public function get_styles() {
+		return '';
+	}
+
 	protected function get_body_node() {
 		return $this->dom->getElementsByTagName( 'body' )->item( 0 );
 	}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -21,7 +21,7 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	public function get_styles() {
-		return '';
+		return array();
 	}
 
 	protected function get_body_node() {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -36,6 +36,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$node->setAttribute( 'class', $new_class );
 					$this->styles[ $class_name ] = $style;
 				}
+
+				$node->removeAttribute( 'style' );
 			}
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -27,6 +27,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$class = $node->getAttribute( 'class' );
 
 			if ( $style ) {
+				$style = $this->process_style( $style );
+
 				$class_name = $this->generate_class_name( $style );
 				$new_class  = trim( $class . ' ' . $class_name );
 
@@ -43,8 +45,19 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 	}
 
+	private function process_style( $string ) {
+		// Filter properties
+		$string = safecss_filter_attr( $string );
+
+		// Normalize order
+		$arr = array_map( 'trim', explode( ';', $string ) );
+		sort( $arr );
+
+		return implode( ";\n", $arr ) . ';';
+	}
+
 	private function generate_class_name( $string ) {
-		return 'amp-style-' . md5( $string );
+		return 'amp-inline-style-' . md5( $string );
 	}
 
 	public function append_styles() {
@@ -52,7 +65,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 /* Inline Styles */
 <?php foreach ( $this->styles as $class_name => $style ) : ?>
-.<?php echo $class_name; ?> { <?php echo $style; ?> }
+.<?php echo $class_name; ?> {
+	<?php echo $style; ?>
+
+}
 <?php endforeach; ?>
 
 		<?php

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php' );
+
+/**
+ * Collects inline styles and outputs them in the amp-custom stylesheet.
+ */
+class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
+	private $styles = array();
+
+	public function sanitize() {
+		$body = $this->get_body_node();
+		$this->collect_styles_recursive( $body );
+
+		if ( ! empty( $this->styles ) ) {
+			add_action( 'amp_post_template_css', array( $this, 'append_styles' ), 99 );
+		}
+	}
+
+	private function collect_styles_recursive( $node ) {
+		if ( $node->nodeType !== XML_ELEMENT_NODE ) {
+			return;
+		}
+
+		if ( $node->hasAttributes() && $node instanceof DOMElement ) {
+			$style = $node->getAttribute( 'style' );
+			$class = $node->getAttribute( 'class' );
+
+			if ( $style ) {
+				$class_name = $this->generate_class_name( $style );
+				$new_class  = trim( $class . ' ' . $class_name );
+
+				$node->setAttribute( 'class', $new_class );
+				$this->styles[ $class_name ] = $style;
+			}
+		}
+
+		$length = $node->childNodes->length;
+		for ( $i = $length - 1; $i >= 0; $i -- ) {
+			$child_node = $node->childNodes->item( $i );
+
+			$this->collect_styles_recursive( $child_node );
+		}
+	}
+
+	private function generate_class_name( $string ) {
+		return 'amp-style-' . md5( $string );
+	}
+
+	public function append_styles() {
+		?>
+
+/* Inline Styles */
+<?php foreach ( $this->styles as $class_name => $style ) : ?>
+.<?php echo $class_name; ?> { <?php echo $style; ?> }
+<?php endforeach; ?>
+
+		<?php
+	}
+}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -77,7 +77,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return '';
 		}
 
-		return implode( ";\n\t", $arr ) . ';';
+		return implode( "; ", $arr ) . ';';
 	}
 
 	private function generate_class_name( $string ) {
@@ -91,10 +91,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 /* Inline Styles */
 <?php foreach ( $this->styles as $class_name => $style ) : ?>
-.<?php echo $class_name; ?> {
-	<?php echo $style; ?>
-
-}
+.<?php echo $class_name; ?> { <?php echo $style; ?> }
 <?php endforeach; ?>
 
 <?php

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -65,7 +65,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $arr as $index => $rule ) {
 			$arr2 = array_map( 'trim', explode( ':', $rule, 2 ) );
 			if ( 2 === count( $arr2 ) ) {
-				$arr[ $index ] = $arr2[0] . ': ' . $arr2[1];
+				$arr[ $index ] = $arr2[0] . ':' . $arr2[1];
 			}
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -53,6 +53,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$arr = array_map( 'trim', explode( ';', $string ) );
 		sort( $arr );
 
+		// Normalize whitespace
+		foreach ( $arr as $index => $rule ) {
+			$arr2 = array_map( 'trim', explode( ':', $rule, 2 ) );
+			if ( 2 === count( $arr2 ) ) {
+				$arr[ $index ] = $arr2[0] . ': ' . $arr2[1];
+			}
+		}
+
 		// Handle overflow rule
 		// https://www.ampproject.org/docs/reference/spec.html#properties
 		if ( $overflow = preg_grep( '/^overflow.*(auto|scroll)$/', $arr ) ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -83,7 +83,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function generate_class_name( $string ) {
-		return 'amp-inline-style-' . md5( $string );
+		return 'amp-wp-inline-style-' . md5( $string );
 	}
 
 	public function append_styles() {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -53,7 +53,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$arr = array_map( 'trim', explode( ';', $string ) );
 		sort( $arr );
 
-		return implode( ";\n", $arr ) . ';';
+		// Handle overflow rule
+		// https://www.ampproject.org/docs/reference/spec.html#properties
+		if ( $overflow = preg_grep( '/^overflow.*(auto|scroll)$/', $arr ) ) {
+			foreach( $overflow as $index => $rule ) {
+				unset( $arr[ $index ] );
+			}
+		}
+
+		return implode( ";\n\t", $arr ) . ';';
 	}
 
 	private function generate_class_name( $string ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -29,11 +29,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $style ) {
 				$style = $this->process_style( $style );
 
-				$class_name = $this->generate_class_name( $style );
-				$new_class  = trim( $class . ' ' . $class_name );
+				if ( $style ) {
+					$class_name = $this->generate_class_name( $style );
+					$new_class  = trim( $class . ' ' . $class_name );
 
-				$node->setAttribute( 'class', $new_class );
-				$this->styles[ $class_name ] = $style;
+					$node->setAttribute( 'class', $new_class );
+					$this->styles[ $class_name ] = $style;
+				}
 			}
 		}
 
@@ -48,6 +50,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_style( $string ) {
 		// Filter properties
 		$string = safecss_filter_attr( $string );
+
+		if ( ! $string ) {
+			return '';
+		}
 
 		// Normalize order
 		$arr = array_map( 'trim', explode( ';', $string ) );
@@ -67,6 +73,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach( $overflow as $index => $rule ) {
 				unset( $arr[ $index ] );
 			}
+		}
+
+		if ( empty( $arr ) ) {
+			return '';
 		}
 
 		return implode( ";\n\t", $arr ) . ';';

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -81,7 +81,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	private function generate_class_name( $string ) {
-		return 'amp-wp-inline-style-' . md5( $string );
+		return 'amp-wp-inline-' . md5( $string );
 	}
 
 	public function get_styles() {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -11,10 +11,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	public function sanitize() {
 		$body = $this->get_body_node();
 		$this->collect_styles_recursive( $body );
-
-		if ( ! empty( $this->styles ) ) {
-			add_action( 'amp_post_template_css', array( $this, 'append_styles' ), 99 );
-		}
 	}
 
 	private function collect_styles_recursive( $node ) {
@@ -88,8 +84,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		return 'amp-wp-inline-style-' . md5( $string );
 	}
 
-	public function append_styles() {
-		?>
+	public function get_styles() {
+		if ( ! empty( $this->styles ) ) {
+			ob_start();
+			?>
 
 /* Inline Styles */
 <?php foreach ( $this->styles as $class_name => $style ) : ?>
@@ -99,6 +97,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 }
 <?php endforeach; ?>
 
-		<?php
+<?php
+
+			return ob_get_clean();
+		}
+
+		return '';
 	}
 }

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -48,7 +48,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	private function generate_class_name( $string ) {
-		return 'amp-inline-style-' . md5( $string );
+		return 'amp-wp-inline-style-' . md5( $string );
 	}
 
 	private function wrap_style( $array ) {

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -11,7 +11,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span style="color: #00ff00;" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
 .amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
@@ -22,8 +22,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'span_one_style_bad_format' => array(
-				'<span style="color  : #00ff00">This is green.</span>',
-				'<span style="color  : #00ff00" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				'<span style="color  :   #00ff00">This is green.</span>',
+				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
 .amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
@@ -35,7 +35,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span style="width: 350px; color: #00ff00;" class="amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
+				'<span class="amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
 				"
 /* Inline Styles */
 .amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60 {
@@ -48,19 +48,19 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'div_kses_banned_style' => array(
 				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
-				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
+				'<span>Specific overflow axis not allowed.</span>',
 				'',
 			),
 
 			'div_amp_banned_style' => array(
 				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
-				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
+				'<span>Scrollbars not allowed.</span>',
 				'',
 			),
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span style="color: #00ff00;" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2"><span style="color: #ff0000;" class="amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
+				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2"><span class="amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
 				"
 /* Inline Styles */
 .amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -11,31 +11,31 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea">This is green.</span>',
+				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e">This is green.</span>',
 				array(
-					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
-						'color: #00ff00',
+					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e' => array(
+						'color:#00ff00',
 					),
 				),
 			),
 
 			'span_one_style_bad_format' => array(
 				'<span style="color  :   #00ff00">This is green.</span>',
-				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea">This is green.</span>',
+				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e">This is green.</span>',
 				array(
-					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
-						'color: #00ff00',
+					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e' => array(
+						'color:#00ff00',
 					),
 				),
 			),
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-9e3a754064939f6cf521fb25f67f8a73">This is green.</span>',
+				'<span class="amp-wp-inline-c83b149f3e9c3426a6eab43e21ac2fba">This is green.</span>',
 				array(
-					'.amp-wp-inline-9e3a754064939f6cf521fb25f67f8a73' => array(
-						'color: #00ff00',
-						'width: 350px',
+					'.amp-wp-inline-c83b149f3e9c3426a6eab43e21ac2fba' => array(
+						'color:#00ff00',
+						'width:350px',
 					),
 				),
 			),
@@ -54,13 +54,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea"><span class="amp-wp-inline-74ce01776d679398d58eba941c5c84bb">This is red.</span></span>',
+				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e"><span class="amp-wp-inline-f146f9bb819d875bbe5cf83e36368b44">This is red.</span></span>',
 				array(
-					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
-						'color: #00ff00',
+					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e' => array(
+						'color:#00ff00',
 					),
-					'.amp-wp-inline-74ce01776d679398d58eba941c5c84bb' => array(
-						'color: #ff0000',
+					'.amp-wp-inline-f146f9bb819d875bbe5cf83e36368b44' => array(
+						'color:#ff0000',
 					),
 				),
 			),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -18,7 +18,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	color: #00ff00;
 }
 
-		",
+",
 			),
 
 			'span_one_style_bad_format' => array(
@@ -30,7 +30,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	color: #00ff00;
 }
 
-		",
+",
 			),
 
 			'span_two_styles_reversed' => array(
@@ -43,7 +43,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	width: 350px;
 }
 
-		",
+",
 			),
 
 			'div_kses_banned_style' => array(
@@ -70,7 +70,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	color: #ff0000;
 }
 
-		",
+",
 			),
 		);
 	}
@@ -88,9 +88,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_content, $content );
 
 		// Test stylesheet
-		ob_start();
-		do_action( 'amp_post_template_css' );
-		$stylesheet = ob_get_clean();
+		$stylesheet = $sanitizer->get_styles();
 		$this->assertEquals( $expected_stylesheet, $stylesheet );
 	}
 }

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -11,10 +11,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
 	color: #00ff00;
 }
 
@@ -23,10 +23,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style_bad_format' => array(
 				'<span style="color  :   #00ff00">This is green.</span>',
-				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
 	color: #00ff00;
 }
 
@@ -35,10 +35,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
+				'<span class="amp-wp-inline-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60 {
+.amp-wp-inline-a754703dea82f6e9d2782874c77bdb60 {
 	color: #00ff00;
 	width: 350px;
 }
@@ -60,13 +60,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2"><span class="amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
+				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2"><span class="amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
 	color: #00ff00;
 }
-.amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831 {
+.amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831 {
 	color: #ff0000;
 }
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1,0 +1,87 @@
+<?php
+
+class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
+	public function get_data() {
+		return array(
+			'empty' => array(
+				'',
+				'',
+				'',
+			),
+
+			'span_one_style' => array(
+				'<span style="color: #00ff00;">This is green.</span>',
+				'<span style="color: #00ff00;" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '">This is green.</span>',
+				$this->wrap_style( array( "color: #00ff00;" ) ),
+			),
+
+			'span_one_style_bad_format' => array(
+				'<span style="color  : #00ff00">This is green.</span>',
+				'<span style="color  : #00ff00" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '">This is green.</span>',
+				$this->wrap_style( array( "color: #00ff00;" ) ),
+			),
+
+			'span_two_styles_reversed' => array(
+				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
+				'<span style="width: 350px; color: #00ff00;" class="' . $this->generate_class_name( "color: #00ff00;\n\twidth: 350px;" ) . '">This is green.</span>',
+				$this->wrap_style( array( "color: #00ff00;\n\twidth: 350px;" ) ),
+			),
+
+			'div_kses_banned_style' => array(
+				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
+				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
+				'',
+			),
+
+			'div_amp_banned_style' => array(
+				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
+				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
+				'',
+			),
+
+			'two_nodes' => array(
+				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
+				'<span style="color: #00ff00;" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '"><span style="color: #ff0000;" class="' . $this->generate_class_name( 'color: #ff0000;' ) . '">This is red.</span></span>',
+				$this->wrap_style( array( "color: #00ff00;", "color: #ff0000;" ) ),
+			),
+		);
+	}
+
+	private function generate_class_name( $string ) {
+		return 'amp-inline-style-' . md5( $string );
+	}
+
+	private function wrap_style( $array ) {
+		ob_start(); ?>
+
+/* Inline Styles */
+<?php foreach ( $array as $style ) : ?>
+.<?php echo $this->generate_class_name( $style ); ?> {
+	<?php echo $style; ?>
+
+}
+<?php endforeach; ?>
+
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * @dataProvider get_data
+	 */
+	public function test_sanitizer( $source, $expected_content, $expected_stylesheet ) {
+		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Style_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
+		// Test content
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEquals( $expected_content, $content );
+
+		// Test stylesheet
+		ob_start();
+		do_action( 'amp_post_template_css' );
+		$stylesheet = ob_get_clean();
+		$this->assertEquals( $expected_stylesheet, $stylesheet );
+	}
+}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -14,9 +14,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
-	color: #00ff00;
-}
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
 
 ",
 			),
@@ -26,22 +24,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
-	color: #00ff00;
-}
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
 
 ",
 			),
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
+				'<span class="amp-wp-inline-858600a8f78ba6085b17e66e6fd02325">This is green.</span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-a754703dea82f6e9d2782874c77bdb60 {
-	color: #00ff00;
-	width: 350px;
-}
+.amp-wp-inline-858600a8f78ba6085b17e66e6fd02325 { color: #00ff00; width: 350px; }
 
 ",
 			),
@@ -63,12 +56,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2"><span class="amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
 				"
 /* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 {
-	color: #00ff00;
-}
-.amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831 {
-	color: #ff0000;
-}
+.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
+.amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831 { color: #ff0000; }
 
 ",
 			),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -11,20 +11,39 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span style="color: #00ff00;" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '">This is green.</span>',
-				$this->wrap_style( array( "color: #00ff00;" ) ),
+				'<span style="color: #00ff00;" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				"
+/* Inline Styles */
+.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+	color: #00ff00;
+}
+
+		",
 			),
 
 			'span_one_style_bad_format' => array(
 				'<span style="color  : #00ff00">This is green.</span>',
-				'<span style="color  : #00ff00" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '">This is green.</span>',
-				$this->wrap_style( array( "color: #00ff00;" ) ),
+				'<span style="color  : #00ff00" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
+				"
+/* Inline Styles */
+.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+	color: #00ff00;
+}
+
+		",
 			),
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span style="width: 350px; color: #00ff00;" class="' . $this->generate_class_name( "color: #00ff00;\n\twidth: 350px;" ) . '">This is green.</span>',
-				$this->wrap_style( array( "color: #00ff00;\n\twidth: 350px;" ) ),
+				'<span style="width: 350px; color: #00ff00;" class="amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60">This is green.</span>',
+				"
+/* Inline Styles */
+.amp-wp-inline-style-a754703dea82f6e9d2782874c77bdb60 {
+	color: #00ff00;
+	width: 350px;
+}
+
+		",
 			),
 
 			'div_kses_banned_style' => array(
@@ -41,29 +60,19 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span style="color: #00ff00;" class="' . $this->generate_class_name( 'color: #00ff00;' ) . '"><span style="color: #ff0000;" class="' . $this->generate_class_name( 'color: #ff0000;' ) . '">This is red.</span></span>',
-				$this->wrap_style( array( "color: #00ff00;", "color: #ff0000;" ) ),
+				'<span style="color: #00ff00;" class="amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2"><span style="color: #ff0000;" class="amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
+				"
+/* Inline Styles */
+.amp-wp-inline-style-bb01159393134c225a1df0d44226c3d2 {
+	color: #00ff00;
+}
+.amp-wp-inline-style-cc68ddc00c4fa7c4e4ea8d4351e25831 {
+	color: #ff0000;
+}
+
+		",
 			),
 		);
-	}
-
-	private function generate_class_name( $string ) {
-		return 'amp-wp-inline-style-' . md5( $string );
-	}
-
-	private function wrap_style( $array ) {
-		ob_start(); ?>
-
-/* Inline Styles */
-<?php foreach ( $array as $style ) : ?>
-.<?php echo $this->generate_class_name( $style ); ?> {
-	<?php echo $style; ?>
-
-}
-<?php endforeach; ?>
-
-		<?php
-		return ob_get_clean();
 	}
 
 	/**

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -6,60 +6,63 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'empty' => array(
 				'',
 				'',
-				'',
+				array(),
 			),
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
-				"
-/* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
-
-",
+				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea">This is green.</span>',
+				array(
+					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
+						'color: #00ff00',
+					),
+				),
 			),
 
 			'span_one_style_bad_format' => array(
 				'<span style="color  :   #00ff00">This is green.</span>',
-				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2">This is green.</span>',
-				"
-/* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
-
-",
+				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea">This is green.</span>',
+				array(
+					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
+						'color: #00ff00',
+					),
+				),
 			),
 
 			'span_two_styles_reversed' => array(
 				'<span style="width: 350px; color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-858600a8f78ba6085b17e66e6fd02325">This is green.</span>',
-				"
-/* Inline Styles */
-.amp-wp-inline-858600a8f78ba6085b17e66e6fd02325 { color: #00ff00; width: 350px; }
-
-",
+				'<span class="amp-wp-inline-9e3a754064939f6cf521fb25f67f8a73">This is green.</span>',
+				array(
+					'.amp-wp-inline-9e3a754064939f6cf521fb25f67f8a73' => array(
+						'color: #00ff00',
+						'width: 350px',
+					),
+				),
 			),
 
 			'div_kses_banned_style' => array(
 				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
 				'<span>Specific overflow axis not allowed.</span>',
-				'',
+				array(),
 			),
 
 			'div_amp_banned_style' => array(
 				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
 				'<span>Scrollbars not allowed.</span>',
-				'',
+				array(),
 			),
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span class="amp-wp-inline-bb01159393134c225a1df0d44226c3d2"><span class="amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831">This is red.</span></span>',
-				"
-/* Inline Styles */
-.amp-wp-inline-bb01159393134c225a1df0d44226c3d2 { color: #00ff00; }
-.amp-wp-inline-cc68ddc00c4fa7c4e4ea8d4351e25831 { color: #ff0000; }
-
-",
+				'<span class="amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea"><span class="amp-wp-inline-74ce01776d679398d58eba941c5c84bb">This is red.</span></span>',
+				array(
+					'.amp-wp-inline-846b203684c92aae7df71d5b8a6ba7ea' => array(
+						'color: #00ff00',
+					),
+					'.amp-wp-inline-74ce01776d679398d58eba941c5c84bb' => array(
+						'color: #ff0000',
+					),
+				),
 			),
 		);
 	}


### PR DESCRIPTION
Adds the `AMP_Style_Sanitizer` sanitizer class, which runs before the Blacklist class, and finds all of the element nodes within the content that have a `style` attribute. For each one, it stores the contents of `style` and generates a unique class name, which it adds to the element. Then, during template rendering, it outputs these class names and their styles in the `amp-custom` stylesheet in the document head.

This preserves critical style information that gets stripped from the elements by the Blacklist class, which appears to be the root cause of the problems in #344, #358, #362, and #395.

This also includes unit tests for the new sanitizer class. Testing on the performance impact of this additional sanitizer class was done using [this script](https://github.com/coreymckrill/amp-sanitize-cases).