### PR TITLE
Youtube playlists: Ignore playlist URLs in embed handler

### DIFF
--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -5,6 +5,7 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-base-embed-handler.php' )
 // Much of this class is borrowed from Jetpack embeds
 class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	const SHORT_URL_HOST = 'youtu.be';
+	// Only handling single videos. Playlists are handled elsewhere.
 	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|watch[/\#?])|youtu\.be/).*#i';
 	const RATIO = 0.5625;
 

--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -5,7 +5,7 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-base-embed-handler.php' )
 // Much of this class is borrowed from Jetpack embeds
 class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	const SHORT_URL_HOST = 'youtu.be';
-	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|playlist|watch[/\#?])|youtu\.be/).*#i';
+	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|watch[/\#?])|youtu\.be/).*#i';
 	const RATIO = 0.5625;
 
 	protected $DEFAULT_WIDTH = 600;


### PR DESCRIPTION
When the embed handler for single Youtube videos ignores playlist
URLs, the standard WP oembed for playlists picks it up and renders
it as an iframe. Then AMP-WP's iframe sanitizer takes care of the
rest.

See https://github.com/Automattic/amp-wp/pull/473

Refs #465 