### PR TITLE
Add content embedding & sanitization to theme support w/ filterable component scripts and custom styles

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -108,3 +108,83 @@ function amp_print_boilerplate_code() {
 	echo '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>';
 	echo '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>';
 }
+
+/**
+ * Get content embed handlers.
+ *
+ * @since 0.7
+ *
+ * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as embeds may apply to non-post data (e.g. Text widget).
+ * @return array Embed handlers.
+ */
+function amp_get_content_embed_handlers( $post = null ) {
+	if ( current_theme_supports( 'amp' ) && $post ) {
+		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
+		$post = null;
+	}
+
+	/**
+	 * Filters the content embed handlers.
+	 *
+	 * @since 0.2
+	 * @since 0.7 Deprecated $post parameter.
+	 *
+	 * @param array   $handlers Handlers.
+	 * @param WP_Post $post     Post. Deprecated. It will be null when `amp_is_canonical()`.
+	 */
+	return apply_filters( 'amp_content_embed_handlers',
+		array(
+			'AMP_Twitter_Embed_Handler'     => array(),
+			'AMP_YouTube_Embed_Handler'     => array(),
+			'AMP_DailyMotion_Embed_Handler' => array(),
+			'AMP_Vimeo_Embed_Handler'       => array(),
+			'AMP_SoundCloud_Embed_Handler'  => array(),
+			'AMP_Instagram_Embed_Handler'   => array(),
+			'AMP_Vine_Embed_Handler'        => array(),
+			'AMP_Facebook_Embed_Handler'    => array(),
+			'AMP_Pinterest_Embed_Handler'   => array(),
+			'AMP_Gallery_Embed_Handler'     => array(),
+			'WPCOM_AMP_Polldaddy_Embed'     => array(),
+		),
+		$post
+	);
+}
+
+/**
+ * Get content sanitizers.
+ *
+ * @since 0.7
+ *
+ * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as sanitizers apply to non-post data (e.g. Text widget).
+ * @return array Embed handlers.
+ */
+function amp_get_content_sanitizers( $post = null ) {
+	if ( current_theme_supports( 'amp' ) && $post ) {
+		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
+		$post = null;
+	}
+
+	/**
+	 * Filters the content sanitizers.
+	 *
+	 * @since 0.2
+	 * @since 0.7 Deprecated $post parameter. It will be null when `amp_is_canonical()`.
+	 *
+	 * @param array   $handlers Handlers.
+	 * @param WP_Post $post     Post. Deprecated.
+	 */
+	return apply_filters( 'amp_content_sanitizers',
+		array(
+			'AMP_Style_Sanitizer'             => array(),
+			'AMP_Img_Sanitizer'               => array(),
+			'AMP_Video_Sanitizer'             => array(),
+			'AMP_Audio_Sanitizer'             => array(),
+			'AMP_Playbuzz_Sanitizer'          => array(),
+			'AMP_Iframe_Sanitizer'            => array(
+				'add_placeholder' => true,
+			),
+			'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
+		),
+		$post
+	);
+}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -114,7 +114,8 @@ function amp_print_boilerplate_code() {
  *
  * @since 0.7
  *
- * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as embeds may apply to non-post data (e.g. Text widget).
+ * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as embeds may apply
+ *                      to non-post data (e.g. Text widget).
  * @return array Embed handlers.
  */
 function amp_get_content_embed_handlers( $post = null ) {
@@ -155,7 +156,8 @@ function amp_get_content_embed_handlers( $post = null ) {
  *
  * @since 0.7
  *
- * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as sanitizers apply to non-post data (e.g. Text widget).
+ * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as sanitizers apply
+ *                      to non-post data (e.g. Text widget).
  * @return array Embed handlers.
  */
 function amp_get_content_sanitizers( $post = null ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -242,14 +242,11 @@ class AMP_Theme_Support {
 			$url = add_query_arg( $added_query_vars, $url );
 		}
 
-		if ( ! amp_is_canonical() ) {
+		// Strip endpoint.
+		$url = preg_replace( ':/' . preg_quote( AMP_QUERY_VAR, ':' ) . '(?=/?(\?|#|$)):', '', $url );
 
-			// Strip endpoint.
-			$url = preg_replace( ':/' . preg_quote( AMP_QUERY_VAR, ':' ) . '(?=/?(\?|#|$)):', '', $url );
-
-			// Strip query var.
-			$url = remove_query_arg( AMP_QUERY_VAR, $url );
-		}
+		// Strip query var.
+		$url = remove_query_arg( AMP_QUERY_VAR, $url );
 
 		return $url;
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -49,6 +49,18 @@ class AMP_Theme_Support {
 	 */
 	public static function init() {
 		require_once AMP__DIR__ . '/includes/amp-post-template-actions.php';
+
+		// Validate theme support usage.
+		$support = get_theme_support( 'amp' );
+		if ( WP_DEBUG && is_array( $support ) ) {
+			$args = array_shift( $support );
+			if ( ! is_array( $args ) ) {
+				trigger_error( esc_html__( 'Expected amp theme support arg to be array.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			} elseif ( count( array_diff( array_keys( $args ), array( 'template_dir', 'available_callback' ) ) ) !== 0 ) {
+				trigger_error( esc_html__( 'Expected amp theme support to only have template_dir and/or available_callback.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			}
+		}
+
 		if ( amp_is_canonical() ) {
 
 			// Permanently redirect to canonical URL if the AMP URL was loaded, since canonical is now AMP.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -90,9 +90,9 @@ class AMP_Theme_Support {
 		if ( WP_DEBUG && is_array( $support ) ) {
 			$args = array_shift( $support );
 			if ( ! is_array( $args ) ) {
-				trigger_error( esc_html__( 'Expected amp theme support arg to be array.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error( esc_html__( 'Expected AMP theme support arg to be array.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			} elseif ( count( array_diff( array_keys( $args ), array( 'template_dir', 'available_callback' ) ) ) !== 0 ) {
-				trigger_error( esc_html__( 'Expected amp theme support to only have template_dir and/or available_callback.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error( esc_html__( 'Expected AMP theme support to only have template_dir and/or available_callback.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			}
 		}
 
@@ -159,7 +159,10 @@ class AMP_Theme_Support {
 		remove_action( 'wp_footer', 'wp_print_footer_scripts', 20 );
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
-		// Replace core's canonical link functionality with one that outputs links for non-singular queries as well. See WP Core #18660.
+		/*
+		 * Replace core's canonical link functionality with one that outputs links for non-singular queries as well.
+		 * See WP Core #18660.
+		 */
 		remove_action( 'wp_head', 'rel_canonical' );
 		add_action( 'wp_head', array( __CLASS__, 'add_canonical_link' ), 1 );
 
@@ -178,7 +181,10 @@ class AMP_Theme_Support {
 		 */
 		add_filter( 'show_admin_bar', '__return_false', 100 );
 
-		// Start output buffering at very low priority for sake of plugins and themes that use template_redirect instead of template_include.
+		/*
+		 * Start output buffering at very low priority for sake of plugins and themes that use template_redirect
+		 * instead of template_include.
+		 */
 		add_action( 'template_redirect', array( __CLASS__, 'start_output_buffering' ), 0 );
 
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), PHP_INT_MAX );
@@ -467,7 +473,8 @@ class AMP_Theme_Support {
 		/**
 		 * Filters AMP component scripts before they are injected onto the output buffer for the response.
 		 *
-		 * Plugins may add their own component scripts which have been rendered but which the plugin doesn't yet recognize.
+		 * Plugins may add their own component scripts which have been rendered but which the plugin doesn't yet
+		 * recognize.
 		 *
 		 * @since 0.7
 		 *

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -390,7 +390,6 @@ class AMP_Theme_Support {
 		// @todo Print contents of get_locale_stylesheet_uri()?
 		$path = get_template_directory() . '/style.css'; // @todo Honor filter in get_stylesheet_directory_uri()? Style must be local.
 		$css  = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions -- It's not a remote file.
-		echo wp_strip_all_tags( $css ); // WPCS: XSS OK.
 
 		// Add styles gleaned from sanitizers.
 		foreach ( self::$amp_styles as $selector => $properties ) {
@@ -465,7 +464,7 @@ class AMP_Theme_Support {
 		}
 
 		foreach ( $amp_components as $component => $props ) {
-			if ( preg_match( '#<(form|input)\b#i', $html ) ) {
+			if ( preg_match( $props['pattern'], $html ) ) {
 				$amp_scripts[ $component ] = $props['source'];
 			}
 		}

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -355,34 +355,8 @@ class AMP_Post_Template {
 	private function build_post_content() {
 		$amp_content = new AMP_Content(
 			$this->post->post_content,
-			apply_filters(
-				'amp_content_embed_handlers', array(
-					'AMP_Twitter_Embed_Handler'     => array(),
-					'AMP_YouTube_Embed_Handler'     => array(),
-					'AMP_DailyMotion_Embed_Handler' => array(),
-					'AMP_Vimeo_Embed_Handler'       => array(),
-					'AMP_SoundCloud_Embed_Handler'  => array(),
-					'AMP_Instagram_Embed_Handler'   => array(),
-					'AMP_Vine_Embed_Handler'        => array(),
-					'AMP_Facebook_Embed_Handler'    => array(),
-					'AMP_Pinterest_Embed_Handler'   => array(),
-					'AMP_Gallery_Embed_Handler'     => array(),
-					'WPCOM_AMP_Polldaddy_Embed'     => array(),
-				), $this->post
-			),
-			apply_filters(
-				'amp_content_sanitizers', array(
-					'AMP_Style_Sanitizer'             => array(),
-					'AMP_Img_Sanitizer'               => array(),
-					'AMP_Video_Sanitizer'             => array(),
-					'AMP_Audio_Sanitizer'             => array(),
-					'AMP_Playbuzz_Sanitizer'          => array(),
-					'AMP_Iframe_Sanitizer'            => array(
-						'add_placeholder' => true,
-					),
-					'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
-				), $this->post
-			),
+			amp_get_content_embed_handlers( $this->post ),
+			amp_get_content_sanitizers( $this->post ),
 			array(
 				'content_max_width' => $this->get( 'content_max_width' ),
 			)

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -32,10 +32,15 @@ class AMP_DOM_Utils {
 		 * Wrap in dummy tags, since XML needs one parent node.
 		 * It also makes it easier to loop through nodes.
 		 * We can later use this to extract our nodes.
-		 * Add utf-8 charset so loadHTML does not have problems parsing it.
-		 * See: http://php.net/manual/en/domdocument.loadhtml.php#78243
+		 * Add charset so loadHTML does not have problems parsing it.
 		 */
-		$result = $dom->loadHTML( '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>' . $content . '</body></html>' );
+		$result = $dom->loadHTML(
+			sprintf(
+				'<html><head><meta http-equiv="content-type" content="text/html; charset=%s"></head><body>%s</body></html>',
+				get_bloginfo( 'charset' ),
+				$content
+			)
+		);
 
 		libxml_clear_errors();
 		libxml_use_internal_errors( $libxml_previous_state );

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -11,6 +11,14 @@
 class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		remove_theme_support( 'amp' );
+		parent::tearDown();
+	}
+
+	/**
 	 * Filter for amp_pre_get_permalink and amp_get_permalink.
 	 *
 	 * @param string $url     URL.
@@ -101,5 +109,104 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		remove_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10 );
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_get_permalink', $url );
+	}
+
+	/**
+	 * Filter calls.
+	 *
+	 * @var array
+	 */
+	protected $last_filter_call;
+
+	/**
+	 * Capture filter call.
+	 *
+	 * @param mixed $value Value.
+	 * @return mixed Value.
+	 */
+	public function capture_filter_call( $value ) {
+		$this->last_filter_call = array(
+			'current_filter' => current_filter(),
+			'args'           => func_get_args(),
+		);
+		return $value;
+	}
+
+	/**
+	 * Test amp_get_content_embed_handlers().
+	 *
+	 * @covers amp_get_content_embed_handlers()
+	 */
+	public function test_amp_get_content_embed_handlers() {
+		$post = $this->factory()->post->create_and_get();
+		add_filter( 'amp_content_embed_handlers', array( $this, 'capture_filter_call' ), 10, 2 );
+
+		$this->last_filter_call = null;
+		add_theme_support( 'amp' );
+		$handlers = amp_get_content_embed_handlers();
+		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
+		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
+		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
+		$this->assertNull( $this->last_filter_call['args'][1] );
+
+		$this->last_filter_call = null;
+		remove_theme_support( 'amp' );
+		$handlers = amp_get_content_embed_handlers( $post );
+		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
+		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
+		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
+		$this->assertEquals( $post, $this->last_filter_call['args'][1] );
+	}
+
+	/**
+	 * Test deprecated $post param for amp_get_content_embed_handlers().
+	 *
+	 * @covers amp_get_content_embed_handlers()
+	 */
+	public function test_amp_get_content_embed_handlers_deprecated_param() {
+		$post = $this->factory()->post->create_and_get();
+		$this->setExpectedDeprecated( 'amp_get_content_embed_handlers' );
+		add_theme_support( 'amp' );
+		amp_get_content_embed_handlers( $post );
+	}
+
+	/**
+	 * Test amp_get_content_sanitizers().
+	 *
+	 * @covers amp_get_content_sanitizers()
+	 */
+	public function test_amp_get_content_sanitizers() {
+		$post = $this->factory()->post->create_and_get();
+		add_filter( 'amp_content_sanitizers', array( $this, 'capture_filter_call' ), 10, 2 );
+
+		$this->last_filter_call = null;
+		add_theme_support( 'amp' );
+		$handlers = amp_get_content_sanitizers();
+		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
+		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
+		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
+		$handler_classes = array_keys( $handlers );
+		$this->assertNull( $this->last_filter_call['args'][1] );
+		$this->assertEquals( 'AMP_Tag_And_Attribute_Sanitizer', end( $handler_classes ) );
+
+		$this->last_filter_call = null;
+		remove_theme_support( 'amp' );
+		$handlers = amp_get_content_sanitizers( $post );
+		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
+		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
+		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
+		$this->assertEquals( $post, $this->last_filter_call['args'][1] );
+	}
+
+	/**
+	 * Test deprecated $post param for amp_get_content_sanitizers().
+	 *
+	 * @covers amp_get_content_sanitizers()
+	 */
+	public function test_amp_get_content_sanitizers_deprecated_param() {
+		$post = $this->factory()->post->create_and_get();
+		$this->setExpectedDeprecated( 'amp_get_content_sanitizers' );
+		add_theme_support( 'amp' );
+		amp_get_content_sanitizers( $post );
 	}
 }


### PR DESCRIPTION
* Creates new helper functions for `amp_get_content_embed_handlers()` and `amp_get_content_sanitizers()` which are used now in both the plugin's paired mode post templates as well as when theme support is present. The `$post` argument is not passed to the `amp_content_embed_handlers` and `amp_content_sanitizers` filters when theme support is present since the content being sanitized/embedded may not be a post at all, e.g. a Text widget.
* It is intended that soon the `\AMP_Theme_Support::filter_the_content()` method could be expanded to also apply to widget output.
* Scripts and styles that are gathered during embedding and sanitizing are now injected into the `head` once output buffering is finalized.
* Scripts and styles which are injected into the head can be filtered via `amp_component_scripts` and `amp_custom_styles`. The former should normally not be needed because the plugin should be able to detect all component scripts required. The styles filter will be useful when a theme, plugin, widget, etc wants to add additional styles, such as for the Recent Comments widget (cf. https://github.com/xwp/ampconf/issues/28).
* When `WP_DEBUG` is on, validation is performed on the `amp` theme support args, warning the user if any unrecognized args were provided.
* The `\AMP_DOM_Utils::get_dom_from_content()` method has been updated to parse HTML with the actual `blog_charset`. This is important for eventually supporting non-UTF8 sites. See #855.
