### PR TITLE
[WIP] Issue #843: Validate Gutenberg blocks for AMP compliance

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -89,6 +89,7 @@ function amp_after_setup_theme() {
 
 	add_action( 'init', 'amp_init' );
 	add_action( 'widgets_init', 'AMP_Theme_Support::register_widgets' );
+	add_action( 'enqueue_block_editor_assets', 'AMP_Theme_Support::enqueue_gutenberg' );
 	add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
 	add_filter( 'amp_post_template_analytics', 'amp_add_custom_analytics' );
 	add_action( 'wp_loaded', 'amp_post_meta_box' );

--- a/amp.php
+++ b/amp.php
@@ -89,7 +89,7 @@ function amp_after_setup_theme() {
 
 	add_action( 'init', 'amp_init' );
 	add_action( 'widgets_init', 'AMP_Theme_Support::register_widgets' );
-	add_action( 'enqueue_block_editor_assets', 'AMP_Theme_Support::enqueue_gutenberg' );
+	add_action( 'admin_enqueue_scripts', 'AMP_Theme_Support::enqueue_editor' );
 	add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
 	add_filter( 'amp_post_template_analytics', 'amp_add_custom_analytics' );
 	add_action( 'wp_loaded', 'amp_post_meta_box' );

--- a/assets/js/amp-gutenberg.js
+++ b/assets/js/amp-gutenberg.js
@@ -1,0 +1,130 @@
+/*jshint esversion: 6 */
+/*global amp, wp:true */
+/**
+ * AMP Gutenberg integration.
+ *
+ * On editing a block, this checks that the content is AMP-compatible.
+ * And it displays a notice if it's not.
+ */
+
+/* exported ampGutenberg */
+var ampGutenberg = ( function( $ ) {
+	'use strict';
+
+	var component = {
+		/**
+		 * Holds data.
+		 */
+		data: {},
+
+		/**
+		 * Boot module.
+		 *
+		 * @param {Object} data Object data.
+		 * @return {void}
+		 */
+		boot: function( data ) {
+			component.data = data;
+			$( document ).ready( function() {
+				component.getScript();
+			} );
+		},
+
+		/**
+		 * Gets the amp CDN validator.js script, and run this file.
+		 *
+		 * The getScript callback is a workaround, and not recommended for production.
+		 * It replaces the wp value that the script overwrote.
+		 *
+		 * @returns void.
+		 */
+		getScript: function() {
+			var previousWp = wp;
+			$.getScript( 'https://cdn.ampproject.org/v0/validator.js', function() {
+				wp = previousWp;
+				component.processBlocks();
+			} );
+		},
+
+		/**
+		 * Gets all of the registered blocks, and overwrites their edit() functions.
+		 *
+		 * THe new edit() functions will check if the content is AMP-compliant.
+		 * If not, the block will display a notice.
+		 *
+		 * @returns {void}
+		 */
+		processBlocks: function() {
+			var blocks = wp.blocks.getBlockTypes(),
+				key = 'name';
+			blocks.forEach( function( block ) {
+				if ( block.hasOwnProperty( key ) ) {
+					component.overwriteEdit( block[ key ] );
+				}
+			} );
+		},
+
+		/**
+		 * Overwrites the edit() function of a block.
+		 *
+		 * Retain the original edit function in OriginalBlockEdit.
+		 * If the block's content isn't valid AMP,
+		 * Prepend a notice to the block.
+		 *
+		 * @see https://riad.blog/2017/10/16/one-thousand-and-one-way-to-extend-gutenberg-today/
+		 * @param {string} blockType the type of the block, like 'core/paragraph'.
+		 * @returns {void}
+		 */
+		overwriteEdit: function( blockType ) {
+			var el = wp.element.createElement,
+				Notice = wp.components.Notice,
+				block = wp.blocks.unregisterBlockType( blockType ),
+				OriginalBlockEdit = block.edit;
+
+			block.edit = function( props ) {
+				var result = [ el( OriginalBlockEdit, props ) ],
+					content = block.save( props );
+
+				if ( 'string' !== typeof content ) {
+					content = wp.element.renderToString( content );
+				}
+
+				// If validation fails, prepend a Notice to the block.
+				if ( ! component.isValidAMP( content ) ) {
+					result.unshift( el(
+						Notice,
+						{
+							status: 'warning',
+							content: component.data.i18n.notice,
+							isDismissible: false
+						}
+					) );
+				}
+				return result;
+			};
+			wp.blocks.registerBlockType( blockType, block );
+		},
+
+		/**
+		 * Whether markup is valid AMP.
+		 *
+		 * Uses the AMP validator from the AMP CDN.
+		 * And places the passed markup inside the <body> tag of a basic valid AMP page.
+		 * Then, validates that page.
+		 *
+		 * @param {string} markup The markup to test.
+		 * @returns {boolean} $valid Whether the passed markup is valid AMP.
+		 */
+		isValidAMP: function( markup ) {
+			var ampDocument = `<!doctype html><html ⚡><head><meta charset="utf-8"><link rel="canonical" href="./regular-html-version.html"><meta name="viewport" content="width=device-width,minimum-scale=1"><style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><script async src="https://cdn.ampproject.org/v0.js"></script></head><body>${markup}</body></html>`,
+				validated = amp.validator.validateString( ampDocument ),
+				validKey = 'status';
+			return ( validated.hasOwnProperty( validKey ) && 'PASS' === validated[ validKey ] );
+		}
+	};
+
+	return {
+		boot: component.boot
+	};
+
+} )( window.jQuery );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -235,6 +235,29 @@ class AMP_Theme_Support {
 	}
 
 	/**
+	 * Enqueues Gutenberg integration script.
+	 *
+	 * @return void.
+	 */
+	public static function enqueue_gutenberg() {
+		$slug = 'amp-gutenberg';
+		wp_enqueue_script(
+			$slug,
+			amp_get_asset_url( 'js/amp-gutenberg.js' ),
+			array( 'jquery' ),
+			AMP__VERSION,
+			true
+		);
+		wp_add_inline_script( $slug, sprintf( 'ampGutenberg.boot( %s );',
+			wp_json_encode( array(
+				'i18n' => array(
+					'notice' => __( 'This is not valid AMP', 'amp' ),
+				),
+			) )
+		) );
+	}
+
+	/**
 	 * Register content embed handlers.
 	 *
 	 * This was copied from `AMP_Content::register_embed_handlers()` due to being a private method

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -135,20 +135,24 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue_gutenberg.
+	 * Test enqueue_editor.
 	 *
-	 * @covers AMP_Theme_Support::enqueue_gutenberg()
+	 * @covers AMP_Theme_Support::enqueue_editor()
 	 */
-	public function test_enqueue_gutenberg() {
-		AMP_Theme_Support::enqueue_gutenberg();
-		$slug = 'amp-gutenberg';
+	public function test_enqueue_editor() {
+		global $post;
+		$post = $this->factory()->post->create();
+		AMP_Theme_Support::enqueue_editor();
+		$slug   = 'amp-editor-validation';
 		$script = wp_scripts()->registered[ $slug ];
-		$this->assertContains( 'js/amp-gutenberg.js', $script->src );
+		$this->assertContains( 'js/amp-editor-validation.js', $script->src );
 		$this->assertEquals( array( 'jquery' ), $script->deps );
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, wp_scripts()->queue, true ) );
 		$this->assertContains( 'ampGutenberg.boot', $script->extra['after'][1] );
 		$this->assertContains( 'This is not valid AMP', $script->extra['after'][1] );
+		$this->assertContains( wp_json_encode( get_the_permalink() ), $script->extra['after'][1] );
+		$this->assertContains( 'doValidatePage', $script->extra['after'][1] );
 	}
 
 }

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -133,4 +133,22 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertContains( '<script async custom-element="amp-ad"', $sanitized_html );
 	}
+
+	/**
+	 * Test enqueue_gutenberg.
+	 *
+	 * @covers AMP_Theme_Support::enqueue_gutenberg()
+	 */
+	public function test_enqueue_gutenberg() {
+		AMP_Theme_Support::enqueue_gutenberg();
+		$slug = 'amp-gutenberg';
+		$script = wp_scripts()->registered[ $slug ];
+		$this->assertContains( 'js/amp-gutenberg.js', $script->src );
+		$this->assertEquals( array( 'jquery' ), $script->deps );
+		$this->assertEquals( AMP__VERSION, $script->ver );
+		$this->assertTrue( in_array( $slug, wp_scripts()->queue, true ) );
+		$this->assertContains( 'ampGutenberg.boot', $script->extra['after'][1] );
+		$this->assertContains( 'This is not valid AMP', $script->extra['after'][1] );
+	}
+
 }


### PR DESCRIPTION
**WIP Pull Request**

Hi @westonruter and @ThierryA,
Here's the beginning of the script to validate Gutenberg blocks. The script is similar to the one [pasted in Issue 843](https://github.com/Automattic/amp-wp/issues/843#issuecomment-360251366). But it applies AMP validation to every block.

As @westonruter suggested, it gets the content by calling the block's `save()` function. As this is what goes to the server.

We might consider not displaying notices for all blocks. Some are valid AMP once the back-end sanitizer alters them. Like the 'Audio' block.

This still works mainly like in the [earlier screencast](https://cloudup.com/cPYRW-m2Ysf), just for all of the blocks. Though I need to test this on more of them.

I still need to handle [Travis issues](https://travis-ci.org/Automattic/amp-wp/jobs/333145167).

For full-page validation on saving, especially in the "classic" editor, we might do something like [this snippet](https://github.com/ampproject/amphtml/issues/9371#issuecomment-306603777).

See #843.