### PR TITLE
Make register_customizer_ui function static to suppress warning

### DIFF
--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -43,7 +43,7 @@ class AMP_Customizer_Design_Settings {
 		) );
 	}
 
-	public function register_customizer_ui( $wp_customize ) {
+	public static function register_customizer_ui( $wp_customize ) {
 		$wp_customize->add_section( 'amp_design', array(
 			'title' => __( 'Design', 'amp' ),
 			'panel' => AMP_Template_Customizer::PANEL_ID,


### PR DESCRIPTION
With `WP_DEBUG` enabled the following error shows up in the customiser:

Strict standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method AMP_Customizer_Design_Settings::register_customizer_ui() should not be called statically in /var/www/wp/wp-includes/plugin.php on line 524

Making the function static seems to fix the issue.

Running WP 4.6.1 PHP 5.6.14 on Ubuntu 14.04.1 LTS.