### PR TITLE
Fix AMP preview icon in Firefox

### DIFF
--- a/assets/css/amp-post-meta-box.css
+++ b/assets/css/amp-post-meta-box.css
@@ -16,16 +16,21 @@
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 	text-indent: -9999px;
-	padding-right: 7px;
-	padding-left: 7px;
+	padding-right: 14px;
+	padding-left: 14px;
+	position: relative;
 }
 
 .wp-core-ui #amp-post-preview.preview::after {
 	content: "icon";
-	width: 14px;
-	float: left;
 	background: no-repeat center url( '../images/amp-icon.svg' );
 	background-size: 14px !important;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	display: block;
+	position: absolute;
 }
 
 .wp-core-ui #amp-post-preview.preview.disabled::after {


### PR DESCRIPTION
The AMP preview icon isn't displaying correctly in Firefox - see screenshot below (probably because of a different interpretation of the text-indent css rule). My proposed fix works in latest releases of Firefox, Chrome, Safari, Edge and IE.

![fix-amp-wp-preview-icon-in-firefox](https://user-images.githubusercontent.com/19647328/35593777-2a3f6d28-0611-11e8-9477-3a4bfb7b653e.png)