### PR TITLE
Update documentation re: featured images

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ You can tweak various parts of the template via code.
 The default template displays the featured image. If you don't want to display the featured image in your amp page, use the following code:
 
 ```php
-add_filter( 'amp_post_template_data', 'xyz_amp_remove_featured_image' }
+add_filter( 'amp_post_template_data', 'xyz_amp_remove_featured_image' )
 
 function xyz_amp_remove_featured_image( $data ) {
     $data['featured_image'] = false;

--- a/readme.md
+++ b/readme.md
@@ -87,22 +87,13 @@ You can tweak various parts of the template via code.
 
 #### Featured Image
 
-The default template does not display the featured image currently. There are many ways to add it, such as the snippet below:
+The default template displays the featured image. If you don't want to display the featured image in your amp page, use the following code:
 
 ```php
-add_action( 'pre_amp_render_post', 'xyz_amp_add_custom_actions' );
-function xyz_amp_add_custom_actions() {
-	add_filter( 'the_content', 'xyz_amp_add_featured_image' );
-}
-
-function xyz_amp_add_featured_image( $content ) {
-	if ( has_post_thumbnail() ) {
-		// Just add the raw <img /> tag; our sanitizer will take care of it later.
-		$image = sprintf( '<p class="xyz-featured-image">%s</p>', get_the_post_thumbnail() );
-		$content = $image . $content;
-	}
-	return $content;
-}
+add_filter( 'amp_post_template_data', function( $data ) {
+    $data['featured_image'] = false;
+    return $data;
+} );
 ```
 
 #### Content Width

--- a/readme.md
+++ b/readme.md
@@ -90,10 +90,12 @@ You can tweak various parts of the template via code.
 The default template displays the featured image. If you don't want to display the featured image in your amp page, use the following code:
 
 ```php
-add_filter( 'amp_post_template_data', function( $data ) {
+add_filter( 'amp_post_template_data', 'xyz_amp_remove_featured_image' }
+
+function xyz_amp_remove_featured_image( $data ) {
     $data['featured_image'] = false;
     return $data;
-} );
+}
 ```
 
 #### Content Width

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ You can tweak various parts of the template via code.
 The default template displays the featured image. If you don't want to display the featured image in your amp page, use the following code:
 
 ```php
-add_filter( 'amp_post_template_data', 'xyz_amp_remove_featured_image' )
+add_filter( 'amp_post_template_data', 'xyz_amp_remove_featured_image' );
 
 function xyz_amp_remove_featured_image( $data ) {
     $data['featured_image'] = false;


### PR DESCRIPTION
Updates readme.md to reflect the fact that the plugin now includes featured images in amp pages by default, and shows a way to turn them off for those that preferred the earlier behaviour, per issue #660 