### PR TITLE
Make amp page work in secondary languages with WPML

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -101,7 +101,7 @@ function amp_add_post_template_actions() {
 }
 
 function amp_prepare_render() {
-	add_action( 'template_redirect', 'amp_render' );
+	add_action( 'template_redirect', 'amp_render', 9 );
 }
 
 function amp_render() {


### PR DESCRIPTION
AMP pages are only working in the default language with the WPML plugin installed.
This problem was reported in WPML forums and we found a workaround that I have included here.

https://wpml.org/forums/topic/wp-amp-pages-only-in-english-but-not-in-other-langauge/

Is this solution acceptable to merge?

If you need a WPML subscription to test this let me know and I will arrange it.