### PR TITLE
Replace explode with preg_split.

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -56,8 +56,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return array();
 		}
 
-		// Normalize order
-		$styles = array_map( 'trim', preg_split("/;(?![^(]*\))/", $string ) );
+		// safecss returns a string but we want individual rules.
+		// Using preg_split to break up rules by `;` but only if the semi-colon is not inside parens (like a data-encoded image).
+		$styles = array_map( 'trim', preg_split( "/;(?![^(]*\))/", $string ) );
+
+		// Normalize the order of the styles
 		sort( $styles );
 
 		$processed_styles = array();

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -57,7 +57,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Normalize order
-		$styles = array_map( 'trim', explode( ';', $string ) );
+		$styles = array_map( 'trim', preg_split("/;(?![^(]*\))/", $string ) );
 		sort( $styles );
 
 		$processed_styles = array();


### PR DESCRIPTION
In cases where Jetpack's `safecss_filter_attr` is used in place of core's function (and possibly other scenarios), there may be semi-colons in unexpected places.

For example, `background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...);`

In that case, `explode` will break the style, splitting it in the middle of a value. With `preg_split` we can specify semi-colons that are not inside parentheses.