### PR TITLE
Make AMP_Video_Sanitizer include amp-video script

### DIFF
--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -10,6 +10,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 	public static $tag = 'video';
 
+	private static $script_slug = 'amp-video';
+	private static $script_src = 'https://cdn.ampproject.org/v0/amp-video-0.1.js';
+
+	public function get_scripts() {
+		if ( ! $this->did_convert_elements ) {
+			return array();
+		}
+
+		return array( self::$script_slug => self::$script_src );
+	}
+
 	public function sanitize() {
 		$nodes = $this->dom->getElementsByTagName( self::$tag );
 		$num_nodes = $nodes->length;
@@ -50,6 +61,8 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 			}
+
+			$this->did_convert_elements = true;
 		}
 	}
 

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -103,14 +103,26 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
-	public function test_get_scripts__empty() {
-		$source = '<video width="300" height="300" src="https://example.com/video.mp4"></video>';
+	public function test_get_scripts__didnt_convert() {
+		$source = '<p>Hello World</p>';
 		$expected = array();
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
+		$scripts = $sanitizer->get_scripts();
+		$this->assertEquals( $expected, $scripts );
+	}
+
+	public function test_get_scripts__did_convert() {
+		$source = '<video width="300" height="300" src="https://example.com/video.mp4"></video>';
+		$expected = array( 'amp-video' => 'https://cdn.ampproject.org/v0/amp-video-0.1.js' );
+
+		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer->sanitize();
+		
 		$scripts = $sanitizer->get_scripts();
 		$this->assertEquals( $expected, $scripts );
 	}


### PR DESCRIPTION
The change makes sure the amp-video script is included if any video elements are sanitized.
It follows the pattern used in the twin AMP_Audio_Sanitizer class.