### PR TITLE
Remove pound symbol from header id

### DIFF
--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -6,7 +6,7 @@
  */
 
 ?>
-<header id="#top" class="amp-wp-header">
+<header id="top" class="amp-wp-header">
 	<div>
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>


### PR DESCRIPTION
Removed the # symbol from <header> id. It was causing 404 errors and
prevented the "Back to top" link in the footer from working.