### PR TITLE
Redirects the old AMP URL to the new AMP URL if post slug is changed. #560

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -61,6 +61,9 @@ function amp_init() {
 	add_filter( 'request', 'amp_force_query_var_value' );
 	add_action( 'wp', 'amp_maybe_add_actions' );
 
+	// Redirect the old url of amp page to the updated url.
+	add_filter( 'old_slug_redirect_url', 'amp_redirect_to_new_url' );
+
 	if ( class_exists( 'Jetpack' ) && ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		require_once( AMP__DIR__ . '/jetpack-helper.php' );
 	}
@@ -157,3 +160,20 @@ function _amp_bootstrap_customizer() {
 	}
 }
 add_action( 'plugins_loaded', '_amp_bootstrap_customizer', 9 );
+
+/**
+ * Redirects the old AMP URL to the new AMP URL.
+ * If post slug is updated the amp page with old post slug will be redirected to the updated url.
+ *
+ * @param  string $link New URL of the post.
+ *
+ * @return string $link URL to be redirected.
+ */
+function amp_redirect_to_new_url( $link ) {
+
+	if ( is_amp_endpoint() ) {
+		$link = trailingslashit( $link ) . AMP_QUERY_VAR;
+	}
+
+	return $link;
+}

--- a/amp.php
+++ b/amp.php
@@ -62,7 +62,7 @@ function amp_init() {
 	add_action( 'wp', 'amp_maybe_add_actions' );
 
 	// Redirect the old url of amp page to the updated url.
-	add_filter( 'old_slug_redirect_url', 'amp_redirect_to_new_url' );
+	add_filter( 'old_slug_redirect_url', 'amp_redirect_old_slug_to_new_url' );
 
 	if ( class_exists( 'Jetpack' ) && ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		require_once( AMP__DIR__ . '/jetpack-helper.php' );
@@ -169,7 +169,7 @@ add_action( 'plugins_loaded', '_amp_bootstrap_customizer', 9 );
  *
  * @return string $link URL to be redirected.
  */
-function amp_redirect_to_new_url( $link ) {
+function amp_redirect_old_slug_to_new_url( $link ) {
 
 	if ( is_amp_endpoint() ) {
 		$link = trailingslashit( $link ) . AMP_QUERY_VAR;


### PR DESCRIPTION
Fixed the old amp url redirect issue after post slug is changed. #560 