### PR TITLE
tel+sms schemes are invalid w/ FILTER_VALIDATE_URL

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -146,9 +146,15 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$valid_protocols = array( 'http', 'https', 'mailto', 'sms', 'tel', 'viber', 'whatsapp' );
+		$special_protocols = array( 'tel', 'sms' ); // these ones don't valid with `filter_var+FILTER_VALIDATE_URL`
 		$protocol = strtok( $href, ':' );
+
 		if ( false === filter_var( $href, FILTER_VALIDATE_URL )
-			|| ! in_array( $protocol, $valid_protocols ) ) {
+			&& ! in_array( $protocol, $special_protocols ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $protocol, $valid_protocols ) ) {
 			return false;
 		}
 

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -113,6 +113,26 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'Link',
 			),
 
+			'a_with_href_scheme_invalid' => array(
+				'<a href="wp://alinktosomething">Link</a>',
+				'Link',
+			),
+
+			'a_with_href_scheme_tel' => array(
+				'<a href="tel:4166669999">Call Me, Maybe</a>',
+				'<a href="tel:4166669999">Call Me, Maybe</a>',
+			),
+
+			'a_with_href_scheme_sms' => array(
+				'<a href="sms:4166669999">SMS Me, Maybe</a>',
+				'<a href="sms:4166669999">SMS Me, Maybe</a>',
+			),
+
+			'a_with_href_scheme_mailto' => array(
+				'<a href="mailto:email@example.com">Email Me, Maybe</a>',
+				'<a href="mailto:email@example.com">Email Me, Maybe</a>',
+			),
+
 			'a_with_href_relative' => array(
 				'<a href="/home">Home</a>',
 				'<a href="/home">Home</a>',


### PR DESCRIPTION
Add special handling for these schemes

h/t soundstrategies

https://wordpress.org/support/topic/tel-link-issue-amp_blacklist_sanitizer-class-validate_a_node-func/