### PR TITLE
Move AMP initialization logic into after_setup_theme, conditioned on amp_is_enabled filter

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -99,7 +99,6 @@ function amp_init() {
 
 	load_plugin_textdomain( 'amp', false, plugin_basename( AMP__DIR__ ) . '/languages' );
 
-	amp_after_setup_theme();
 	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
 
 	add_filter( 'request', 'amp_force_query_var_value' );
@@ -199,6 +198,13 @@ function amp_render_post( $post ) {
 
 	amp_load_classes();
 
+	/**
+	 * Fires before rendering a post in AMP.
+	 *
+	 * @since 0.2
+	 *
+	 * @param int $post_id Post ID.
+	 */
 	do_action( 'pre_amp_render_post', $post_id );
 
 	amp_add_post_template_actions();

--- a/amp.php
+++ b/amp.php
@@ -30,6 +30,7 @@ require_once AMP__DIR__ . '/includes/actions/class-amp-paired-post-actions.php';
 
 register_activation_hook( __FILE__, 'amp_activate' );
 function amp_activate() {
+	amp_after_setup_theme();
 	if ( ! did_action( 'amp_init' ) ) {
 		amp_init();
 	}
@@ -50,19 +51,55 @@ function amp_deactivate() {
 	flush_rewrite_rules();
 }
 
-AMP_Post_Type_Support::init();
-
-add_action( 'init', 'amp_init' );
-function amp_init() {
+/**
+ * Set up AMP.
+ *
+ * This function must be invoked through the 'after_setup_theme' action to allow
+ * the AMP setting to declare the post types support earlier than plugins/theme.
+ *
+ * @since 0.6
+ */
+function amp_after_setup_theme() {
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
 		return;
 	}
 
+	if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+		/**
+		 * Filter the AMP query variable.
+		 *
+		 * @since 0.3.2
+		 * @param string $query_var The AMP query variable.
+		 */
+		define( 'AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp' ) );
+	}
+
+	add_action( 'init', 'amp_init' );
+	add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
+	add_filter( 'amp_post_template_analytics', 'amp_add_custom_analytics' );
+	add_action( 'wp_loaded', 'amp_post_meta_box' );
+	add_action( 'wp_loaded', 'amp_add_options_menu' );
+	AMP_Post_Type_Support::add_post_type_support();
+}
+add_action( 'after_setup_theme', 'amp_after_setup_theme', 5 );
+
+/**
+ * Init AMP.
+ *
+ * @since 0.1
+ */
+function amp_init() {
+
+	/**
+	 * Triggers on init when AMP plugin is active.
+	 *
+	 * @since 0.3
+	 */
 	do_action( 'amp_init' );
 
 	load_plugin_textdomain( 'amp', false, plugin_basename( AMP__DIR__ ) . '/languages' );
 
-	amp_define_query_var();
+	amp_after_setup_theme();
 	add_rewrite_endpoint( AMP_QUERY_VAR, EP_PERMALINK );
 
 	add_filter( 'request', 'amp_force_query_var_value' );
@@ -75,29 +112,6 @@ function amp_init() {
 		require_once( AMP__DIR__ . '/jetpack-helper.php' );
 	}
 }
-
-/**
- * Define AMP query var.
- *
- * This function must be invoked through the 'after_setup_theme' action to allow
- * the AMP setting to declare the post types support earlier than plugins/theme.
- *
- * @since 0.6
- */
-function amp_define_query_var() {
-	if ( defined( 'AMP_QUERY_VAR' ) ) {
-		return;
-	}
-
-	/**
-	 * Filter the AMP query variable.
-	 *
-	 * @since 0.3.2
-	 * @param string $query_var The AMP query variable.
-	 */
-	define( 'AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp' ) );
-}
-add_action( 'after_setup_theme', 'amp_define_query_var', 3 );
 
 // Make sure the `amp` query var has an explicit value.
 // Avoids issues when filtering the deprecated `query_string` hook.
@@ -159,10 +173,12 @@ function amp_prepare_render() {
  * @since 0.1
  */
 function amp_render() {
-
 	// Note that queried object is used instead of the ID so that the_preview for the queried post can apply.
-	amp_render_post( get_queried_object() );
-	exit;
+	$post = get_queried_object();
+	if ( $post instanceof WP_Post ) {
+		amp_render_post( $post );
+		exit;
+	}
 }
 
 /**

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -6,8 +6,6 @@ require_once AMP__DIR__ . '/includes/options/views/class-amp-options-manager.php
 
 define( 'AMP_CUSTOMIZER_QUERY_VAR', 'customize_amp' );
 
-add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
-
 /**
  * Sets up the AMP template editor for the Customizer.
  */
@@ -104,7 +102,6 @@ function amp_add_options_menu() {
 	$amp_options = new AMP_Options_Menu();
 	$amp_options->init();
 }
-add_action( 'wp_loaded', 'amp_add_options_menu' );
 
 function amp_add_custom_analytics( $analytics ) {
 	$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
@@ -123,7 +120,6 @@ function amp_add_custom_analytics( $analytics ) {
 
 	return $analytics;
 }
-add_filter( 'amp_post_template_analytics', 'amp_add_custom_analytics' );
 
 /**
  * Bootstrap AMP post meta box.
@@ -136,4 +132,3 @@ function amp_post_meta_box() {
 	$post_meta_box = new AMP_Post_Meta_Box();
 	$post_meta_box->init();
 }
-add_action( 'wp_loaded', 'amp_post_meta_box' );

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -12,13 +12,6 @@
 class AMP_Post_Type_Support {
 
 	/**
-	 * Add hooks.
-	 */
-	public static function init() {
-		add_action( 'after_setup_theme', array( __CLASS__, 'add_post_type_support' ), 5 );
-	}
-
-	/**
 	 * Get post types that plugin supports out of the box (which cannot be disabled).
 	 *
 	 * @return string[] Post types.

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -23,16 +23,6 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_hooks().
-	 *
-	 * @covers AMP_Post_Type_Support::init()
-	 */
-	public function test_init() {
-		AMP_Post_Type_Support::init();
-		$this->assertEquals( 5, has_action( 'after_setup_theme', array( 'AMP_Post_Type_Support', 'add_post_type_support' ) ) );
-	}
-
-	/**
 	 * Test get_builtin_supported_post_types.
 	 *
 	 * @covers AMP_Post_Type_Support::get_builtin_supported_post_types()


### PR DESCRIPTION
Move AMP initialization logic to `after_setup_theme` to only run if `amp_is_enabled` filter applies as `true`.

Amends #813.
See #709.