### PR TITLE
Drop language_attributes

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -50,6 +50,8 @@ class AMP_Post_Template {
 			'canonical_url' => get_permalink( $post_id ),
 			'home_url' => home_url(),
 			'blog_name' => get_bloginfo( 'name' ),
+
+			'html_tag_attributes' => array(),
 			'body_class' => '',
 
 			'site_icon_url' => apply_filters( 'amp_site_icon_url', function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '' ),
@@ -84,6 +86,7 @@ class AMP_Post_Template {
 		$this->build_post_content();
 		$this->build_post_data();
 		$this->build_customizer_settings();
+		$this->build_html_tag_attributes();
 
 		$this->data = apply_filters( 'amp_post_template_data', $this->data, $this->post );
 	}
@@ -198,7 +201,7 @@ class AMP_Post_Template {
 
 		$comments_open = comments_open( $this->ID );
 
-		// Don't show link if close and no comments 
+		// Don't show link if close and no comments
 		if ( ! $comments_open
 			&& ! $this->post->comment_count ) {
 			return;
@@ -345,6 +348,21 @@ class AMP_Post_Template {
 		}
 
 		return $post_image_meta;
+	}
+
+	private function build_html_tag_attributes() {
+		$attributes = array();
+
+		if ( function_exists( 'is_rtl' ) && is_rtl() ) {
+			$attributes['dir'] = 'rtl';
+		}
+
+		$lang = get_bloginfo( 'language' );
+		if ( $lang ) {
+			$attributes['lang'] = $lang;
+		}
+
+		$this->add_data_by_key( 'html_tag_attributes', $attributes );
 	}
 
 	private function verify_and_include( $file, $template_type ) {

--- a/templates/single.php
+++ b/templates/single.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html amp <?php language_attributes(); ?>>
+<html amp <?php echo AMP_HTML_Utils::build_attributes_string( $this->get( 'html_tag_attributes' ) ); ?>>
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">


### PR DESCRIPTION
And just manually set up and output lang+rtl attributes instead. Other plugins were using language_attributes to output things like `prefix` and `xmlns` attributes, which break validation.

See https://wordpress.org/support/topic/amp-prefix-validation-error/#post-8290191

Previously #531