### PR TITLE
Remove erroneous additional allowance of script[type=text/javascript]

### DIFF
--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -87,22 +87,18 @@ abstract class AMP_Rule_Spec {
 	 */
 	public static $additional_allowed_tags = array(
 
-		/**
-		 * An experimental tag with no protoascii
-		 */
+		// An experimental tag with no protoascii.
 		'amp-share-tracking' => array(
 			'attr_spec_list' => array(),
 			'tag_spec'       => array(),
 		),
 
-		/**
-		 *  Needed for some tags such as analytics
-		 */
+		// Needed for some tags such as analytics.
 		'script'             => array(
 			'attr_spec_list' => array(
 				'type' => array(
 					'mandatory'   => true,
-					'value_casei' => 'text/javascript',
+					'value_casei' => 'application/json',
 				),
 			),
 			'tag_spec'       => array(),


### PR DESCRIPTION
Issue introduced in #828 via 5c1fa2086 when attempting to remove duplicated `script` array key. Since the latter duplicated key with the AMP-valid `application/json` it previously overrode the erroneous `text/javascript` entry. When the latter was removed, the former was left which was invalid. So this change ensures that the previous behavior is retained.

Fixes #883.