### PR TITLE
Require `$sanitizer_classes` to be an array

### DIFF
--- a/includes/class-amp-content.php
+++ b/includes/class-amp-content.php
@@ -92,7 +92,7 @@ class AMP_Content {
 }
 
 class AMP_Content_Sanitizer {
-	public static function sanitize( $content, $sanitizer_classes, $global_args = array() ) {
+	public static function sanitize( $content, array $sanitizer_classes, $global_args = array() ) {
 		$scripts = array();
 		$styles = array();
 		$dom = AMP_DOM_Utils::get_dom_from_content( $content );


### PR DESCRIPTION
Require `$sanitizer_classes` to be an array because we use it in `foreach()`.

Fixes #788