### PR TITLE
Fix for AMP height & width invalid attributes

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -84,6 +84,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 		$new_attributes = $this->filter_attributes( $old_attributes );
 		$new_attributes = $this->enforce_sizes_attribute( $new_attributes );
+		if ( $new_attributes['height'] === '' ) {
+			$new_attributes['height'] = self::FALLBACK_HEIGHT;
+		}
+		if ( $new_attributes['width'] === '' ) {
+			$new_attributes['width'] = self::FALLBACK_WIDTH;
+		}
 		if ( $this->is_gif_url( $new_attributes['src'] ) ) {
 			$this->did_convert_elements = true;
 			$new_tag = 'amp-anim';


### PR DESCRIPTION
Sometimes, there are dimensions for height and not the width and vice-versa. This leaves one attribute with no value which results as an invalid layout property. With this, now it will use the dimension for the given attribute and for the other dimension that wasn't given, it will use the default dimension.