### PR TITLE
Youtube playlists: Use the standard oembed handler

### DIFF
--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -64,6 +64,12 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	public function oembed( $matches, $attr, $url, $rawattr ) {
+		// Use the standard oembed handler if it's a playlist
+		$parsed_url = wp_parse_url( $url );
+		if ( isset( $parsed_url['path'] ) && false !== strpos( $parsed_url['path'], 'playlist' ) ) {
+			return wp_oembed_get( $url );
+		}
+
 		return $this->shortcode( array( $url ) );
 	}
 

--- a/tests/test-amp-youtube-embed.php
+++ b/tests/test-amp-youtube-embed.php
@@ -38,6 +38,11 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 				'https://www.youtube.com/playlist?list=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA' . PHP_EOL,
 				'<p><iframe width="660" height="371" src="https://www.youtube.com/embed/videoseries?list=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA" frameborder="0" allowfullscreen></iframe></p>' . PHP_EOL,
 			),
+
+			'url_playlist_broken' => array(
+				'https://www.youtube.com/playlist?asdf=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA' . PHP_EOL,
+				'<p>https://www.youtube.com/playlist?asdf=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA</p>' . PHP_EOL,
+			),
 		);
 	}
 

--- a/tests/test-amp-youtube-embed.php
+++ b/tests/test-amp-youtube-embed.php
@@ -33,6 +33,11 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 				'[youtube http://www.youtube.com/watch?v=kfVsfOSbJY0]' . PHP_EOL,
 				'<amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube>' . PHP_EOL
 			),
+
+			'url_playlist' => array(
+				'https://www.youtube.com/playlist?list=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA' . PHP_EOL,
+				'<p><iframe width="660" height="371" src="https://www.youtube.com/embed/videoseries?list=PLtn57NsUdLz7Phy4bzX0f3d5_eAQQ7FCA" frameborder="0" allowfullscreen></iframe></p>' . PHP_EOL,
+			),
 		);
 	}
 


### PR DESCRIPTION
From #465 : 

> AMP's `amp-youtube` element currently only handles individual videos.

Playlists are therefore output as just links. However, the standard oembed handler for Youtube URLs takes a URL and outputs an iframe. Since AMP has a sanitizer for handling iframes, we can simply output the iframe when the URL is for a playlist instead of an individual video, and then the iframe sanitizer will take care of the rest.