### PR TITLE
Add better color contrast to light color scheme

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -13,6 +13,7 @@
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
+define( 'AMP__VERSION', '0.3.3' );
 
 require_once( AMP__DIR__ . '/back-compat/back-compat.php' );
 require_once( AMP__DIR__ . '/includes/amp-helper-functions.php' );

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -211,6 +211,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			'embed',
 			'embedvideo',
 
+			// Other weird ones
+			'comments-count',
+
 			// These are converted into amp-* versions
 			//'img',
 			//'video',
@@ -223,6 +226,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		return $this->merge_defaults_with_args( 'add_blacklisted_attributes', array(
 			'style',
 			'size',
+			'clear',
+			'align',
+			'valign',
 		) );
 	}
 }

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -28,7 +28,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
-			if ( ! array_key_exists( 'src', $old_attributes ) ) {
+			if ( empty( $old_attributes['src'] ) ) {
 				$node->parentNode->removeChild( $node );
 				continue;
 			}

--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -119,9 +119,9 @@ class AMP_Customizer_Design_Settings {
 			'light' => array(
 				// Convert colors to greyscale for light theme color; see http://goo.gl/2gDLsp
 				'theme_color'      => '#fff',
-				'text_color'       => '#535353',
-				'muted_text_color' => '#9f9f9f',
-				'border_color'     => '#d4d4d4',
+				'text_color'       => '#353535',
+				'muted_text_color' => '#696969',
+				'border_color'     => '#c2c2c2',
 			),
 			'dark' => array(
 				// Convert and invert colors to greyscale for dark theme color; see http://goo.gl/uVB2cO

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -22,6 +22,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<p></p>'
 			),
 
+			'image_with_empty_src' => array(
+				'<p><img src="" width="300" height="300" /></p>',
+				'<p></p>'
+			),
+
 			'image_with_self_closing_tag' => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" sizes="(min-width: 350px) 350px, 100vw" class="amp-wp-enforced-sizes"></amp-img>',


### PR DESCRIPTION
Increases the text color contrast on the light color scheme for better legibility. Text color passes http://contrastchecker.com/ and muted color is slightly below the pass level to keep color hierarchy. Border colors are slightly adjusted to match perceived muted color.