### PR TITLE
Prevent saveHTML from munging amp-mustache curly braces via URL-encoding

### DIFF
--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -317,7 +317,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'attribute_value_valid'                                     => array(
-				'<template type="amp-mustache">Template Data</template>',
+				'<template type="amp-mustache">Hello {{world}}! <a href="{{user_url}}" title="{{user_name}}">Homepage</a> User content: {{{some_formatting}}} A guy with Mustache: :-{). {{#returning}}Welcome back!{{/returning}} {{^returning}}Welcome for the first time!{{/returning}} </template>',
 				null,
 				array( 'amp-mustache' ),
 			),


### PR DESCRIPTION
Cherry-picked from #871. URL-encoding of braces in `href` attributes is a side effect of switching from `saveXML` to `saveHTML` in #891.