### PR TITLE
Include the max-width with the iframe sanitizer

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -232,7 +232,8 @@ class AMP_Post_Template {
 				 'AMP_Video_Sanitizer' => array(),
 				 'AMP_Audio_Sanitizer' => array(),
 				 'AMP_Iframe_Sanitizer' => array(
-					 'add_placeholder' => true,
+					'add_placeholder' => true,
+					'content_max_width' => $this->get( 'content_max_width' ),
 				 ),
 			), $this->post ),
 			array(


### PR DESCRIPTION
Introduced with 40660765f66b50b72f162a34b6fffa1d1a60dadc, unless we pass in the to all sanitizers the width of the iframe (when used with a percentage) [will break](https://github.com/Automattic/amp-wp/blob/master/includes/sanitizers/class-amp-base-sanitizer.php#L45) when sanitizing the width since `content_max_width` is never passed in.