### PR TITLE
Remove double border from grouped preview buttons

### DIFF
--- a/assets/css/amp-post-meta-box.css
+++ b/assets/css/amp-post-meta-box.css
@@ -8,7 +8,12 @@
 .wp-core-ui #preview-action.has-amp-preview #post-preview {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
+	border-right-width: 0;
 	float: none;
+}
+
+.wp-core-ui #post-preview:hover + #amp-post-preview {
+	border-left: 1px solid #999 !important;
 }
 
 /* AMP preview button */


### PR DESCRIPTION
https://i.imgur.com/aui7Ypd.png

!important is needed for when the AMP preview button is .disabled