### PR TITLE
Update Travis to use precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ php:
 env:
     - WP_VERSION=latest
 
+# Newer versions like trusty don't have PHP 5.2 or 5.3
+# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+dist: precise
+
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === AMP ===
-Contributors: batmoo, joen, automattic, potatomaster
+Contributors: batmoo, joen, automattic, potatomaster, albertomedina
 Tags: amp, mobile
 Requires at least: 4.7
 Tested up to: 4.8


### PR DESCRIPTION
Newer versions like trusty don't have PHP 5.2 or 5.3

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming


