### PR TITLE
Add support for amp-bind

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -340,6 +340,21 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! empty( $tag_spec['requires_extension'] ) ) {
 				$this->script_components = array_merge( $this->script_components, $tag_spec['requires_extension'] );
 			}
+
+			// Check if element needs amp-bind component.
+			if ( $node instanceof DOMElement && ! in_array( 'amp-bind', $this->script_components, true ) ) {
+				foreach ( $node->attributes as $name => $value ) {
+					$is_bind_attribute = (
+						'[' === $name[0]
+						||
+						( isset( $this->rev_alternate_attr_name_lookup[ $name ] ) && '[' === $this->rev_alternate_attr_name_lookup[ $name ][0] )
+					);
+					if ( $is_bind_attribute ) {
+						$this->script_components[] = 'amp-bind';
+						break;
+					}
+				}
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -279,19 +279,21 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		// Obtain list of component scripts required.
-		if ( ! empty( $tag_spec['also_requires_tag_warning'] ) ) {
-			$this->script_components[] = strtok( $tag_spec['also_requires_tag_warning'][0], ' ' );
-		}
-		if ( ! empty( $tag_spec['requires_extension'] ) ) {
-			$this->script_components = array_merge( $this->script_components, $tag_spec['requires_extension'] );
-		}
-
 		// Remove any remaining disallowed attributes.
 		$this->sanitize_disallowed_attributes_in_node( $node, $attr_spec_list );
 
 		// Remove values that don't conform to the attr_spec.
 		$this->sanitize_disallowed_attribute_values_in_node( $node, $attr_spec_list );
+
+		// Add required AMP component scripts if the element is still in the document.
+		if ( $node->parentNode ) {
+			if ( ! empty( $tag_spec['also_requires_tag_warning'] ) ) {
+				$this->script_components[] = strtok( $tag_spec['also_requires_tag_warning'][0], ' ' );
+			}
+			if ( ! empty( $tag_spec['requires_extension'] ) ) {
+				$this->script_components = array_merge( $this->script_components, $tag_spec['requires_extension'] );
+			}
+		}
 	}
 
 	/**

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -56,6 +56,8 @@ class AMP_DOM_Utils {
 
 		$dom = new DOMDocument();
 
+		$document = self::convert_amp_bind_attributes( $document );
+
 		/*
 		 * Wrap in dummy tags, since XML needs one parent node.
 		 * It also makes it easier to loop through nodes.
@@ -72,6 +74,110 @@ class AMP_DOM_Utils {
 		}
 
 		return $dom;
+	}
+
+	/**
+	 * Get attribute prefix for converted amp-bind attributes.
+	 *
+	 * This contains a random string to prevent HTML content containing this data- attribute
+	 * originally from being mutated to contain an amp-bind attribute when attributes are restored.
+	 *
+	 * @since 0.7
+	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
+	 * @see \AMP_DOM_Utils::restore_amp_bind_attributes()
+	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
+	 *
+	 * @return string HTML5 data-* attribute name prefix for AMP binding attributes.
+	 */
+	public static function get_amp_bind_placeholder_attribute_prefix() {
+		static $attribute_prefix;
+		if ( ! isset( $attribute_prefix ) ) {
+			$attribute_prefix = sprintf( 'data-amp-binding-%s-', md5( wp_rand() ) );
+		}
+		return $attribute_prefix;
+	}
+
+	/**
+	 * Replace AMP binding attributes with something that libxml can parse (as HTML5 data-* attributes).
+	 *
+	 * This is necessary necessary because attributes in square brackets are not understood in PHP and
+	 * get dropped with an error raised:
+	 * > Warning: DOMDocument::loadHTML(): error parsing attribute name
+	 * This is a reciprocal function of AMP_DOM_Utils::restore_amp_bind_attributes().
+	 *
+	 * @since 0.7
+	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
+	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
+	 *
+	 * @param string $html HTML containing amp-bind attributes.
+	 * @return string HTML with AMP binding attributes replaced with HTML5 data-* attributes.
+	 */
+	public static function convert_amp_bind_attributes( $html ) {
+		$amp_bind_attr_prefix = self::get_amp_bind_placeholder_attribute_prefix();
+
+		// Pattern for HTML attribute accounting for binding attr name, boolean attribute, single/double-quoted attribute value, and unquoted attribute values.
+		$attr_regex = '#^\s+(?P<name>\[?[a-zA-Z0-9_\-]+\]?)(?P<value>=(?:"[^"]*"|\'[^\']*\'|[^\'"\s]+))?#';
+
+		/**
+		 * Replace callback.
+		 *
+		 * @param array $tag_matches Tag matches.
+		 * @return string Replacement.
+		 */
+		$replace_callback = function( $tag_matches ) use ( $amp_bind_attr_prefix, $attr_regex ) {
+			$old_attrs = rtrim( $tag_matches['attrs'] );
+			$new_attrs = '';
+			$offset    = 0;
+			while ( preg_match( $attr_regex, substr( $old_attrs, $offset ), $attr_matches ) ) {
+				$offset += strlen( $attr_matches[0] );
+
+				if ( '[' === $attr_matches['name'][0] ) {
+					$new_attrs .= ' ' . $amp_bind_attr_prefix . trim( $attr_matches['name'], '[]' );
+					if ( isset( $attr_matches['value'] ) ) {
+						$new_attrs .= $attr_matches['value'];
+					}
+				} else {
+					$new_attrs .= $attr_matches[0];
+				}
+			}
+
+			// Bail on parse error which occurs when the regex isn't able to consume the entire $new_attrs string.
+			if ( strlen( $old_attrs ) !== $offset ) {
+				return $tag_matches[0];
+			}
+
+			return '<' . $tag_matches['name'] . $new_attrs . '>';
+		};
+
+		$html = preg_replace_callback(
+			// Match all start tags that probably contain a binding attribute.
+			'#<(?P<name>\w\S+)(?P<attrs>\s+[^<]+\]=[^<]+)\s*>#',
+			$replace_callback,
+			$html
+		);
+
+		return $html;
+	}
+
+	/**
+	 * Convert AMP bind-attributes back to their original syntax.
+	 *
+	 * This is a reciprocal function of AMP_DOM_Utils::convert_amp_bind_attributes().
+	 *
+	 * @since 0.7
+	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
+	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
+	 *
+	 * @param string $html HTML with amp-bind attributes converted.
+	 * @return string HTML with amp-bind attributes restored.
+	 */
+	public static function restore_amp_bind_attributes( $html ) {
+		$html = preg_replace(
+			'#\s' . self::get_amp_bind_placeholder_attribute_prefix() . '([a-zA-Z0-9_\-]+)#',
+			' [$1]',
+			$html
+		);
+		return $html;
 	}
 
 	/**
@@ -174,6 +280,8 @@ class AMP_DOM_Utils {
 		if ( '' === trim( $html ) ) {
 			return '';
 		}
+
+		$html = self::restore_amp_bind_attributes( $html );
 
 		/*
 		 * Travis w/PHP 7.1 generates <br></br> and <hr></hr> vs. <br/> and <hr/>, respectively.

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -56,6 +56,7 @@ class AMP_DOM_Utils {
 
 		$dom = new DOMDocument();
 
+		// @todo In the future consider an AMP_DOMDocument subclass that does this automatically. See <https://github.com/Automattic/amp-wp/pull/895/files#r163825513>.
 		$document = self::convert_amp_bind_attributes( $document );
 
 		/*
@@ -100,7 +101,7 @@ class AMP_DOM_Utils {
 	/**
 	 * Replace AMP binding attributes with something that libxml can parse (as HTML5 data-* attributes).
 	 *
-	 * This is necessary necessary because attributes in square brackets are not understood in PHP and
+	 * This is necessary because attributes in square brackets are not understood in PHP and
 	 * get dropped with an error raised:
 	 * > Warning: DOMDocument::loadHTML(): error parsing attribute name
 	 * This is a reciprocal function of AMP_DOM_Utils::restore_amp_bind_attributes().
@@ -252,6 +253,7 @@ class AMP_DOM_Utils {
 	 * @see Called by function get_content_from_dom()
 	 *
 	 * @since 0.6
+	 * @todo In the future consider an AMP_DOMDocument subclass that does this automatically at saveHTML(). See <https://github.com/Automattic/amp-wp/pull/895/files#r163825513>.
 	 *
 	 * @param DOMDocument $dom  Represents an HTML document.
 	 * @param DOMNode     $node Represents an HTML element of the $dom from which to extract HTML content.

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -89,10 +89,10 @@ class AMP_DOM_Utils {
 	 *
 	 * @return string HTML5 data-* attribute name prefix for AMP binding attributes.
 	 */
-	public static function get_amp_bind_placeholder_attribute_prefix() {
+	public static function get_amp_bind_placeholder_prefix() {
 		static $attribute_prefix;
 		if ( ! isset( $attribute_prefix ) ) {
-			$attribute_prefix = sprintf( 'data-amp-binding-%s-', md5( wp_rand() ) );
+			$attribute_prefix = sprintf( 'amp-binding-%s-', md5( wp_rand() ) );
 		}
 		return $attribute_prefix;
 	}
@@ -113,7 +113,7 @@ class AMP_DOM_Utils {
 	 * @return string HTML with AMP binding attributes replaced with HTML5 data-* attributes.
 	 */
 	public static function convert_amp_bind_attributes( $html ) {
-		$amp_bind_attr_prefix = self::get_amp_bind_placeholder_attribute_prefix();
+		$amp_bind_attr_prefix = self::get_amp_bind_placeholder_prefix();
 
 		// Pattern for HTML attribute accounting for binding attr name, boolean attribute, single/double-quoted attribute value, and unquoted attribute values.
 		$attr_regex = '#^\s+(?P<name>\[?[a-zA-Z0-9_\-]+\]?)(?P<value>=(?:"[^"]*"|\'[^\']*\'|[^\'"\s]+))?#';
@@ -151,7 +151,7 @@ class AMP_DOM_Utils {
 
 		$html = preg_replace_callback(
 			// Match all start tags that probably contain a binding attribute.
-			'#<(?P<name>\w\S+)(?P<attrs>\s+[^<]+\]=[^<]+)\s*>#',
+			'#<(?P<name>[a-zA-Z0-9_\-]+)(?P<attrs>\s+[^>]+\]=[^>]+)\s*>#',
 			$replace_callback,
 			$html
 		);
@@ -173,7 +173,7 @@ class AMP_DOM_Utils {
 	 */
 	public static function restore_amp_bind_attributes( $html ) {
 		$html = preg_replace(
-			'#\s' . self::get_amp_bind_placeholder_attribute_prefix() . '([a-zA-Z0-9_\-]+)#',
+			'#\s' . self::get_amp_bind_placeholder_prefix() . '([a-zA-Z0-9_\-]+)#',
 			' [$1]',
 			$html
 		);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,7 +30,7 @@
 	</rule>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
-	<config name="testVersion" value="5.2-99.0"/>
+	<config name="testVersion" value="5.3-99.0"/>
 	<rule ref="PHPCompatibility">
 		<exclude-pattern>bin/*</exclude-pattern>
 	</rule>

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -97,7 +97,6 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 * @covers \AMP_DOM_Utils::convert_amp_bind_attributes()
 	 * @covers \AMP_DOM_Utils::restore_amp_bind_attributes()
 	 * @covers \AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix()
-	 * \AMP_DOM_Utils::restore_amp_bind_attributes()
 	 */
 	public function test_amp_bind_conversion() {
 		$original  = '<amp-img width=300 height="200" data-foo="bar" selected src="/img/dog.jpg" [src]="myAnimals[currentAnimal].imageUrl"></amp-img>';

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -96,13 +96,13 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 *
 	 * @covers \AMP_DOM_Utils::convert_amp_bind_attributes()
 	 * @covers \AMP_DOM_Utils::restore_amp_bind_attributes()
-	 * @covers \AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix()
+	 * @covers \AMP_DOM_Utils::get_amp_bind_placeholder_prefix()
 	 */
 	public function test_amp_bind_conversion() {
 		$original  = '<amp-img width=300 height="200" data-foo="bar" selected src="/img/dog.jpg" [src]="myAnimals[currentAnimal].imageUrl"></amp-img>';
 		$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $original );
 		$this->assertNotEquals( $converted, $original );
-		$this->assertContains( AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix() . 'src="myAnimals[currentAnimal].imageUrl"', $converted );
+		$this->assertContains( AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'src="myAnimals[currentAnimal].imageUrl"', $converted );
 		$this->assertContains( 'width=300 height="200" data-foo="bar" selected', $converted );
 		$restored = AMP_DOM_Utils::restore_amp_bind_attributes( $converted );
 		$this->assertEquals( $original, $restored );
@@ -115,7 +115,7 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		);
 		foreach ( $malformed_html as $html ) {
 			$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $html );
-			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix(), $converted );
+			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_prefix(), $converted );
 		}
 	}
 }

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -90,4 +90,33 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Test convert_amp_bind_attributes.
+	 *
+	 * @covers \AMP_DOM_Utils::convert_amp_bind_attributes()
+	 * @covers \AMP_DOM_Utils::restore_amp_bind_attributes()
+	 * @covers \AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix()
+	 * \AMP_DOM_Utils::restore_amp_bind_attributes()
+	 */
+	public function test_amp_bind_conversion() {
+		$original  = '<amp-img width=300 height="200" data-foo="bar" selected src="/img/dog.jpg" [src]="myAnimals[currentAnimal].imageUrl"></amp-img>';
+		$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $original );
+		$this->assertNotEquals( $converted, $original );
+		$this->assertContains( AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix() . 'src="myAnimals[currentAnimal].imageUrl"', $converted );
+		$this->assertContains( 'width=300 height="200" data-foo="bar" selected', $converted );
+		$restored = AMP_DOM_Utils::restore_amp_bind_attributes( $converted );
+		$this->assertEquals( $original, $restored );
+
+		// Test malformed.
+		$malformed_html = array(
+			'<amp-img width="123" [text]="..."</amp-img>',
+			'<amp-img width="123" [text] data-test="asd"></amp-img>',
+			'<amp-img width="123" [text]="..." *bad*></amp-img>',
+		);
+		foreach ( $malformed_html as $html ) {
+			$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $html );
+			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_attribute_prefix(), $converted );
+		}
+	}
 }

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -520,6 +520,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<font size="1">Headline</font><span style="color: blue">Span</span>',
 				'Headline<span>Span</span>',
 			),
+
+			'amp_bind_attr' => array(
+				'<p [text]="\'Hello \' + foo">Hello World</p><button on="tap:AMP.setState({foo: \'amp-bind\'})">Update</button>',
+			),
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -612,8 +612,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp_bad_bind_attr' => array(
-				'<p [unrecognized]="123">Hello World</p>',
-				'<p>Hello World</p>',
+				'<a [unrecognized] [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
+				'<a [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
 			),
 		);
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -614,6 +614,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'amp_bad_bind_attr' => array(
 				'<a [unrecognized] [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
 				'<a [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
+				array( 'amp-bind' ),
 			),
 		);
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -19,91 +19,128 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'a4a'                                                       => array(
 				'<amp-ad width="300" height="400" type="fake" data-use-a4a="true" data-vars-analytics-var="bar" src="fake_amp.json"><div placeholder=""></div><div fallback=""></div></amp-ad>',
+				null, // No change.
+				array( 'amp-ad' ),
 			),
 
 			'ads'                                                       => array(
 				'<amp-ad width="300" height="250" type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302"><div placeholder=""></div><div fallback=""></div></amp-ad>',
+				null, // No change.
+				array( 'amp-ad' ),
 			),
 
 			'adsense'                                                   => array(
 				'<amp-ad width="300" height="250" type="adsense" data-ad-client="ca-pub-2005682797531342" data-ad-slot="7046626912"><div placeholder=""></div><div fallback=""></div></amp-ad>',
+				null, // No change.
+				array( 'amp-ad' ),
 			),
 
 			'amp-3q-player'                                             => array(
 				'<amp-3q-player data-id="c8dbe7f4-7f7f-11e6-a407-0cc47a188158" layout="responsive" width="480" height="270"></amp-3q-player>',
+				null,
+				array( 'amp-3q-player' ),
 			),
 
 			'amp-ad'                                                    => array(
 				'<amp-ad width="300" height="250" type="foo"></amp-ad>',
+				null, // No change.
+				array( 'amp-ad' ),
 			),
 
 			'amp-ad-exit'                                               => array(
 				'<amp-ad-exit id="exit-api"><script type="application/json"></script></amp-ad-exit>',
+				null, // No change.
+				array( 'amp-ad-exit' ),
 			),
 
 			'amp-animation'                                             => array(
 				'<amp-animation layout="nodisplay"><script type="application/json"></script></amp-animation>',
+				null, // No change.
+				array( 'amp-animation' ),
 			),
 
 			'amp-call-tracking'                                         => array(
 				'<amp-call-tracking config="https://example.com/calltracking.json"><a href="tel:123456789">+1 (23) 456-789</a></amp-call-tracking>',
+				null,
+				array( 'amp-call-tracking' ),
 			),
 
 			'amp-call-tracking_blacklisted_config'                      => array(
 				'<amp-call-tracking config="__amp_source_origin"><a href="tel:123456789">+1 (23) 456-789</a></amp-call-tracking>',
 				'',
+				array(), // Important: This needs to be empty because the amp-call-tracking is stripped.
 			),
 
 			'amp-embed'                                                 => array(
 				'<amp-embed type="taboola" width="400" height="300" layout="responsive"></amp-embed>',
+				null, // No change.
+				array( 'amp-ad' ),
 			),
 
 			'amp-facebook-comments'                                     => array(
 				'<amp-facebook-comments width="486" height="657" data-href="http://example.com/baz" layout="responsive" data-numposts="5"></amp-facebook-comments>',
+				null, // No change.
+				array( 'amp-facebook-comments' ),
 			),
 
 			'amp-facebook-comments_missing_required_attribute'          => array(
 				'<amp-facebook-comments width="486" height="657" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				'',
+				array(), // Empty because invalid.
 			),
 
 			'amp-facebook-like'                                         => array(
 				'<amp-facebook-like width="90" height="20" data-href="http://example.com/baz" layout="fixed" data-layout="button_count"></amp-facebook-like>',
+				null, // No change.
+				array( 'amp-facebook-like' ),
 			),
 
 			'amp-facebook-like_missing_required_attribute'              => array(
 				'<amp-facebook-like width="90" height="20" layout="fixed" data-layout="button_count"></amp-facebook-like>',
 				'',
+				array(), // Empty because invalid.
 			),
 
 			'amp-fit-text'                                              => array(
 				'<amp-fit-text width="300" height="200" layout="responsive">Lorem ipsum</amp-fit-text>',
+				null, // No change.
+				array( 'amp-fit-text' ),
 			),
 
 			'amp-gist'                                                  => array(
 				'<amp-gist layout="fixed-height" data-gistid="a19" height="1613"></amp-gist>',
+				null, // No change.
+				array( 'amp-gist' ),
 			),
 
 			'amp-gist_missing_mandatory_attribute'                      => array(
 				'<amp-gist layout="fixed-height" height="1613"></amp-gist>',
 				'',
+				array(),
 			),
 
 			'amp-gwd-animation'                                         => array(
 				'<amp-gwd-animation id="4321" layout="nodisplay"></amp-gwd-animation>',
+				null, // No change.
+				array( 'amp-gwd-animation' ),
 			),
 
 			'amp-iframe'                                                => array(
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="https://www.example.com"></amp-iframe>',
+				null, // No change.
+				array( 'amp-iframe' ),
 			),
 
 			'amp-iframe_incorrect_protocol'                             => array(
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="masterprotocol://www.example.com"></amp-iframe>',
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0"></amp-iframe>',
+				array( 'amp-iframe' ),
 			),
 
 			'amp-ima-video'                                             => array(
 				'<amp-ima-video width="640" height="360" data-tag="https://example.com/foo" layout="responsive" data-src="https://example.com/bar"></amp-ima-video>',
+				null, // No change.
+				array( 'amp-ima-video' ),
 			),
 
 			'amp-ima-video_missing_required_attribute'                  => array(
@@ -113,52 +150,74 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp-imgur'                                                 => array(
 				'<amp-imgur data-imgur-id="54321" layout="responsive" width="540" height="663"></amp-imgur>',
+				null, // No change.
+				array( 'amp-imgur' ),
 			),
 
 			'amp-install-serviceworker'                                 => array(
 				'<amp-install-serviceworker src="https://www.emample.com/worker.js" data-iframe-src="https://www.example.com/serviceworker.html" layout="nodisplay"></amp-install-serviceworker>',
+				null, // No change.
+				array( 'amp-install-serviceworker' ),
 			),
 
 			'amp-izlesene'                                              => array(
 				'<amp-izlesene data-videoid="4321" layout="responsive" width="432" height="123"></amp-izlesene>',
+				null, // No change.
+				array( 'amp-izlesene' ),
 			),
 
 			'amp-nexxtv-player'                                         => array(
 				'<amp-nexxtv-player data-mediaid="123ABC" data-client="4321"></amp-nexxtv-player>',
+				null, // No change.
+				array( 'amp-nexxtv-player' ),
 			),
 
 			'amp-playbuzz'                                              => array(
 				'<amp-playbuzz src="id-from-the-content-here" height="500" data-item-info="true" data-share-buttons="true" data-comments="true"></amp-playbuzz>',
+				null, // No change.
+				array( 'amp-playbuzz' ),
 			),
 
 			'amp-playbuzz_no_src'                                       => array(
 				'<amp-playbuzz height="500" data-item-info="true"></amp-playbuzz>',
+				null, // @todo This actually should be stripped because .
+				array( 'amp-playbuzz' ),
 			),
 
 			'amp-position-observer'                                     => array(
 				'<amp-position-observer intersection-ratios="1"></amp-position-observer>',
+				null, // No change.
+				array( 'amp-position-observer' ),
 			),
 
 			'amp-twitter'                                               => array(
 				'<amp-twitter width="321" height="543" layout="responsive" data-tweetid="98765"></amp-twitter>',
+				null, // No change.
+				array( 'amp-twitter' ),
 			),
 
 			'amp-user-notification'                                     => array(
 				'<amp-user-notification layout="nodisplay" id="amp-user-notification1" data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP" data-dismiss-href="https://example.com/api/echo/post">This site uses cookies to personalize content.<a class="btn" on="tap:amp-user-notification1.dismiss">I accept</a></amp-user-notification>',
 				'<amp-user-notification layout="nodisplay" id="amp-user-notification1" data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP" data-dismiss-href="https://example.com/api/echo/post">This site uses cookies to personalize content.<a class="btn" on="tap:amp-user-notification1.dismiss">I accept</a></amp-user-notification>',
+				array( 'amp-user-notification' ),
 			),
 
 			'amp-video'                                                 => array(
 				'<amp-video width="432" height="987" src="/video/location.mp4"></amp-video>',
+				null, // No change.
+				array( 'amp-video' ),
 			),
 
 			'amp-vk'                                                    => array(
 				'<amp-vk width="500" height="300" data-embedtype="post" layout="responsive"></amp-vk>',
+				null, // No change.
+				array( 'amp-vk' ),
 			),
 
 			'amp-apester-media'                                         => array(
 				'<amp-apester-media height="444" data-apester-media-id="57a336dba187a2ca3005e826" layout="fixed-height"></amp-apester-media>',
 				'<amp-apester-media height="444" data-apester-media-id="57a336dba187a2ca3005e826" layout="fixed-height"></amp-apester-media>',
+				array( 'amp-apester-media' ),
 			),
 
 			'button'                                                    => array(
@@ -169,31 +228,37 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'brid-player'                                               => array(
 				'<amp-brid-player data-partner="264" data-player="4144" data-video="13663" layout="responsive" width="480" height="270"></amp-brid-player>',
 				'<amp-brid-player data-partner="264" data-player="4144" data-video="13663" layout="responsive" width="480" height="270"></amp-brid-player>',
+				array( 'amp-brid-player' ),
 			),
 
 			'brightcove'                                                => array(
 				'<amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove>',
 				'<amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove>',
+				array( 'amp-brightcove' ),
 			),
 
 			'carousel'                                                  => array(
 				'<amp-carousel width="400" height="300" layout="responsive" type="slides" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout="fill"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove><amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="381" height="381" layout="responsive"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="358" height="204" layout="responsive" controls=""></amp-video></amp-carousel><amp-carousel width="auto" height="300" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="300" height="300"></amp-brightcove><amp-vimeo data-videoid="27246366" width="300" height="300"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="300" height="300"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="300" height="300"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="300" height="300" controls=""></amp-video></amp-carousel>',
 				'<amp-carousel width="400" height="300" layout="responsive" type="slides" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout="fill"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove><amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="381" height="381" layout="responsive"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="358" height="204" layout="responsive" controls=""></amp-video></amp-carousel><amp-carousel width="auto" height="300" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="300" height="300"></amp-brightcove><amp-vimeo data-videoid="27246366" width="300" height="300"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="300" height="300"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="300" height="300"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="300" height="300" controls=""></amp-video></amp-carousel>',
+				array( 'amp-anim', 'amp-audio', 'amp-brightcove', 'amp-carousel', 'amp-dailymotion', 'amp-soundcloud', 'amp-video', 'amp-vimeo', 'amp-vine', 'amp-youtube' ),
 			),
 
 			'amp-dailymotion'                                           => array(
 				'<amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><h4>Default (responsive)</h4><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281" layout="responsive"></amp-dailymotion><h4>Custom</h4><amp-dailymotion data-videoid="x3rdtfy" data-endscreen-enable="false" data-sharing-enable="false" data-ui-highlight="444444" data-ui-logo="false" data-info="false" width="640" height="360"></amp-dailymotion>',
 				'<amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><h4>Default (responsive)</h4><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281" layout="responsive"></amp-dailymotion><h4>Custom</h4><amp-dailymotion data-videoid="x3rdtfy" data-endscreen-enable="false" data-sharing-enable="false" data-ui-highlight="444444" data-ui-logo="false" data-info="false" width="640" height="360"></amp-dailymotion>',
+				array( 'amp-dailymotion' ),
 			),
 
 			'doubleclick-1'                                             => array(
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
+				array( 'amp-ad' ),
 			),
 
 			'facebook'                                                  => array(
 				'<amp-facebook width="552" height="303" layout="responsive" data-href="https://www.facebook.com/zuck/posts/10102593740125791"></amp-facebook><h1>More Posts</h1>',
 				'<amp-facebook width="552" height="303" layout="responsive" data-href="https://www.facebook.com/zuck/posts/10102593740125791"></amp-facebook><h1>More Posts</h1>',
+				array( 'amp-facebook' ),
 			),
 
 			'font'                                                      => array(
@@ -204,11 +269,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'form'                                                      => array(
 				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
 				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
+				array( 'amp-form' ),
 			),
 
 			'gfycat'                                                    => array(
 				'<amp-gfycat data-gfyid="BareSecondaryFlamingo" width="225" height="400"></amp-gfycat>',
 				'<amp-gfycat data-gfyid="BareSecondaryFlamingo" width="225" height="400"></amp-gfycat>',
+				array( 'amp-gfycat' ),
 			),
 
 			'h2'                                                        => array(
@@ -251,16 +318,21 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'attribute_value_valid'                                     => array(
 				'<template type="amp-mustache">Template Data</template>',
+				null,
+				array( 'amp-mustache' ),
 			),
 
 			'attribute_value_invalid'                                   => array(
 				// type is mandatory, so the node is removed.
 				'<template type="bad-type">Template Data</template>',
 				'',
+				array(), // No scripts because removed.
 			),
 
 			'attribute_amp_accordion_value'                             => array(
 				'<amp-accordion disable-session-states="">test</amp-accordion>',
+				null, // No change.
+				array( 'amp-accordion' ),
 			),
 
 			'attribute_value_with_blacklisted_regex_removed'            => array(
@@ -301,26 +373,33 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'attribute_value_with_value_regex_casei_lower'              => array(
 				'<amp-dailymotion data-videoid="abc"></amp-dailymotion>',
+				null, // No change.
+				array( 'amp-dailymotion' ),
 			),
 
 			'attribute_value_with_value_regex_casei_upper'              => array(
 				'<amp-dailymotion data-videoid="ABC"></amp-dailymotion>',
+				null, // No change.
+				array( 'amp-dailymotion' ),
 			),
 
 			'attribute_value_with_bad_value_regex_casei_removed'        => array(
 				// data-ui-logo should be true|false.
 				'<amp-dailymotion data-videoid="123" data-ui-logo="maybe"></amp-dailymotion>',
 				'<amp-dailymotion data-videoid="123"></amp-dailymotion>',
+				array( 'amp-dailymotion' ),
 			),
 
 			'attribute_bad_attr_with_no_value_removed'                  => array(
 				'<amp-ad type="adsense" bad-attr-no-value>something here</amp-alt>',
 				'<amp-ad type="adsense">something here</amp-ad>',
+				array( 'amp-ad' ),
 			),
 
 			'attribute_bad_attr_with_value_removed'                     => array(
 				'<amp-ad type="adsense" bad-attr="some-value">something here</amp-alt>',
 				'<amp-ad type="adsense">something here</amp-ad>',
+				array( 'amp-ad' ),
 			),
 
 			'remove_node_with_invalid_mandatory_attribute'              => array(
@@ -346,6 +425,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'allow_node_with_valid_mandatory_attribute'                 => array(
 				'<amp-analytics><script type="application/json"></script></amp-analytics>',
+				null, // No change.
+				array( 'amp-analytics' ),
 			),
 
 			'nodes_with_non_whitelisted_tags_replaced_by_children'      => array(
@@ -371,11 +452,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'leave_attribute_on_node_with_present_mandatory_parent'     => array(
 				'<form action="form.php" target="_top"><div submit-success>This is a test.</div></form>',
 				'<form action="form.php" target="_top"><div submit-success>This is a test.</div></form>',
+				array( 'amp-form' ),
 			),
 
 			'disallowed_empty_attr_removed'                             => array(
 				'<amp-user-notification data-dismiss-href></amp-user-notification>',
 				'<amp-user-notification></amp-user-notification>',
+				array( 'amp-user-notification' ),
 			),
 
 			'allowed_empty_attr'                                        => array(
@@ -385,6 +468,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'remove_node_with_disallowed_ancestor'                      => array(
 				'<amp-sidebar>The sidebar<amp-app-banner>This node is not allowed here.</amp-app-banner></amp-sidebar>',
 				'<amp-sidebar>The sidebar</amp-sidebar>',
+				array( 'amp-sidebar' ),
 			),
 
 			'remove_node_without_mandatory_ancestor'                    => array(
@@ -523,6 +607,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp_bind_attr' => array(
 				'<p [text]="\'Hello \' + foo">Hello World</p><button on="tap:AMP.setState({foo: \'amp-bind\'})">Update</button>',
+				null, // No change.
+				array( 'amp-bind' ),
+			),
+
+			'amp_bad_bind_attr' => array(
+				'<p [unrecognized]="123">Hello World</p>',
+				'<p>Hello World</p>',
 			),
 		);
 	}
@@ -563,10 +654,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_data
 	 * @group allowed-tags
-	 * @param string $source Markup to process.
+	 * @param string $source   Markup to process.
 	 * @param string $expected The markup to expect.
+	 * @param array  $scripts  The AMP component script names that are obtained through sanitization.
 	 */
-	public function test_sanitizer( $source, $expected = null ) {
+	public function test_sanitizer( $source, $expected = null, $scripts = array() ) {
 		$expected  = isset( $expected ) ? $expected : $source;
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
@@ -574,5 +666,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
 		$this->assertEquals( $expected, $content );
+		$this->assertEqualSets( $scripts, array_keys( $sanitizer->get_scripts() ) );
 	}
 }


### PR DESCRIPTION
- [x] Rename `[x]` binding attribute syntax with `data-amp-binding-RANDOMSTRING---x` so PHP can parse it.
- [x] When iterating over attributes in the sanitizer, treat attribute names prefixed by `data-amp-binding...---` as being bracketed instead.
- [x] Make sure that the whitelist sanitizer adds the `amp-bind` component script when it comes across an AMP bound attribute.
- [x] When serializing back-out, replace `data-amp-binding-...` with the original syntax.

Fixes  #836.