### PR TITLE
Issue 848: Allow theme support of canonical AMP

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/automattic/amp-wp
  * Author: Automattic
  * Author URI: https://automattic.com
- * Version: 0.6-alpha
+ * Version: 0.7-alpha
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -15,7 +15,7 @@
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '0.6-alpha' );
+define( 'AMP__VERSION', '0.7-alpha' );
 
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();

--- a/amp.php
+++ b/amp.php
@@ -127,7 +127,7 @@ function amp_force_query_var_value( $query_vars ) {
  * @return void
  */
 function amp_maybe_add_actions() {
-	if ( ! is_singular() || is_feed() ) {
+	if ( amp_is_canonical() || ! is_singular() || is_feed() ) {
 		return;
 	}
 
@@ -137,7 +137,7 @@ function amp_maybe_add_actions() {
 	global $wp_query;
 	$post = $wp_query->post;
 
-	$supports = post_supports_amp( $post ) && ! amp_is_canonical();
+	$supports = post_supports_amp( $post );
 
 	if ( ! $supports ) {
 		if ( $is_amp_endpoint ) {

--- a/amp.php
+++ b/amp.php
@@ -117,6 +117,15 @@ function amp_force_query_var_value( $query_vars ) {
 	return $query_vars;
 }
 
+/**
+ * Conditionally add AMP actions or render the 'paired mode' template(s).
+ *
+ * If the request is for an AMP page and this is in 'canonical mode,'
+ * redirect to the non-AMP page.
+ * It won't need this plugin's template system, nor the frontend actions like the 'rel' link.
+ *
+ * @return void.
+ */
 function amp_maybe_add_actions() {
 	if ( ! is_singular() || is_feed() ) {
 		return;
@@ -128,7 +137,7 @@ function amp_maybe_add_actions() {
 	global $wp_query;
 	$post = $wp_query->post;
 
-	$supports = post_supports_amp( $post );
+	$supports = post_supports_amp( $post ) && ! amp_is_canonical();
 
 	if ( ! $supports ) {
 		if ( $is_amp_endpoint ) {
@@ -143,6 +152,22 @@ function amp_maybe_add_actions() {
 	} else {
 		amp_add_frontend_actions();
 	}
+}
+
+/**
+ * Whether this is in 'canonical mode.'
+ *
+ * Themes can register support for this with add_theme_support( 'amp' ).
+ * Then, this will change the plugin from 'paired mode,' and it won't use its own templates.
+ * Nor output frontend markup like the 'rel' link.
+ * If the theme registers support for AMP with:
+ * add_theme_support( 'amp', array( 'template_path' => get_template_directory() . 'my-amp-templates/' ) )
+ * it will retain 'paired mode.'
+ *
+ * @return boolean $is_canonical Whether this is in AMP 'canonical mode'.
+ */
+function amp_is_canonical() {
+	return ( true === get_theme_support( 'amp' ) );
 }
 
 function amp_load_classes() {
@@ -225,10 +250,16 @@ function amp_render_post( $post ) {
 /**
  * Bootstraps the AMP customizer.
  *
+ * Uses the priority of 12 for the 'after_setup_theme' action.
+ * Many themes run add_theme_support() on the 'after_setup_theme' hook, at the default priority of 10.
+ * And that function's documentation suggests adding it to that action.
+ * So this enables themes to add_theme_support( 'amp' ).
+ * And amp_init_customizer() will be able to recognize theme support by calling amp_is_canonical().
+ *
  * @since 0.4
  */
 function _amp_bootstrap_customizer() {
-	add_action( 'after_setup_theme', 'amp_init_customizer' );
+	add_action( 'after_setup_theme', 'amp_init_customizer', 12 );
 }
 add_action( 'plugins_loaded', '_amp_bootstrap_customizer', 9 ); // Should be hooked before priority 10 on 'plugins_loaded' to properly unhook core panels.
 

--- a/amp.php
+++ b/amp.php
@@ -120,11 +120,11 @@ function amp_force_query_var_value( $query_vars ) {
 /**
  * Conditionally add AMP actions or render the 'paired mode' template(s).
  *
- * If the request is for an AMP page and this is in 'canonical mode,'
- * redirect to the non-AMP page.
+ * If the request is for an AMP page and this is in 'canonical mode,' redirect to the non-AMP page.
  * It won't need this plugin's template system, nor the frontend actions like the 'rel' link.
  *
- * @return void.
+ * @since 0.2
+ * @return void
  */
 function amp_maybe_add_actions() {
 	if ( ! is_singular() || is_feed() ) {
@@ -157,17 +157,26 @@ function amp_maybe_add_actions() {
 /**
  * Whether this is in 'canonical mode.'
  *
- * Themes can register support for this with add_theme_support( 'amp' ).
+ * Themes can register support for this with `add_theme_support( 'amp' )`.
  * Then, this will change the plugin from 'paired mode,' and it won't use its own templates.
- * Nor output frontend markup like the 'rel' link.
- * If the theme registers support for AMP with:
- * add_theme_support( 'amp', array( 'template_path' => get_template_directory() . 'my-amp-templates/' ) )
- * it will retain 'paired mode.'
+ * Nor output frontend markup like the 'rel' link. If the theme registers support for AMP with:
+ * `add_theme_support( 'amp', array( 'template_path' => get_template_directory() . 'my-amp-templates/' ) )`
+ * it will retain 'paired mode.
  *
- * @return boolean $is_canonical Whether this is in AMP 'canonical mode'.
+ * @return boolean Whether this is in AMP 'canonical mode'.
  */
 function amp_is_canonical() {
-	return ( true === get_theme_support( 'amp' ) );
+	$support = get_theme_support( 'amp' );
+	if ( true === $support ) {
+		return true;
+	}
+	if ( is_array( $support ) ) {
+		$args = array_shift( $support );
+		if ( empty( $args['template_path'] ) ) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function amp_load_classes() {
@@ -251,10 +260,10 @@ function amp_render_post( $post ) {
  * Bootstraps the AMP customizer.
  *
  * Uses the priority of 12 for the 'after_setup_theme' action.
- * Many themes run add_theme_support() on the 'after_setup_theme' hook, at the default priority of 10.
+ * Many themes run `add_theme_support()` on the 'after_setup_theme' hook, at the default priority of 10.
  * And that function's documentation suggests adding it to that action.
- * So this enables themes to add_theme_support( 'amp' ).
- * And amp_init_customizer() will be able to recognize theme support by calling amp_is_canonical().
+ * So this enables themes to `add_theme_support( 'amp' )`.
+ * And `amp_init_customizer()` will be able to recognize theme support by calling `amp_is_canonical()`.
  *
  * @since 0.4
  */

--- a/assets/js/amp-post-meta-box.js
+++ b/assets/js/amp-post-meta-box.js
@@ -18,6 +18,7 @@ var ampPostMetaBox = ( function( $ ) {
 		 * @since 0.6
 		 */
 		data: {
+			canonical: false,
 			previewLink: '',
 			disabled: false,
 			statusInputName: '',
@@ -58,7 +59,7 @@ var ampPostMetaBox = ( function( $ ) {
 	component.boot = function boot( data ) {
 		component.data = data;
 		$( document ).ready( function() {
-			if ( ! component.data.disabled ) {
+			if ( ! component.data.disabled && ! component.data.canonical ) {
 				component.addPreviewButton();
 			}
 			component.listen();

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,5 @@
     "homepage": "https://github.com/Automattic/amp-wp",
     "type": "wordpress-plugin",
     "license": "GPL-2.0",
-    "version": "0.6.0"
+    "version": "0.7.0"
 }

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -99,8 +99,6 @@ class AMP_Post_Meta_Box {
 			isset( $screen->base )
 			&&
 			'post' === $screen->base
-			&&
-			! amp_is_canonical()
 		);
 		if ( ! $validate ) {
 			return;
@@ -124,6 +122,7 @@ class AMP_Post_Meta_Box {
 		wp_add_inline_script( self::ASSETS_HANDLE, sprintf( 'ampPostMetaBox.boot( %s );',
 			wp_json_encode( array(
 				'previewLink'     => esc_url_raw( add_query_arg( AMP_QUERY_VAR, '', get_preview_post_link( $post ) ) ),
+				'canonical'       => amp_is_canonical(),
 				'disabled'        => (bool) get_post_meta( $post->ID, self::DISABLED_POST_META_KEY, true ) || ! $this->is_amp_available( $post ),
 				'statusInputName' => self::STATUS_INPUT_NAME,
 				'l10n'            => array(

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -99,6 +99,8 @@ class AMP_Post_Meta_Box {
 			isset( $screen->base )
 			&&
 			'post' === $screen->base
+			&&
+			! amp_is_canonical()
 		);
 		if ( ! $validate ) {
 			return;
@@ -142,6 +144,8 @@ class AMP_Post_Meta_Box {
 			isset( $post->ID )
 			&&
 			current_user_can( 'edit_post', $post->ID )
+			&&
+			! amp_is_canonical()
 		);
 
 		if ( true !== $verify ) {

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -15,8 +15,16 @@ define( 'AMP_CUSTOMIZER_QUERY_VAR', 'customize_amp' );
 
 /**
  * Sets up the AMP template editor for the Customizer.
+ *
+ * If this is in AMP canonical mode, exit.
+ * There's no need for the 'AMP' Customizer panel,
+ * And this does not need to toggle between the AMP and normal display.
  */
 function amp_init_customizer() {
+	if ( amp_is_canonical() ) {
+		return;
+	}
+
 	// Fire up the AMP Customizer.
 	add_action( 'customize_register', array( 'AMP_Template_Customizer', 'init' ), 500 );
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -84,7 +84,7 @@ class AMP_Options_Menu {
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
 				<?php
 				$element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}";
-				$is_builtin = in_array( $post_type->name, $builtin_support, true );
+				$is_builtin = amp_is_canonical() || in_array( $post_type->name, $builtin_support, true );
 				?>
 				<?php if ( $is_builtin ) : ?>
 					<input type="hidden" name="<?php echo esc_attr( $element_name ); ?>" value="<?php echo esc_attr( $post_type->name ); ?>">
@@ -94,7 +94,7 @@ class AMP_Options_Menu {
 					id="<?php echo esc_attr( $element_id ); ?>"
 					name="<?php echo esc_attr( $element_name ); ?>"
 					value="<?php echo esc_attr( $post_type->name ); ?>"
-					<?php checked( true, post_type_supports( $post_type->name, AMP_QUERY_VAR ) ); ?>
+					<?php checked( true, amp_is_canonical() || post_type_supports( $post_type->name, AMP_QUERY_VAR ) ); ?>
 					<?php disabled( $is_builtin ); ?>
 					>
 				<label for="<?php echo esc_attr( $element_id ); ?>">
@@ -102,7 +102,15 @@ class AMP_Options_Menu {
 				</label>
 				<br>
 			<?php endforeach; ?>
-			<p class="description"><?php esc_html_e( 'Enable/disable AMP post type(s) support', 'amp' ); ?></p>
+			<p class="description">
+				<?php
+				if ( ! amp_is_canonical() ) :
+					esc_html_e( 'Enable/disable AMP post type(s) support', 'amp' );
+				else :
+					esc_html_e( 'Canonical AMP is enabled in your theme, so all post types will render.', 'amp' );
+				endif;
+			?>
+			</p>
 		</fieldset>
 		<?php
 	}
@@ -124,7 +132,9 @@ class AMP_Options_Menu {
 				<?php
 				settings_fields( AMP_Options_Manager::OPTION_NAME );
 				do_settings_sections( AMP_Options_Manager::OPTION_NAME );
-				submit_button();
+				if ( ! amp_is_canonical() ) {
+					submit_button();
+				}
 				?>
 			</form>
 		</div>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "git",
   "url": "https://github.com/Automattic/amp-wp.git"
  },
- "version": "0.6.0",
+ "version": "0.7.0",
  "license": "GPL-2.0+",
  "private": true,
  "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,9 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 
 ## Changelog ##
 
+### 0.7 (unreleased) ###
+- Add support for canonical AMP.
+
 ### 0.6 (unreleased) ###
 - Add: support for the "page" post type, except when used as homepage or page for posts. A new `page.php` is introduced with template parts factored out (`html-start.php`, `header.php`, `footer.php`, `html-end.php`) and re-used from `single.php`. Note that AMP URLs will end in `?amp` instead of `/amp/`. See [#825](https://github.com/Automattic/amp-wp/pull/825). Props technosailor, ThierryA, westonruter.
 - Add: AMP post preview button alongside non-AMP preview button. See [#813](https://github.com/Automattic/amp-wp/pull/813). Props ThierryA, westonruter.

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 
 == Changelog ==
 
+= 0.7 (unreleased) =
+
+- Add support for canonical AMP.
+
 = 0.6 (unreleased) =
 
 - Add: support for the "page" post type, except when used as homepage or page for posts. A new `page.php` is introduced with template parts factored out (`html-start.php`, `header.php`, `footer.php`, `html-end.php`) and re-used from `single.php`. Note that AMP URLs will end in `?amp` instead of `/amp/`. See [#825](https://github.com/Automattic/amp-wp/pull/825). Props technosailor, ThierryA, westonruter.

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -11,22 +11,29 @@
 class Test_AMP extends WP_UnitTestCase {
 
 	/**
-	 * Test amp_is_canonical().
-	 *
-	 * @see amp_is_canonical()
+	 * Tear down and clean up.
 	 */
-	public function test_amp_is_canonical() {
-		global $_wp_theme_features;
-		$this->assertFalse( amp_is_canonical() );
-
-		$_wp_theme_features['amp'] = true;
-		$this->assertTrue( amp_is_canonical() );
-
-		$_wp_theme_features['amp'] = array(
-			'template_path' => get_template_directory() . 'amp-templates/',
-		);
-		$this->assertFalse( amp_is_canonical() );
-		unset( $_wp_theme_features['amp'] );
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
 	}
 
+	/**
+	 * Test amp_is_canonical().
+	 *
+	 * @covers amp_is_canonical()
+	 */
+	public function test_amp_is_canonical() {
+		remove_theme_support( 'amp' );
+		$this->assertFalse( amp_is_canonical() );
+
+		add_theme_support( 'amp' );
+		$this->assertTrue( amp_is_canonical() );
+
+		remove_theme_support( 'amp' );
+		add_theme_support( 'amp', array(
+			'template_path' => get_template_directory() . 'amp-templates/',
+		) );
+		$this->assertFalse( amp_is_canonical() );
+	}
 }

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -35,5 +35,11 @@ class Test_AMP extends WP_UnitTestCase {
 			'template_path' => get_template_directory() . 'amp-templates/',
 		) );
 		$this->assertFalse( amp_is_canonical() );
+
+		remove_theme_support( 'amp' );
+		add_theme_support( 'amp', array(
+			'custom_prop' => 'something',
+		) );
+		$this->assertTrue( amp_is_canonical() );
 	}
 }

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for amp.php.
+ *
+ * @package AMP
+ */
+
+/**
+ * Tests for amp.php.
+ */
+class Test_AMP extends WP_UnitTestCase {
+
+	/**
+	 * Test amp_is_canonical().
+	 *
+	 * @see amp_is_canonical()
+	 */
+	public function test_amp_is_canonical() {
+		global $_wp_theme_features;
+		$this->assertFalse( amp_is_canonical() );
+
+		$_wp_theme_features['amp'] = true;
+		$this->assertTrue( amp_is_canonical() );
+
+		$_wp_theme_features['amp'] = array(
+			'template_path' => get_template_directory() . 'amp-templates/',
+		);
+		$this->assertFalse( amp_is_canonical() );
+		unset( $_wp_theme_features['amp'] );
+	}
+
+}

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -55,15 +55,6 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$post            = self::factory()->post->create_and_get();
 		$GLOBALS['post'] = $post;
 		set_current_screen( 'post.php' );
-		$GLOBALS['_wp_theme_features']['amp'] = true;
-		$this->instance->enqueue_admin_assets();
-
-		// AMP is in 'canonical mode,' so these assets shouldn't be enqueued.
-		$this->assertFalse( wp_style_is( AMP_Post_Meta_Box::ASSETS_HANDLE ) );
-		$this->assertFalse( wp_script_is( AMP_Post_Meta_Box::ASSETS_HANDLE ) );
-
-		// AMP is not 'canonical mode'.
-		unset( $GLOBALS['_wp_theme_features']['amp'] );
 		$this->instance->enqueue_admin_assets();
 		$this->assertTrue( wp_style_is( AMP_Post_Meta_Box::ASSETS_HANDLE ) );
 		$this->assertTrue( wp_script_is( AMP_Post_Meta_Box::ASSETS_HANDLE ) );

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -91,13 +91,13 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$amp_status_markup = '<div class="misc-pub-section misc-amp-status"';
 
 		// This is in AMP 'canonical mode,' so it shouldn't have the AMP status.
-		$GLOBALS['_wp_theme_features']['amp'] = true;
+		add_theme_support( 'amp' );
 		ob_start();
 		$this->instance->render_status( $post );
 		$this->assertNotContains( $amp_status_markup, ob_get_clean() );
 
 		// This is not in AMP 'canonical mode'.
-		unset( $GLOBALS['_wp_theme_features']['amp'] );
+		remove_theme_support( 'amp' );
 		ob_start();
 		$this->instance->render_status( $post );
 		$this->assertContains( $amp_status_markup, ob_get_clean() );


### PR DESCRIPTION
**Request For Review**

Hi @ThierryA or @westonruter,
Could you please review this pull request for Issue #848?

If the theme runs `add_theme_support( 'amp' )` without any other arguments, the plugin will be in 'canonical mode.' The theme will still use its own template(s).

But if any other argumnents are passed to `add_theme_support( 'amp' )`, it will retain 'paired mode.' That case is in #849.

When in 'canonical mode':
* There's no Customizer 'AMP' panel
* There's no AMP 'rel' link
* The plugin doesn't use its template system
* The `post.php` page's 'Publish' meta box doesn't have the AMP preview link, nor the "AMP: Enabled" section:
<img width="1392" alt="removed-in-canonical" src="https://user-images.githubusercontent.com/4063887/34789963-f15b6e8c-f61e-11e7-8dfc-9f7196bf0f09.png">

Also, should we keep the 'AMP Settings' page?
<img width="1072" alt="post-type-support" src="https://user-images.githubusercontent.com/4063887/34790015-1b3ffbd2-f61f-11e7-9294-d1ceb7445653.png">

When you add or remove support for a custom post type, `amp_is_canonical()` [short-circuits this](https://github.com/Automattic/amp-wp/compare/add/848-theme-support-canonical?expand=1#diff-4805c837d3390517773926fb26726bcdR140) if it is `true`, and prevents the plugin from using its own templates and running frontend actions. 

Fixes #848.