### PR TITLE
Also need the amp-list script for the related posts example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -395,7 +395,10 @@ class XYZ_AMP_Related_Posts_Embed extends AMP_Base_Embed_Handler {
 	}
 
 	public function get_scripts() {
-		return array( 'amp-mustache' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js' );
+        return array(
+            'amp-mustache' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+            'amp-list' => 'https://cdn.ampproject.org/v0/amp-list-0.1.js',
+        );
 	}
 
 	public function add_related_posts( $content ) {


### PR DESCRIPTION
@mjangda,

While working on the related posts embed module, I noticed that we also need to specify `amp-list-0.1.js` in `get_scripts()`.