### PR TITLE
Allow the AMP submit-error and submit-success tags

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -6183,6 +6183,8 @@ class AMP_Allowed_Tags_Generated {
 					'value' => '',
 		),
 		'role' => array(),
+		'submit-error' => array(),
+		'submit-success' => array(),
 		'tabindex' => array(),
 		'title' => array(),
 		'translate' => array(),


### PR DESCRIPTION
Currently, the submit-error and submit-success are being removed from the div inside the form. This change allows them to stick around.