### PR TITLE
Use whitelist sanitizer to determine AMP component scripts needed for embeds

### DIFF
--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -27,6 +27,16 @@ abstract class AMP_Base_Embed_Handler {
 		) );
 	}
 
+	/**
+	 * Get mapping of AMP component names to AMP script URLs.
+	 *
+	 * This is normally no longer needed because the wnitelist
+	 * sanitizer will automatically detect the need for them via
+	 * the spec.
+	 *
+	 * @see AMP_Tag_And_Attribute_Sanitizer::get_scripts()
+	 * @return array Scripts.
+	 */
 	public function get_scripts() {
 		return array();
 	}

--- a/includes/embeds/class-amp-dailymotion-embed.php
+++ b/includes/embeds/class-amp-dailymotion-embed.php
@@ -18,9 +18,6 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 600;
 	protected $DEFAULT_HEIGHT = 338;
 
-	private static $script_slug = 'amp-dailymotion';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js';
-
 	function __construct( $args = array() ) {
 		parent::__construct( $args );
 
@@ -39,14 +36,6 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-dailymotion', -1 );
 		remove_shortcode( 'dailymotion' );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function shortcode( $attr ) {

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -14,23 +14,12 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 600;
 	protected $DEFAULT_HEIGHT = 400;
 
-	private static $script_slug = 'amp-facebook';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-facebook-0.1.js';
-
 	public function register_embed() {
 		wp_embed_register_handler( 'amp-facebook', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
 	}
 
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-facebook', -1 );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function oembed( $matches, $attr, $url, $rawattr ) {

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -9,8 +9,6 @@
  * Class AMP_Gallery_Embed_Handler
  */
 class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
-	private static $script_slug = 'amp-carousel';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-carousel-0.1.js';
 
 	public function register_embed() {
 		add_shortcode( 'gallery', array( $this, 'shortcode' ) );
@@ -18,14 +16,6 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	public function unregister_embed() {
 		remove_shortcode( 'gallery' );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function shortcode( $attr ) {

--- a/includes/embeds/class-amp-instagram-embed.php
+++ b/includes/embeds/class-amp-instagram-embed.php
@@ -17,9 +17,6 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 600;
 	protected $DEFAULT_HEIGHT = 600;
 
-	private static $script_slug = 'amp-instagram';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-instagram-0.1.js';
-
 	public function register_embed() {
 		wp_embed_register_handler( 'amp-instagram', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
 		add_shortcode( 'instagram', array( $this, 'shortcode' ) );
@@ -28,14 +25,6 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-instagram', -1 );
 		remove_shortcode( 'instagram' );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function shortcode( $attr ) {

--- a/includes/embeds/class-amp-pinterest-embed.php
+++ b/includes/embeds/class-amp-pinterest-embed.php
@@ -15,9 +15,6 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 450;
 	protected $DEFAULT_HEIGHT = 750;
 
-	private static $script_slug = 'amp-pinterest';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-pinterest-0.1.js';
-
 	public function register_embed() {
 		wp_embed_register_handler(
 			'amp-pinterest',
@@ -28,14 +25,6 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	public function unregister_embed() {
 		wp_embed_unregister_handler('amp-pinterest', -1);
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src);
 	}
 
 	public function oembed( $matches, $attr, $url, $rawattr ) {

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -17,21 +17,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @var int
 	 */
-	protected $DEFAULT_HEIGHT = 200;
-
-	/**
-	 * Script slug.
-	 *
-	 * @var string
-	 */
-	private static $script_slug = 'amp-soundcloud';
-
-	/**
-	 * Script source.
-	 *
-	 * @var string
-	 */
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js';
+	protected $DEFAULT_HEIGHT = 200; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase
 
 	/**
 	 * Register embed.
@@ -47,19 +33,6 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		remove_shortcode( 'soundcloud' );
 		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
-	}
-
-	/**
-	 * Get scripts needed by component.
-	 *
-	 * @return array Scripts.
-	 */
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	/**

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -13,9 +13,6 @@
 class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	const URL_PATTERN = '#http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)#i';
 
-	private static $script_slug = 'amp-twitter';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-twitter-0.1.js';
-
 	public function register_embed() {
 		add_shortcode( 'tweet', array( $this, 'shortcode' ) );
 		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
@@ -24,14 +21,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		remove_shortcode( 'tweet' );
 		wp_embed_unregister_handler( 'amp-twitter', -1 );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	function shortcode( $attr ) {

--- a/includes/embeds/class-amp-vimeo-embed.php
+++ b/includes/embeds/class-amp-vimeo-embed.php
@@ -19,9 +19,6 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 600;
 	protected $DEFAULT_HEIGHT = 338;
 
-	private static $script_slug = 'amp-vimeo';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js';
-
 	function __construct( $args = array() ) {
 		parent::__construct( $args );
 
@@ -40,14 +37,6 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-vimeo', -1 );
 		remove_shortcode( 'vimeo' );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function shortcode( $attr ) {

--- a/includes/embeds/class-amp-vine-embed.php
+++ b/includes/embeds/class-amp-vine-embed.php
@@ -14,23 +14,12 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 400;
 	protected $DEFAULT_HEIGHT = 400;
 
-	private static $script_slug = 'amp-vine';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-vine-0.1.js';
-
 	public function register_embed() {
 		wp_embed_register_handler( 'amp-vine', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
 	}
 
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-vine', -1 );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function oembed( $matches, $attr, $url, $rawattr ) {

--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -19,9 +19,6 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	protected $DEFAULT_WIDTH = 600;
 	protected $DEFAULT_HEIGHT = 338;
 
-	private static $script_slug = 'amp-youtube';
-	private static $script_src = 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js';
-
 	function __construct( $args = array() ) {
 		parent::__construct( $args );
 
@@ -40,14 +37,6 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function unregister_embed() {
 		wp_embed_unregister_handler( 'amp-youtube', -1 );
 		remove_shortcode( 'youtube' );
-	}
-
-	public function get_scripts() {
-		if ( ! $this->did_convert_elements ) {
-			return array();
-		}
-
-		return array( self::$script_slug => self::$script_src );
 	}
 
 	public function shortcode( $attr ) {

--- a/tests/test-amp-dailymotion-embed.php
+++ b/tests/test-amp-dailymotion-embed.php
@@ -50,7 +50,7 @@ class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.dailymotion.com/video/x5awwth' . PHP_EOL,
-				array( 'amp-dailymotion' => 'https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js' ),
+				array( 'amp-dailymotion' => 'https://cdn.ampproject.org/v0/amp-dailymotion-latest.js' ),
 			),
 		);
 	}
@@ -61,8 +61,15 @@ class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_DailyMotion_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -54,7 +54,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				array( 'amp-facebook' => 'https://cdn.ampproject.org/v0/amp-facebook-0.1.js' ),
+				array( 'amp-facebook' => 'https://cdn.ampproject.org/v0/amp-facebook-latest.js' ),
 			),
 		);
 	}
@@ -65,8 +65,15 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Facebook_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-instagram-embed.php
+++ b/tests/test-amp-instagram-embed.php
@@ -53,7 +53,7 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
-				array( 'amp-instagram' => 'https://cdn.ampproject.org/v0/amp-instagram-0.1.js' ),
+				array( 'amp-instagram' => 'https://cdn.ampproject.org/v0/amp-instagram-latest.js' ),
 			),
 		);
 	}
@@ -64,8 +64,15 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Instagram_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-pinterest-embed.php
+++ b/tests/test-amp-pinterest-embed.php
@@ -37,7 +37,7 @@ class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
-				array( 'amp-pinterest' => 'https://cdn.ampproject.org/v0/amp-pinterest-0.1.js' ),
+				array( 'amp-pinterest' => 'https://cdn.ampproject.org/v0/amp-pinterest-latest.js' ),
 			),
 		);
 	}
@@ -48,8 +48,15 @@ class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Pinterest_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-soundcloud-embed.php
+++ b/tests/test-amp-soundcloud-embed.php
@@ -112,7 +112,7 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted'     => array(
 				'https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor' . PHP_EOL,
-				array( 'amp-soundcloud' => 'https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js' ),
+				array( 'amp-soundcloud' => 'https://cdn.ampproject.org/v0/amp-soundcloud-latest.js' ),
 			),
 		);
 	}
@@ -129,8 +129,15 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_SoundCloud_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -66,7 +66,7 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://twitter.com/altjoen/status/118252236836061184' . PHP_EOL,
-				array( 'amp-twitter' => 'https://cdn.ampproject.org/v0/amp-twitter-0.1.js' ),
+				array( 'amp-twitter' => 'https://cdn.ampproject.org/v0/amp-twitter-latest.js' ),
 			),
 		);
 	}
@@ -77,8 +77,15 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Twitter_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-vimeo-embed.php
+++ b/tests/test-amp-vimeo-embed.php
@@ -50,7 +50,7 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://vimeo.com/172355597' . PHP_EOL,
-				array( 'amp-vimeo' => 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js' ),
+				array( 'amp-vimeo' => 'https://cdn.ampproject.org/v0/amp-vimeo-latest.js' ),
 			),
 		);
 	}
@@ -61,8 +61,15 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Vimeo_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-vine-embed.php
+++ b/tests/test-amp-vine-embed.php
@@ -33,7 +33,7 @@ class AMP_Vine_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://vine.co/v/MdKjXez002d' . PHP_EOL,
-				array( 'amp-vine' => 'https://cdn.ampproject.org/v0/amp-vine-0.1.js' ),
+				array( 'amp-vine' => 'https://cdn.ampproject.org/v0/amp-vine-latest.js' ),
 			),
 		);
 	}
@@ -44,8 +44,15 @@ class AMP_Vine_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Vine_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}

--- a/tests/test-amp-youtube-embed.php
+++ b/tests/test-amp-youtube-embed.php
@@ -55,7 +55,7 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
-				array( 'amp-youtube' => 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js' ),
+				array( 'amp-youtube' => 'https://cdn.ampproject.org/v0/amp-youtube-latest.js' ),
 			),
 		);
 	}
@@ -66,8 +66,15 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_YouTube_Embed_Handler();
 		$embed->register_embed();
-		apply_filters( 'the_content', $source );
-		$scripts = $embed->get_scripts();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
 
 		$this->assertEquals( $expected, $scripts );
 	}


### PR DESCRIPTION
Follow-up on #882. See https://github.com/Automattic/amp-wp/pull/882#issuecomment-358975977