### PR TITLE
Fix URL handling for schemaless URLS in PHP5.3

### DIFF
--- a/includes/class-amp-post-template.php
+++ b/includes/class-amp-post-template.php
@@ -3,6 +3,7 @@
 require_once( AMP__DIR__ . '/includes/utils/class-amp-dom-utils.php' );
 require_once( AMP__DIR__ . '/includes/utils/class-amp-html-utils.php' );
 require_once( AMP__DIR__ . '/includes/utils/class-amp-string-utils.php' );
+require_once( AMP__DIR__ . '/includes/utils/class-amp-wp-utils.php' );
 
 require_once( AMP__DIR__ . '/includes/class-amp-content.php' );
 

--- a/includes/embeds/class-amp-dailymotion-embed.php
+++ b/includes/embeds/class-amp-dailymotion-embed.php
@@ -92,7 +92,7 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	private function get_video_id_from_url( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = AMP_WP_Utils::parse_url( $url );
 		parse_str( $parsed_url['path'], $path );
 		$tok = explode( '/', $parsed_url['path'] );
 		$tok = explode( '_', $tok[2] );

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -86,7 +86,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	private function get_track_id_from_url( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = AMP_WP_Utils::parse_url( $url );
 		$tok = explode( '/', $parsed_url['path'] );
 		$track_id = $tok[2];
 

--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -92,7 +92,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	private function get_video_id_from_url( $url ) {
 		$video_id = false;
-		$parsed_url = parse_url( $url );
+		$parsed_url = AMP_WP_Utils::parse_url( $url );
 
 		if ( self::SHORT_URL_HOST === substr( $parsed_url['host'], -strlen( self::SHORT_URL_HOST ) ) ) {
 			// youtu.be/{id}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -144,7 +144,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 	private function is_gif_url( $url ) {
 		$ext = self::$anim_extension;
-		$path = parse_url( $url, PHP_URL_PATH );
+		$path = AMP_WP_Utils::parse_url( $url, PHP_URL_PATH );
 		return substr( $path, -strlen( $ext ) ) === $ext;
 	}
 }

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -767,7 +767,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[AMP_Rule_Spec::disallowed_domain] ) &&
 			$node->hasAttribute( $attr_name ) ) {
 			$attr_value = $node->getAttribute( $attr_name );
-			$url_domain = parse_url( $attr_value, PHP_URL_HOST );
+			$url_domain = wp_parse_url( $attr_value, PHP_URL_HOST );
 			if ( ! empty( $url_domain ) ) {
 				foreach ( $attr_spec_rule[AMP_Rule_Spec::disallowed_domain] as $disallowed_domain ) {
 					if ( strtolower( $url_domain ) == strtolower( $disallowed_domain ) ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -9,7 +9,7 @@ require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generate
  * Allowed tags array is generated from this protocol buffer:
  *     https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii
  *     by the python script in amp-wp/bin/amp_wp_build.py. See the comment at the top
- *     of that file for instructions to generate class-amp-allowed-tags-generated.php. 
+ *     of that file for instructions to generate class-amp-allowed-tags-generated.php.
  *
  * TODO: AMP Spec items not checked by this sanitizer -
  * - `if_value_regex` - if one attribute value matches, this places a restriction
@@ -64,7 +64,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 		}
-	} 
+	}
 
 	private function process_node( $node ) {
 		// Don't process text or comment nodes
@@ -117,7 +117,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 			$attr_spec_list = array();
 
-			// If we have exactly one rule_spec, use it's attr_spec_list to 
+			// If we have exactly one rule_spec, use it's attr_spec_list to
 			// validate the node's attributes.
 			if ( 1 == count( $rule_spec_list_to_validate ) ) {
 				$rule_spec = array_pop( $rule_spec_list_to_validate );
@@ -195,9 +195,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Checks to see if a node's placement with the DOM is be valid for the 
-	 * given tag_spec. If there are restrictions placed on the type of node 
-	 * that can be an immediate parent or an ancestor of this node, then make 
+	 * Checks to see if a node's placement with the DOM is be valid for the
+	 * given tag_spec. If there are restrictions placed on the type of node
+	 * that can be an immediate parent or an ancestor of this node, then make
 	 * sure those restrictions are met.
 	 *
 	 * If any of the tests on the restrictions fail, return false, otherwise
@@ -313,7 +313,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
-			// If the given attribute's value exists, is non-empty and the rule's value 
+			// If the given attribute's value exists, is non-empty and the rule's value
 			// is false, then pass.
 			if ( isset( $attr_spec_rule[AMP_Rule_Spec::allow_empty] ) ) {
 				if ( AMP_Rule_Spec::pass == $this->check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) ) {
@@ -337,13 +337,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 		}
-					
+
 		// return true;
 		return $score;
 	}
 
 	/**
-	 * If an attribute is not listed in $allowed_attrs, then it will be removed 
+	 * If an attribute is not listed in $allowed_attrs, then it will be removed
 	 * from $node.
 	 */
 	private function sanitize_disallowed_attributes_in_node( $node, $attr_spec_list ) {
@@ -483,7 +483,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Checks to see if the given attribute is mandatory for the given node and
 	 * whether the attribute (or a specified alternate) exists.
-	 *	
+	 *
 	 *	Returns:
 	 *		- AMP_Rule_Spec::pass - $attr_name is mandatory and it exists
 	 *		- AMP_Rule_Spec::fail - $attr_name is mandatory, but doesn't exist
@@ -651,7 +651,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $urls_to_test as $url ) {
 					// This seems to be an acceptable check since the AMP validator
 					//	will allow a URL with no protocol to pass validation.
-					if ( $url_scheme = parse_url( $url, PHP_URL_SCHEME ) ) {
+					if ( $url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME ) ) {
 						if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[AMP_Rule_Spec::allowed_protocol] ) ) {
 							return AMP_Rule_Spec::fail;
 						}
@@ -667,7 +667,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 						foreach ( $urls_to_test as $url ) {
 							// This seems to be an acceptable check since the AMP validator
 							//	will allow a URL with no protocol to pass validation.
-							if ( $url_scheme = parse_url( $url, PHP_URL_SCHEME ) ) {
+							if ( $url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME ) ) {
 								if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[AMP_Rule_Spec::allowed_protocol] ) ) {
 									return AMP_Rule_Spec::fail;
 								}
@@ -699,8 +699,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				$attr_value = preg_replace( '/\s*,\s*/', ',', $attr_value );
 				$urls_to_test = explode( ',', $attr_value );
 				foreach ( $urls_to_test as $url ) {
-					$parsed_url = parse_url( $url );
-					// The JS AMP validator seems to consider 'relative' to mean 
+					$parsed_url = AMP_WP_Utils::parse_url( $url );
+					// The JS AMP validator seems to consider 'relative' to mean
 					//	*protocol* relative, not *host* relative for this rule. So,
 					//	a url with an empty 'scheme' is considered "relative" by AMP.
 					// 	ie. '//domain.com/path' and '/path' should both be considered
@@ -717,7 +717,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 						$attr_value = preg_replace( '/\s*,\s*/', ',', $attr_value );
 						$urls_to_test = explode( ',', $attr_value );
 						foreach ( $urls_to_test as $url ) {
-							$parsed_url = parse_url( $url );
+							$parsed_url = AMP_WP_Utils::parse_url( $url );
 							if ( empty( $parsed_url['scheme'] ) ) {
 								return AMP_Rule_Spec::fail;
 							}
@@ -767,7 +767,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[AMP_Rule_Spec::disallowed_domain] ) &&
 			$node->hasAttribute( $attr_name ) ) {
 			$attr_value = $node->getAttribute( $attr_name );
-			$url_domain = wp_parse_url( $attr_value, PHP_URL_HOST );
+			$url_domain = AMP_WP_Utils::parse_url( $attr_value, PHP_URL_HOST );
 			if ( ! empty( $url_domain ) ) {
 				foreach ( $attr_spec_rule[AMP_Rule_Spec::disallowed_domain] as $disallowed_domain ) {
 					if ( strtolower( $url_domain ) == strtolower( $disallowed_domain ) ) {
@@ -821,7 +821,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * Return true if the attribute name is valid for this attr_spec, false otherwise.
 	 */
 	private function is_amp_allowed_attribute( $attr_name, $attr_spec_list ) {
-		if ( isset( $this->globally_allowed_attributes[ $attr_name ] ) || 
+		if ( isset( $this->globally_allowed_attributes[ $attr_name ] ) ||
 			isset( $this->layout_allowed_attributes[ $attr_name ] ) ||
 			isset( $attr_spec_list[ $attr_name ] ) ) {
 			return true;
@@ -842,7 +842,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		// Return true if node is on the allowed tags list or if it is a text
 		// or comment node.
 		return ( ( XML_TEXT_NODE == $node->nodeType ) ||
-			isset( $this->allowed_tags[ $node->nodeName ] ) || 
+			isset( $this->allowed_tags[ $node->nodeName ] ) ||
 			( XML_COMMENT_NODE == $node->nodeType ) ||
 			( XML_CDATA_SECTION_NODE == $node->nodeType ) );
 	}
@@ -966,13 +966,13 @@ abstract class AMP_Rule_Spec {
 	const value_regex = 'value_regex';
 	const value_regex_casei = 'value_regex_casei';
 
-	// If a node type listed here is invalid, it and it's subtree will be 
-	//	removed if it is invalid. This is mainly  because any children will be 
+	// If a node type listed here is invalid, it and it's subtree will be
+	//	removed if it is invalid. This is mainly  because any children will be
 	//	non-functional without this parent.
 	//
 	// If a tag is not listed here, it will be replaced by its children if it
 	//	is invalid.
-	//	
+	//
 	// TODO: There are other nodes that should probably be listed here as well.
 	static $node_types_to_remove_if_invalid = array(
 		'form',

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -37,7 +37,7 @@ class AMP_Image_Dimension_Extractor {
 			return set_url_scheme( $url, 'http' );
 		}
 
-		$parsed = parse_url( $url );
+		$parsed = AMP_WP_Utils::parse_url( $url );
 		if ( ! isset( $parsed['host'] ) ) {
 			$path = '';
 			if ( isset( $parsed['path'] ) ) {

--- a/includes/utils/class-amp-wp-utils.php
+++ b/includes/utils/class-amp-wp-utils.php
@@ -1,0 +1,61 @@
+<?php
+
+class AMP_WP_Utils {
+	/**
+	 * wp_parse_url in < WordPress 4.7 does not respect the component arg, so we're adding this helper so we can use it.
+	 *
+	 * This can be removed once 4.8 is out and we bump up our min supported WP version.
+	 */
+	public static function parse_url( $url, $component = -1 ) {
+		$parsed = wp_parse_url( $url, $component );
+
+		// Because < 4.7 always returned a full array regardless of component
+		if ( -1 !== $component && is_array( $parsed ) ) {
+			return self::_get_component_from_parsed_url_array( $parsed, $component );
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Included for 4.6 back-compat
+	 *
+	 * Copied from https://developer.wordpress.org/reference/functions/_get_component_from_parsed_url_array/
+	 */
+	protected static function _get_component_from_parsed_url_array( $url_parts, $component = -1 ) {
+		if ( -1 === $component ) {
+			return $url_parts;
+		}
+
+		$key = self::_wp_translate_php_url_constant_to_key( $component );
+		if ( false !== $key && is_array( $url_parts ) && isset( $url_parts[ $key ] ) ) {
+			return $url_parts[ $key ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Included for 4.6 back-compat
+	 *
+	 * Copied from https://developer.wordpress.org/reference/functions/_wp_translate_php_url_constant_to_key/
+	 */
+	protected static function _wp_translate_php_url_constant_to_key( $constant ) {
+		$translation = array(
+			PHP_URL_SCHEME   => 'scheme',
+			PHP_URL_HOST     => 'host',
+			PHP_URL_PORT     => 'port',
+			PHP_URL_USER     => 'user',
+			PHP_URL_PASS     => 'pass',
+			PHP_URL_PATH     => 'path',
+			PHP_URL_QUERY    => 'query',
+			PHP_URL_FRAGMENT => 'fragment',
+		);
+
+		if ( isset( $translation[ $constant ] ) ) {
+			return $translation[ $constant ];
+		}
+
+		return false;
+	}
+}

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -56,7 +56,7 @@ function jetpack_amp_build_stats_pixel_url() {
 		$blog = Jetpack_Options::get_option( 'id' );
 		$tz = get_option( 'gmt_offset' );
 		$v = 'ext';
-		$blog_url = parse_url( site_url() );
+		$blog_url = AMP_WP_Utils::parse_url( site_url() );
 		$srv = $blog_url['host'];
 		$j = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
 		$post = $wp_the_query->get_queried_object_id();

--- a/tests/test-amp-wp-utils.php
+++ b/tests/test-amp-wp-utils.php
@@ -1,0 +1,47 @@
+<?php
+
+class AMP_WP_Utils__Parse_Url__Test extends WP_UnitTestCase {
+	function get_test_data() {
+		return array(
+			'valid__no_component' => array(
+				'https://example.com/path',
+				array(
+					'scheme' => 'https',
+					'host' => 'example.com',
+					'path' => '/path',
+				),
+				-1,
+			),
+
+			'valid__with_component' => array(
+				'https://example.com/path',
+				'example.com',
+				PHP_URL_HOST,
+			),
+
+			'valid__schemaless__no_component' => array(
+				'//example.com/path',
+				array(
+					'host' => 'example.com',
+					'path' => '/path',
+				),
+				-1,
+			),
+
+			'valid__schemaless__with_component' => array(
+				'//example.com/path',
+				'example.com',
+				PHP_URL_HOST,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_test_data
+	 */
+	function test__method( $url, $expected, $component ) {
+		$actual = AMP_WP_Utils::parse_url( $url, $component );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}


### PR DESCRIPTION
`parse_url` doesn't handle schemaless URLs well in 5.3. `wp_parse_url` has a shim that fixes those bugs.

Fixes #699 