### PR TITLE
Issue #864: Support <amp-carousel> in 'Gallery' widget.

### DIFF
--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -86,6 +86,7 @@ class AMP_Autoloader {
 		'AMP_WP_Utils'                                => 'includes/utils/class-amp-wp-utils',
 		'AMP_Widget_Archives'                         => 'includes/widgets/class-amp-widget-archives',
 		'AMP_Widget_Categories'                       => 'includes/widgets/class-amp-widget-categories',
+		'AMP_Widget_Media_Gallery'                    => 'includes/widgets/class-amp-widget-media-gallery',
 		'AMP_Widget_Recent_Comments'                  => 'includes/widgets/class-amp-widget-recent-comments',
 		'WPCOM_AMP_Polldaddy_Embed'                   => 'wpcom/class-amp-polldaddy-embed',
 		'AMP_Test_Stub_Sanitizer'                     => 'tests/stubs',

--- a/includes/widgets/class-amp-widget-media-gallery.php
+++ b/includes/widgets/class-amp-widget-media-gallery.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class AMP_Widget_Media_Gallery
+ *
+ * @since 0.7.0
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Widget_Media_Gallery
+ *
+ * @since 0.7.0
+ * @package AMP
+ */
+class AMP_Widget_Media_Gallery extends WP_Widget_Media_Gallery {
+
+	/**
+	 * Renders the markup of the widget.
+	 *
+	 * Mainly copied from WP_Widget_Media_Gallery::render_media().
+	 * But instead of calling shortcode_gallery(),
+	 * It uses this plugin's embed handler for galleries.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param array $instance Data for widget.
+	 * @return void
+	 */
+	public function render_media( $instance ) {
+		if ( ! is_amp_endpoint() ) {
+			parent::render_media( $instance );
+			return;
+		}
+
+		$instance       = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
+		$shortcode_atts = array_merge(
+			$instance,
+			array(
+				'link' => $instance['link_type'],
+			)
+		);
+
+		if ( isset( $instance['orderby_random'] ) && ( true === $instance['orderby_random'] ) ) {
+			$shortcode_atts['orderby'] = 'rand';
+		}
+
+		$handler = new AMP_Gallery_Embed_Handler();
+		echo $handler->shortcode( $shortcode_atts ); // WPCS: XSS ok.
+	}
+
+}

--- a/includes/widgets/class-amp-widget-media-gallery.php
+++ b/includes/widgets/class-amp-widget-media-gallery.php
@@ -6,46 +6,48 @@
  * @package AMP
  */
 
-/**
- * Class AMP_Widget_Media_Gallery
- *
- * @since 0.7.0
- * @package AMP
- */
-class AMP_Widget_Media_Gallery extends WP_Widget_Media_Gallery {
-
+if ( class_exists( 'WP_Widget_Media_Gallery' ) ) {
 	/**
-	 * Renders the markup of the widget.
-	 *
-	 * Mainly copied from WP_Widget_Media_Gallery::render_media().
-	 * But instead of calling shortcode_gallery(),
-	 * It uses this plugin's embed handler for galleries.
+	 * Class AMP_Widget_Media_Gallery
 	 *
 	 * @since 0.7.0
-	 *
-	 * @param array $instance Data for widget.
-	 * @return void
+	 * @package AMP
 	 */
-	public function render_media( $instance ) {
-		if ( ! is_amp_endpoint() ) {
-			parent::render_media( $instance );
-			return;
+	class AMP_Widget_Media_Gallery extends WP_Widget_Media_Gallery {
+
+		/**
+		 * Renders the markup of the widget.
+		 *
+		 * Mainly copied from WP_Widget_Media_Gallery::render_media().
+		 * But instead of calling shortcode_gallery(),
+		 * It uses this plugin's embed handler for galleries.
+		 *
+		 * @since 0.7.0
+		 *
+		 * @param array $instance Data for widget.
+		 * @return void
+		 */
+		public function render_media( $instance ) {
+			if ( ! is_amp_endpoint() ) {
+				parent::render_media( $instance );
+				return;
+			}
+
+			$instance       = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
+			$shortcode_atts = array_merge(
+				$instance,
+				array(
+					'link' => $instance['link_type'],
+				)
+			);
+
+			if ( isset( $instance['orderby_random'] ) && ( true === $instance['orderby_random'] ) ) {
+				$shortcode_atts['orderby'] = 'rand';
+			}
+
+			$handler = new AMP_Gallery_Embed_Handler();
+			echo $handler->shortcode( $shortcode_atts ); // WPCS: XSS ok.
 		}
 
-		$instance       = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
-		$shortcode_atts = array_merge(
-			$instance,
-			array(
-				'link' => $instance['link_type'],
-			)
-		);
-
-		if ( isset( $instance['orderby_random'] ) && ( true === $instance['orderby_random'] ) ) {
-			$shortcode_atts['orderby'] = 'rand';
-		}
-
-		$handler = new AMP_Gallery_Embed_Handler();
-		echo $handler->shortcode( $shortcode_atts ); // WPCS: XSS ok.
 	}
-
 }

--- a/includes/widgets/class-amp-widget-media-gallery.php
+++ b/includes/widgets/class-amp-widget-media-gallery.php
@@ -10,6 +10,8 @@ if ( class_exists( 'WP_Widget_Media_Gallery' ) ) {
 	/**
 	 * Class AMP_Widget_Media_Gallery
 	 *
+	 * @todo This subclass can eventually be eliminated once #25435 is merged and the WP_Widget_Media_Gallery::render_media() does do_single_shortcode( 'gallery', $instance ).
+	 * @link https://core.trac.wordpress.org/ticket/25435
 	 * @since 0.7.0
 	 * @package AMP
 	 */
@@ -19,8 +21,7 @@ if ( class_exists( 'WP_Widget_Media_Gallery' ) ) {
 		 * Renders the markup of the widget.
 		 *
 		 * Mainly copied from WP_Widget_Media_Gallery::render_media().
-		 * But instead of calling shortcode_gallery(),
-		 * It uses this plugin's embed handler for galleries.
+		 * But instead of calling shortcode_gallery(), it calls do_shortcode().
 		 *
 		 * @since 0.7.0
 		 *
@@ -45,8 +46,21 @@ if ( class_exists( 'WP_Widget_Media_Gallery' ) ) {
 				$shortcode_atts['orderby'] = 'rand';
 			}
 
-			$handler = new AMP_Gallery_Embed_Handler();
-			echo $handler->shortcode( $shortcode_atts ); // WPCS: XSS ok.
+			/*
+			 * The following calls do_shortcode() in case another plugin overrides the gallery shortcode.
+			 * The AMP_Gallery_Embed_Handler in the plugin is doing this itself, but other plugins may
+			 * do it as well, so this ensures that a plugin has the option to override the gallery behavior
+			 * via registering a different gallery shortcode handler. The shortcode serialization can be
+			 * eliminated once WP Trac #25435 is merged and the Gallery widget uses the proposed do_single_shortcode().
+			 */
+			$shortcode_atts_str = '';
+			if ( is_array( $shortcode_atts['ids'] ) ) {
+				$shortcode_atts['ids'] = join( ',', $shortcode_atts['ids'] );
+			}
+			foreach ( $shortcode_atts as $key => $value ) {
+				$shortcode_atts_str .= sprintf( ' %s="%s"', $key, esc_attr( $value ) );
+			}
+			echo do_shortcode( "[gallery $shortcode_atts_str]" ); // WPCS: XSS ok.
 		}
 
 	}

--- a/tests/test-class-amp-widget-media-gallery.php
+++ b/tests/test-class-amp-widget-media-gallery.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for class AMP_Widget_Media_Gallery.
+ *
+ * @package AMP
+ */
+
+/**
+ * Tests for class AMP_Widget_Media_Gallery.
+ *
+ * @package AMP
+ */
+class Test_AMP_Widget_Media_Gallery extends WP_UnitTestCase {
+
+	/**
+	 * Instance of the widget.
+	 *
+	 * @var object
+	 */
+	public $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		AMP_Theme_Support::register_widgets();
+		$this->instance = new AMP_Widget_Media_Gallery();
+	}
+
+	/**
+	 * Test render_media().
+	 *
+	 * @see AMP_Widget_Media_Gallery::widget().
+	 */
+	public function test_render_media() {
+		$first_test_image = '/tmp/test-image.jpg';
+		copy( DIR_TESTDATA . '/images/test-image.jpg', $first_test_image );
+		$first_attachment_id = self::factory()->attachment->create_object( array(
+			'file'           => $first_test_image,
+			'post_parent'    => 0,
+			'post_mime_type' => 'image/jpeg',
+			'post_title'     => 'Test Image',
+		) );
+		wp_update_attachment_metadata( $first_attachment_id, wp_generate_attachment_metadata( $first_attachment_id, $first_test_image ) );
+		$ids[] = $first_attachment_id;
+
+		$second_test_image = '/tmp/test-image.jpg';
+		copy( DIR_TESTDATA . '/images/test-image.jpg', $second_test_image );
+		$second_attachment_id = self::factory()->attachment->create_object( array(
+			'file'           => $second_test_image,
+			'post_parent'    => 0,
+			'post_mime_type' => 'image/jpeg',
+			'post_title'     => 'Test Image',
+		) );
+		wp_update_attachment_metadata( $second_attachment_id, wp_generate_attachment_metadata( $second_attachment_id, $second_test_image ) );
+		$ids[]    = $second_attachment_id;
+		$instance = array(
+			'title' => 'Test Gallery Widget',
+			'ids'   => $ids,
+		);
+
+		ob_start();
+		$this->instance->render_media( $instance );
+		$output = ob_get_clean();
+
+		$this->assertContains( 'amp-carousel', $output );
+		$this->assertContains( $first_test_image, $output );
+		$this->assertContains( $second_test_image, $output );
+	}
+
+}

--- a/tests/test-class-amp-widget-media-gallery.php
+++ b/tests/test-class-amp-widget-media-gallery.php
@@ -28,6 +28,9 @@ class Test_AMP_Widget_Media_Gallery extends WP_UnitTestCase {
 		parent::setUp();
 		AMP_Theme_Support::register_widgets();
 		$this->instance = new AMP_Widget_Media_Gallery();
+		if ( ! class_exists( 'WP_Widget_Media_Gallery' ) ) {
+			$this->markTestSkipped( 'This WordPress version does not have a Gallery widget' );
+		}
 	}
 
 	/**

--- a/tests/test-class-amp-widget-media-gallery.php
+++ b/tests/test-class-amp-widget-media-gallery.php
@@ -25,12 +25,12 @@ class Test_AMP_Widget_Media_Gallery extends WP_UnitTestCase {
 	 * @inheritdoc
 	 */
 	public function setUp() {
+		if ( ! class_exists( 'AMP_Widget_Media_Gallery' ) ) {
+			$this->markTestSkipped( 'This WordPress version does not have a Gallery widget.' );
+		}
 		parent::setUp();
 		AMP_Theme_Support::register_widgets();
 		$this->instance = new AMP_Widget_Media_Gallery();
-		if ( ! class_exists( 'WP_Widget_Media_Gallery' ) ) {
-			$this->markTestSkipped( 'This WordPress version does not have a Gallery widget' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
**Request For Code Review**

Hi @ThierryA or @westonruter, 
Could you please review this pull request, which makes the 'Gallery' widget use an `<amp-carousel>`?

<img width="525" alt="new-media-gallery-widget" src="https://user-images.githubusercontent.com/4063887/35542036-8b1ecef2-0523-11e8-9f9b-e5a86591aee1.png">

It overrides the 'Gallery' widget's `render()` function, and uses the [embed handler](https://github.com/Automattic/amp-wp/blob/develop/includes/embeds/class-amp-gallery-embed.php) for galleries. 

Before, the gallery appeared without a carousel, and of course unstyled:
<img width="857" alt="gallery-widget" src="https://user-images.githubusercontent.com/4063887/35542060-a19dc71e-0523-11e8-8fc4-5ef465d14294.png">

Fixes #864.