### PR TITLE
Adding `! is_wp_error()` check to templates/meta-taxonomy.php

### DIFF
--- a/templates/meta-taxonomy.php
+++ b/templates/meta-taxonomy.php
@@ -7,7 +7,7 @@
 <?php endif; ?>
 
 <?php $tags = get_the_tag_list( '', _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ) ); ?>
-<?php if ( $tags ) : ?>
+<?php if ( $tags && ! is_wp_error( $tags ) ) : ?>
 	<li class="amp-wp-tax-tag">
 		<span class="screen-reader-text">Tags:</span>
 		<?php echo $tags; ?>


### PR DESCRIPTION
Since the `get_the_tag_list` function may return WP_Error in some cases (see https://developer.wordpress.org/reference/functions/get_the_tag_list/), we should not be checking only for a boolean / string in the conditional before using the returned value as a string, but we also should check for WP_Error case.

This commit is adding the conditional to the mix and should prevent Fatal Errors in cases when the code is trying to use an object of WP_Error as a string.