### PR TITLE
Add/jetpack related hosts

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -19,6 +19,7 @@ require_once( AMP__DIR__ . '/includes/embeds/class-amp-gallery-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-instagram-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-vine-embed.php' );
 require_once( AMP__DIR__ . '/includes/embeds/class-amp-facebook-embed.php' );
+require_once( AMP__DIR__ . '/includes/embeds/class-amp-related-posts-embed.php' );
 
 class AMP_Post_Template {
 	const SITE_ICON_SIZE = 32;
@@ -227,6 +228,7 @@ class AMP_Post_Template {
 				'AMP_Vine_Embed_Handler' => array(),
 				'AMP_Facebook_Embed_Handler' => array(),
 				'AMP_Gallery_Embed_Handler' => array(),
+				'AMP_Related_Posts_Embed_Handler' => array(),
 			), $this->post ),
 			apply_filters( 'amp_content_sanitizers', array(
 				 'AMP_Style_Sanitizer' => array(),

--- a/includes/embeds/class-amp-related-posts-embed.php
+++ b/includes/embeds/class-amp-related-posts-embed.php
@@ -1,0 +1,238 @@
+<?php
+
+class AMP_Related_Posts_Embed_Handler extends AMP_Base_Embed_Handler {
+	public function register_embed() {
+		if ( class_exists( 'Jetpack_RelatedPosts' ) && method_exists( 'Jetpack_RelatedPosts', 'init' ) ) {
+			// If we have an existing callback we are overriding, remove it.
+			$jprp = Jetpack_RelatedPosts::init();
+			remove_filter( 'the_content', array( $jprp, 'filter_add_target_to_dom' ) );
+
+			// Add our new callbacks
+			add_action( 'amp_post_template_css', array( $this, 'add_related_posts_styles' ) );
+			add_filter( 'the_content', array( $this, 'add_related_posts' ) );
+		}
+
+		do_action( 'amp_related_posts_register_embed' );
+	}
+
+	public function unregister_embed() {
+		if ( class_exists( 'Jetpack_RelatedPosts' ) && method_exists( 'Jetpack_RelatedPosts', 'init' ) ) {
+			// Let's clean up after ourselves, just in case.
+			$jprp = Jetpack_RelatedPosts::init();
+			add_filter( 'the_content', array( $jprp, 'filter_add_target_to_dom' ) );
+			remove_filter( 'the_content', array( $this, 'add_related_posts' ) );
+		}
+
+		do_action( 'amp_related_posts_unregister_embed' );
+	}
+
+	public function get_scripts() {
+		$scripts = array(
+			'amp-mustache' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+			'amp-list' => 'https://cdn.ampproject.org/v0/amp-list-0.1.js',
+		);
+		return apply_filters( 'amp_related_posts_scripts', $scripts );
+	}
+
+  	private function get_options() {
+  		$defaults = array(
+  			'size' => 3,
+  			'show_thumbnails' => false,
+  			'show_headline' => true,
+  			'show_date' => true,
+  			'show_context' => true,
+  			'headline' => 'Related',
+  		);
+
+  		$options = array();
+		if( class_exists( 'Jetpack_RelatedPosts' ) && method_exists( 'Jetpack_RelatedPosts', 'get_options' ) ) {
+			$jprp = Jetpack_RelatedPosts::init();
+			$options = $jprp->get_options();
+		}
+
+		$options = wp_parse_args( $options, $defaults );
+		
+		return apply_filters( 'amp_related_posts_options', $options );
+	}
+
+	public function add_related_posts_styles( $amp_template ) {
+
+		$amp_related_posts_styles = <<<EOT
+/* AMP Related Posts */
+
+	.amp-related-posts {
+		font-size: 0.8rem;
+		line-height: 1.4285714286em;
+		font-family: inherit;
+		margin: 1em 0;
+		padding: 1em 0;
+	}
+	.amp-related-posts-headline {
+		margin: 1em 0;
+		padding-top: 1.2em;
+		display: inline-block;
+		border-top: 1px rgba(0,0,0,0.3) solid;
+	}
+	.amp-related-posts-list > div {
+		display: flex;
+		justify-content: space-around;
+		flex-wrap: wrap;
+	}
+	.amp-related-posts-item {
+		max-width: 200px;
+		overflow: hidden;
+		position: relative;
+		flex-grow: 1;
+		flex-shrink: 1;
+		opacity: 0.8
+	}
+	.amp-related-posts-item:hover {
+		opacity: 1.0;
+	}
+	.amp-related-posts-item + .amp-related-posts-item {
+		margin-left: 20px;
+	}
+	h4.amp-related-posts-title {
+		margin: 0 0 1em;
+		padding: 0;
+	}
+	.amp-related-posts-overlay {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		display: block;
+	}
+	.amp-related-posts-image {
+		width: 200px;
+		margin-bottom: 1em;
+	}
+	.amp-related-posts-excerpt {
+		max-height: 7.1428571429em;
+		overflow: hidden;
+		display: block;
+	}
+	.amp-related-posts-date,
+	.amp-related-posts-context {
+		display: block;
+		opacity: 0.6
+	}
+EOT;
+		echo apply_filters( 'amp_related_posts_styles', $amp_related_posts_styles );
+	}
+
+	public function add_related_posts( $content ) {
+
+		$options = $this->get_options();	
+
+		$permalink = get_permalink();
+		$parsed_permalink = wp_parse_url( $permalink );
+		if ( 'https' != $parsed_permalink['scheme'] ) {
+			$related_posts_url = '//' . $parsed_permalink['host'];
+			if ( ! empty( $parsed_permalink['port'] ) ) {
+				$related_posts_url .= ':' . $parsed_permalink['port'];
+			}
+			if ( ! empty( $parsed_permalink['path'] ) ) {
+				$related_posts_url .= $parsed_permalink['path'];
+			}
+			if ( ! empty( $parsed_permalink['query'] ) ) {
+				$related_posts_url .= '?' . $parsed_permalink['query'] . '&relatedposts=1';
+			} else {
+				$related_posts_url .= '?relatedposts=1';
+			}
+		}
+
+		$related_posts_wrap_begin = <<<EOT
+<div class="amp-related-posts">
+EOT;
+
+
+		$related_posts_headline = sprintf(
+			'<h3 class="amp-related-posts-headline"><em>%s</em></h3>',
+			esc_html__( 'Related', 'jetpack' )
+		);
+
+		$related_posts_header_thumbs = <<<EOT
+	<amp-list class="amp-related-posts-list" src="$related_posts_url" width="200" height="284" layout="responsive">
+		<template type="amp-mustache">
+			<div class="amp-related-posts-item" data-post-id="{{id}}" data-post-format="{{format}}">
+EOT;
+
+		$related_posts_header_excerpt = <<<EOT
+	<amp-list class="amp-related-posts-list" src="$related_posts_url" width="200" height="171" layout="responsive">
+		<template type="amp-mustache">
+			<div class="amp-related-posts-item" data-post-id="{{id}}" data-post-format="{{format}}">
+EOT;
+
+		$related_posts_thumb = <<<EOT
+				<a class="amp-related-posts-a" href="{{url}}" title="{{title}}&#13;&#13;{{excerpt}}" rel="{{rel}}" target="_self">
+					{{#img.src}}
+					<amp-img width="{{img.width}}" height="{{img.height}}" layout="responsive" alt="{{title}}" src="{{img.src}}"></amp-img>
+					{{/img.src}}
+				</a>
+EOT;
+			
+
+		$related_posts_title = <<<EOT
+				<h4 class="amp-related-posts-title"><a class="amp-relatedposts-post-a" href="{{url}}" title="{{title}}&#13;&#13;{{excerpt}}" rel="{{rel}}" target="_self">{{title}}</a></h4>
+EOT;
+
+		$related_posts_excerpt = <<<EOT
+				<a class="amp-related-posts-overlay" href="{{url}}" title="{{title}}&#13;&#13;{{excerpt}}" rel="{{rel}}" target="_self"></a>
+				<p class="amp-related-posts-excerpt">{{excerpt}}</p>
+EOT;
+
+		$related_posts_date = <<<EOT
+				{{#date}}
+				<div class="amp-related-posts-date">{{date}}</div>
+				{{/date}}
+EOT;
+
+		$related_posts_context = <<<EOT
+				{{#context}}
+				<div class="amp-related-posts-context">{{context}}</div>
+				{{/context}}
+EOT;
+
+		$related_posts_footer = <<<EOT
+			</div>
+		</template>
+	</amp-list>
+EOT;
+
+		$related_posts_wrap_end = <<<EOT
+<div>
+EOT;
+
+		$related_posts = apply_filters( 'amp_related_posts_template_wrap_begin', $related_posts_wrap_begin );
+		if ( true == $options['show_headline'] ) {
+			$related_posts .= apply_filters( 'amp_related_posts_template_headline', $related_posts_headline );
+		}
+		if ( true == $options['show_thumbnails'] ) {
+			$related_posts .= apply_filters( 'amp_related_posts_template_header_thumbs', $related_posts_header_thumbs );
+		} else {
+			$related_posts .= apply_filters( 'amp_related_posts_template_header_excerpt', $related_posts_header_excerpt );
+		}
+		if ( true == $options['show_thumbnails'] ) {
+			$related_posts .= apply_filters( 'amp_related_posts_template_thumb', $related_posts_thumb );
+		}
+		$related_posts .= $related_posts_title;
+		if ( false == $options['show_thumbnails'] ) {
+			$related_posts .= apply_filters( 'amp_related_posts_template_excerpt', $related_posts_excerpt );
+		}
+		if ( true == $options['show_date'] ) {	
+			$related_posts .= apply_filters( 'amp_related_posts_template_date', $related_posts_date );
+		}
+		if ( true == $options['show_context'] ) {
+			$related_posts .= apply_filters( 'amp_related_posts_template_context', $related_posts_context );
+		}
+		$related_posts .= apply_filters( 'amp_related_posts_template_footer', $related_posts_footer );
+		$related_posts .= apply_filters( 'amp_related_posts_template_wrap_end', $related_posts_wrap_end );
+
+
+
+		$content .= apply_filters( 'amp_related_posts_template', $related_posts );
+		return $content;
+	}
+}

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -69,3 +69,26 @@ function jetpack_amp_build_stats_pixel_url() {
 	$data = array_map( 'rawurlencode' , $data );
 	return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
 }
+
+/**
+ * Convert the URL of the Jetpack Related Posts to the corresponding
+ * AMP endpoint, if the post supports AMP.
+ * 
+ * @param  array  $related_posts The related posts returned by Jetpack.
+ * @param  int 	  $post_id       The ID of the post where these related posts will appear.
+ * @return array                 The array of posts with modified URLs.
+ */
+function amp_modify_jetpack_related_post_links( $related_posts, $post_id ) {
+	$amp_related_posts = array();
+
+	foreach( $related_posts as $related_post ) {
+		$post = get_post( $related_post['id'] );
+		if ( post_supports_amp( $post ) ) {
+			$related_post['url'] = amp_get_permalink( $related_post['id'] );
+		}
+		$amp_related_posts[] = $related_post;
+	}
+
+	return $amp_related_posts;
+}
+add_filter( 'jetpack_relatedposts_returned_results', 'amp_modify_jetpack_related_post_links', 10, 2 );

--- a/tests/test-amp-blacklist-sanitizer.php
+++ b/tests/test-amp-blacklist-sanitizer.php
@@ -163,6 +163,16 @@ class AMP_Blacklist_Sanitizer_Test extends WP_UnitTestCase {
 				'<span>Red</span>&amp;<span>Orange</span>'
 			),
 
+			'a_with_mustache_value_for_href' => array(
+				'<template type="amp-mustache"><a href="{{url}}">clickety clack</a></template>',
+				'<template type="amp-mustache"><a href="{{url}}">clickety clack</a></template>',
+			),
+
+			'a_with_mustache_value_for_href_not_in_template' => array(
+				'<a href="{{url}}">clickety clack</a>',
+				'clickety clack',
+			),
+
 			'h1_with_size' => array(
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',


### PR DESCRIPTION
@mjangda, This PR is to address issue #124.

To render related posts using Jetpack's engine, on AMP pages, this PR uses amp-list to access a site's related posts feed and renders it in a manner similar to the related posts built into Jetpack.

Other (non-Jetpack) related posts modules could also take advantage of this embed handler by hooking the `amp_related_posts_register_embed` and `amp_related_posts_unregister_embed` actions to add their own callbacks and filters.

There are a number of other hooks and filters available:
* `amp_related_posts_scripts` can be used to filter scripts to be added
* `amp_related_posts_options` can add/remove/update the options array
* `amp_related_posts_styles` filter can be used to modify the custom css
* `amp_related_posts_url` to generate the related posts data endpoint
* `amp_related_posts_template` to modify the template used to generate the related posts output

`amp_modify_jetpack_related_post_links()` was added to `jetpack-helper.php`to modify the related posts URLs so that they returned AMP URLs.

`AMP_Blacklist_Sanitizer` was modified to allow mustache template variable replacement in the `href` attribute of `<a>` tags.

For testing in a local development environment, here is a simple plugin I put together that will allow Jetpack's Related Posts module to run without a connection to WordPress.com: https://gist.github.com/delputnam/e6bb2f596f2995ae42f00b20957b5b07