### PR TITLE
back-compat for sanitize_hex_color

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -113,6 +113,7 @@ function amp_add_frontend_actions() {
 
 function amp_add_post_template_actions() {
 	require_once( AMP__DIR__ . '/includes/amp-post-template-actions.php' );
+	require_once( AMP__DIR__ . '/includes/amp-post-template-functions.php' );
 }
 
 function amp_prepare_render() {

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -1,0 +1,15 @@
+<?php
+
+// Was only available in Customizer > 4.6
+if ( ! function_exists( 'sanitize_hex_color' ) ) {
+	function sanitize_hex_color( $color ) {
+		if ( '' === $color ) {
+			return '';
+		}
+
+		// 3 or 6 hex digits, or the empty string.
+		if ( preg_match('|^#([A-Fa-f0-9]{3}){1,2}$|', $color ) ) {
+			return $color;
+		}
+	}
+}


### PR DESCRIPTION
It was introduced globally in 4.6 so let's add it if it's not defined.

see https://wordpress.org/support/topic/style-fatal-error/#post-8276539

h/t xotihcan