### PR TITLE
Add amp_render_post

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -130,6 +130,11 @@ function amp_render() {
 }
 
 function amp_render_post( $post_id ) {
+	$post = get_post( $post_id );
+	if ( ! $post ) {
+		return;
+	}
+
 	amp_load_classes();
 
 	do_action( 'pre_amp_render_post', $post_id );

--- a/amp.php
+++ b/amp.php
@@ -124,15 +124,19 @@ function amp_prepare_render() {
 }
 
 function amp_render() {
+	$post_id = get_queried_object_id();
+	amp_render_post( $post_id );
+	exit;
+}
+
+function amp_render_post( $post_id ) {
 	amp_load_classes();
 
-	$post_id = get_queried_object_id();
 	do_action( 'pre_amp_render_post', $post_id );
 
 	amp_add_post_template_actions();
 	$template = new AMP_Post_Template( $post_id );
 	$template->load();
-	exit;
 }
 
 /**

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -1,0 +1,24 @@
+<?php
+
+class AMP_Render_Post_Test extends WP_UnitTestCase {
+	public function test__invalid_post() {
+		// No ob here since it bails early
+		$amp_rendered = amp_render_post( PHP_INT_MAX );
+
+		$this->assertNull( $amp_rendered, 'Response was not null' );
+		$this->assertEquals( 0, did_action( 'pre_amp_render_post' ), 'pre_amp_render_post action fire when it should not have.' );
+	}
+
+	public function test__valid_post() {
+		$user_id = $this->factory->user->create();
+		$post_id = $this->factory->post->create( array( 'post_author' => $user_id ) );
+
+		// Need to use ob here since the method echos
+		ob_start();
+		amp_render_post( $post_id );
+		$amp_rendered = ob_get_clean();
+
+		$this->assertContains( '<html amp', $amp_rendered, 'Response does not include html tag with amp attribute.' );
+		$this->assertEquals( 1, did_action( 'pre_amp_render_post', 'pre_amp_render_post action fire either did not fire or fired too many times.' ) );
+	}
+}


### PR DESCRIPTION
Accepts a post_id and renders the AMP version of that post. Will allow for other contexts to generate AMP without needing remote requests and also for easier testing of AMP validation.

Example usage:

```
ob_start();
amp_render_post( $post_id );
$content = ob_get_clean(); // get the full AMP page
```