### PR TITLE
Account for post_supports_amp() in is_paired_available()

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -127,6 +127,10 @@ class AMP_Theme_Support {
 			return false;
 		}
 
+		if ( is_singular() && ! post_supports_amp( get_queried_object() ) ) {
+			return false;
+		}
+
 		$args = array_shift( $support );
 
 		if ( isset( $args['available_callback'] ) && is_callable( $args['available_callback'] ) ) {

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Tests for Theme Support.
+ *
+ * @package AMP
+ * @since 0.7
+ */
+
+/**
+ * Tests for Theme Support.
+ *
+ * @covers AMP_Theme_Support
+ */
+class Test_AMP_Theme_Support extends WP_UnitTestCase {
+
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
+	}
+
+	/**
+	 * Test is_paired_available.
+	 *
+	 * @covers AMP_Theme_Support::is_paired_available()
+	 */
+	public function test_is_paired_available() {
+
+		// Establish initial state.
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test' ) );
+		remove_theme_support( 'amp' );
+		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
+		$this->assertTrue( is_singular() );
+
+		// Paired support is not available if theme support is not present or canonical.
+		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
+		add_theme_support( 'amp' );
+		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
+
+		// Paired mode is available once template_dir is supplied.
+		add_theme_support( 'amp', array(
+			'template_dir' => 'amp-templates',
+		) );
+		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
+
+		// Paired mode not available when post does not support AMP.
+		add_filter( 'amp_skip_post', '__return_true' );
+		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
+		$this->assertTrue( is_singular() );
+		query_posts( array( 's' => 'test' ) ); // phpcs:ignore
+		$this->assertTrue( is_search() );
+		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
+		remove_filter( 'amp_skip_post', '__return_true' );
+
+		// Check that available_callback works.
+		add_theme_support( 'amp', array(
+			'template_dir'       => 'amp-templates',
+			'available_callback' => 'is_singular',
+		) );
+		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
+		$this->assertTrue( is_singular() );
+		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
+
+		query_posts( array( 's' => $post_id ) ); // phpcs:ignore
+		$this->assertTrue( is_search() );
+		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
+	}
+}


### PR DESCRIPTION
Discovered in https://github.com/Automattic/amp-wp/pull/872#issuecomment-358424533

Let's merge the #872 into this branch and add unit tests for `is_paired_available()` prior to merging this PR.