### PR TITLE
Define shortcode for amp-analytics component

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -20,8 +20,7 @@ require_once( AMP__DIR__ . '/includes/amp-helper-functions.php' );
 require_once( AMP__DIR__ . '/includes/admin/functions.php' );
 require_once( AMP__DIR__ . '/includes/settings/class-amp-customizer-settings.php' );
 require_once( AMP__DIR__ . '/includes/settings/class-amp-customizer-design-settings.php' );
-
-require_once( AMP__DIR__ . '/includes/shortcodes/amp-analytics-shortcode.php' );
+require_once( AMP__DIR__ . '/includes/shortcodes/amp-analytics.php' );
 
 register_activation_hook( __FILE__, 'amp_activate' );
 function amp_activate() {

--- a/amp.php
+++ b/amp.php
@@ -21,6 +21,8 @@ require_once( AMP__DIR__ . '/includes/admin/functions.php' );
 require_once( AMP__DIR__ . '/includes/settings/class-amp-customizer-settings.php' );
 require_once( AMP__DIR__ . '/includes/settings/class-amp-customizer-design-settings.php' );
 
+require_once( AMP__DIR__ . '/includes/shortcodes/amp-analytics-shortcode.php' );
+
 register_activation_hook( __FILE__, 'amp_activate' );
 function amp_activate() {
 	if ( ! did_action( 'amp_init' ) ) {

--- a/amp.php
+++ b/amp.php
@@ -65,9 +65,20 @@ function amp_init() {
 	// Redirect the old url of amp page to the updated url.
 	add_filter( 'old_slug_redirect_url', 'amp_redirect_old_slug_to_new_url' );
 
+	// Register available AMP shortcodes
+	register_amp_shortcodes();
+
 	if ( class_exists( 'Jetpack' ) && ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		require_once( AMP__DIR__ . '/jetpack-helper.php' );
 	}
+}
+
+/**
+ * Register AMP shortcodes
+ *
+ */
+function register_amp_shortcodes() {
+	add_shortcode('amp-analytics', 'amp_analytics');
 }
 
 // Make sure the `amp` query var has an explicit value.

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -74,6 +74,7 @@ function amp_post_template_add_analytics_script( $data ) {
 
 add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
 function amp_post_template_add_analytics_data( $amp_template ) {
+
 	$analytics_entries = $amp_template->get( 'amp_analytics' );
 	if ( empty( $analytics_entries ) ) {
 		return;

--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -36,6 +36,9 @@ class AMP_Post_Template {
 	private $data;
 
 	public function __construct( $post_id ) {
+		error_log('Constructing post template!');
+		flush();
+
 		$this->template_dir = apply_filters( 'amp_post_template_dir', AMP__DIR__ . '/templates' );
 
 		$this->ID = $post_id;

--- a/includes/shortcodes/amp-analytics-shortcode.php
+++ b/includes/shortcodes/amp-analytics-shortcode.php
@@ -1,0 +1,23 @@
+<?php
+
+// Add shortcode to list of tags to not be texturized.
+// Needed to maintain the JSON string in the tag content properly
+// formated
+add_filter( 'no_texturize_shortcodes', 'shortcodes_to_exempt_from_wptexturize' );
+function shortcodes_to_exempt_from_wptexturize( $shortcodes ) {
+	$shortcodes[] = 'amp-analytics';
+	return $shortcodes;
+}
+
+// Change the order of the wpautop filter to prevent
+// the JSON string to be "pulluted" with "extraneous" characters
+remove_filter( 'the_content', 'wpautop' );
+add_filter( 'the_content', 'wpautop' , 12);
+
+// Primary handler
+function amp_analytics( $atts, $content ) {
+	$ga = json_decode($content);
+	var_dump($ga);
+	return '';
+}
+add_shortcode('amp-analytics', 'amp_analytics');

--- a/includes/shortcodes/amp-analytics-shortcode.php
+++ b/includes/shortcodes/amp-analytics-shortcode.php
@@ -2,7 +2,7 @@
 
 // Add shortcode to list of tags to not be texturized.
 // Needed to maintain the JSON string in the tag content properly
-// formated
+// formatted
 add_filter( 'no_texturize_shortcodes', 'shortcodes_to_exempt_from_wptexturize' );
 function shortcodes_to_exempt_from_wptexturize( $shortcodes ) {
 	$shortcodes[] = 'amp-analytics';
@@ -10,7 +10,7 @@ function shortcodes_to_exempt_from_wptexturize( $shortcodes ) {
 }
 
 // Change the order of the wpautop filter to prevent
-// the JSON string to be "pulluted" with "extraneous" characters
+// the JSON string to be "polluted" with "extraneous" characters
 remove_filter( 'the_content', 'wpautop' );
 add_filter( 'the_content', 'wpautop' , 12);
 

--- a/includes/shortcodes/amp-analytics.php
+++ b/includes/shortcodes/amp-analytics.php
@@ -17,7 +17,10 @@ add_filter( 'the_content', 'wpautop' , 12);
 // Primary handler
 function amp_analytics( $atts, $content ) {
 	$ga = json_decode($content);
-	var_dump($ga);
+
+	// TODO (@amedina): Define here the logic to add the amp-analytics
+	// component to the footer section
+
 	return '';
 }
 add_shortcode('amp-analytics', 'amp_analytics');

--- a/includes/shortcodes/amp-analytics.php
+++ b/includes/shortcodes/amp-analytics.php
@@ -3,9 +3,11 @@
 // Add shortcode to list of tags to not be texturized.
 // Needed to maintain the JSON string in the tag content properly
 // formatted
-add_filter( 'no_texturize_shortcodes', 'shortcodes_to_exempt_from_wptexturize' );
-function shortcodes_to_exempt_from_wptexturize( $shortcodes ) {
-	$shortcodes[] = 'amp-analytics';
+add_filter( 'no_texturize_shortcodes', 'amp_shortcodes_exempt_from_wptexturize' );
+function amp_shortcodes_exempt_from_wptexturize( $shortcodes ) {
+	$shortcodes = array(
+		'amp-analytics'
+	);
 	return $shortcodes;
 }
 
@@ -16,11 +18,53 @@ add_filter( 'the_content', 'wpautop' , 12);
 
 // Primary handler
 function amp_analytics( $atts, $content ) {
-	$ga = json_decode($content);
 
-	// TODO (@amedina): Define here the logic to add the amp-analytics
-	// component to the footer section
+	// Encode shortcode content into GA config object
+	$ga_config = json_decode($content);
+	
+	$analytics = array();
+	foreach ($ga_config as $config) {
+		$type = $config->{'type'};
+		$analytics[$type] = array();
+		$analytics[$type]['type'] = $config->{'type'};
+		$analytics[$type]['attributes'] = get_object_vars($config->{'attributes'});
+		$analytics[$type]['config_data'] = get_object_vars($config->{'config_data'});
+	}
 
-	return '';
+	function add_analytics_script($data) {
+		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';
+		return $data;
+	}
+
+	// Define a closure to capturing the state in $analytics
+	// Pass it to the add_action for the amp_post_template_footer
+	// When the action is executed, the function will receive the
+	// $template and will add the $analytics script and data
+	$add_analytics_data = function($template) use ($analytics) {
+		error_log( "Adding analytics data!" );
+
+		foreach ( $analytics as $id => $analytics_entry ) {
+			if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['config_data'] ) ) {
+				_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'Analytics entry for %s is missing one of the following keys: `type`, `attributes`, or `config_data` (array keys: %s)', 'amp' ), esc_html( $id ), esc_html( implode( ', ', array_keys( $analytics_entry ) ) ) ), '0.3.2' );
+				continue;
+			}
+
+			$script_element = AMP_HTML_Utils::build_tag( 'script', array(
+				'type' => 'application/json',
+			), wp_json_encode( $analytics_entry['config_data'] ) );
+
+			$amp_analytics_attr = array_merge( array(
+				'id'   => $id,
+				'type' => $analytics_entry['type'],
+			), $analytics_entry['attributes'] );
+
+			echo AMP_HTML_Utils::build_tag( 'amp-analytics', $amp_analytics_attr, $script_element );
+		}
+	};
+
+	if ( ! empty($analytics) ) {
+		add_action( 'amp_post_template_data', 'add_analytics_script' );
+		add_action( 'amp_post_template_footer', $add_analytics_data);
+	}
 }
-add_shortcode('amp-analytics', 'amp_analytics');
+


### PR DESCRIPTION
The goal is to provide a shortcode that users can apply to add an amp-analytics component to their posts. The shortcode will be used in this way:

``` javascript
[amp-analytics]
[
  { 
    "type": "googleanalytics",
    "attributes": {},
    "config_data": {
       "requests": {
          "pageview": "https://example.com/analytics?url=${canonicalUrl}&amp;title=${title}&amp;acct=${account}",
          "event": "https://example.com/analytics?eid=${eventId}&amp;elab=${eventLabel}&amp;acct=${account}"
       },
       "vars": {
          "account": "ABC123"
        },
        "triggers": {
           "trackPageview": {
               "on": "visible",
               "request": "pageview"
            },
           "trackAnchorClicks": {
              "on": "click",
              "selector": "a",
              "request": "event",
              "vars": {
                "eventId": "42",
                "eventLabel": "clicked on a link"
              }
            }
         }
      }
   }
]
[/amp-analytics]
```

Creating this PR to enable the discussion of a few details for hooking up the shortcode to the "add-analytics" action. 