### PR TITLE
Make redirect for non-supported AMP pages a 301

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -97,7 +97,7 @@ function amp_maybe_add_actions() {
 
 	if ( ! $supports ) {
 		if ( $is_amp_endpoint ) {
-			wp_safe_redirect( get_permalink( $post->ID ) );
+			wp_safe_redirect( get_permalink( $post->ID ), 301 );
 			exit;
 		}
 		return;


### PR DESCRIPTION
The 302 redirect for AMP to non-AMP cannot be cached and can also not transfer value properly for Google. Changing to a 301 fixes this.