### PR TITLE
Back-compat support for v0.3 templates

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -14,6 +14,7 @@
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
 
+require_once( AMP__DIR__ . '/back-compat/back-compat.php' );
 require_once( AMP__DIR__ . '/includes/amp-helper-functions.php' );
 require_once( AMP__DIR__ . '/includes/admin/functions.php' );
 

--- a/back-compat/back-compat.php
+++ b/back-compat/back-compat.php
@@ -1,0 +1,11 @@
+<?php
+
+// If you want to use the template that shipped with v0.3 and earlier, you can use this to force that.
+// Note that this may not stick around forever, so use caution and `function_exists`.
+function amp_backcompat_use_v03_templates() {
+	add_filter( 'amp_post_template_dir', '_amp_backcompat_use_v03_templates_callback', 0 ); // early in case there are other overrides
+}
+
+function _amp_backcompat_use_v03_templates_callback( $templates ) {
+	return AMP__DIR__ . '/back-compat/templates-v0-3';
+}

--- a/back-compat/templates-v0-3/header-bar.php
+++ b/back-compat/templates-v0-3/header-bar.php
@@ -1,0 +1,13 @@
+<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
+
+<nav class="amp-wp-title-bar">
+	<div>
+		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
+			<?php if ( $site_icon_url ) : ?>
+				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon"></amp-img>
+			<?php endif; ?>
+
+			<?php echo esc_html( $this->get( 'blog_name' ) ); ?>
+		</a>
+	</div>
+</nav>

--- a/back-compat/templates-v0-3/meta-author.php
+++ b/back-compat/templates-v0-3/meta-author.php
@@ -1,0 +1,9 @@
+<?php $post_author = $this->get( 'post_author' ); ?>
+<li class="amp-wp-byline">
+	<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
+	<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array(
+		'size' => 24,
+	) ) ); ?>" width="24" height="24" layout="fixed"></amp-img>
+	<?php endif; ?>
+	<span class="amp-wp-author"><?php echo esc_html( $post_author->display_name ); ?></span>
+</li>

--- a/back-compat/templates-v0-3/meta-taxonomy.php
+++ b/back-compat/templates-v0-3/meta-taxonomy.php
@@ -1,0 +1,15 @@
+<?php $categories = get_the_category_list( _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ) ); ?>
+<?php if ( $categories ) : ?>
+	<li class="amp-wp-tax-category">
+		<span class="screen-reader-text">Categories:</span>
+		<?php echo $categories; ?>
+	</li>
+<?php endif; ?>
+
+<?php $tags = get_the_tag_list( '', _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ) ); ?>
+<?php if ( $tags && ! is_wp_error( $tags ) ) : ?>
+	<li class="amp-wp-tax-tag">
+		<span class="screen-reader-text">Tags:</span>
+		<?php echo $tags; ?>
+	</li>
+<?php endif; ?>

--- a/back-compat/templates-v0-3/meta-time.php
+++ b/back-compat/templates-v0-3/meta-time.php
@@ -1,0 +1,12 @@
+<li class="amp-wp-posted-on">
+	<time datetime="<?php echo esc_attr( date( 'c', $this->get( 'post_publish_timestamp' ) ) ); ?>">
+		<?php
+		echo esc_html(
+			sprintf(
+				_x( '%s ago', '%s = human-readable time difference', 'amp' ),
+				human_time_diff( $this->get( 'post_publish_timestamp' ), current_time( 'timestamp' ) )
+			)
+		);
+		?>
+	</time>
+</li>

--- a/back-compat/templates-v0-3/single.php
+++ b/back-compat/templates-v0-3/single.php
@@ -1,0 +1,24 @@
+<!doctype html>
+<html amp <?php language_attributes(); ?>>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+	<?php do_action( 'amp_post_template_head', $this ); ?>
+
+	<style amp-custom>
+	<?php $this->load_parts( array( 'style' ) ); ?>
+	<?php do_action( 'amp_post_template_css', $this ); ?>
+	</style>
+</head>
+<body>
+<?php $this->load_parts( array( 'header-bar' ) ); ?>
+<div class="amp-wp-content">
+	<h1 class="amp-wp-title"><?php echo wp_kses_data( $this->get( 'post_title' ) ); ?></h1>
+	<ul class="amp-wp-meta">
+		<?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', array( 'meta-author', 'meta-time', 'meta-taxonomy' ) ) ); ?>
+	</ul>
+	<?php echo $this->get( 'post_amp_content' ); // amphtml content; no kses ?>
+</div>
+<?php do_action( 'amp_post_template_footer', $this ); ?>
+</body>
+</html>

--- a/back-compat/templates-v0-3/style.php
+++ b/back-compat/templates-v0-3/style.php
@@ -1,0 +1,242 @@
+/* Merriweather fonts */
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-regular-webfont.svg#merriweatherregular') format('svg');
+	font-weight:400;
+	font-style:normal;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-italic-webfont.svg#merriweatheritalic') format('svg');
+	font-weight:400;
+	font-style:italic;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bold-webfont.svg#merriweatherbold') format('svg');
+	font-weight:700;
+	font-style:normal;
+}
+
+@font-face {
+	font-family:'Merriweather';
+	src:url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.woff2') format('woff2'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.woff') format('woff'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.ttf') format('truetype'),
+		url('https://s1.wp.com/i/fonts/merriweather/merriweather-bolditalic-webfont.svg#merriweatherbold_italic') format('svg');
+	font-weight:700;
+	font-style:italic;
+}
+
+/* Generic WP styling */
+amp-img.alignright { float: right; margin: 0 0 1em 1em; }
+amp-img.alignleft { float: left; margin: 0 1em 1em 0; }
+amp-img.aligncenter { display: block; margin-left: auto; margin-right: auto; }
+.alignright { float: right; }
+.alignleft { float: left; }
+.aligncenter { display: block; margin-left: auto; margin-right: auto; }
+
+.wp-caption.alignleft { margin-right: 1em; }
+.wp-caption.alignright { margin-left: 1em; }
+
+.amp-wp-enforced-sizes {
+	/** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
+	max-width: 100%;
+}
+
+.amp-wp-unknown-size img {
+	/** Worst case scenario when we can't figure out dimensions for an image. **/
+	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/
+	object-fit: contain;
+}
+
+/* Template Styles */
+.amp-wp-content, .amp-wp-title-bar div {
+	<?php $content_max_width = absint( $this->get( 'content_max_width' ) ); ?>
+	<?php if ( $content_max_width > 0 ) : ?>
+	max-width: <?php echo sprintf( '%dpx', $content_max_width ); ?>;
+	margin: 0 auto;
+	<?php endif; ?>
+}
+
+body {
+	font-family: 'Merriweather', Serif;
+	font-size: 16px;
+	line-height: 1.8;
+	background: #fff;
+	color: #3d596d;
+	padding-bottom: 100px;
+}
+
+.amp-wp-content {
+	padding: 16px;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	font-weight: 400;
+	color: #3d596d;
+}
+
+.amp-wp-title {
+	margin: 36px 0 0 0;
+	font-size: 36px;
+	line-height: 1.258;
+	font-weight: 700;
+	color: #2e4453;
+}
+
+.amp-wp-meta {
+	margin-bottom: 16px;
+}
+
+p,
+ol,
+ul,
+figure {
+	margin: 0 0 24px 0;
+}
+
+a,
+a:visited {
+	color: #0087be;
+}
+
+a:hover,
+a:active,
+a:focus {
+	color: #33bbe3;
+}
+
+
+/* UI Fonts */
+.amp-wp-meta,
+nav.amp-wp-title-bar,
+.wp-caption-text {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 15px;
+}
+
+
+/* Meta */
+ul.amp-wp-meta {
+	padding: 24px 0 0 0;
+	margin: 0 0 24px 0;
+}
+
+ul.amp-wp-meta li {
+	list-style: none;
+	display: inline-block;
+	margin: 0;
+	line-height: 24px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 300px;
+}
+
+ul.amp-wp-meta li:before {
+	content: "\2022";
+	margin: 0 8px;
+}
+
+ul.amp-wp-meta li:first-child:before {
+	display: none;
+}
+
+.amp-wp-meta,
+.amp-wp-meta a {
+	color: #4f748e;
+}
+
+.amp-wp-meta .screen-reader-text {
+	/* from twentyfifteen */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	width: 1px;
+}
+
+.amp-wp-byline amp-img {
+	border-radius: 50%;
+	border: 0;
+	background: #f3f6f8;
+	position: relative;
+	top: 6px;
+	margin-right: 6px;
+}
+
+/* Titlebar */
+nav.amp-wp-title-bar {
+	background: <?php echo esc_html( $this->get_customizer_setting( 'navbar_background', self::DEFAULT_NAVBAR_BACKGROUND ) ); // not ideal for escaping here, but better than nothing? ?>;
+	padding: 0 16px;
+}
+
+nav.amp-wp-title-bar div {
+	line-height: 54px;
+	color: <?php echo esc_html( $this->get_customizer_setting( 'navbar_color', self::DEFAULT_NAVBAR_COLOR ) ); ?>;
+}
+
+nav.amp-wp-title-bar a {
+	color: <?php echo esc_html( $this->get_customizer_setting( 'navbar_color', self::DEFAULT_NAVBAR_COLOR ) ); ?>;
+	text-decoration: none;
+}
+
+nav.amp-wp-title-bar .amp-wp-site-icon {
+	/** site icon is 32px **/
+	float: left;
+	margin: 11px 8px 0 0;
+	border-radius: 50%;
+}
+
+/* Captions */
+.wp-caption-text {
+	padding: 8px 16px;
+	font-style: italic;
+}
+
+
+/* Quotes */
+blockquote {
+	padding: 16px;
+	margin: 8px 0 24px 0;
+	border-left: 2px solid #87a6bc;
+	color: #4f748e;
+	background: #e9eff3;
+}
+
+blockquote p:last-child {
+	margin-bottom: 0;
+}
+
+/* Other Elements */
+amp-carousel {
+	background: #000;
+}
+
+amp-iframe,
+amp-youtube,
+amp-instagram,
+amp-vine {
+	background: #f3f6f8;
+}
+
+amp-carousel > amp-img > img {
+	object-fit: contain;
+}
+
+.amp-wp-iframe-placeholder {
+	background: #f3f6f8 url( <?php echo esc_url( $this->get( 'placeholder_image_url' ) ); ?> ) no-repeat center 40%;
+	background-size: 48px 48px;
+	min-height: 48px;
+}


### PR DESCRIPTION
v0.4 ships with some breaking template changes. For folks that want to
stick with the old template until they can upgrade, they can use this
back-compat layer.

```
if ( function_exists( 'amp_backcompat_use_v03_templates' ) ) {
    amp_backcompat_use_v03_templates();
}
```

Related #464 