### PR TITLE
Fix template/meta-author on older versions of WP

### DIFF
--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -1,9 +1,8 @@
 <?php $post_author = $this->get( 'post_author' ); ?>
 <?php if ( $post_author ) : ?>
-	<?php $author_avatar_url = get_avatar_url( $post_author->user_email, array( 'size' => 24 ) ); ?>
 	<div class="amp-wp-meta amp-wp-byline">
 		<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
-			<amp-img src="<?php echo esc_url( $author_avatar_url ); ?>" width="24" height="24" layout="fixed"></amp-img>
+			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array( 'size' => 24 ) ) ); ?>" width="24" height="24" layout="fixed"></amp-img>
 		<?php endif; ?>
 		<span class="amp-wp-author author vcard"><?php echo esc_html( $post_author->display_name ); ?></span>
 	</div>


### PR DESCRIPTION
Versions of WordPress prior to 4.2.0 did not include the get_avatar_url function, and will fail on meta-author.php. It appears that there was code in place using "if function_exists" to check for the existence of get_avatar_url, but it was not placed properly in the file. This change corrects the code so that get_avatar_url is only used if the function exists, which was the original intent of the if statement.