### PR TITLE
Force is_amp_endpoint to true when rendering.

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -192,6 +192,12 @@ function amp_render_post( $post ) {
 	}
 	$post_id = $post->ID;
 
+	// If amp_render_post is called directly outside of the standard endpoint, is_amp_endpoint will return false, which is not ideal for any code that expects to run in an AMP context.
+	// Let's force the value to be true while we render AMP.
+	add_filter( 'is_amp_endpoint', '__return_true' );
+
+	amp_load_classes();
+
 	/**
 	 * Fires before rendering a post in AMP.
 	 *
@@ -204,6 +210,8 @@ function amp_render_post( $post ) {
 	amp_add_post_template_actions();
 	$template = new AMP_Post_Template( $post );
 	$template->load();
+
+	remove_filter( 'is_amp_endpoint', '__return_true' );
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -78,9 +78,7 @@ function is_amp_endpoint() {
 		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'parse_query' hook was called. This function will always return 'false' before the 'parse_query' hook is called.", 'amp' ) ), '0.4.2' );
 	}
 
-	$is_amp_endpoint = false !== get_query_var( AMP_QUERY_VAR, false );
-
-	return apply_filters( 'is_amp_endpoint', $is_amp_endpoint );
+	return false !== get_query_var( AMP_QUERY_VAR, false );
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -78,7 +78,9 @@ function is_amp_endpoint() {
 		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'parse_query' hook was called. This function will always return 'false' before the 'parse_query' hook is called.", 'amp' ) ), '0.4.2' );
 	}
 
-	return false !== get_query_var( AMP_QUERY_VAR, false );
+	$is_amp_endpoint = false !== get_query_var( AMP_QUERY_VAR, false );
+
+	return apply_filters( 'is_amp_endpoint', $is_amp_endpoint );
 }
 
 /**

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -21,4 +21,33 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->assertContains( '<html amp', $amp_rendered, 'Response does not include html tag with amp attribute.' );
 		$this->assertEquals( 1, did_action( 'pre_amp_render_post', 'pre_amp_render_post action fire either did not fire or fired too many times.' ) );
 	}
+
+	public function test__is_amp_endpoint() {
+		$user_id = $this->factory->user->create();
+		$post_id = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+
+		$pre_is_amp_endpoint = is_amp_endpoint();
+
+		add_action( 'pre_amp_render_post', array( $this, '_check_is_amp_endpoint' ) );
+
+		// Need to use ob here since the method echos
+		ob_start();
+		amp_render_post( $post_id );
+		$amp_rendered = ob_get_clean();
+
+		$mid_is_amp_endpoint = $GLOBALS['mid_is_amp_endpoint'];
+		$post_is_amp_endpoint = is_amp_endpoint();
+
+		$this->assertFalse( $pre_is_amp_endpoint, 'is_amp_endpoint was not defaulting to false before amp_render_post' );
+		$this->assertTrue( $mid_is_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
+		$this->assertFalse( $post_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
+
+		unset( $GLOBALS['mid_is_amp_endpoint'] );
+	}
+
+	public function _check_is_amp_endpoint() {
+		$GLOBALS['mid_is_amp_endpoint'] = is_amp_endpoint();
+	}
 }

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -22,32 +22,46 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, did_action( 'pre_amp_render_post', 'pre_amp_render_post action fire either did not fire or fired too many times.' ) );
 	}
 
+	/**
+	 * Stored result of is_amp_endpoint() when calling amp_render_post().
+	 *
+	 * @var bool
+	 */
+	protected $was_amp_endpoint;
+
+	/**
+	 * Test is_amp_endpoint.
+	 *
+	 * @covers is_amp_endpoint()
+	 */
 	public function test__is_amp_endpoint() {
 		$user_id = $this->factory->user->create();
 		$post_id = $this->factory->post->create( array(
 			'post_author' => $user_id,
 		) );
 
-		$pre_is_amp_endpoint = is_amp_endpoint();
+		$before_is_amp_endpoint = is_amp_endpoint();
 
-		add_action( 'pre_amp_render_post', array( $this, '_check_is_amp_endpoint' ) );
+		add_action( 'pre_amp_render_post', array( $this, 'check_is_amp_endpoint' ) );
+		$this->was_amp_endpoint = false;
 
-		// Need to use ob here since the method echos
+		// Need to use output buffering here since the method echos.
 		ob_start();
 		amp_render_post( $post_id );
 		$amp_rendered = ob_get_clean();
+		$this->assertContains( '<html amp', $amp_rendered );
 
-		$mid_is_amp_endpoint = $GLOBALS['mid_is_amp_endpoint'];
-		$post_is_amp_endpoint = is_amp_endpoint();
+		$after_is_amp_endpoint = is_amp_endpoint();
 
-		$this->assertFalse( $pre_is_amp_endpoint, 'is_amp_endpoint was not defaulting to false before amp_render_post' );
-		$this->assertTrue( $mid_is_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
-		$this->assertFalse( $post_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
-
-		unset( $GLOBALS['mid_is_amp_endpoint'] );
+		$this->assertFalse( $before_is_amp_endpoint, 'is_amp_endpoint was not defaulting to false before amp_render_post' );
+		$this->assertTrue( $this->was_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
+		$this->assertFalse( $after_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
 	}
 
-	public function _check_is_amp_endpoint() {
-		$GLOBALS['mid_is_amp_endpoint'] = is_amp_endpoint();
+	/**
+	 * Store whether it currently is_amp_endpoint().
+	 */
+	public function check_is_amp_endpoint() {
+		$this->was_amp_endpoint = is_amp_endpoint();
 	}
 }


### PR DESCRIPTION
If amp_render_post is called directly outside of the standard endpoint, is_amp_endpoint will return false, which is not ideal for any code that expects to run in an AMP context (e.g. inside shortcodes).

Let's force the value to be true while we render AMP content.