### PR TITLE
Fix sanitization of input placeholder attributes

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -569,10 +569,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->delegated_sanitize_disallowed_attribute_values_in_node( $node, $this->globally_allowed_attributes );
-		if ( ! empty( $attr_spec_list ) ) {
-			$this->delegated_sanitize_disallowed_attribute_values_in_node( $node, $attr_spec_list );
-		}
+		$this->delegated_sanitize_disallowed_attribute_values_in_node( $node, array_merge(
+			$this->globally_allowed_attributes,
+			$attr_spec_list
+		) );
 	}
 
 	/**

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -202,8 +202,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'form'                                                      => array(
-				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" name="term" required=""/></label><input type="submit" value="Search"/></fieldset></form>',
-				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" name="term" required=""/></label><input type="submit" value="Search"/></fieldset></form>',
+				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required=""/></label><input type="submit" value="Search"/></fieldset></form>',
+				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required=""/></label><input type="submit" value="Search"/></fieldset></form>',
 			),
 
 			'gfycat'                                                    => array(


### PR DESCRIPTION
An element's own spec should override the global spec, so we can accomplish this via merging.