### PR TITLE
Only run Img_Sanitizer for featured image

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -259,21 +259,16 @@ class AMP_Post_Template {
 
 		$featured_image = get_post( $featured_id );
 
-		remove_filter( 'the_content', 'wpautop' ); // We don't want our image wrapped in a <p>
-		$featured_amp_content = new AMP_Content(
+		list( $sanitized_html ) = AMP_Content_Sanitizer::sanitize(
 			$featured_html,
-			array(),
+			array( 'AMP_Img_Sanitizer' => array() ),
 			array(
-				 'AMP_Img_Sanitizer' => array(),
-			),
-			array(
-				'content_max_width' => $this->get( 'content_max_width' ),
+				'content_max_width' => $this->get( 'content_max_width' )
 			)
 		);
-		add_filter( 'the_content', 'wpautop' );
 
 		$this->add_data_by_key( 'featured_image', array(
-			'amp_html' => $featured_amp_content->get_amp_content(),
+			'amp_html' => $sanitized_html,
 			'caption' => $featured_image->post_excerpt,
 		) );
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,10 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/amp.php';
+
 	amp_load_classes();
+
+	require dirname( __FILE__ ) . '/stubs.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -1,0 +1,25 @@
+<?php
+
+// stub classes for AMP_Base_Sanitizer, since it is an abstract class
+class AMP_Test_Stub_Sanitizer extends AMP_Base_Sanitizer {
+	public function sanitize() {
+		return $this->dom;
+	}
+}
+
+class AMP_Test_World_Sanitizer extends AMP_Base_Sanitizer {
+	public function sanitize() {
+		$node = $this->dom->createElement( 'em' );
+		$text = $this->dom->createTextNode( 'World' );
+		$node->appendChild( $text );
+		$this->dom->getElementsByTagName( 'body' )->item( 0 )->appendChild( $node );
+	}
+
+	public function get_scripts() {
+		return array( 'scripts' );
+	}
+
+	public function get_styles() {
+		return array( 'styles' );
+	}
+}

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -1,10 +1,4 @@
 <?php
-// stub class since AMP_Base_Sanitizer is abstract
-class AMP_Stub_Sanitizer extends AMP_Base_Sanitizer {
-	public function sanitize() {
-		return $this->dom;
-	}
-}
 
 class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase {
 	public function get_data() {
@@ -106,7 +100,7 @@ class AMP_Base_Sanitizer__Enforce_Sizes_Attribute__Test extends WP_UnitTestCase 
 	 * @dataProvider get_data
 	 */
 	public function test_enforce_sizes_attribute( $source_attributes, $expected_attributes, $args = array() ) {
-		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
+		$sanitizer = new AMP_Test_Stub_Sanitizer( new DOMDocument, $args );
 		$returned_attributes = $sanitizer->enforce_sizes_attribute( $source_attributes );
 
 		$this->assertEquals( $expected_attributes, $returned_attributes );
@@ -172,7 +166,7 @@ class AMP_Base_Sanitizer__Enforce_Fixed_Height__Test extends WP_UnitTestCase {
 	 * @dataProvider get_data
 	 */
 	public function test_enforce_fixed_height( $source_attributes, $expected_attributes, $args = array() ) {
-		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
+		$sanitizer = new AMP_Test_Stub_Sanitizer( new DOMDocument, $args );
 		$returned_attributes = $sanitizer->enforce_fixed_height( $source_attributes );
 
 		$this->assertEquals( $expected_attributes, $returned_attributes );
@@ -240,7 +234,7 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 	 * @dataProvider get_data
 	 */
 	public function test_enforce_sizes_attribute( $source_params, $expected_value, $args = array() ) {
-		$sanitizer = new AMP_Stub_Sanitizer( new DOMDocument, $args );
+		$sanitizer = new AMP_Test_Stub_Sanitizer( new DOMDocument, $args );
 		list( $value, $dimension ) = $source_params;
 
 		$actual_value = $sanitizer->sanitize_dimension( $value, $dimension );

--- a/tests/test-class-amp-content-sanitizer.php
+++ b/tests/test-class-amp-content-sanitizer.php
@@ -1,0 +1,21 @@
+<?php
+
+class AMP_Content_Sanitizer__Test extends WP_UnitTestCase {
+	public function test__sanitize__unchanged() {
+		$source_html = '<b>Hello</b>';
+		$expected_return = array( '<b>Hello</b>', array(), array() );
+
+		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, array( 'AMP_Test_Stub_Sanitizer' => array() ) );
+
+		$this->assertEquals( $expected_return, $actual_return );
+	}
+
+	public function test__sanitize__append_with_scripts_and_styles() {
+		$source_html = '<b>Hello</b>';
+		$expected_return = array( '<b>Hello</b><em>World</em>', array( 'scripts' ), array( 'styles' ) );
+
+		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, array( 'AMP_Test_World_Sanitizer' => array() ) );
+
+		$this->assertEquals( $expected_return, $actual_return );
+	}
+}


### PR DESCRIPTION
Running it through AMP_Content forces the_content filter over it which can lead to unexpected behavior from other plugins.

- [x] Static function for sanitizer to pass in html and get back data.
- [x] Wire up featured image.
- [x] Tests.

Fixes #522