### PR TITLE
Improved page default status logic and add overwrite ability; ensure front page and page for posts can be served as AMP when enabled

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -158,20 +158,27 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
 	}
 }
 
+/**
+ * Add AMP actions when the request can be served as AMP.
+ *
+ * Actions will only be added if the request is for a singular post (including front page and page for posts), excluding feeds.
+ *
+ * @since 0.2
+ */
 function amp_maybe_add_actions() {
-	if ( ! is_singular() || is_feed() ) {
+	global $wp_query;
+	if ( ! ( is_singular() || $wp_query->is_posts_page ) || is_feed() ) {
 		return;
 	}
-
 	$is_amp_endpoint = is_amp_endpoint();
 
-	// Cannot use `get_queried_object` before canonical redirect; see https://core.trac.wordpress.org/ticket/35344
-	global $wp_query;
-	$post = $wp_query->post;
-
-	$supports = post_supports_amp( $post );
-
-	if ( ! $supports ) {
+	/**
+	 * Queried post object.
+	 *
+	 * @var WP_Post $post
+	 */
+	$post = get_queried_object();
+	if ( ! post_supports_amp( $post ) ) {
 		if ( $is_amp_endpoint ) {
 			wp_safe_redirect( get_permalink( $post->ID ), 301 );
 			exit;

--- a/amp.php
+++ b/amp.php
@@ -75,6 +75,7 @@ function amp_after_setup_theme() {
 	add_filter( 'amp_post_template_analytics', 'amp_add_custom_analytics' );
 	add_action( 'wp_loaded', 'amp_post_meta_box' );
 	add_action( 'wp_loaded', 'amp_add_options_menu' );
+	add_action( 'parse_query', 'amp_correct_query_when_is_front_page' );
 	AMP_Post_Type_Support::add_post_type_support();
 }
 add_action( 'after_setup_theme', 'amp_after_setup_theme', 5 );
@@ -115,6 +116,46 @@ function amp_force_query_var_value( $query_vars ) {
 		$query_vars[ AMP_QUERY_VAR ] = 1;
 	}
 	return $query_vars;
+}
+
+/**
+ * Fix up WP_Query for front page when amp query var is present.
+ *
+ * Normally the front page would not get served if a query var is present other than preview, page, paged, and cpage.
+ *
+ * @since 0.6
+ * @see WP_Query::parse_query()
+ * @link https://github.com/WordPress/wordpress-develop/blob/0baa8ae85c670d338e78e408f8d6e301c6410c86/src/wp-includes/class-wp-query.php#L951-L971
+ *
+ * @param WP_Query $query Query.
+ */
+function amp_correct_query_when_is_front_page( WP_Query $query ) {
+	$is_front_page_query = (
+		$query->is_main_query()
+		&&
+		$query->is_home()
+		&&
+		// Is AMP endpoint.
+		false !== $query->get( AMP_QUERY_VAR, false )
+		&&
+		// Is query not yet fixed uo up to be front page.
+		! $query->is_front_page()
+		&&
+		// Is showing pages on front.
+		'page' === get_option( 'show_on_front' )
+		&&
+		// Has page on front set.
+		get_option( 'page_on_front' )
+		&&
+		// See line in WP_Query::parse_query() at <https://github.com/WordPress/wordpress-develop/blob/0baa8ae/src/wp-includes/class-wp-query.php#L961>.
+		0 === count( array_diff( array_keys( wp_parse_args( $query->query ) ), array( AMP_QUERY_VAR, 'preview', 'page', 'paged', 'cpage' ) ) )
+	);
+	if ( $is_front_page_query ) {
+		$query->is_home     = false;
+		$query->is_page     = true;
+		$query->is_singular = true;
+		$query->set( 'page_id', get_option( 'page_on_front' ) );
+	}
 }
 
 function amp_maybe_add_actions() {

--- a/amp.php
+++ b/amp.php
@@ -180,7 +180,7 @@ function amp_maybe_add_actions() {
 	$post = get_queried_object();
 	if ( ! post_supports_amp( $post ) ) {
 		if ( $is_amp_endpoint ) {
-			wp_safe_redirect( get_permalink( $post->ID ), 301 );
+			wp_safe_redirect( get_permalink( $post->ID ), 302 ); // Temporary redirect because AMP may be supported in future.
 			exit;
 		}
 		return;

--- a/assets/js/amp-post-meta-box.js
+++ b/assets/js/amp-post-meta-box.js
@@ -19,7 +19,7 @@ var ampPostMetaBox = ( function( $ ) {
 		 */
 		data: {
 			previewLink: '',
-			disabled: false,
+			enabled: '',
 			statusInputName: '',
 			l10n: {
 				ampPreviewBtnLabel: ''
@@ -58,7 +58,7 @@ var ampPostMetaBox = ( function( $ ) {
 	component.boot = function boot( data ) {
 		component.data = data;
 		$( document ).ready( function() {
-			if ( ! component.data.disabled ) {
+			if ( component.data.enabled ) {
 				component.addPreviewButton();
 			}
 			component.listen();
@@ -161,7 +161,7 @@ var ampPostMetaBox = ( function( $ ) {
 		$container.slideToggle( component.toggleSpeed );
 
 		// Update status.
-		if ( ! component.data.disabled ) {
+		if ( component.data.enabled ) {
 			$container.data( 'amp-status', status );
 			$checked.prop( 'checked', true );
 			$( '.amp-status-text' ).text( $checked.next().text() );

--- a/assets/js/amp-post-meta-box.js
+++ b/assets/js/amp-post-meta-box.js
@@ -19,7 +19,8 @@ var ampPostMetaBox = ( function( $ ) {
 		 */
 		data: {
 			previewLink: '',
-			enabled: '',
+			enabled: true, // Overridden by post_supports_amp( $post ).
+			canSupport: true, // Overridden by count( AMP_Post_Type_Support::get_support_errors( $post ) ) === 0.
 			statusInputName: '',
 			l10n: {
 				ampPreviewBtnLabel: ''
@@ -164,7 +165,7 @@ var ampPostMetaBox = ( function( $ ) {
 		$container.slideToggle( component.toggleSpeed );
 
 		// Update status.
-		if ( component.data.enabled ) {
+		if ( component.data.canSupport ) {
 			$container.data( 'amp-status', status );
 			$checked.prop( 'checked', true );
 			$( '.amp-status-text' ).text( $checked.next().text() );

--- a/assets/js/amp-post-meta-box.js
+++ b/assets/js/amp-post-meta-box.js
@@ -58,6 +58,7 @@ var ampPostMetaBox = ( function( $ ) {
 	component.boot = function boot( data ) {
 		component.data = data;
 		$( document ).ready( function() {
+			component.statusRadioInputs = $( '[name="' + component.data.statusInputName + '"]' );
 			if ( component.data.enabled ) {
 				component.addPreviewButton();
 			}
@@ -77,8 +78,10 @@ var ampPostMetaBox = ( function( $ ) {
 			component.onAmpPreviewButtonClick();
 		} );
 
+		component.statusRadioInputs.prop( 'disabled', true ); // Prevent cementing setting default status as overridden status.
 		$( '.edit-amp-status, [href="#amp_status"]' ).click( function( e ) {
 			e.preventDefault();
+			component.statusRadioInputs.prop( 'disabled', false );
 			component.toggleAmpStatus( $( e.target ) );
 		} );
 
@@ -147,7 +150,7 @@ var ampPostMetaBox = ( function( $ ) {
 
 		// Don't modify status on cancel button click.
 		if ( ! $target.hasClass( 'button-cancel' ) ) {
-			status = $( '[name="' + component.data.statusInputName + '"]:checked' ).val();
+			status = component.statusRadioInputs.filter( ':checked' ).val();
 		}
 
 		$checked = $( '#amp-status-' + status );

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -116,6 +116,7 @@ class AMP_Post_Meta_Box {
 			wp_json_encode( array(
 				'previewLink'     => esc_url_raw( add_query_arg( AMP_QUERY_VAR, '', get_preview_post_link( $post ) ) ),
 				'enabled'         => post_supports_amp( $post ),
+				'canSupport'      => count( AMP_Post_Type_Support::get_support_errors( $post ) ) === 0,
 				'statusInputName' => self::STATUS_INPUT_NAME,
 				'l10n'            => array(
 					'ampPreviewBtnLabel' => __( 'Preview changes in AMP (opens in new window)', 'amp' ),

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -102,7 +102,7 @@ function post_supports_amp( $post ) {
 			 * @param string  $status Status.
 			 * @param WP_Post $post   Post.
 			 */
-			return apply_filters( 'amp_status_default_enabled', $enabled, $post );
+			return apply_filters( 'amp_post_status_default_enabled', $enabled, $post );
 	}
 }
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -55,7 +55,7 @@ function amp_get_permalink( $post_id ) {
  * Determine whether a given post supports AMP.
  *
  * @since 0.1
- * @since 0.6 Returns false when post has meta to disable AMP or when page is homepage or page for posts.
+ * @since 0.6 Returns false when post has meta to disable AMP.
  * @see   AMP_Post_Type_Support::get_support_errors()
  *
  * @param WP_Post $post Post.
@@ -63,7 +63,45 @@ function amp_get_permalink( $post_id ) {
  * @return bool Whether the post supports AMP.
  */
 function post_supports_amp( $post ) {
-	return 0 === count( AMP_Post_Type_Support::get_support_errors( $post ) );
+	// Return false if an error is found.
+	if ( ! empty( AMP_Post_Type_Support::get_support_errors( $post ) ) ) {
+		return false;
+	}
+
+	switch ( get_post_meta( $post->ID, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
+		case AMP_Post_Meta_Box::ENABLED_STATUS:
+			return true;
+
+		case AMP_Post_Meta_Box::DISABLED_STATUS:
+			return false;
+
+		// Disabled by default for custom page templates, page on front and page for posts.
+		default:
+			$enabled = (
+				! (bool) get_page_template_slug( $post )
+				&&
+				! (
+					'page' === $post->post_type
+					&&
+					'page' === get_option( 'show_on_front' )
+					&&
+					in_array( (int) $post->ID, array(
+						(int) get_option( 'page_on_front' ),
+						(int) get_option( 'page_for_posts' ),
+					), true )
+				)
+			);
+
+			/**
+			 * Filters whether default AMP status should be enabled or not.
+			 *
+			 * @since 0.6
+			 *
+			 * @param string  $status Status.
+			 * @param WP_Post $post   Post.
+			 */
+			return apply_filters( 'amp_status_default_enabled', $enabled, $post );
+	}
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -63,8 +63,10 @@ function amp_get_permalink( $post_id ) {
  * @return bool Whether the post supports AMP.
  */
 function post_supports_amp( $post ) {
+	$errors = AMP_Post_Type_Support::get_support_errors( $post );
+
 	// Return false if an error is found.
-	if ( ! empty( AMP_Post_Type_Support::get_support_errors( $post ) ) ) {
+	if ( ! empty( $errors ) ) {
 		return false;
 	}
 

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -17,7 +17,7 @@ class AMP_Post_Type_Support {
 	 * @return string[] Post types.
 	 */
 	public static function get_builtin_supported_post_types() {
-		return array_filter( array( 'post', 'page' ), 'post_type_exists' );
+		return array_filter( array( 'post' ), 'post_type_exists' );
 	}
 
 	/**
@@ -29,6 +29,7 @@ class AMP_Post_Type_Support {
 	public static function get_eligible_post_types() {
 		return array_merge(
 			self::get_builtin_supported_post_types(),
+			array( 'page' ),
 			array_values( get_post_types(
 				array(
 					'public'   => true,

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -76,20 +76,6 @@ class AMP_Post_Type_Support {
 			$errors[] = 'post-type-support';
 		}
 
-		// Skip based on postmeta.
-		if ( ! isset( $post->ID ) || (bool) get_post_meta( $post->ID, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true ) ) {
-			$errors[] = 'post-disabled';
-		}
-
-		// Homepage and page for posts are not supported yet.
-		if ( 'page' === get_post_type( $post ) && 'page' === get_option( 'show_on_front' ) ) {
-			if ( (int) get_option( 'page_for_posts' ) === (int) $post->ID ) {
-				$errors[] = 'page-for-posts';
-			} elseif ( (int) get_option( 'page_on_front' ) === (int) $post->ID ) {
-				$errors[] = 'page-on-front';
-			}
-		}
-
 		if ( post_password_required( $post ) ) {
 			$errors[] = 'password-protected';
 		}

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -199,7 +199,8 @@ class AMP_Post_Template {
 	 * Load and print the template parts for the given post.
 	 */
 	public function load() {
-		$template = is_page() ? 'page' : 'single';
+		global $wp_query;
+		$template = is_page() || $wp_query->is_posts_page ? 'page' : 'single';
 		$this->load_parts( array( $template ) );
 	}
 

--- a/templates/admin/amp-status.php
+++ b/templates/admin/amp-status.php
@@ -13,11 +13,10 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 /**
  * Inherited template vars.
  *
- * @var array  $labels    Labels for enabled or disabled.
- * @var string $status    Enabled or disabled.
- * @var bool   $available Whether AMP is available.
+ * @var array  $labels Labels for enabled or disabled.
+ * @var string $status Enabled or disabled.
+ * @var array  $errors Support errors.
  */
-
 ?>
 <div class="misc-pub-section misc-amp-status">
 	<span class="amp-icon"></span>
@@ -28,12 +27,12 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 		<span class="screen-reader-text"><?php esc_html_e( 'Edit Status', 'amp' ); ?></span>
 	</a>
 	<div id="amp-status-select" class="hide-if-js" data-amp-status="<?php echo esc_attr( $status ); ?>">
-		<?php if ( $available ) : ?>
+		<?php if ( empty( $errors ) ) : ?>
 			<fieldset>
-				<input id="amp-status-enabled" type="radio" name="<?php echo esc_attr( self::STATUS_INPUT_NAME ); ?>" value="enabled" <?php checked( ! $disabled ); ?>>
+				<input id="amp-status-enabled" type="radio" name="<?php echo esc_attr( self::STATUS_INPUT_NAME ); ?>" value="<?php echo esc_attr( self::ENABLED_STATUS ); ?>" <?php checked( self::ENABLED_STATUS, $status ); ?>>
 				<label for="amp-status-enabled" class="selectit"><?php echo esc_html( $labels['enabled'] ); ?></label>
 				<br />
-				<input id="amp-status-disabled" type="radio" name="<?php echo esc_attr( self::STATUS_INPUT_NAME ); ?>" value="disabled" <?php checked( $disabled ); ?>>
+				<input id="amp-status-disabled" type="radio" name="<?php echo esc_attr( self::STATUS_INPUT_NAME ); ?>" value="<?php echo esc_attr( self::DISABLED_STATUS ); ?>" <?php checked( self::DISABLED_STATUS, $status ); ?>>
 				<label for="amp-status-disabled" class="selectit"><?php echo esc_html( $labels['disabled'] ); ?></label>
 				<br />
 				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME ); ?>
@@ -44,9 +43,6 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 					<?php
 					$support_errors_codes = AMP_Post_Type_Support::get_support_errors( $post );
 					$support_errors       = array();
-					if ( in_array( 'page-on-front', $support_errors_codes, true ) || in_array( 'page-for-posts', $support_errors_codes, true ) ) {
-						$support_errors[] = __( 'AMP cannot yet be enabled on homepage or page for posts.', 'amp' );
-					}
 					if ( in_array( 'password-protected', $support_errors_codes, true ) ) {
 						$support_errors[] = __( 'AMP cannot be enabled on password protected posts.', 'amp' );
 					}
@@ -66,7 +62,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 			</div>
 		<?php endif; ?>
 		<div class="amp-status-actions">
-			<?php if ( $available ) : ?>
+			<?php if ( empty( $errors ) ) : ?>
 				<a href="#amp_status" class="save-amp-status hide-if-no-js button"><?php esc_html_e( 'OK', 'amp' ); ?></a>
 			<?php endif; ?>
 			<a href="#amp_status" class="cancel-amp-status hide-if-no-js button-cancel"><?php esc_html_e( 'Cancel', 'amp' ); ?></a>

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -109,7 +109,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \post_supports_amp()
 	 */
 	public function test_post_supports_amp() {
+		add_post_type_support( 'page', AMP_QUERY_VAR );
+
 		// Test disabled by default for page for posts and show on front.
+		update_option( 'show_on_front', 'page' );
 		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) );
 		$this->assertTrue( post_supports_amp( $post ) );
 		update_option( 'show_on_front', 'page' );
@@ -125,5 +128,8 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// Test disabled by default for page templates.
 		update_post_meta( $post->ID, '_wp_page_template', 'foo.php' );
 		$this->assertFalse( post_supports_amp( $post ) );
+
+		// Reset.
+		remove_post_type_support( 'page', AMP_QUERY_VAR );
 	}
 }

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -102,4 +102,28 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_get_permalink', $url );
 	}
+
+	/**
+	 * Test post_supports_amp().
+	 *
+	 * @covers \post_supports_amp()
+	 */
+	public function test_post_supports_amp() {
+		// Test disabled by default for page for posts and show on front.
+		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) );
+		$this->assertTrue( post_supports_amp( $post ) );
+		update_option( 'show_on_front', 'page' );
+		$this->assertTrue( post_supports_amp( $post ) );
+		update_option( 'page_for_posts', $post->ID );
+		$this->assertFalse( post_supports_amp( $post ) );
+		update_option( 'page_for_posts', '' );
+		update_option( 'page_on_front', $post->ID );
+		$this->assertFalse( post_supports_amp( $post ) );
+		update_option( 'show_on_front', 'posts' );
+		$this->assertTrue( post_supports_amp( $post ) );
+
+		// Test disabled by default for page templates.
+		update_post_meta( $post->ID, '_wp_page_template', 'foo.php' );
+		$this->assertFalse( post_supports_amp( $post ) );
+	}
 }

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -108,7 +108,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	public function test_save_amp_status() {
 		// Test failure.
 		$post_id = $this->factory->post->create();
-		$this->assertEmpty( get_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true ) );
+		$this->assertEmpty( get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 
 		// Setup for success.
 		wp_set_current_user( $this->factory->user->create( array(
@@ -119,27 +119,27 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 
 		// Test revision bail.
 		$post_id = $this->factory->post->create();
-		delete_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY );
+		delete_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY );
 		wp_save_post_revision( $post_id );
-		$this->assertEmpty( get_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true ) );
+		$this->assertEmpty( get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 
 		// Test post update success to disable.
 		$post_id = $this->factory->post->create();
-		delete_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY );
+		delete_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY );
 		wp_update_post( array(
 			'ID'         => $post_id,
 			'post_title' => 'updated',
 		) );
-		$this->assertTrue( (bool) get_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true ) );
+		$this->assertTrue( (bool) get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 
 		// Test post update success to enable.
 		$_POST[ AMP_Post_Meta_Box::STATUS_INPUT_NAME ] = 'enabled';
-		delete_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY );
+		delete_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY );
 		wp_update_post( array(
 			'ID'         => $post_id,
 			'post_title' => 'updated',
 		) );
-		$this->assertFalse( (bool) get_post_meta( $post_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true ) );
+		$this->assertEquals( AMP_Post_Meta_Box::ENABLED_STATUS, get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 	}
 
 	/**

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -28,7 +28,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::get_builtin_supported_post_types()
 	 */
 	public function test_get_builtin_supported_post_types() {
-		$this->assertEquals( array( 'post', 'page' ), AMP_Post_Type_Support::get_builtin_supported_post_types() );
+		$this->assertEquals( array( 'post' ), AMP_Post_Type_Support::get_builtin_supported_post_types() );
 	}
 
 	/**

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -95,12 +95,6 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		add_post_type_support( 'book', AMP_QUERY_VAR );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
-		// Disabled.
-		update_post_meta( $book_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY, true );
-		$this->assertEquals( array( 'post-disabled' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
-		delete_post_meta( $book_id, AMP_Post_Meta_Box::DISABLED_POST_META_KEY );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
-
 		// Password-protected.
 		add_filter( 'post_password_required', '__return_true' );
 		$this->assertEquals( array( 'password-protected' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
@@ -112,18 +106,5 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		$this->assertEquals( array( 'skip-post' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
-
-		// Page for posts and show on front.
-		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $page_id ) );
-		update_option( 'show_on_front', 'page' );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $page_id ) );
-		update_option( 'page_for_posts', $page_id );
-		$this->assertEquals( array( 'page-for-posts' ), AMP_Post_Type_Support::get_support_errors( $page_id ) );
-		update_option( 'page_for_posts', '' );
-		update_option( 'page_on_front', $page_id );
-		$this->assertEquals( array( 'page-on-front' ), AMP_Post_Type_Support::get_support_errors( $page_id ) );
-		update_option( 'show_on_front', 'posts' );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $page_id ) );
 	}
 }


### PR DESCRIPTION
This PR implements the workflow [discussed here](https://github.com/Automattic/amp-wp/issues/837#issuecomment-358144627). For pages with custom templates assigned or for pages assigned to the front page or posts page, the default status will be disabled. For all others, the default status will be enabled.

The default status has a filter to allow devs to change the default status to disabled as such `add_filter( 'amp_status_default_enabled', '__return_false' );`

Closes #837
Closes #867