### PR TITLE
<a> with id attribute is an anchor

### DIFF
--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -124,15 +124,10 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		// Get the href attribute
 		$href = $node->getAttribute( 'href' );
 
-		// If no href is set and this isn't an anchor, it's invalid
 		if ( empty( $href ) ) {
-			$name_attr = $node->getAttribute( 'name' );
-			if ( ! empty( $name_attr ) ) {
-				// No further validation is required
-				return true;
-			} else {
-				return false;
-			}
+			// If no href, check that a is an anchor or not.
+			// We don't need to validate anchors any further.
+			return $node->hasAttribute( 'name' ) || $node->hasAttribute( 'id' );
 		}
 
 		// If this is an anchor link, just return true

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -148,6 +148,11 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<a name="section2"></a>',
 			),
 
+			'a_is_achor_with_id' => array(
+				'<a id="section3"></a>',
+				'<a id="section3"></a>',
+			),
+
 			'a_empty' => array(
 				'<a>Hello World</a>',
 				'Hello World',


### PR DESCRIPTION
Don't delete it.

See https://wordpress.org/support/topic/the-anchor-can-not-be-parsed/