### PR TITLE
Check if node has attributes before iterating

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -45,6 +45,10 @@ class AMP_DOM_Utils {
 
 	public static function get_node_attributes_as_assoc_array( $node ) {
 		$attributes = array();
+		if ( ! $node->hasAttributes() ) {
+			return $attributes;
+		}
+
 		foreach ( $node->attributes as $attribute ) {
 			$attributes[ $attribute->nodeName ] = $attribute->nodeValue;
 		}


### PR DESCRIPTION
If the node has no attributes, `->attributes` is null which results in errors when we try to loop through.

```
Warning: Invalid argument supplied for foreach() in /wp-content/plugins/amp/includes/utils/class-amp-dom-utils.php on line 48
```

h/t stephenmax