### PR TITLE
Allow the new `html_tag_attributes` to be filtered

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -369,6 +369,15 @@ class AMP_Post_Template {
 		if ( $lang ) {
 			$attributes['lang'] = $lang;
 		}
+		
+		/**
+		 * Filter the HTML tag attributes
+		 *
+		 * @since  0.4.3
+		 * @param  array   $attributes The attributes (key => value)
+		 * @return array
+		 */
+		$attributes = apply_filters( 'amp_html_tag_attributes', $attributes );
 
 		$this->add_data_by_key( 'html_tag_attributes', $attributes );
 	}


### PR DESCRIPTION
Related: https://github.com/Automattic/amp-wp/pull/537
