### PR TITLE
Fix dispatch_key handling for NAME_VALUE_DISPATCH; add cdata validation

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -248,8 +248,8 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 	sorted_properties = sorted(properties.items())
 	for (prop, values) in collections.OrderedDict(sorted_properties).iteritems():
 		logging.info('generating php for property: %s...' % prop.lower())
-		if isinstance(values, (str, bool)):
-			if isinstance(values, str):
+		if isinstance(values, (unicode,str, bool)):
+			if isinstance(values, (unicode,str)):
 				values = values.lower()
 			out.append('%s\'%s\' => \'%s\',' % (indent, prop.lower(), values))
 		elif isinstance(values, (int)):
@@ -257,13 +257,13 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 		else:
 			out.append('%s\'%s\' => array(' % (indent, prop.lower()))
 			sorted_values = sorted(values.items())
-			for(value_type, value) in collections.OrderedDict(sorted_values).iteritems():
-				if isinstance(value, (str, bool)):
+			for(key, value) in collections.OrderedDict(sorted_values).iteritems():
+				if isinstance(value, (unicode, str, bool)):
 					if isinstance(value, str):
 						value = value.lower()
-					out.append('%s\t\'%s\' => \'%s\',' % (indent, value_type, value))
+					out.append('%s\t\'%s\' => \'%s\',' % (indent, key, value))
 				elif isinstance(value, (int)):
-					out.append('%s\t\'%s\' => %d,' % (indent, value_type, value))
+					out.append('%s\t\'%s\' => %d,' % (indent, key, value))
 				else:
 					GenerateValuesPHP(out, value)
 			out.append('%s),' % indent)
@@ -442,7 +442,6 @@ def GetTagSpec(tag_spec, attr_lists):
 
 	tag_dict = GetTagRules(tag_spec)
 	attr_dict = GetAttrs(tag_spec.attrs)
-	# TODO: add CDATA section if validation of non-body elements is required.
 
 	# Now add attributes from any attribute lists to this tag.
 	for (tag_field_desc, tag_field_val) in tag_spec.ListFields():
@@ -451,7 +450,24 @@ def GetTagSpec(tag_spec, attr_lists):
 				attr_dict.update(attr_lists[UnicodeEscape(attr_list)])
 
 	logging.info('... done')
-	return {'tag_spec':tag_dict, 'attr_spec_list':attr_dict}
+	tag_spec_dict = {'tag_spec':tag_dict, 'attr_spec_list':attr_dict}
+	if tag_spec.HasField('cdata'):
+		cdata_dict = {}
+		for (field_descriptor, field_value) in tag_spec.cdata.ListFields():
+			if isinstance(field_value, (unicode, str, bool, int)):
+				cdata_dict[ field_descriptor.name ] = field_value
+			else:
+				if 'css_spec' == field_descriptor.name:
+					continue
+				if hasattr( field_value, '_values' ):
+					cdata_dict[ field_descriptor.name ] = {}
+					for _value in field_value._values:
+						for (key,val) in _value.ListFields():
+							cdata_dict[ field_descriptor.name ][ key.name ] = val
+		if len( cdata_dict ) > 0:
+			tag_spec_dict['cdata'] = cdata_dict
+
+	return tag_spec_dict
 
 
 def GetTagRules(tag_spec):

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -457,8 +457,6 @@ def GetTagSpec(tag_spec, attr_lists):
 			if isinstance(field_value, (unicode, str, bool, int)):
 				cdata_dict[ field_descriptor.name ] = field_value
 			else:
-				if 'css_spec' == field_descriptor.name:
-					continue
 				if hasattr( field_value, '_values' ):
 					cdata_dict[ field_descriptor.name ] = {}
 					for _value in field_value._values:

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -252,6 +252,8 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 			if isinstance(values, str):
 				values = values.lower()
 			out.append('%s\'%s\' => \'%s\',' % (indent, prop.lower(), values))
+		elif isinstance(values, (int)):
+			out.append('%s\'%s\' => %d,' % (indent, prop.lower(), values))
 		else:
 			out.append('%s\'%s\' => array(' % (indent, prop.lower()))
 			sorted_values = sorted(values.items())
@@ -260,6 +262,8 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 					if isinstance(value, str):
 						value = value.lower()
 					out.append('%s\t\'%s\' => \'%s\',' % (indent, value_type, value))
+				elif isinstance(value, (int)):
+					out.append('%s\t\'%s\' => %d,' % (indent, value_type, value))
 				else:
 					GenerateValuesPHP(out, value)
 			out.append('%s),' % indent)
@@ -283,6 +287,9 @@ def GenerateValuesPHP(out, values, indent_level = 6):
 
 			if isinstance(value, (str, bool)):
 				out.append('%s\'%s\' => \'%s\',' % (indent, key.lower(), value))
+
+			elif isinstance(value, (int)):
+				out.append('%s\'%s\' => %d,' % (indent, key.lower(), value))
 
 			else:
 				out.append('%s\'%s\' => array(' % (indent, key.lower()))
@@ -552,7 +559,7 @@ def GetValues(attr_spec):
 	if attr_spec.HasField('blacklisted_value_regex'):
 		value_dict['blacklisted_value_regex'] = UnicodeEscape(attr_spec.blacklisted_value_regex)
 
-	# dispatch_key is a boolean
+	# dispatch_key is an int
 	if attr_spec.HasField('dispatch_key'):
 		value_dict['dispatch_key'] = attr_spec.dispatch_key
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -179,7 +179,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'alt' => array(),
 					'data-multi-size' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
+						'value' => '',
 					),
 					'json' => array(),
 					'media' => array(),
@@ -746,6 +748,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'alt' => array(),
 					'data-multi-size' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => '',
 					),
@@ -2948,6 +2951,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'align' => array(),
 					'submitting' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
 				),
@@ -2961,6 +2965,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'align' => array(),
 					'submit-success' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
 				),
@@ -2974,6 +2979,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'align' => array(),
 					'submit-error' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
 				),
@@ -3965,6 +3971,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'enctype' => array(),
 					'method' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'post',
 					),
@@ -4942,6 +4949,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'hreflang' => array(),
 					'itemprop' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'sameas',
 					),
@@ -5239,6 +5247,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'x-ua-compatible',
 					),
@@ -5279,6 +5288,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'text/html; charset=utf-8',
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'content-type',
 					),
@@ -5300,6 +5310,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'content-language',
 					),
@@ -5321,6 +5332,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'pics-label',
 					),
@@ -5342,6 +5354,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'imagetoolbar',
 					),
@@ -5364,6 +5377,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'text/css',
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'content-style-type',
 					),
@@ -5386,6 +5400,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'text/javascript',
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'content-script-type',
 					),
@@ -5407,6 +5422,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'origin-trial',
 					),
@@ -5428,6 +5444,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'http-equiv' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'resource-type',
 					),
@@ -5500,6 +5517,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'toolbar' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
 					'toolbar-target' => array(
@@ -6307,6 +6325,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'application/ld+json',
 					),
@@ -6319,6 +6338,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
 					),
@@ -6336,6 +6356,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value' => 'application/json',
 					),
@@ -6357,6 +6378,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
 					),
@@ -6379,6 +6401,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
 					),
@@ -6396,6 +6419,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
 					),
@@ -6417,6 +6441,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
 					),
@@ -6795,6 +6820,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'amp-boilerplate' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value' => '',
 					),
@@ -6816,6 +6842,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'amp-keyframes' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 						'value' => '',
 					),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -6330,6 +6330,12 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'application/ld+json',
 					),
 				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
 				'tag_spec' => array(
 					'spec_name' => 'script type=application/ld+json',
 				),
@@ -6341,6 +6347,12 @@ class AMP_Allowed_Tags_Generated {
 						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
 					),
 				),
 				'tag_spec' => array(
@@ -6383,6 +6395,12 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'application/json',
 					),
 				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
 				'tag_spec' => array(
 					'html_format' => array(
 							'amp',
@@ -6406,6 +6424,12 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'application/json',
 					),
 				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-animation',
 					'requires_extension' => array(
@@ -6422,6 +6446,12 @@ class AMP_Allowed_Tags_Generated {
 						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
 					),
 				),
 				'tag_spec' => array(
@@ -6444,6 +6474,12 @@ class AMP_Allowed_Tags_Generated {
 						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value_casei' => 'application/json',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
 					),
 				),
 				'tag_spec' => array(
@@ -6826,6 +6862,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'nonce' => array(),
 				),
+				'cdata' => array(
+					'cdata_regex' => '\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\s*',
+				),
 				'tag_spec' => array(
 					'html_format' => array(
 							'amp',
@@ -6846,6 +6885,10 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => '',
 					),
+				),
+				'cdata' => array(
+					'max_bytes' => 500000,
+					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#keyframes-stylesheet',
 				),
 				'tag_spec' => array(
 					'html_format' => array(

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -17,6 +17,7 @@ abstract class AMP_Rule_Spec {
 	 */
 	const ATTR_SPEC_LIST = 'attr_spec_list';
 	const TAG_SPEC       = 'tag_spec';
+	const CDATA          = 'cdata';
 
 	/**
 	 * AMP attr_spec value check results

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -47,6 +47,23 @@ abstract class AMP_Rule_Spec {
 	const VALUE_REGEX             = 'value_regex';
 	const VALUE_REGEX_CASEI       = 'value_regex_casei';
 
+	/*
+	 * DispatchKeyTypes:
+	 * https://github.com/ampproject/amphtml/blob/eda1daa8c40f830207edc8d8088332b32a15c1a4/validator/validator.proto#L111-L120
+	 */
+
+	// Indicates that the attribute does not form a dispatch key.
+	const NONE_DISPATCH = 0;
+
+	// Indicates that the name of the attribute alone forms a dispatch key.
+	const NAME_DISPATCH = 1;
+
+	// Indicates that the name + value of the attribute forms a dispatch key.
+	const NAME_VALUE_DISPATCH = 2;
+
+	// Indicates that the name + value + mandatory parent forms a dispatch key.
+	const NAME_VALUE_PARENT_DISPATCH = 3;
+
 	/**
 	 * If a node type listed here is invalid, it and it's subtree will be
 	 * removed if it is invalid. This is mainly  because any children will be

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -143,4 +143,45 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		// Test stylesheet.
 		$this->assertEquals( $expected_stylesheets, array_values( $sanitizer->get_stylesheets() ) );
 	}
+
+	/**
+	 * Get amp-keyframe styles.
+	 *
+	 * @return array
+	 */
+	public function get_keyframe_data() {
+		return array(
+			'style_amp_keyframes'              => array(
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes foo {} }</style>',
+				null, // No Change.
+			),
+
+			'style_amp_keyframes_max_overflow' => array(
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes ' . str_repeat( 'a', 500000 ) . ' {} }</style>',
+				'',
+			),
+
+			'style_amp_keyframes_last_child'   => array(
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes foo {} }</style> as <b>after</b>',
+				' as <b>after</b>',
+			),
+		);
+	}
+
+	/**
+	 * Test amp-keyframe styles.
+	 *
+	 * @dataProvider get_keyframe_data
+	 * @param string $source   Markup to process.
+	 * @param string $expected The markup to expect.
+	 */
+	public function test_keyframe_sanitizer( $source, $expected = null ) {
+		$expected  = isset( $expected ) ? $expected : $source;
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Style_Sanitizer( $dom );
+		$sanitizer->sanitize();
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
+		$this->assertEquals( $expected, $content );
+	}
 }

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -264,7 +264,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			// Try to test for NAME_VALUE_PARENT_DISPATCH.
 			'amp_ima_video'                                             => array(
 				'<amp-ima-video width="640" height="360" layout="responsive" data-tag="ads.xml" data-poster="poster.png"><source src="foo.mp4" type="video/mp4"><source src="foo.webm" type="video/webm"><track label="English subtitles" kind="subtitles" srclang="en" src="https://example.com/subtitles.vtt"><script type="application/json">{"locale": "en", "numRedirects": 4}</script></amp-ima-video>',
-				null,
+				null, // No change.
 				array( 'amp-ima-video' ),
 			),
 
@@ -279,6 +279,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'nav_dispatch_key'                                          => array(
 				'<nav><a href="https://example.com">Example</a></nav>',
 				null,
+			),
+
+			'json_linked_data'                                          => array(
+				'<script type="application/ld+json">{"@context":"http:\/\/schema.org"}</script>',
+				null, // No Change.
+			),
+
+			'json_linked_data_with_bad_cdata'                          => array(
+				'<script type="application/ld+json"><!-- {"@context":"http:\/\/schema.org"} --></script>',
+				'',
 			),
 
 			'facebook'                                                  => array(

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -261,10 +261,24 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-dailymotion' ),
 			),
 
+			// Try to test for NAME_VALUE_PARENT_DISPATCH.
+			'amp_ima_video'                                             => array(
+				'<amp-ima-video width="640" height="360" layout="responsive" data-tag="ads.xml" data-poster="poster.png"><source src="foo.mp4" type="video/mp4"><source src="foo.webm" type="video/webm"><track label="English subtitles" kind="subtitles" srclang="en" src="https://example.com/subtitles.vtt"><script type="application/json">{"locale": "en", "numRedirects": 4}</script></amp-ima-video>',
+				null,
+				array( 'amp-ima-video' ),
+			),
+
+			// Try to test for NAME_VALUE_DISPATCH.
 			'doubleclick-1'                                             => array(
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
 				array( 'amp-ad' ),
+			),
+
+			// Try to test for NAME_DISPATCH.
+			'nav_dispatch_key'                                          => array(
+				'<nav><a href="https://example.com">Example</a></nav>',
+				null,
 			),
 
 			'facebook'                                                  => array(


### PR DESCRIPTION
This fixes the longstanding annoyance for when the spec was read, the one `value` had to be removed for `data-multi-size` or else unit tests would fail. It turns out to be due to the `dispatch_key` not being supported. So this is now fixed and the list of tags and attributes can be re-generated at will.

In addition to `dispatch_key` being included in the generated PHP file, so too `cdata` is now included, with validation for blacklisted regex and amp-keyframes styles. This is needed for validating elements in the `head`. See #926.