### PR TITLE
Trigger a doing it wrong when calling is_amp_endpoint() too early

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -39,6 +39,10 @@ function post_supports_amp( $post ) {
  * Note: will always return `false` if called before the `parse_query` hook.
  */
 function is_amp_endpoint() {
+	if ( 0 === did_action( 'parse_query' ) ) {
+		_doing_it_wrong( __FUNCTION__, sprintf( __( 'is_amp_endpoint() was called before the \'parse_query\' hook was called. This function will always return \'false\' before the \'parse_query\' hook is called.', 'amp' ) ), '0.4.2' );
+	}
+
 	return false !== get_query_var( AMP_QUERY_VAR, false );
 }
 


### PR DESCRIPTION
@mjangda This is to address issue #564.