### PR TITLE
Add full document sanitization in theme support

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -34,6 +34,8 @@ import subprocess
 import sys
 import tempfile
 import collections
+import json
+import google
 
 def Die(msg):
 		print >> sys.stderr, msg
@@ -164,8 +166,7 @@ def GenerateSpecVersionPHP(out, versions):
 	if versions['spec_file_revision']:
 		out.append('\tprivate static $spec_file_revision = %d;' % versions['spec_file_revision'])
 	if versions['min_validator_revision_required']:
-		out.append('\tprivate static $minimum_validator_revision_required = %d;' %
-							 versions['min_validator_revision_required'])
+		out.append('\tprivate static $minimum_validator_revision_required = %d;' % versions['min_validator_revision_required'])
 	logging.info('... done')
 
 
@@ -174,11 +175,7 @@ def GenerateAllowedTagsPHP(out, allowed_tags):
 
   # Output the allowed tags dictionary along with each tag's allowed attributes
 	out.append('')
-	out.append('\tprivate static $allowed_tags = array(')
-	sorted_tags = sorted(allowed_tags.items())
-	for (tag, attributes_list) in collections.OrderedDict(sorted_tags).iteritems():
-		GenerateTagPHP(out, tag, attributes_list)
-	out.append('\t);')
+	out.append('\tprivate static $allowed_tags = %s;' % Phpize( allowed_tags, 1 ).lstrip() )
 	logging.info('... done')
 
 
@@ -187,9 +184,7 @@ def GenerateLayoutAttributesPHP(out, attr_lists):
 
 	# Output the attribute list allowed for layouts.
 	out.append('')
-	out.append('\tprivate static $layout_allowed_attrs = array(')
-	GenerateAttributesPHP(out, attr_lists['$AMP_LAYOUT_ATTRS'], 2)
-	out.append('\t);')
+	out.append('\tprivate static $layout_allowed_attrs = %s;' % Phpize( attr_lists['$AMP_LAYOUT_ATTRS'], 1 ).lstrip() )
 	out.append('')
 	logging.info('... done')
 
@@ -199,114 +194,9 @@ def GenerateGlobalAttributesPHP(out, attr_lists):
 
 	# Output the globally allowed attribute list.
 	out.append('')
-	out.append('\tprivate static $globally_allowed_attrs = array(')
-	GenerateAttributesPHP(out, attr_lists['$GLOBAL_ATTRS'], 2)
-	out.append('\t);')
+	out.append('\tprivate static $globally_allowed_attrs = %s;' % Phpize( attr_lists['$GLOBAL_ATTRS'], 1 ).lstrip() )
 	out.append('')
 	logging.info('... done')
-
-
-def GenerateTagPHP(out, tag, attributes_list):
-	logging.info('generating php for tag: %s...' % tag.lower())
-
-	# Output an attributes list for a tag
-	out.append('\t\t\'%s\' => array(' % tag.lower())
-	for attributes in attributes_list:
-		out.append('\t\t\tarray(')
-		GenerateAttributesPHP(out, attributes)
-		out.append('\t\t\t),')
-	out.append('\t\t),')
-	logging.info('... done with: %s' % tag.lower())
-
-
-def GenerateAttributesPHP(out, attributes, indent_level = 4):
-	logging.info('entering ...')
-
-	indent = ''
-	for i in range(0,indent_level):
-		indent += '\t'
-
-	sorted_attributes = sorted(attributes.items())
-	for (attribute, values) in collections.OrderedDict(sorted_attributes).iteritems():
-		logging.info('generating php for attribute: %s...' % attribute.lower())
-		out.append('%s\'%s\' => array(' % (indent, attribute.lower()))
-		GeneratePropertiesPHP(out, values)
-		out.append('%s),' % indent)
-		logging.info('...done with: %s' % attribute.lower())
-
-	out.append('')
-	logging.info('... done')
-
-
-def GeneratePropertiesPHP(out, properties, indent_level = 5):
-	logging.info('entering ...')
-
-	indent = ''
-	for i in range(0,indent_level):
-		indent += '\t'
-
-	sorted_properties = sorted(properties.items())
-	for (prop, values) in collections.OrderedDict(sorted_properties).iteritems():
-		logging.info('generating php for property: %s...' % prop.lower())
-		if isinstance(values, (unicode, str, bool)):
-			if isinstance(values, (unicode, str) ) and prop in ( 'mandatory_parent', 'mandatory_ancestor', 'mandatory_ancestor_suggested_alternative' ):
-				values = values.lower()
-			out.append('%s\'%s\' => \'%s\',' % (indent, prop.lower(), values))
-		elif isinstance(values, (int)):
-			out.append('%s\'%s\' => %d,' % (indent, prop.lower(), values))
-		else:
-			out.append('%s\'%s\' => array(' % (indent, prop.lower()))
-			sorted_values = sorted(values.items())
-			for(key, value) in collections.OrderedDict(sorted_values).iteritems():
-				if isinstance(value, (unicode, str, bool)):
-					out.append('%s\t\'%s\' => \'%s\',' % (indent, key, value))
-				elif isinstance(value, (int)):
-					out.append('%s\t\'%s\' => %d,' % (indent, key, value))
-				else:
-					GenerateValuesPHP(out, value)
-			out.append('%s),' % indent)
-		logging.info('...done with: %s' % prop.lower())
-
-	logging.info('...done')
-
-
-def GenerateValuesPHP(out, values, indent_level = 6):
-	logging.info('entering...')
-
-	indent = ''
-	for i in range(0, indent_level):
-		indent += '\t'
-
-	if isinstance(values, dict):
-		sorted_values = sorted(values.items())
-		for (key, value) in collections.OrderedDict(sorted_values).iteritems():
-
-			logging.info('generating php for value: %s...' % key.lower())
-
-			if isinstance(value, (str, bool, unicode)):
-				out.append('%s\'%s\' => \'%s\',' % (indent, key.lower(), value))
-
-			elif isinstance(value, (int)):
-				out.append('%s\'%s\' => %d,' % (indent, key.lower(), value))
-
-			else:
-				out.append('%s\'%s\' => array(' % (indent, key.lower()))
-				sorted_value = sorted(value)
-				for v in sorted_value:
-					out.append('%s\t\'%s\',' % (indent, v))
-				out.append('%s),' % indent)
-
-			logging.info('...done with: %s' % key.lower())
-
-	elif isinstance(values, list):
-		sorted_values = sorted(values)
-		for v in sorted_values:
-			logging.info('generating php for value: %s' % v.lower())
-			out.append('%s\t\'%s\',' % (indent, v.lower()))
-			logging.info('...done with: %s' % v.lower())
-
-	logging.info('...done')
-
 
 def GenerateFooterPHP(out):
 	logging.info('entering ...')
@@ -430,16 +320,16 @@ def ParseRules(out_dir):
 					continue
 
 				# If we made it here, then start adding the tag_spec
-				if tag_spec.tag_name not in allowed_tags:
+				if tag_spec.tag_name.lower() not in allowed_tags:
 					tag_list = []
 				else:
-					tag_list = allowed_tags[UnicodeEscape(tag_spec.tag_name)]
+					tag_list = allowed_tags[UnicodeEscape(tag_spec.tag_name).lower()]
 				# AddTag(allowed_tags, tag_spec, attr_lists)
 
 				gotten_tag_spec = GetTagSpec(tag_spec, attr_lists)
 				if gotten_tag_spec is not None:
 					tag_list.append(gotten_tag_spec)
-					allowed_tags[UnicodeEscape(tag_spec.tag_name)] = tag_list
+					allowed_tags[UnicodeEscape(tag_spec.tag_name).lower()] = tag_list
 
 	logging.info('... done')
 	return allowed_tags, attr_lists, versions
@@ -487,25 +377,25 @@ def GetTagRules(tag_spec):
 		also_requires_tag_list = []
 		for also_requires_tag in tag_spec.also_requires_tag:
 			also_requires_tag_list.append(UnicodeEscape(also_requires_tag))
-		tag_rules['also_requires_tag'] = {'also_requires_tag': also_requires_tag_list}
+		tag_rules['also_requires_tag'] = also_requires_tag_list
 
 	if hasattr(tag_spec, 'requires_extension') and len( tag_spec.requires_extension ) != 0:
 		requires_extension_list = []
 		for requires_extension in tag_spec.requires_extension:
 			requires_extension_list.append(requires_extension)
-		tag_rules['requires_extension'] = {'requires_extension': requires_extension_list}
+		tag_rules['requires_extension'] = requires_extension_list
 
 	if hasattr(tag_spec, 'also_requires_tag_warning') and len( tag_spec.also_requires_tag_warning ) != 0:
 		also_requires_tag_warning_list = []
 		for also_requires_tag_warning in tag_spec.also_requires_tag_warning:
 			also_requires_tag_warning_list.append(also_requires_tag_warning)
-		tag_rules['also_requires_tag_warning'] = {'also_requires_tag_warning': also_requires_tag_warning_list}
+		tag_rules['also_requires_tag_warning'] = also_requires_tag_warning_list
 
 	if tag_spec.disallowed_ancestor:
 		disallowed_ancestor_list = []
 		for disallowed_ancestor in tag_spec.disallowed_ancestor:
-			disallowed_ancestor_list.append(UnicodeEscape(disallowed_ancestor))
-		tag_rules['disallowed_ancestor'] = {'disallowed_ancestor': disallowed_ancestor_list}
+			disallowed_ancestor_list.append(UnicodeEscape(disallowed_ancestor).lower())
+		tag_rules['disallowed_ancestor'] = disallowed_ancestor_list
 
 	if tag_spec.html_format:
 		html_format_list = []
@@ -519,8 +409,13 @@ def GetTagRules(tag_spec):
 	if tag_spec.HasField('extension_spec'):
 		extension_spec = {}
 		for field in tag_spec.extension_spec.ListFields():
-			extension_spec[ field[0].name ] = field[1]
-		tag_rules['extension_spec'] = {'extension_spec':extension_spec}
+			if isinstance(field[1], (list, google.protobuf.internal.containers.RepeatedScalarFieldContainer)):
+				extension_spec[ field[0].name ] = []
+				for val in field[1]:
+					extension_spec[ field[0].name ].append( val )
+			else:
+				extension_spec[ field[0].name ] = field[1]
+		tag_rules['extension_spec'] = extension_spec
 
 	if tag_spec.HasField('mandatory'):
 		tag_rules['mandatory'] = tag_spec.mandatory
@@ -529,13 +424,13 @@ def GetTagRules(tag_spec):
 		tag_rules['mandatory_alternatives'] = UnicodeEscape(tag_spec.mandatory_alternatives)
 
 	if tag_spec.HasField('mandatory_ancestor'):
-		tag_rules['mandatory_ancestor'] = UnicodeEscape(tag_spec.mandatory_ancestor)
+		tag_rules['mandatory_ancestor'] = UnicodeEscape(tag_spec.mandatory_ancestor).lower()
 
 	if tag_spec.HasField('mandatory_ancestor_suggested_alternative'):
-		tag_rules['mandatory_ancestor_suggested_alternative'] = UnicodeEscape(tag_spec.mandatory_ancestor_suggested_alternative)
+		tag_rules['mandatory_ancestor_suggested_alternative'] = UnicodeEscape(tag_spec.mandatory_ancestor_suggested_alternative).lower()
 
 	if tag_spec.HasField('mandatory_parent'):
-		tag_rules['mandatory_parent'] = UnicodeEscape(tag_spec.mandatory_parent)
+		tag_rules['mandatory_parent'] = UnicodeEscape(tag_spec.mandatory_parent).lower()
 
 	if tag_spec.HasField('spec_name'):
 		tag_rules['spec_name'] = UnicodeEscape(tag_spec.spec_name)
@@ -548,8 +443,6 @@ def GetTagRules(tag_spec):
 
 	if tag_spec.HasField('unique_warning'):
 		tag_rules['unique_warning'] = tag_spec.unique_warning
-
-
 
 	logging.info('... done')
 	return tag_rules
@@ -580,11 +473,11 @@ def GetValues(attr_spec):
 		alt_names_list = []
 		for alternative_name in attr_spec.alternative_names:
 			alt_names_list.append(UnicodeEscape(alternative_name))
-		value_dict['alternative_names'] = {'alternative_names': alt_names_list}
+		value_dict['alternative_names'] = alt_names_list
 
 	# Add blacklisted value regex
 	if attr_spec.HasField('blacklisted_value_regex'):
-		value_dict['blacklisted_value_regex'] = UnicodeEscape(attr_spec.blacklisted_value_regex)
+		value_dict['blacklisted_value_regex'] = attr_spec.blacklisted_value_regex
 
 	# dispatch_key is an int
 	if attr_spec.HasField('dispatch_key'):
@@ -596,19 +489,19 @@ def GetValues(attr_spec):
 
 	# Add allowed value
 	if attr_spec.HasField('value'):
-		value_dict['value'] = UnicodeEscape(attr_spec.value)
+		value_dict['value'] = attr_spec.value
 
 	# value_casei
 	if attr_spec.HasField('value_casei'):
-		value_dict['value_casei'] = UnicodeEscape(attr_spec.value_casei)
+		value_dict['value_casei'] = attr_spec.value_casei
 
 	# value_regex
 	if attr_spec.HasField('value_regex'):
-		value_dict['value_regex'] = UnicodeEscape(attr_spec.value_regex)
+		value_dict['value_regex'] = attr_spec.value_regex
 
 	# value_regex_casei
 	if attr_spec.HasField('value_regex_casei'):
-		value_dict['value_regex_casei'] = UnicodeEscape(attr_spec.value_regex_casei)
+		value_dict['value_regex_casei'] = attr_spec.value_regex_casei
 
 	#value_properties is a dictionary of dictionaries
 	if attr_spec.HasField('value_properties'):
@@ -629,7 +522,7 @@ def GetValues(attr_spec):
 	if attr_spec.HasField('value_url'):
 		value_url_dict = {}
 		for (value_url_key, value_url_val) in attr_spec.value_url.ListFields():
-			if isinstance(value_url_val, (list, collections.Sequence)):
+			if isinstance(value_url_val, (list, collections.Sequence, google.protobuf.internal.containers.RepeatedScalarFieldContainer)):
 				value_url_val_val = []
 				for val in value_url_val:
 					value_url_val_val.append(UnicodeEscape(val))
@@ -652,6 +545,31 @@ def UnicodeEscape(string):
 	"""
 	return ('' + string).encode('unicode-escape')
 
+def Phpize(data, indent=0):
+	"""Helper function to convert JSON-serializable data into PHP literals.
+
+	Args:
+		data: Any JSON-serializable.
+	Returns:
+		String formatted as PHP literal.
+	"""
+	json_string = json.dumps(data, sort_keys=True, ensure_ascii=False)
+
+	pipe = subprocess.Popen(['php', '-r', 'var_export( json_decode( file_get_contents( "php://stdin" ), true ) );'], stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+	php_stdout = pipe.communicate(input=json_string)[0]
+	php_exported = php_stdout.decode()
+
+	# Clean up formatting.
+	# TODO: Just use PHPCBF for this.
+	php_exported = re.sub( r'^ +', lambda match: ( len(match.group(0))/2 ) * '\t', php_exported, flags=re.MULTILINE )
+	php_exported = php_exported.replace( 'array (', 'array(' )
+	php_exported = re.sub( r' => \n\s+', ' => ', php_exported, flags=re.MULTILINE )
+	php_exported = re.sub( r'^(\s+)\d+ =>\s*', r'\1', php_exported, flags=re.MULTILINE )
+
+	# Add additional indents.
+	if indent > 0:
+		php_exported = re.sub( r'^', '\t' * indent, php_exported, flags=re.MULTILINE )
+	return php_exported
 
 def Main():
 	"""The main method, which executes all build steps and runs the tests."""

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -248,8 +248,8 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 	sorted_properties = sorted(properties.items())
 	for (prop, values) in collections.OrderedDict(sorted_properties).iteritems():
 		logging.info('generating php for property: %s...' % prop.lower())
-		if isinstance(values, (unicode,str, bool)):
-			if isinstance(values, (unicode,str)):
+		if isinstance(values, (unicode, str, bool)):
+			if isinstance(values, (unicode, str) ) and prop in ( 'mandatory_parent', 'mandatory_ancestor', 'mandatory_ancestor_suggested_alternative' ):
 				values = values.lower()
 			out.append('%s\'%s\' => \'%s\',' % (indent, prop.lower(), values))
 		elif isinstance(values, (int)):
@@ -259,8 +259,6 @@ def GeneratePropertiesPHP(out, properties, indent_level = 5):
 			sorted_values = sorted(values.items())
 			for(key, value) in collections.OrderedDict(sorted_values).iteritems():
 				if isinstance(value, (unicode, str, bool)):
-					if isinstance(value, str):
-						value = value.lower()
 					out.append('%s\t\'%s\' => \'%s\',' % (indent, key, value))
 				elif isinstance(value, (int)):
 					out.append('%s\t\'%s\' => %d,' % (indent, key, value))

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -324,6 +324,22 @@ def GenerateFooterPHP(out):
 	}
 
 	/**
+	 * Get allowed tag.
+	 *
+	 * Get the rules for a single tag so that the entire data structure needn't be passed around.
+	 *
+	 * @since 0.7
+	 * @param string $node_name Tag name.
+	 * @return array|null Allowed tag, or null if the tag does not exist.
+	 */
+	public static function get_allowed_tag( $node_name ) {
+		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
+			return self::$allowed_tags[ $node_name ];
+		}
+		return null;
+	}
+
+	/**
 	 * Get list of globally-allowed attributes.
 	 *
 	 * @since 0.5

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -398,7 +398,6 @@ def ParseRules(out_dir):
 		'$ROOT',
 		'!DOCTYPE',
 		'HTML',
-		'HEAD',
 	]
 
 	for (field_desc, field_val) in rules.ListFields():

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -392,12 +392,11 @@ def ParseRules(out_dir):
 	# attributes, values and other criteria.
 
 	# Don't include tags that have a mandatory parent with one of these tag names
-	# since we're only concerned with using this tag list to validate the body
+	# since we're only concerned with using this tag list to validate the HTML
 	# of the DOM
 	mandatory_parent_blacklist = [
 		'$ROOT',
 		'!DOCTYPE',
-		'HTML',
 	]
 
 	for (field_desc, field_val) in rules.ListFields():
@@ -405,7 +404,7 @@ def ParseRules(out_dir):
 			for tag_spec in field_val:
 
 				# Ignore tags that are outside of the body
-				if tag_spec.HasField('mandatory_parent') and tag_spec.mandatory_parent in mandatory_parent_blacklist and tag_spec.tag_name != 'BODY':
+				if tag_spec.HasField('mandatory_parent') and tag_spec.mandatory_parent in mandatory_parent_blacklist and tag_spec.tag_name != 'HTML':
 					continue
 
 				# Ignore the special $REFERENCE_POINT tag

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -421,9 +421,9 @@ def ParseRules(out_dir):
 				# AddTag(allowed_tags, tag_spec, attr_lists)
 
 				gotten_tag_spec = GetTagSpec(tag_spec, attr_lists)
-
-				tag_list.append(gotten_tag_spec)
-				allowed_tags[UnicodeEscape(tag_spec.tag_name)] = tag_list
+				if gotten_tag_spec is not None:
+					tag_list.append(gotten_tag_spec)
+					allowed_tags[UnicodeEscape(tag_spec.tag_name)] = tag_list
 
 	logging.info('... done')
 	return allowed_tags, attr_lists, versions
@@ -433,6 +433,8 @@ def GetTagSpec(tag_spec, attr_lists):
 	logging.info('entering ...')
 
 	tag_dict = GetTagRules(tag_spec)
+	if tag_dict is None:
+		return None
 	attr_dict = GetAttrs(tag_spec.attrs)
 
 	# Now add attributes from any attribute lists to this tag.
@@ -491,12 +493,12 @@ def GetTagRules(tag_spec):
 
 	if tag_spec.html_format:
 		html_format_list = []
+		has_amp_format = False
 		for html_format in tag_spec.html_format:
 			if 1 == html_format:
-				html_format_list.append('amp')
-			elif 2 == html_format:
-				html_format_list.append('amp4ads')
-		tag_rules['html_format'] = {'html_format': html_format_list}
+				has_amp_format = True
+		if not has_amp_format:
+			return None
 
 	if tag_spec.HasField('extension_spec'):
 		extension_spec = {}

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -285,7 +285,7 @@ def GenerateValuesPHP(out, values, indent_level = 6):
 
 			logging.info('generating php for value: %s...' % key.lower())
 
-			if isinstance(value, (str, bool)):
+			if isinstance(value, (str, bool, unicode)):
 				out.append('%s\'%s\' => \'%s\',' % (indent, key.lower(), value))
 
 			elif isinstance(value, (int)):
@@ -425,10 +425,6 @@ def ParseRules(out_dir):
 
 				gotten_tag_spec = GetTagSpec(tag_spec, attr_lists)
 
-				# Temporarily skip extension SCRIPT elemeents which appear in the HEAD.
-				if 'SCRIPT' == tag_spec.tag_name and gotten_tag_spec['tag_spec'].get( '_is_extension_spec', False ):
-					continue
-
 				tag_list.append(gotten_tag_spec)
 				allowed_tags[UnicodeEscape(tag_spec.tag_name)] = tag_list
 
@@ -506,7 +502,10 @@ def GetTagRules(tag_spec):
 		tag_rules['html_format'] = {'html_format': html_format_list}
 
 	if tag_spec.HasField('extension_spec'):
-		tag_rules['_is_extension_spec'] = True;
+		extension_spec = {}
+		for field in tag_spec.extension_spec.ListFields():
+			extension_spec[ field[0].name ] = field[1]
+		tag_rules['extension_spec'] = {'extension_spec':extension_spec}
 
 	if tag_spec.HasField('mandatory'):
 		tag_rules['mandatory'] = tag_spec.mandatory

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -140,13 +140,15 @@ function amp_get_asset_url( $file ) {
 }
 
 /**
- * Print AMP boilerplate code.
+ * Get AMP boilerplate code.
  *
+ * @since 0.7
  * @link https://www.ampproject.org/docs/reference/spec#boilerplate
+ * @return string Boilerplate code.
  */
-function amp_print_boilerplate_code() {
-	echo '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>';
-	echo '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>';
+function amp_get_boilerplate_code() {
+	return '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>'
+		. '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>';
 }
 
 /**

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -79,11 +79,12 @@ function amp_post_template_add_fonts( $amp_template ) {
 
 /**
  * Print boilerplate CSS.
+ *
+ * @since 0.3
+ * @see amp_get_boilerplate_code()
  */
 function amp_post_template_add_boilerplate_css() {
-	?>
-	<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-	<?php
+	echo amp_get_boilerplate_code(); // WPCS: xss ok.
 }
 
 /**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -783,6 +783,12 @@ class AMP_Theme_Support {
 			'use_document_element' => true,
 		);
 
+		// @todo Remove any existing meta[viewport] and meta[charset] to be supplied by us here?
+		// Make sure amp attribute is present on the html element, as otherwise it will be stripped entirely.
+		if ( ! $dom->documentElement->hasAttribute( 'amp' ) && ! $dom->documentElement->hasAttribute( '⚡️' ) ) {
+			$dom->documentElement->setAttribute( 'amp', '' );
+		}
+
 		$assets = AMP_Content_Sanitizer::sanitize_document( $dom, self::$sanitizer_classes, $args );
 
 		$output  = "<!DOCTYPE html>\n";

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -769,7 +769,7 @@ class AMP_Theme_Support {
 	/**
 	 * Finish output buffering.
 	 *
-	 * @todo Do this in shutdown instead of output buffering callback?
+	 * @todo Do this in shutdown instead of output buffering callback? This will make it easier to debug things since printing can be done in shutdown function but cannot in output buffer callback.
 	 * @global int $content_width
 	 * @param string $output Buffered output.
 	 * @return string Finalized output.
@@ -785,14 +785,6 @@ class AMP_Theme_Support {
 
 		$assets = AMP_Content_Sanitizer::sanitize_document( $dom, self::$sanitizer_classes, $args );
 
-		/*
-		 * @todo The sanitize method needs to be updated to sanitize the entire HTML element and not just the BODY.
-		 * This will require updating mandatory_parent_blacklist in amphtml-update.py to include elements that appear in the HEAD.
-		 * This will ensure that the scripts and styles that plugins output via wp_head() will be sanitized as well. However,
-		 * since the the old paired mode is sending content from the *body* we'll need to be able to filter out the elements
-		 * from outside the body from being part of the whitelist sanitizer when it runs when theme support is not present,
-		 * as otherwise elements from the HEAD could get added to the BODY.
-		 */
 		$output  = "<!DOCTYPE html>\n";
 		$output .= AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -779,7 +779,8 @@ class AMP_Theme_Support {
 
 		$dom  = AMP_DOM_Utils::get_dom( $output );
 		$args = array(
-			'content_max_width' => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
+			'content_max_width'    => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
+			'use_document_element' => true,
 		);
 
 		$assets = AMP_Content_Sanitizer::sanitize_document( $dom, self::$sanitizer_classes, $args );

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -25,26 +25,28 @@ class AMP_Allowed_Tags_Generated {
 					'download' => array(),
 					'href' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'bbmi',
-							'fb-messenger',
-							'ftp',
-							'http',
-							'https',
-							'intent',
-							'line',
-							'mailto',
-							'skype',
-							'sms',
-							'snapchat',
-							'tel',
-							'tg',
-							'threema',
-							'twitter',
-							'viber',
-							'whatsapp',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'ftp',
+								'http',
+								'https',
+								'mailto',
+								'bbmi',
+								'fb-messenger',
+								'intent',
+								'line',
+								'skype',
+								'sms',
+								'snapchat',
+								'tel',
+								'tg',
+								'threema',
+								'twitter',
+								'viber',
+								'whatsapp',
+							),
 						),
 					),
 					'hreflang' => array(),
@@ -65,28 +67,24 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#links',
 				),
-
 			),
 		),
 		'abbr' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'acronym' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'address' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'amp-3q-player' => array(
@@ -105,10 +103,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-3q-player',
+						'amp-3q-player',
 					),
 				),
-
 			),
 		),
 		'amp-accordion' => array(
@@ -120,11 +117,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-accordion',
+						'amp-accordion',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-accordion',
 				),
-
 			),
 		),
 		'amp-ad' => array(
@@ -138,9 +134,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -149,17 +147,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
-							'amp-ad extension .js script',
+						'amp-ad extension .js script',
 					),
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'requires_extension' => array(
-							'amp-ad',
+						'amp-ad',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -176,9 +173,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -187,22 +186,21 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
-							'amp-ad extension .js script',
+						'amp-ad extension .js script',
 					),
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
-							'amp-carousel',
-							'amp-fx-flying-carpet',
-							'amp-lightbox',
-							'amp-sticky-ad',
+						'amp-app-banner',
+						'amp-carousel',
+						'amp-fx-flying-carpet',
+						'amp-lightbox',
+						'amp-sticky-ad',
 					),
 					'requires_extension' => array(
-							'amp-ad',
+						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-multi-size attribute',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
 				),
-
 			),
 		),
 		'amp-analytics' => array(
@@ -210,21 +208,22 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'config' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-analytics',
+						'amp-analytics',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-analytics',
 				),
-
 			),
 		),
 		'amp-anim' => array(
@@ -243,21 +242,22 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'data',
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'data',
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-anim',
+						'amp-anim',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-anim',
 				),
-
 			),
 		),
 		'amp-animation' => array(
@@ -273,10 +273,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-animation',
+						'amp-animation',
 					),
 				),
-
 			),
 		),
 		'amp-apester-media' => array(
@@ -295,11 +294,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-apester-media',
+						'amp-apester-media',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-apester-media',
 				),
-
 			),
 		),
 		'amp-app-banner' => array(
@@ -316,12 +314,11 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-app-banner',
 					'unique' => true,
 				),
-
 			),
 		),
 		'amp-audio' => array(
@@ -347,22 +344,23 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-story',
+						'amp-story',
 					),
 					'requires_extension' => array(
-							'amp-audio',
+						'amp-audio',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -387,21 +385,22 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
-							'amp-audio',
+						'amp-audio',
 					),
 					'spec_name' => 'amp-story >> amp-audio',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
-
 			),
 		),
 		'amp-auto-ads' => array(
@@ -418,11 +417,10 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
-							'amp-auto-ads',
+						'amp-auto-ads',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-auto-ads',
 				),
-
 			),
 		),
 		'amp-brid-player' => array(
@@ -453,11 +451,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-brid-player',
+						'amp-brid-player',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-brid-player',
 				),
-
 			),
 		),
 		'amp-brightcove' => array(
@@ -479,11 +476,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-brightcove',
+						'amp-brightcove',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-brightcove',
 				),
-
 			),
 		),
 		'amp-call-tracking' => array(
@@ -492,9 +488,11 @@ class AMP_Allowed_Tags_Generated {
 					'config' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'media' => array(),
@@ -504,11 +502,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-call-tracking',
+						'amp-call-tracking',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-call-tracking',
 				),
-
 			),
 		),
 		'amp-carousel' => array(
@@ -541,11 +538,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-carousel',
+						'amp-carousel',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
 				),
-
 			),
 		),
 		'amp-dailymotion' => array(
@@ -584,11 +580,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-dailymotion',
+						'amp-dailymotion',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-dailymotion',
 				),
-
 			),
 		),
 		'amp-embed' => array(
@@ -602,9 +597,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -613,17 +610,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
-							'amp-ad extension .js script',
+						'amp-ad extension .js script',
 					),
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'requires_extension' => array(
-							'amp-ad',
+						'amp-ad',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -640,9 +636,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -651,22 +649,21 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
-							'amp-ad extension .js script',
+						'amp-ad extension .js script',
 					),
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
-							'amp-carousel',
-							'amp-fx-flying-carpet',
-							'amp-lightbox',
-							'amp-sticky-ad',
+						'amp-app-banner',
+						'amp-carousel',
+						'amp-fx-flying-carpet',
+						'amp-lightbox',
+						'amp-sticky-ad',
 					),
 					'requires_extension' => array(
-							'amp-ad',
+						'amp-ad',
 					),
 					'spec_name' => 'amp-embed with data-multi-size attribute',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
 				),
-
 			),
 		),
 		'amp-experiment' => array(
@@ -674,12 +671,11 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-experiment',
+						'amp-experiment',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
 					'unique' => true,
 				),
-
 			),
 		),
 		'amp-facebook' => array(
@@ -695,10 +691,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-facebook',
+						'amp-facebook',
 					),
 				),
-
 			),
 		),
 		'amp-facebook-comments' => array(
@@ -714,10 +709,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-facebook-comments',
+						'amp-facebook-comments',
 					),
 				),
-
 			),
 		),
 		'amp-facebook-like' => array(
@@ -725,10 +719,12 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-href' => array(
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'media' => array(),
@@ -738,10 +734,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-facebook-like',
+						'amp-facebook-like',
 					),
 				),
-
 			),
 		),
 		'amp-fit-text' => array(
@@ -756,10 +751,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-fit-text',
+						'amp-fit-text',
 					),
 				),
-
 			),
 		),
 		'amp-font' => array(
@@ -785,10 +779,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-font',
+						'amp-font',
 					),
 				),
-
 			),
 		),
 		'amp-fx-flying-carpet' => array(
@@ -804,10 +797,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-fx-flying-carpet',
+						'amp-fx-flying-carpet',
 					),
 				),
-
 			),
 		),
 		'amp-gfycat' => array(
@@ -826,11 +818,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-gfycat',
+						'amp-gfycat',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-gfycat',
 				),
-
 			),
 		),
 		'amp-gist' => array(
@@ -846,11 +837,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-gist',
+						'amp-gist',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-gist',
 				),
-
 			),
 		),
 		'amp-hulu' => array(
@@ -866,11 +856,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-hulu',
+						'amp-hulu',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-hulu',
 				),
-
 			),
 		),
 		'amp-iframe' => array(
@@ -906,20 +895,21 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'data',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'data',
+								'https',
+							),
 						),
 					),
 					'srcdoc' => array(),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-iframe',
+						'amp-iframe',
 					),
 				),
-
 			),
 		),
 		'amp-ima-video' => array(
@@ -927,16 +917,20 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'data-tag' => array(
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'media' => array(),
@@ -946,11 +940,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-ima-video',
+						'amp-ima-video',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ima-video',
 				),
-
 			),
 		),
 		'amp-image-lightbox' => array(
@@ -964,10 +957,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-image-lightbox',
+						'amp-image-lightbox',
 					),
 				),
-
 			),
 		),
 		'amp-img' => array(
@@ -990,18 +982,19 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'data',
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'data',
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
 				),
-
 			),
 		),
 		'amp-imgur' => array(
@@ -1017,10 +1010,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-imgur',
+						'amp-imgur',
 					),
 				),
-
 			),
 		),
 		'amp-instagram' => array(
@@ -1037,10 +1029,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-instagram',
+						'amp-instagram',
 					),
 				),
-
 			),
 		),
 		'amp-install-serviceworker' => array(
@@ -1048,26 +1039,29 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-iframe-src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-install-serviceworker',
+						'amp-install-serviceworker',
 					),
 				),
-
 			),
 		),
 		'amp-izlesene' => array(
@@ -1084,10 +1078,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-izlesene',
+						'amp-izlesene',
 					),
 				),
-
 			),
 		),
 		'amp-jwplayer' => array(
@@ -1106,10 +1099,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-jwplayer',
+						'amp-jwplayer',
 					),
 				),
-
 			),
 		),
 		'amp-kaltura-player' => array(
@@ -1125,10 +1117,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-kaltura-player',
+						'amp-kaltura-player',
 					),
 				),
-
 			),
 		),
 		'amp-layout' => array(
@@ -1142,7 +1133,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-layout',
 				),
-
 			),
 		),
 		'amp-lightbox' => array(
@@ -1158,10 +1148,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-lightbox',
+						'amp-lightbox',
 					),
 				),
-
 			),
 		),
 		'amp-list' => array(
@@ -1180,19 +1169,20 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'template' => array(),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-list',
+						'amp-list',
 					),
 				),
-
 			),
 		),
 		'amp-live-list' => array(
@@ -1214,10 +1204,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-live-list',
+						'amp-live-list',
 					),
 				),
-
 			),
 		),
 		'amp-nexxtv-player' => array(
@@ -1234,10 +1223,12 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => 'api|static',
 					),
 					'data-origin' => array(
-						'allow_empty' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allowed_protocol' => array(
+								'https',
+								'http',
+							),
 						),
 					),
 					'data-seek-to' => array(),
@@ -1251,10 +1242,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-nexxtv-player',
+						'amp-nexxtv-player',
 					),
 				),
-
 			),
 		),
 		'amp-o2-player' => array(
@@ -1273,10 +1263,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-o2-player',
+						'amp-o2-player',
 					),
 				),
-
 			),
 		),
 		'amp-ooyala-player' => array(
@@ -1298,10 +1287,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-ooyala-player',
+						'amp-ooyala-player',
 					),
 				),
-
 			),
 		),
 		'amp-pinterest' => array(
@@ -1317,11 +1305,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-pinterest',
+						'amp-pinterest',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pinterest',
 				),
-
 			),
 		),
 		'amp-pixel' => array(
@@ -1337,17 +1324,18 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pixel',
 				),
-
 			),
 		),
 		'amp-playbuzz' => array(
@@ -1371,10 +1359,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-playbuzz',
+						'amp-playbuzz',
 					),
 				),
-
 			),
 		),
 		'amp-position-observer' => array(
@@ -1394,10 +1381,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-position-observer',
+						'amp-position-observer',
 					),
 				),
-
 			),
 		),
 		'amp-reach-player' => array(
@@ -1414,10 +1400,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-reach-player',
+						'amp-reach-player',
 					),
 				),
-
 			),
 		),
 		'amp-reddit' => array(
@@ -1443,10 +1428,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-reddit',
+						'amp-reddit',
 					),
 				),
-
 			),
 		),
 		'amp-selector' => array(
@@ -1473,13 +1457,12 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-selector',
+						'amp-selector',
 					),
 					'requires_extension' => array(
-							'amp-selector',
+						'amp-selector',
 					),
 				),
-
 			),
 		),
 		'amp-sidebar' => array(
@@ -1496,10 +1479,9 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
-							'amp-sidebar',
+						'amp-sidebar',
 					),
 				),
-
 			),
 		),
 		'amp-social-share' => array(
@@ -1507,24 +1489,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-share-endpoint' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'bbmi',
-							'fb-messenger',
-							'ftp',
-							'http',
-							'https',
-							'intent',
-							'line',
-							'mailto',
-							'skype',
-							'sms',
-							'snapchat',
-							'tel',
-							'tg',
-							'threema',
-							'viber',
-							'whatsapp',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'ftp',
+								'http',
+								'https',
+								'mailto',
+								'bbmi',
+								'fb-messenger',
+								'intent',
+								'line',
+								'skype',
+								'sms',
+								'snapchat',
+								'tel',
+								'tg',
+								'threema',
+								'viber',
+								'whatsapp',
+							),
 						),
 					),
 					'media' => array(),
@@ -1537,10 +1521,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-social-share',
+						'amp-social-share',
 					),
 				),
-
 			),
 		),
 		'amp-soundcloud' => array(
@@ -1568,10 +1551,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-soundcloud',
+						'amp-soundcloud',
 					),
 				),
-
 			),
 		),
 		'amp-springboard-player' => array(
@@ -1605,10 +1587,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-springboard-player',
+						'amp-springboard-player',
 					),
 				),
-
 			),
 		),
 		'amp-state' => array(
@@ -1621,20 +1602,21 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-bind',
+						'amp-bind',
 					),
 					'spec_name' => 'amp-state',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bind',
 				),
-
 			),
 		),
 		'amp-sticky-ad' => array(
@@ -1647,29 +1629,32 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'requires_extension' => array(
-							'amp-sticky-ad',
+						'amp-sticky-ad',
 					),
 					'unique' => true,
 				),
-
 			),
 		),
 		'amp-story' => array(
 			array(
 				'attr_spec_list' => array(
 					'background-audio' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'bookend-config-src' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'standalone' => array(
@@ -1680,10 +1665,9 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
-							'amp-story',
+						'amp-story',
 					),
 				),
-
 			),
 		),
 		'amp-story-grid-layer' => array(
@@ -1697,7 +1681,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-story-page',
 				),
-
 			),
 		),
 		'amp-story-page' => array(
@@ -1705,9 +1688,11 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'auto-advance-after' => array(),
 					'background-audio' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'id' => array(
@@ -1717,10 +1702,9 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-story',
 					'requires_extension' => array(
-							'amp-story',
+						'amp-story',
 					),
 				),
-
 			),
 		),
 		'amp-timeago' => array(
@@ -1741,11 +1725,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-timeago',
+						'amp-timeago',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-timeago',
 				),
-
 			),
 		),
 		'amp-twitter' => array(
@@ -1761,27 +1744,30 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-twitter',
+						'amp-twitter',
 					),
 				),
-
 			),
 		),
 		'amp-user-notification' => array(
 			array(
 				'attr_spec_list' => array(
 					'data-dismiss-href' => array(
-						'allow_empty' => false,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'data-show-if-href' => array(
-						'allow_empty' => false,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'enctype' => array(
@@ -1794,10 +1780,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-user-notification',
+						'amp-user-notification',
 					),
 				),
-
 			),
 		),
 		'amp-video' => array(
@@ -1848,22 +1833,23 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
-							'amp-video extension .js script',
+						'amp-video extension .js script',
 					),
 					'disallowed_ancestor' => array(
-							'amp-story',
+						'amp-story',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -1914,21 +1900,22 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
-							'amp-video',
+						'amp-video',
 					),
 					'spec_name' => 'amp-story >> amp-video',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
-
 			),
 		),
 		'amp-vimeo' => array(
@@ -1945,10 +1932,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-vimeo',
+						'amp-vimeo',
 					),
 				),
-
 			),
 		),
 		'amp-vine' => array(
@@ -1964,10 +1950,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-vine',
+						'amp-vine',
 					),
 				),
-
 			),
 		),
 		'amp-vk' => array(
@@ -1983,10 +1968,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-vk',
+						'amp-vk',
 					),
 				),
-
 			),
 		),
 		'amp-web-push' => array(
@@ -1994,9 +1978,11 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'helper-iframe-url' => array(
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'id' => array(
@@ -2009,26 +1995,29 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'permission-dialog-url' => array(
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'service-worker-url' => array(
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-web-push',
+						'amp-web-push',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-web-push',
 				),
-
 			),
 		),
 		'amp-web-push-widget' => array(
@@ -2045,11 +2034,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-web-push',
+						'amp-web-push',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-web-push',
 				),
-
 			),
 		),
 		'amp-youtube' => array(
@@ -2071,24 +2059,21 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
-							'amp-youtube',
+						'amp-youtube',
 					),
 				),
-
 			),
 		),
 		'article' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'aside' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'audio' => array(
@@ -2101,10 +2086,12 @@ class AMP_Allowed_Tags_Generated {
 					'preload' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'data',
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'data',
+								'https',
+							),
 						),
 					),
 				),
@@ -2113,14 +2100,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor_suggested_alternative' => 'amp-audio',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
-
 			),
 		),
 		'b' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'base' => array(
@@ -2137,14 +2122,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'unique' => true,
 				),
-
 			),
 		),
 		'bdi' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'bdo' => array(
@@ -2153,14 +2136,12 @@ class AMP_Allowed_Tags_Generated {
 					'dir' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'big' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'blockquote' => array(
@@ -2169,16 +2150,17 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 					'cite' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'body' => array(
@@ -2190,14 +2172,12 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 		),
 		'br' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'button' => array(
@@ -2218,7 +2198,6 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -2237,21 +2216,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'amp-app-banner',
 					'spec_name' => 'amp-app-banner button[open-button]',
 				),
-
 			),
 		),
 		'caption' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'center' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'circle' => array(
@@ -2338,14 +2314,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'cite' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'clippath' => array(
@@ -2429,14 +2403,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'code' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'col' => array(
@@ -2445,7 +2417,6 @@ class AMP_Allowed_Tags_Generated {
 					'span' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'colgroup' => array(
@@ -2454,14 +2425,12 @@ class AMP_Allowed_Tags_Generated {
 					'span' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'data' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'datalist' => array(
@@ -2470,14 +2439,12 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'dd' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'defs' => array(
@@ -2560,7 +2527,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'del' => array(
@@ -2568,17 +2534,18 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'cite' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'datetime' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'desc' => array(
@@ -2596,21 +2563,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'dfn' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'dir' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'div' => array(
@@ -2619,7 +2583,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -2633,7 +2596,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'form',
 					'spec_name' => 'FORM > DIV [submitting]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -2647,7 +2609,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'form',
 					'spec_name' => 'FORM > DIV [submit-success]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -2661,21 +2622,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'form',
 					'spec_name' => 'FORM > DIV [submit-error]',
 				),
-
 			),
 		),
 		'dl' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'dt' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'ellipse' => array(
@@ -2763,14 +2721,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'em' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'fecolormatrix' => array(
@@ -2856,7 +2812,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'fecomposite' => array(
@@ -2946,7 +2901,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'feflood' => array(
@@ -3029,7 +2983,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'fegaussianblur' => array(
@@ -3115,7 +3068,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'femerge' => array(
@@ -3198,7 +3150,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'femergenode' => array(
@@ -3217,7 +3168,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'feoffset' => array(
@@ -3303,7 +3253,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'fieldset' => array(
@@ -3316,21 +3265,18 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'figcaption' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'figure' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'filter' => array(
@@ -3412,11 +3358,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -3433,14 +3381,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'footer' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'foreignobject' => array(
@@ -3527,7 +3473,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'form' => array(
@@ -3538,16 +3483,20 @@ class AMP_Allowed_Tags_Generated {
 					'action' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'action-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'autocomplete' => array(),
@@ -3566,22 +3515,23 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'verify-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'requires_extension' => array(
-							'amp-form',
+						'amp-form',
 					),
 					'spec_name' => 'FORM [method=GET]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -3590,9 +3540,11 @@ class AMP_Allowed_Tags_Generated {
 					'action-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'autocomplete' => array(),
@@ -3613,22 +3565,23 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'verify-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-app-banner',
+						'amp-app-banner',
 					),
 					'requires_extension' => array(
-							'amp-form',
+						'amp-form',
 					),
 					'spec_name' => 'FORM [method=POST]',
 				),
-
 			),
 		),
 		'g' => array(
@@ -3711,7 +3664,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'glyph' => array(
@@ -3798,7 +3750,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'glyphref' => array(
@@ -3878,11 +3829,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -3899,7 +3852,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'h1' => array(
@@ -3908,7 +3860,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'h2' => array(
@@ -3917,7 +3868,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'h3' => array(
@@ -3926,7 +3876,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'h4' => array(
@@ -3935,7 +3884,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'h5' => array(
@@ -3944,7 +3892,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'h6' => array(
@@ -3953,7 +3900,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'head' => array(
@@ -3965,21 +3911,18 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 		),
 		'header' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'hgroup' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'hkern' => array(
@@ -4002,20 +3945,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'hr' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'html' => array(
 			array(
 				'attr_spec_list' => array(
-					'\u26a1' => array(
+					'\\u26a1' => array(
 						'alternative_names' => array(
 							'amp',
 						),
@@ -4026,18 +3967,16 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => '!doctype',
-					'spec_name' => 'html \u26a1 for top-level html',
+					'spec_name' => 'html \\u26a1 for top-level html',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 		),
 		'i' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'iframe' => array(
@@ -4058,10 +3997,12 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'data',
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'data',
+								'https',
+							),
 						),
 					),
 					'srcdoc' => array(),
@@ -4072,7 +4013,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor_suggested_alternative' => 'amp-iframe',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-iframe',
 				),
-
 			),
 		),
 		'image' => array(
@@ -4157,12 +4097,14 @@ class AMP_Allowed_Tags_Generated {
 							'href',
 						),
 						'blacklisted_value_regex' => '(^|\\s)data:image\\/svg\\+xml',
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'data',
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'data',
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -4179,7 +4121,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'img' => array(
@@ -4191,10 +4132,12 @@ class AMP_Allowed_Tags_Generated {
 					'ismap' => array(),
 					'longdesc' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'src' => array(
@@ -4203,10 +4146,12 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'data',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'data',
+								'https',
+							),
 						),
 					),
 					'width' => array(),
@@ -4216,7 +4161,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor_suggested_alternative' => 'amp-img',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
 				),
-
 			),
 		),
 		'input' => array(
@@ -4280,7 +4224,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'ins' => array(
@@ -4288,24 +4231,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'cite' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'datetime' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'kbd' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'label' => array(
@@ -4316,14 +4259,12 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'legend' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'li' => array(
@@ -4334,7 +4275,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'line' => array(
@@ -4422,7 +4362,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'lineargradient' => array(
@@ -4503,11 +4442,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -4525,7 +4466,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'link' => array(
@@ -4548,12 +4488,11 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'template',
+						'template',
 					),
 					'spec_name' => 'link rel=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4564,10 +4503,12 @@ class AMP_Allowed_Tags_Generated {
 					'href' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'hreflang' => array(),
@@ -4588,7 +4529,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4599,9 +4539,11 @@ class AMP_Allowed_Tags_Generated {
 					'href' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'hreflang' => array(),
@@ -4620,7 +4562,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'link rel=manifest',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4646,7 +4587,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'link rel=stylesheet for fonts',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#custom-fonts',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4672,7 +4612,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'link itemprop=sameAs',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4696,7 +4635,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'link itemprop=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -4720,28 +4658,24 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'link property=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 		),
 		'listing' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'main' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'mark' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'marker' => array(
@@ -4829,7 +4763,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'mask' => array(
@@ -4917,7 +4850,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'meta' => array(
@@ -4936,25 +4868,26 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'height' => array(),
-						'initial-scale' => array(),
-						'maximum-scale' => array(),
-						'minimum-scale' => array(
-							'mandatory',
-							'value_double',
-						),
-						'shrink-to-fit' => array(),
-						'user-scalable' => array(),
-						'viewport-fit' => array(),
-						'width' => array(
-							'mandatory',
-							'value',
+						'value_properties' => array(
+							'height' => array(),
+							'initial-scale' => array(),
+							'maximum-scale' => array(),
+							'minimum-scale' => array(
+								'mandatory' => true,
+								'value_double' => 1.0,
+							),
+							'shrink-to-fit' => array(),
+							'user-scalable' => array(),
+							'viewport-fit' => array(),
+							'width' => array(
+								'mandatory' => true,
+								'value' => 'device-width',
+							),
 						),
 					),
 					'name' => array(
@@ -4970,17 +4903,18 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'chrome' => array(
-							'value',
-						),
-						'ie' => array(
-							'value',
+						'value_properties' => array(
+							'chrome' => array(
+								'value' => '1',
+							),
+							'ie' => array(
+								'value' => 'edge',
+							),
 						),
 					),
 					'http-equiv' => array(
@@ -4994,7 +4928,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=X-UA-Compatible',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5013,7 +4946,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta name=apple-itunes-app',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5030,14 +4962,15 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-experiments-opt-in',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'name' => array(
@@ -5051,7 +4984,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta name=amp-3p-iframe-src',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5068,7 +5000,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-experiment-token',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5085,7 +5016,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-link-variable-allowed-origin',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5102,7 +5032,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-google-clientid-id-api',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5116,7 +5045,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_name' => 'meta name= and content=',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5135,7 +5063,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=Content-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5153,7 +5080,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=content-language',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5171,7 +5097,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=pics-label',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5189,7 +5114,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=imagetoolbar',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5208,7 +5132,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=Content-Style-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5227,7 +5150,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=Content-Script-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5245,7 +5167,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=origin-trial',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5263,7 +5184,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'meta http-equiv=resource-type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
-
 			),
 		),
 		'metadata' => array(
@@ -5281,7 +5201,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'meter' => array(
@@ -5295,21 +5214,18 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'multicol' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'nav' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -5325,21 +5241,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-sidebar',
 					'spec_name' => 'amp-sidebar > nav',
 				),
-
 			),
 		),
 		'nextid' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'nobr' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'noscript' => array(
@@ -5352,24 +5265,21 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'noscript',
+						'noscript',
 					),
 					'mandatory_ancestor' => 'body',
 				),
-
 			),
 		),
 		'o:p' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'ol' => array(
@@ -5386,7 +5296,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'optgroup' => array(
@@ -5401,7 +5310,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'select',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'option' => array(
@@ -5419,7 +5327,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'output' => array(
@@ -5432,7 +5339,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'p' => array(
@@ -5441,7 +5347,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'path' => array(
@@ -5527,7 +5432,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'pattern' => array(
@@ -5614,11 +5518,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -5635,7 +5541,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'polygon' => array(
@@ -5720,7 +5625,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'polyline' => array(
@@ -5805,14 +5709,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'pre' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'progress' => array(
@@ -5822,7 +5724,6 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'q' => array(
@@ -5830,16 +5731,17 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'cite' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_empty' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'radialgradient' => array(
@@ -5924,11 +5826,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -5944,14 +5848,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'rb' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'rect' => array(
@@ -6041,49 +5943,42 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'rp' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'rt' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'rtc' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'ruby' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		's' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'samp' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'script' => array(
@@ -6116,7 +6011,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6136,7 +6030,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_name' => 'script type=application/ld+json',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6162,7 +6055,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'script id=amp-rtc',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6182,7 +6074,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > script[type=application/json]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6204,7 +6095,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-3q-player',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6227,10 +6117,9 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 3,
 					),
 					'requires_extension' => array(
-							'amp-access',
+						'amp-access',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6254,7 +6143,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6278,13 +6166,12 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'requires_extension' => array(
-							'amp-access',
-							'amp-analytics',
+						'amp-access',
+						'amp-analytics',
 					),
 					'spec_name' => 'amp-access extension .json script',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6308,7 +6195,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6333,7 +6219,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-ad extension .js script',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6357,7 +6242,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6377,12 +6261,11 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-analytics',
 					'requires_extension' => array(
-							'amp-analytics',
+						'amp-analytics',
 					),
 					'spec_name' => 'amp-analytics extension .json script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-analytics',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6406,7 +6289,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6428,7 +6310,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-animation',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6448,11 +6329,10 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-animation',
 					'requires_extension' => array(
-							'amp-animation',
+						'amp-animation',
 					),
 					'spec_name' => 'amp-animation extension .json script',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6476,7 +6356,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6499,7 +6378,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-app-banner',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6523,7 +6401,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6545,7 +6422,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-auto-ads',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6568,7 +6444,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 3,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6588,12 +6463,11 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-state',
 					'requires_extension' => array(
-							'amp-bind',
+						'amp-bind',
 					),
 					'spec_name' => 'amp-bind extension .json script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bind',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6617,7 +6491,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6641,7 +6514,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6664,7 +6536,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6688,7 +6559,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6712,7 +6582,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6736,7 +6605,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 3,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6760,7 +6628,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6782,7 +6649,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-experiment extension .json script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6804,7 +6670,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-facebook-comments',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6826,7 +6691,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-facebook-like',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6850,7 +6714,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6874,7 +6737,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6898,7 +6760,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6922,7 +6783,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6946,7 +6806,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6970,7 +6829,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -6992,7 +6850,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-gist',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7014,7 +6871,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-hulu',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7038,7 +6894,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7060,7 +6915,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-ima-video',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7084,7 +6938,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7106,7 +6959,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-imgur',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7130,7 +6982,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7154,7 +7005,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7177,7 +7027,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7201,7 +7050,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7225,7 +7073,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7249,7 +7096,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7273,7 +7119,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7298,7 +7143,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'unique_warning' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7323,7 +7167,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7345,7 +7188,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-nexxtv-player',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7369,7 +7211,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7391,7 +7232,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-ooyala-player',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7415,7 +7255,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7437,7 +7276,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-playbuzz',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7459,7 +7297,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-position-observer',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7483,7 +7320,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7506,7 +7342,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-reddit',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7529,7 +7364,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7553,7 +7387,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7577,7 +7410,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7601,7 +7433,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7625,7 +7456,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7652,7 +7482,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7674,7 +7503,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-story',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7696,7 +7524,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-timeago',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7720,7 +7547,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7744,7 +7570,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7768,7 +7593,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-video extension .js script',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7792,7 +7616,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7816,7 +7639,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7838,7 +7660,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-vk',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7860,7 +7681,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-web-push',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7884,7 +7704,6 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 					),
 				),
-
 			),
 		),
 		'section' => array(
@@ -7892,10 +7711,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'amp-accordion',
+						'amp-accordion',
 					),
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -7907,7 +7725,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-accordion',
 					'spec_name' => 'amp-accordion > section',
 				),
-
 			),
 		),
 		'select' => array(
@@ -7930,7 +7747,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'slot' => array(
@@ -7939,14 +7755,12 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'small' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'solidcolor' => array(
@@ -8026,7 +7840,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'source' => array(
@@ -8037,9 +7850,11 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(),
@@ -8049,7 +7864,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-video > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8058,9 +7872,11 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(),
@@ -8070,7 +7886,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-audio > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8078,9 +7893,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -8092,7 +7909,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'audio > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8100,9 +7916,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(
@@ -8114,7 +7932,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'video > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8123,9 +7940,11 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'type' => array(),
@@ -8133,25 +7952,22 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-ima-video',
 					'requires_extension' => array(
-							'amp-ima-video',
+						'amp-ima-video',
 					),
 					'spec_name' => 'amp-ima-video > source',
 				),
-
 			),
 		),
 		'spacer' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'span' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'stop' => array(
@@ -8169,7 +7985,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'lineargradient > stop',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8185,21 +8000,18 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'radialgradient > stop',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'strike' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'strong' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'style' => array(
@@ -8228,7 +8040,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#stylesheets',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8240,7 +8051,7 @@ class AMP_Allowed_Tags_Generated {
 					'nonce' => array(),
 				),
 				'cdata' => array(
-					'cdata_regex' => '\s*body{-webkit-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-moz-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-ms-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both}@-webkit-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\s*',
+					'cdata_regex' => '\\s*body{-webkit-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-moz-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;-ms-animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both;animation:-amp-start\\s+8s\\s+steps\\(1,end\\)\\s+0s\\s+1\\s+normal\\s+both}@-webkit-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\\s*',
 				),
 				'tag_spec' => array(
 					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
@@ -8249,7 +8060,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8261,7 +8071,7 @@ class AMP_Allowed_Tags_Generated {
 					'nonce' => array(),
 				),
 				'cdata' => array(
-					'cdata_regex' => '\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\s*',
+					'cdata_regex' => '\\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\\s*',
 				),
 				'tag_spec' => array(
 					'mandatory_alternatives' => 'noscript > style[amp-boilerplate]',
@@ -8271,7 +8081,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
 					'unique' => true,
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8290,21 +8099,18 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'style[amp-keyframes]',
 					'unique' => true,
 				),
-
 			),
 		),
 		'sub' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'sup' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'svg' => array(
@@ -8394,7 +8200,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'switch' => array(
@@ -8475,7 +8280,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'symbol' => array(
@@ -8556,7 +8360,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'table' => array(
@@ -8573,14 +8376,12 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'tbody' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'td' => array(
@@ -8596,7 +8397,6 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'template' => array(
@@ -8609,13 +8409,12 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
-							'template',
+						'template',
 					),
 					'requires_extension' => array(
-							'amp-mustache',
+						'amp-mustache',
 					),
 				),
-
 			),
 		),
 		'text' => array(
@@ -8705,7 +8504,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'textarea' => array(
@@ -8748,7 +8546,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
 				),
-
 			),
 		),
 		'textpath' => array(
@@ -8830,11 +8627,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -8850,14 +8649,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'tfoot' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'th' => array(
@@ -8876,14 +8673,12 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'thead' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'time' => array(
@@ -8892,7 +8687,6 @@ class AMP_Allowed_Tags_Generated {
 					'datetime' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'title' => array(
@@ -8901,7 +8695,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'spec_name' => 'title',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8918,7 +8711,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'svg title',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'tr' => array(
@@ -8930,7 +8722,6 @@ class AMP_Allowed_Tags_Generated {
 					'valign' => array(),
 				),
 				'tag_spec' => array(),
-
 			),
 		),
 		'track' => array(
@@ -8946,9 +8737,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(),
@@ -8957,7 +8750,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > track',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8972,9 +8764,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(
@@ -8985,7 +8779,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > track[kind=subtitles]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -8999,9 +8792,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(),
@@ -9010,7 +8805,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > track',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9025,9 +8819,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(
@@ -9038,7 +8834,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > track[kind=subtitles]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9055,9 +8850,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(),
@@ -9066,7 +8863,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > track',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9084,9 +8880,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(
@@ -9097,7 +8895,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > track[kind=subtitles]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9114,9 +8911,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(),
@@ -9125,7 +8924,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > track',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9143,9 +8941,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(
@@ -9156,7 +8956,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > track[kind=subtitles]',
 				),
-
 			),
 			array(
 				'attr_spec_list' => array(
@@ -9174,9 +8973,11 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'https',
+							),
 						),
 					),
 					'srclang' => array(
@@ -9188,7 +8989,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-ima-video > track[kind=subtitles]',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ima-video',
 				),
-
 			),
 		),
 		'tref' => array(
@@ -9267,11 +9067,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -9287,7 +9089,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'tspan' => array(
@@ -9376,28 +9177,24 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'tt' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'u' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'ul' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'use' => array(
@@ -9480,11 +9277,13 @@ class AMP_Allowed_Tags_Generated {
 						'alternative_names' => array(
 							'href',
 						),
-						'allow_empty' => false,
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allow_empty' => false,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 					'xlink:role' => array(),
@@ -9501,14 +9300,12 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'var' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'video' => array(
@@ -9524,10 +9321,12 @@ class AMP_Allowed_Tags_Generated {
 					'preload' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => false,
-						'allowed_protocol' => array(
-							'data',
-							'https',
+						'value_url' => array(
+							'allow_relative' => false,
+							'allowed_protocol' => array(
+								'data',
+								'https',
+							),
 						),
 					),
 					'width' => array(),
@@ -9537,7 +9336,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor_suggested_alternative' => 'amp-video',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
-
 			),
 		),
 		'view' => array(
@@ -9560,7 +9358,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'vkern' => array(
@@ -9583,21 +9380,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
-
 			),
 		),
 		'wbr' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 		'xmp' => array(
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
-
 			),
 		),
 	);
@@ -9610,7 +9404,6 @@ class AMP_Allowed_Tags_Generated {
 		'layout' => array(),
 		'sizes' => array(),
 		'width' => array(),
-
 	);
 
 
@@ -9703,21 +9496,21 @@ class AMP_Allowed_Tags_Generated {
 		'aria-valuenow' => array(),
 		'aria-valuetext' => array(),
 		'class' => array(
-					'blacklisted_value_regex' => '(^|\\W)i-amphtml-',
+			'blacklisted_value_regex' => '(^|\\W)i-amphtml-',
 		),
 		'content' => array(),
 		'datatype' => array(),
 		'dir' => array(),
 		'draggable' => array(),
 		'fallback' => array(
-					'value' => '',
+			'value' => '',
 		),
 		'hidden' => array(
-					'value' => '',
+			'value' => '',
 		),
 		'i-amp-access-id' => array(),
 		'id' => array(
-					'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+			'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 		),
 		'inlist' => array(),
 		'itemid' => array(),
@@ -9730,12 +9523,12 @@ class AMP_Allowed_Tags_Generated {
 		'on' => array(),
 		'overflow' => array(),
 		'placeholder' => array(
-					'value' => '',
+			'value' => '',
 		),
 		'prefix' => array(),
 		'property' => array(),
 		'rel' => array(
-					'blacklisted_value_regex' => '(^|\\s)(canonical|components|dns-prefetch|import|manifest|preconnect|preload|prerender|serviceworker|stylesheet|subresource)(\\s|$)',
+			'blacklisted_value_regex' => '(^|\\s)(canonical|components|dns-prefetch|import|manifest|preconnect|preload|prerender|serviceworker|stylesheet|subresource)(\\s|$)',
 		),
 		'resource' => array(),
 		'rev' => array(),
@@ -9746,10 +9539,9 @@ class AMP_Allowed_Tags_Generated {
 		'typeof' => array(),
 		'validation-for' => array(),
 		'visible-when-invalid' => array(
-					'value_regex' => '(badInput|customError|patternMismatch|rangeOverflow|rangeUnderflow|stepMismatch|tooLong|typeMismatch|valueMissing)',
+			'value_regex' => '(badInput|customError|patternMismatch|rangeOverflow|rangeUnderflow|stepMismatch|tooLong|typeMismatch|valueMissing)',
 		),
 		'vocab' => array(),
-
 	);
 
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -4363,6 +4363,18 @@ class AMP_Allowed_Tags_Generated {
 
 			),
 		),
+		'head' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'mandatory' => true,
+					'mandatory_parent' => 'html',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+		),
 		'header' => array(
 			array(
 				'attr_spec_list' => array(),
@@ -4412,6 +4424,52 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
+
+			),
+		),
+		'html' => array(
+			array(
+				'attr_spec_list' => array(
+					'\u26a1' => array(
+						'alternative_names' => array(
+							'amp',
+						),
+						'mandatory' => true,
+						'value' => '',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => '!doctype',
+					'spec_name' => 'html \u26a1 for top-level html',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'\u26a14ads' => array(
+						'alternative_names' => array(
+							'amp4ads',
+						),
+						'mandatory' => true,
+						'value' => '',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp4ads',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => '!doctype',
+					'spec_name' => 'html \u26a14ads for top-level html',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#a4a-format-rules',
+					'unique' => true,
+				),
 
 			),
 		),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -4977,6 +4977,7 @@ class AMP_Allowed_Tags_Generated {
 					'hreflang' => array(),
 					'media' => array(),
 					'rel' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'canonical',
 					),
@@ -5013,6 +5014,7 @@ class AMP_Allowed_Tags_Generated {
 					'hreflang' => array(),
 					'media' => array(),
 					'rel' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'manifest',
 					),
@@ -5042,6 +5044,7 @@ class AMP_Allowed_Tags_Generated {
 					'integrity' => array(),
 					'media' => array(),
 					'rel' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'stylesheet',
 					),
@@ -5360,6 +5363,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
+						'dispatch_key' => 1,
 						'mandatory' => true,
 						'value_casei' => 'utf-8',
 					),
@@ -5393,6 +5397,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => 'viewport',
 					),
@@ -5445,6 +5450,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '.*app-id=.*',
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'apple-itunes-app',
 					),
@@ -5466,6 +5472,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-experiments-opt-in',
 					),
@@ -5489,6 +5496,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-3p-iframe-src',
 					),
@@ -5509,6 +5517,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-experiment-token',
 					),
@@ -5528,6 +5537,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-link-variable-allowed-origin',
 					),
@@ -5547,6 +5557,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-google-client-id-api',
 					),
@@ -5566,6 +5577,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'name' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp4ads-id',
 					),
@@ -6659,11 +6671,18 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'nonce' => array(),
 					'src' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => 'https://cdn.ampproject.org/v0.js',
 					),
 					'type' => array(
 						'value_casei' => 'text/javascript',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'contents',
+						'regex' => '.',
 					),
 				),
 				'tag_spec' => array(
@@ -6686,11 +6705,18 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'nonce' => array(),
 					'src' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => 'https://cdn.ampproject.org/amp4ads-v0.js',
 					),
 					'type' => array(
 						'value_casei' => 'text/javascript',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'contents',
+						'regex' => '.',
 					),
 				),
 				'tag_spec' => array(
@@ -6728,6 +6754,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'id' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => 'amp-rtc',
 					),
@@ -6735,6 +6762,12 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'mandatory' => true,
 						'value_casei' => 'application/json',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
 					),
 				),
 				'tag_spec' => array(
@@ -6772,7 +6805,89 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-3q-player',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-access-laterpay',
+						'requires_usage' => 3,
+					),
+					'html_format' => array(
+							'amp',
+					),
+					'requires_extension' => array(
+							'amp-access',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-access',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
 					'id' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => 'amp-access',
 					),
@@ -6780,6 +6895,12 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'mandatory' => true,
 						'value_casei' => 'application/json',
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
 					),
 				),
 				'tag_spec' => array(
@@ -6793,6 +6914,55 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-access extension .json script',
 					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-accordion',
+						'requires_usage' => 2,
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-ad-exit',
+					),
+					'html_format' => array(
+							'amp4ads',
+					),
 				),
 
 			),
@@ -6815,6 +6985,62 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-ad-exit configuration json',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad-exit',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-ad',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+					'spec_name' => 'amp-ad extension .js script',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-analytics',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
 				),
 
 			),
@@ -6849,6 +7075,60 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-anim',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-animation',
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -6868,6 +7148,134 @@ class AMP_Allowed_Tags_Generated {
 							'amp-animation',
 					),
 					'spec_name' => 'amp-animation extension .json script',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-apester-media',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-app-banner',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-audio',
+						'requires_usage' => 2,
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-auto-ads',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-bind',
+						'requires_usage' => 3,
+					),
+					'html_format' => array(
+							'amp',
+					),
 				),
 
 			),
@@ -6901,6 +7309,191 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-brid-player',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-brightcove',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-call-tracking',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-carousel',
+						'requires_usage' => 2,
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-dailymotion',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-dynamic-css-classes',
+						'requires_usage' => 3,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-experiment',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -6921,6 +7514,1269 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment extension .json script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-facebook-comments',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-facebook-like',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-facebook',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-fit-text',
+						'requires_usage' => 2,
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-font',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-form',
+						'requires_usage' => 2,
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-fx-flying-carpet',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-gfycat',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-gist',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-gwd-animation',
+					),
+					'html_format' => array(
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-hulu',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-iframe',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-ima-video',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-image-lightbox',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-imgur',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-instagram',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-install-serviceworker',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-izlesene',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-jwplayer',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-kaltura-player',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-lightbox',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-list',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-live-list',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'unique_warning' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'is_custom_template' => true,
+						'name' => 'amp-mustache',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-nexxtv-player',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-o2-player',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-ooyala-player',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-pinterest',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-playbuzz',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-position-observer',
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-reach-player',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-reddit',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-selector',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-sidebar',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-social-share',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-soundcloud',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-springboard-player',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'1.0',
+							'latest',
+						),
+						'deprecated_versions' => array(
+							'0.1',
+						),
+						'name' => 'amp-sticky-ad',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-story',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-timeago',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-twitter',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-user-notification',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-video',
+						'requires_usage' => 3,
+					),
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'spec_name' => 'amp-video extension .js script',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-vimeo',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-vine',
+						'requires_usage' => 2,
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-vk',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'name' => 'amp-web-push',
+					),
+					'html_format' => array(
+							'amp',
+					),
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'allowed_versions' => array(
+							'0.1',
+							'latest',
+						),
+						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-youtube',
+						'requires_usage' => 2,
+					),
 				),
 
 			),
@@ -7296,6 +9152,14 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'text/css',
 					),
 				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'CSS !important',
+						'regex' => '!important',
+					),
+					'max_bytes' => 50000,
+					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#maximum-size',
+				),
 				'tag_spec' => array(
 					'html_format' => array(
 							'amp',
@@ -7318,6 +9182,14 @@ class AMP_Allowed_Tags_Generated {
 						'value_casei' => 'text/css',
 					),
 				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'CSS !important',
+						'regex' => '!important',
+					),
+					'max_bytes' => 20000,
+					'max_bytes_spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#css',
+				),
 				'tag_spec' => array(
 					'html_format' => array(
 							'amp4ads',
@@ -7332,10 +9204,14 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'amp-boilerplate' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value' => '',
 					),
 					'nonce' => array(),
+				),
+				'cdata' => array(
+					'cdata_regex' => '\s*body{-webkit-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-moz-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-ms-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both}@-webkit-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\s*',
 				),
 				'tag_spec' => array(
 					'html_format' => array(
@@ -7352,10 +9228,14 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'amp4ads-boilerplate' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value' => '',
 					),
 					'nonce' => array(),
+				),
+				'cdata' => array(
+					'cdata_regex' => '\s*body{visibility:hidden}\s*',
 				),
 				'tag_spec' => array(
 					'html_format' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -2434,6 +2434,27 @@ class AMP_Allowed_Tags_Generated {
 
 			),
 		),
+		'base' => array(
+			array(
+				'attr_spec_list' => array(
+					'href' => array(
+						'value' => '/',
+					),
+					'target' => array(
+						'value_regex_casei' => '(_blank|_self|_top)',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'unique' => true,
+				),
+
+			),
+		),
 		'bdi' => array(
 			array(
 				'attr_spec_list' => array(),
@@ -4945,6 +4966,107 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'color' => array(),
 					'href' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'allow_relative' => true,
+						'allowed_protocol' => array(
+							'http',
+							'https',
+						),
+					),
+					'hreflang' => array(),
+					'media' => array(),
+					'rel' => array(
+						'mandatory' => true,
+						'value_casei' => 'canonical',
+					),
+					'sizes' => array(),
+					'target' => array(),
+					'type' => array(),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'link rel=canonical',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'charset' => array(
+						'value_casei' => 'utf-8',
+					),
+					'color' => array(),
+					'href' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'allow_relative' => true,
+						'allowed_protocol' => array(
+							'https',
+						),
+					),
+					'hreflang' => array(),
+					'media' => array(),
+					'rel' => array(
+						'mandatory' => true,
+						'value_casei' => 'manifest',
+					),
+					'sizes' => array(),
+					'target' => array(),
+					'type' => array(),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'link rel=manifest',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(),
+					'crossorigin' => array(),
+					'href' => array(
+						'mandatory' => true,
+						'value_regex' => 'https://cdn\\.materialdesignicons\\.com/([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css|https://cloud\\.typography\\.com/[0-9]*/[0-9]*/css/fonts\\.css|https://fast\\.fonts\\.net/.*|https://fonts\\.googleapis\\.com/css\\?.*|https://fonts\\.googleapis\\.com/icon\\?.*|https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|https://maxcdn\\.bootstrapcdn\\.com/font-awesome/([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|https://use\\.typekit\\.net/[\\w\\p{l}\\p{n}_]+\\.css',
+					),
+					'integrity' => array(),
+					'media' => array(),
+					'rel' => array(
+						'mandatory' => true,
+						'value_casei' => 'stylesheet',
+					),
+					'type' => array(
+						'value_casei' => 'text/css',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'link rel=stylesheet for fonts',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#custom-fonts',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'charset' => array(
+						'value_casei' => 'utf-8',
+					),
+					'color' => array(),
+					'href' => array(
 						'mandatory' => true,
 					),
 					'hreflang' => array(),
@@ -5237,6 +5359,59 @@ class AMP_Allowed_Tags_Generated {
 		'meta' => array(
 			array(
 				'attr_spec_list' => array(
+					'charset' => array(
+						'mandatory' => true,
+						'value_casei' => 'utf-8',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta charset=utf-8',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+						'height' => array(),
+						'initial-scale' => array(),
+						'maximum-scale' => array(),
+						'minimum-scale' => array(
+							'mandatory',
+							'value_double',
+						),
+						'shrink-to-fit' => array(),
+						'user-scalable' => array(),
+						'viewport-fit' => array(),
+						'width' => array(
+							'mandatory',
+							'value',
+						),
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value' => 'viewport',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=viewport',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
 						'chrome' => array(
@@ -5260,6 +5435,147 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=x-ua-compatible',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+						'value_regex' => '.*app-id=.*',
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'apple-itunes-app',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=apple-itunes-app',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-experiments-opt-in',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-experiments-opt-in',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+						'allowed_protocol' => array(
+							'https',
+						),
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-3p-iframe-src',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-3p-iframe-src',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-experiment-token',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-experiment-token',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-link-variable-allowed-origin',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-link-variable-allowed-origin',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-google-client-id-api',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-google-clientid-id-api',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp4ads-id',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp4ads-id',
 				),
 
 			),
@@ -5557,6 +5873,20 @@ class AMP_Allowed_Tags_Generated {
 			),
 		),
 		'noscript' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'noscript enclosure for boilerplate',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'unique' => true,
+				),
+
+			),
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
@@ -6323,6 +6653,60 @@ class AMP_Allowed_Tags_Generated {
 		'script' => array(
 			array(
 				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'src' => array(
+						'mandatory' => true,
+						'value' => 'https://cdn.ampproject.org/v0.js',
+					),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'amphtml engine v0.js script',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'src' => array(
+						'mandatory' => true,
+						'value' => 'https://cdn.ampproject.org/amp4ads-v0.js',
+					),
+					'type' => array(
+						'value_casei' => 'text/javascript',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp4ads',
+					),
+					'mandatory' => true,
+					'mandatory_parent' => 'head',
+					'spec_name' => 'amp4ads engine amp4ads-v0.js script',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 2,
@@ -6338,6 +6722,28 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'script type=application/ld+json',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'id' => array(
+						'mandatory' => true,
+						'value_casei' => 'amp-rtc',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => 'application/json',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'script id=amp-rtc',
+					'unique' => true,
 				),
 
 			),
@@ -6361,6 +6767,32 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > script[type=application/json]',
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'id' => array(
+						'mandatory' => true,
+						'value' => 'amp-access',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => 'application/json',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'requires_extension' => array(
+							'amp-access',
+							'amp-analytics',
+					),
+					'spec_name' => 'amp-access extension .json script',
+					'unique' => true,
 				),
 
 			),
@@ -6853,6 +7285,89 @@ class AMP_Allowed_Tags_Generated {
 			),
 		),
 		'style' => array(
+			array(
+				'attr_spec_list' => array(
+					'amp-custom' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/css',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'style amp-custom',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#stylesheets',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-custom' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => 'text/css',
+					),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'style amp-custom (amp4ads)',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#css',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-boilerplate' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp',
+					),
+					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
+					'mandatory_parent' => 'head',
+					'spec_name' => 'head > style[amp-boilerplate]',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'unique' => true,
+				),
+
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp4ads-boilerplate' => array(
+						'mandatory' => true,
+						'value' => '',
+					),
+					'nonce' => array(),
+				),
+				'tag_spec' => array(
+					'html_format' => array(
+							'amp4ads',
+					),
+					'mandatory_parent' => 'head',
+					'spec_name' => 'head > style[amp4ads-boilerplate]',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#boilerplate',
+					'unique' => true,
+				),
+
+			),
 			array(
 				'attr_spec_list' => array(
 					'amp-boilerplate' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -63,10 +63,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#links',
 				),
 
@@ -82,11 +78,7 @@ class AMP_Allowed_Tags_Generated {
 		'acronym' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -112,9 +104,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-3q-player',
 					),
@@ -165,9 +154,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'amp-app-banner',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-ad',
 					),
@@ -210,37 +196,11 @@ class AMP_Allowed_Tags_Generated {
 							'amp-lightbox',
 							'amp-sticky-ad',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-multi-size attribute',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
-				),
-
-			),
-		),
-		'amp-ad-exit' => array(
-			array(
-				'attr_spec_list' => array(
-					'id' => array(
-						'mandatory' => true,
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => '',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'requires_extension' => array(
-							'amp-ad-exit',
-					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad-exit',
 				),
 
 			),
@@ -259,10 +219,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-analytics',
 					),
@@ -296,10 +252,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-anim',
 					),
@@ -320,10 +272,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-animation',
 					),
@@ -346,9 +294,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-apester-media',
 					),
@@ -369,9 +314,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 							'amp-app-banner',
@@ -415,9 +357,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'amp-story',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-audio',
 					),
@@ -455,51 +394,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
 							'amp-audio',
 					),
 					'spec_name' => 'amp-story >> amp-audio',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'album' => array(),
-					'artist' => array(),
-					'artwork' => array(),
-					'controls' => array(),
-					'controlslist' => array(),
-					'loop' => array(
-						'value' => '',
-					),
-					'media' => array(),
-					'muted' => array(
-						'value' => '',
-					),
-					'noloading' => array(
-						'value' => '',
-					),
-					'src' => array(
-						'blacklisted_value_regex' => '__amp_source_origin',
-						'allow_relative' => true,
-						'allowed_protocol' => array(
-							'https',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'requires_extension' => array(
-							'amp-audio',
-					),
-					'spec_name' => 'amp-audio (A4A)',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
 
@@ -517,9 +416,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 							'amp-auto-ads',
@@ -556,9 +452,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-brid-player',
 					),
@@ -585,9 +478,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-brightcove',
 					),
@@ -613,9 +503,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-call-tracking',
 					),
@@ -696,9 +583,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-dailymotion',
 					),
@@ -733,9 +617,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'disallowed_ancestor' => array(
 							'amp-app-banner',
-					),
-					'html_format' => array(
-							'amp',
 					),
 					'requires_extension' => array(
 							'amp-ad',
@@ -779,9 +660,6 @@ class AMP_Allowed_Tags_Generated {
 							'amp-lightbox',
 							'amp-sticky-ad',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-ad',
 					),
@@ -795,9 +673,6 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-experiment',
 					),
@@ -819,9 +694,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-facebook',
 					),
@@ -841,9 +713,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-facebook-comments',
 					),
@@ -868,9 +737,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-facebook-like',
 					),
@@ -918,10 +784,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-font',
 					),
@@ -941,9 +803,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-fx-flying-carpet',
 					),
@@ -966,9 +825,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-gfycat',
 					),
@@ -989,35 +845,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-gist',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-gist',
-				),
-
-			),
-		),
-		'amp-gwd-animation' => array(
-			array(
-				'attr_spec_list' => array(
-					'media' => array(),
-					'noloading' => array(
-						'value' => '',
-					),
-					'timeline-event-prefix' => array(
-						'value' => '',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'requires_extension' => array(
-							'amp-gwd-animation',
-					),
 				),
 
 			),
@@ -1034,9 +865,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-hulu',
 					),
@@ -1087,9 +915,6 @@ class AMP_Allowed_Tags_Generated {
 					'srcdoc' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-iframe',
 					),
@@ -1120,9 +945,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-ima-video',
 					),
@@ -1141,9 +963,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-image-lightbox',
 					),
@@ -1180,10 +999,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
 				),
 
@@ -1201,9 +1016,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-imgur',
 					),
@@ -1224,9 +1036,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-instagram',
 					),
@@ -1254,9 +1063,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-install-serviceworker',
 					),
@@ -1277,9 +1083,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-izlesene',
 					),
@@ -1302,9 +1105,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-jwplayer',
 					),
@@ -1324,9 +1124,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-kaltura-player',
 					),
@@ -1343,10 +1140,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-layout',
 				),
 
@@ -1364,9 +1157,6 @@ class AMP_Allowed_Tags_Generated {
 					'scrollable' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-lightbox',
 					),
@@ -1398,9 +1188,6 @@ class AMP_Allowed_Tags_Generated {
 					'template' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-list',
 					),
@@ -1426,9 +1213,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-live-list',
 					),
@@ -1466,9 +1250,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-nexxtv-player',
 					),
@@ -1491,9 +1272,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-o2-player',
 					),
@@ -1519,9 +1297,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-ooyala-player',
 					),
@@ -1541,9 +1316,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-pinterest',
 					),
@@ -1573,10 +1345,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pixel',
 				),
 
@@ -1602,9 +1370,6 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-playbuzz',
 					),
@@ -1628,10 +1393,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-position-observer',
 					),
@@ -1652,9 +1413,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-reach-player',
 					),
@@ -1684,9 +1442,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-reddit',
 					),
@@ -1720,9 +1475,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'amp-selector',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-selector',
 					),
@@ -1742,9 +1494,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 							'amp-sidebar',
@@ -1787,10 +1536,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-social-share',
 					),
@@ -1822,9 +1567,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-soundcloud',
 					),
@@ -1862,9 +1604,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-springboard-player',
 					),
@@ -1889,9 +1628,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-bind',
 					),
@@ -1912,9 +1648,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
 							'amp-app-banner',
-					),
-					'html_format' => array(
-							'amp',
 					),
 					'requires_extension' => array(
 							'amp-sticky-ad',
@@ -1945,9 +1678,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 							'amp-story',
@@ -1965,9 +1695,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'amp-story-page',
 				),
 
@@ -1988,9 +1715,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'amp-story',
 					'requires_extension' => array(
 							'amp-story',
@@ -2016,9 +1740,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-timeago',
 					),
@@ -2039,9 +1760,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-twitter',
 					),
@@ -2075,9 +1793,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-user-notification',
 					),
@@ -2146,10 +1861,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'amp-story',
 					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
 				),
 
@@ -2210,10 +1921,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
 							'amp-video',
@@ -2237,9 +1944,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-vimeo',
 					),
@@ -2259,9 +1963,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-vine',
 					),
@@ -2281,9 +1982,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-vk',
 					),
@@ -2325,9 +2023,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-web-push',
 					),
@@ -2349,9 +2044,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'requires_extension' => array(
 							'amp-web-push',
 					),
@@ -2417,9 +2109,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-audio',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
@@ -2445,10 +2134,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'head',
 					'unique' => true,
 				),
@@ -2474,11 +2159,7 @@ class AMP_Allowed_Tags_Generated {
 		'big' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -2553,10 +2234,6 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'amp-app-banner',
 					'spec_name' => 'amp-app-banner button[open-button]',
 				),
@@ -2573,11 +2250,7 @@ class AMP_Allowed_Tags_Generated {
 		'center' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -2662,10 +2335,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -2757,10 +2426,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -2892,10 +2557,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -2932,10 +2593,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -2952,11 +2609,7 @@ class AMP_Allowed_Tags_Generated {
 		'dir' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -3107,10 +2760,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3204,10 +2853,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3298,10 +2943,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3385,10 +3026,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3475,10 +3112,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3562,10 +3195,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3585,10 +3214,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3675,10 +3300,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3809,10 +3430,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3907,10 +3524,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -3963,10 +3576,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'amp-app-banner',
 					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'requires_extension' => array(
 							'amp-form',
 					),
@@ -4013,10 +3622,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
 							'amp-app-banner',
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 					'requires_extension' => array(
 							'amp-form',
@@ -4103,10 +3708,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4194,10 +3795,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4299,10 +3896,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4385,11 +3978,7 @@ class AMP_Allowed_Tags_Generated {
 		'hgroup' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -4410,10 +3999,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4439,35 +4024,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory' => true,
 					'mandatory_parent' => '!doctype',
 					'spec_name' => 'html \u26a1 for top-level html',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
-					'unique' => true,
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'\u26a14ads' => array(
-						'alternative_names' => array(
-							'amp4ads',
-						),
-						'mandatory' => true,
-						'value' => '',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory' => true,
-					'mandatory_parent' => '!doctype',
-					'spec_name' => 'html \u26a14ads for top-level html',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#a4a-format-rules',
 					'unique' => true,
 				),
 
@@ -4508,9 +4068,6 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-iframe',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-iframe',
@@ -4619,10 +4176,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4659,9 +4212,6 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-img',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
@@ -4869,10 +4419,6 @@ class AMP_Allowed_Tags_Generated {
 					'y2' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -4976,10 +4522,6 @@ class AMP_Allowed_Tags_Generated {
 					'y2' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -5007,10 +4549,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
 							'template',
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 					'spec_name' => 'link rel=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5044,9 +4582,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=canonical',
@@ -5081,10 +4616,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=manifest',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5111,10 +4642,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=stylesheet for fonts',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#custom-fonts',
@@ -5142,10 +4669,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_name' => 'link itemprop=sameAs',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
@@ -5170,10 +4693,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_name' => 'link itemprop=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
@@ -5198,10 +4717,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_name' => 'link property=',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
@@ -5211,11 +4726,7 @@ class AMP_Allowed_Tags_Generated {
 		'listing' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -5315,10 +4826,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -5407,10 +4914,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -5461,10 +4964,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=viewport',
@@ -5491,10 +4990,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=X-UA-Compatible',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5514,10 +5009,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=apple-itunes-app',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5536,10 +5027,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-experiments-opt-in',
 				),
@@ -5560,9 +5047,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-3p-iframe-src',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
@@ -5581,9 +5065,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-experiment-token',
 				),
@@ -5601,9 +5082,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-link-variable-allowed-origin',
 				),
@@ -5621,31 +5099,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-google-clientid-id-api',
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'content' => array(
-						'mandatory' => true,
-					),
-					'name' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value_casei' => 'amp4ads-id',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory_parent' => 'head',
-					'spec_name' => 'meta name=amp4ads-id',
 				),
 
 			),
@@ -5659,10 +5114,6 @@ class AMP_Allowed_Tags_Generated {
 					'property' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_name' => 'meta name= and content=',
 				),
 
@@ -5680,10 +5131,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5702,10 +5149,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=content-language',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5724,10 +5167,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=pics-label',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5746,10 +5185,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=imagetoolbar',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5769,10 +5204,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Style-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5792,10 +5223,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Script-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5814,10 +5241,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=origin-trial',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5836,10 +5259,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=resource-type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
@@ -5859,10 +5278,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -5886,11 +5301,7 @@ class AMP_Allowed_Tags_Generated {
 		'multicol' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -5911,9 +5322,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'amp-sidebar',
 					'spec_name' => 'amp-sidebar > nav',
 				),
@@ -5923,22 +5331,14 @@ class AMP_Allowed_Tags_Generated {
 		'nextid' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
 		'nobr' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -5946,9 +5346,6 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'noscript enclosure for boilerplate',
@@ -5963,9 +5360,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 							'noscript',
 					),
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'body',
 				),
 
@@ -5974,11 +5368,7 @@ class AMP_Allowed_Tags_Generated {
 		'o:p' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -6134,10 +5524,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6246,10 +5632,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6335,10 +5717,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6424,10 +5802,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6567,10 +5941,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6668,10 +6038,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -6744,46 +6110,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
-					'unique' => true,
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-					'src' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value' => 'https://cdn.ampproject.org/amp4ads-v0.js',
-					),
-					'type' => array(
-						'value_casei' => 'text/javascript',
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'contents',
-						'regex' => '.',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory' => true,
-					'mandatory_parent' => 'head',
-					'spec_name' => 'amp4ads engine amp4ads-v0.js script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
 					'unique' => true,
 				),
@@ -6829,9 +6158,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'script id=amp-rtc',
 					'unique' => true,
@@ -6853,9 +6179,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > script[type=application/json]',
 				),
@@ -6880,9 +6203,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-3q-player',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -6905,9 +6225,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-access-laterpay',
 						'requires_usage' => 3,
-					),
-					'html_format' => array(
-							'amp',
 					),
 					'requires_extension' => array(
 							'amp-access',
@@ -6936,9 +6253,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-access',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -6962,9 +6276,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'requires_extension' => array(
 							'amp-access',
@@ -7016,59 +6327,9 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-ad-exit',
-					),
-					'html_format' => array(
-							'amp4ads',
-					),
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'nonce' => array(),
-					'type' => array(
-						'dispatch_key' => 3,
-						'mandatory' => true,
-						'value' => 'application/json',
-					),
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory_parent' => 'amp-ad-exit',
-					'requires_extension' => array(
-							'amp-ad-exit',
-					),
-					'spec_name' => 'amp-ad-exit configuration JSON',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad-exit',
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => 'text/javascript',
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-ad',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 					'spec_name' => 'amp-ad extension .js script',
 				),
@@ -7095,10 +6356,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-analytics',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 				),
 
 			),
@@ -7118,10 +6375,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-analytics',
 					'requires_extension' => array(
 							'amp-analytics',
@@ -7152,10 +6405,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-anim',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 				),
 
 			),
@@ -7177,10 +6426,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-animation',
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 				),
 
@@ -7230,9 +6475,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-apester-media',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7255,9 +6497,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-app-banner',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7305,9 +6544,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-auto-ads',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7331,9 +6567,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-bind',
 						'requires_usage' => 3,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7353,9 +6586,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'amp-state',
 					'requires_extension' => array(
 							'amp-bind',
@@ -7386,9 +6616,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-brid-player',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7413,9 +6640,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-brightcove',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7438,9 +6662,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-call-tracking',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7490,9 +6711,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-dailymotion',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7516,9 +6734,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-dynamic-css-classes',
 						'requires_usage' => 3,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7544,9 +6759,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-experiment',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7566,9 +6778,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment extension .json script',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
@@ -7594,9 +6803,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-facebook-comments',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7618,9 +6824,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-facebook-like',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7645,9 +6848,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-facebook',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7697,10 +6897,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-font',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 				),
 
 			),
@@ -7749,9 +6945,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-fx-flying-carpet',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7776,9 +6969,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-gfycat',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7801,34 +6991,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-gist',
 					),
-					'html_format' => array(
-							'amp',
-					),
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => 'text/javascript',
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
-						'name' => 'amp-gwd-animation',
-					),
-					'html_format' => array(
-							'amp4ads',
-					),
 				),
 
 			),
@@ -7850,9 +7012,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-hulu',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7878,9 +7037,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-iframe',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7902,9 +7058,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-ima-video',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7930,9 +7083,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-image-lightbox',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -7954,9 +7104,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-imgur',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -7982,9 +7129,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-instagram',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8009,9 +7153,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-install-serviceworker',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8034,9 +7175,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-izlesene',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8062,9 +7200,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-jwplayer',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8088,9 +7223,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-kaltura-player',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8116,9 +7248,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-lightbox',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8143,9 +7272,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-list',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8168,9 +7294,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-live-list',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 					'mandatory_parent' => 'head',
 					'unique_warning' => true,
@@ -8199,9 +7322,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-mustache',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8223,9 +7343,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-nexxtv-player',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8251,9 +7368,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-o2-player',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8275,9 +7389,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-ooyala-player',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8303,9 +7414,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-pinterest',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8328,9 +7436,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-playbuzz',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8352,10 +7457,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-position-observer',
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 				),
 
@@ -8381,9 +7482,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-reach-player',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8407,9 +7505,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-reddit',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8432,9 +7527,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-selector',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8460,9 +7552,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-sidebar',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8486,10 +7575,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-social-share',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 				),
 
@@ -8515,9 +7600,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-soundcloud',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8541,9 +7623,6 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-springboard-player',
 						'requires_usage' => 2,
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8572,9 +7651,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-sticky-ad',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8597,9 +7673,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-story',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8621,9 +7694,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-timeago',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8649,9 +7719,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-twitter',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8676,9 +7743,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-user-notification',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8701,10 +7765,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-video',
 						'requires_usage' => 3,
-					),
-					'html_format' => array(
-							'amp',
-							'amp4ads',
 					),
 					'spec_name' => 'amp-video extension .js script',
 				),
@@ -8731,9 +7791,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-vimeo',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8758,9 +7815,6 @@ class AMP_Allowed_Tags_Generated {
 						'name' => 'amp-vine',
 						'requires_usage' => 2,
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8783,9 +7837,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'name' => 'amp-vk',
 					),
-					'html_format' => array(
-							'amp',
-					),
 				),
 
 			),
@@ -8807,9 +7858,6 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 						'name' => 'amp-web-push',
-					),
-					'html_format' => array(
-							'amp',
 					),
 				),
 
@@ -8890,11 +7938,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'name' => array(),
 				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -8979,10 +8023,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -9005,10 +8045,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
@@ -9030,10 +8066,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
@@ -9056,10 +8088,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
@@ -9082,10 +8110,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > source',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
@@ -9107,10 +8131,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-ima-video',
 					'requires_extension' => array(
 							'amp-ima-video',
@@ -9123,11 +8143,7 @@ class AMP_Allowed_Tags_Generated {
 		'spacer' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -9149,10 +8165,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'lineargradient',
 					'spec_name' => 'lineargradient > stop',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
@@ -9169,10 +8181,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'radialgradient',
 					'spec_name' => 'radialgradient > stop',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
@@ -9183,11 +8191,7 @@ class AMP_Allowed_Tags_Generated {
 		'strike' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -9219,42 +8223,9 @@ class AMP_Allowed_Tags_Generated {
 					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#maximum-size',
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_parent' => 'head',
 					'spec_name' => 'style amp-custom',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#stylesheets',
-					'unique' => true,
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'amp-custom' => array(
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => 'text/css',
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'CSS !important',
-						'regex' => '!important',
-					),
-					'max_bytes' => 20000,
-					'max_bytes_spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#css',
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory_parent' => 'head',
-					'spec_name' => 'style amp-custom (AMP4ADS)',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#css',
 					'unique' => true,
 				),
 
@@ -9272,36 +8243,10 @@ class AMP_Allowed_Tags_Generated {
 					'cdata_regex' => '\s*body{-webkit-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-moz-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;-ms-animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both;animation:-amp-start\s+8s\s+steps\(1,end\)\s+0s\s+1\s+normal\s+both}@-webkit-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes\s+-amp-start{from{visibility:hidden}to{visibility:visible}}\s*',
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'head > style[amp-boilerplate]',
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
-					'unique' => true,
-				),
-
-			),
-			array(
-				'attr_spec_list' => array(
-					'amp4ads-boilerplate' => array(
-						'dispatch_key' => 3,
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-				),
-				'cdata' => array(
-					'cdata_regex' => '\s*body{visibility:hidden}\s*',
-				),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp4ads',
-					),
-					'mandatory_parent' => 'head',
-					'spec_name' => 'head > style[amp4ads-boilerplate]',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#boilerplate',
 					'unique' => true,
 				),
 
@@ -9319,9 +8264,6 @@ class AMP_Allowed_Tags_Generated {
 					'cdata_regex' => '\s*body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}\s*',
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_alternatives' => 'noscript > style[amp-boilerplate]',
 					'mandatory_ancestor' => 'head',
 					'mandatory_parent' => 'noscript',
@@ -9344,10 +8286,6 @@ class AMP_Allowed_Tags_Generated {
 					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#keyframes-stylesheet',
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'body',
 					'spec_name' => 'style[amp-keyframes]',
 					'unique' => true,
@@ -9454,10 +8392,6 @@ class AMP_Allowed_Tags_Generated {
 					'zoomandpan' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
 
@@ -9538,10 +8472,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -9623,10 +8553,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -9776,10 +8702,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -9925,10 +8847,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -9996,10 +8914,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_name' => 'svg title',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
@@ -10040,10 +8954,6 @@ class AMP_Allowed_Tags_Generated {
 					'srclang' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > track',
 				),
@@ -10072,10 +8982,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > track[kind=subtitles]',
 				),
@@ -10101,10 +9007,6 @@ class AMP_Allowed_Tags_Generated {
 					'srclang' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > track',
 				),
@@ -10133,10 +9035,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > track[kind=subtitles]',
 				),
@@ -10165,10 +9063,6 @@ class AMP_Allowed_Tags_Generated {
 					'srclang' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > track',
 				),
@@ -10200,10 +9094,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > track[kind=subtitles]',
 				),
@@ -10232,10 +9122,6 @@ class AMP_Allowed_Tags_Generated {
 					'srclang' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > track',
 				),
@@ -10267,10 +9153,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > track[kind=subtitles]',
 				),
@@ -10302,10 +9184,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > track[kind=subtitles]',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ima-video',
@@ -10406,10 +9284,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -10499,10 +9373,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -10512,11 +9382,7 @@ class AMP_Allowed_Tags_Generated {
 		'tt' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),
@@ -10632,10 +9498,6 @@ class AMP_Allowed_Tags_Generated {
 					'y' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -10671,9 +9533,6 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-video',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
@@ -10698,10 +9557,6 @@ class AMP_Allowed_Tags_Generated {
 					'zoomandpan' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -10725,10 +9580,6 @@ class AMP_Allowed_Tags_Generated {
 					'xmlns:xlink' => array(),
 				),
 				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-							'amp4ads',
-					),
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
@@ -10745,11 +9596,7 @@ class AMP_Allowed_Tags_Generated {
 		'xmp' => array(
 			array(
 				'attr_spec_list' => array(),
-				'tag_spec' => array(
-					'html_format' => array(
-							'amp',
-					),
-				),
+				'tag_spec' => array(),
 
 			),
 		),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -335,10 +335,10 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-apester-channel-token' => array(
-						'value_regex' => '[0-9a-za-z]+',
+						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'data-apester-media-id' => array(
-						'value_regex' => '[0-9a-za-z]+',
+						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'media' => array(),
 					'noloading' => array(
@@ -499,7 +499,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 							'amp-audio',
 					),
-					'spec_name' => 'amp-audio (a4a)',
+					'spec_name' => 'amp-audio (A4A)',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
 				),
 
@@ -1710,7 +1710,7 @@ class AMP_Allowed_Tags_Generated {
 						'value' => '',
 					),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'noloading' => array(
 						'value' => '',
@@ -1808,7 +1808,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]+',
 					),
 					'data-secret-token' => array(
-						'value_regex' => '[a-za-z0-9_-]+',
+						'value_regex' => '[A-Za-z0-9_-]+',
 					),
 					'data-trackid' => array(
 						'value_regex' => '[0-9]+',
@@ -2007,7 +2007,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'datetime' => array(
 						'mandatory' => true,
-						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dt[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(z|[+-][0-1][0-9]:[0-5][0-9])',
+						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])',
 					),
 					'locale' => array(),
 					'media' => array(),
@@ -2529,7 +2529,7 @@ class AMP_Allowed_Tags_Generated {
 						'value' => '',
 					),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'role' => array(),
 					'tabindex' => array(),
@@ -2542,7 +2542,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'open-button' => array(
 						'value' => '',
@@ -2978,7 +2978,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'form',
-					'spec_name' => 'form > div [submitting]',
+					'spec_name' => 'FORM > DIV [submitting]',
 				),
 
 			),
@@ -2992,7 +2992,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'form',
-					'spec_name' => 'form > div [submit-success]',
+					'spec_name' => 'FORM > DIV [submit-success]',
 				),
 
 			),
@@ -3006,7 +3006,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'form',
-					'spec_name' => 'form > div [submit-error]',
+					'spec_name' => 'FORM > DIV [submit-error]',
 				),
 
 			),
@@ -3691,7 +3691,7 @@ class AMP_Allowed_Tags_Generated {
 					'[disabled]' => array(),
 					'disabled' => array(),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 				),
 				'tag_spec' => array(),
@@ -3970,7 +3970,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 							'amp-form',
 					),
-					'spec_name' => 'form [method=get]',
+					'spec_name' => 'FORM [method=GET]',
 				),
 
 			),
@@ -4021,7 +4021,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 							'amp-form',
 					),
-					'spec_name' => 'form [method=post]',
+					'spec_name' => 'FORM [method=POST]',
 				),
 
 			),
@@ -4710,7 +4710,7 @@ class AMP_Allowed_Tags_Generated {
 					'minlength' => array(),
 					'multiple' => array(),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'pattern' => array(),
 					'placeholder' => array(),
@@ -5097,7 +5097,7 @@ class AMP_Allowed_Tags_Generated {
 					'crossorigin' => array(),
 					'href' => array(
 						'mandatory' => true,
-						'value_regex' => 'https://cdn\\.materialdesignicons\\.com/([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css|https://cloud\\.typography\\.com/[0-9]*/[0-9]*/css/fonts\\.css|https://fast\\.fonts\\.net/.*|https://fonts\\.googleapis\\.com/css\\?.*|https://fonts\\.googleapis\\.com/icon\\?.*|https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|https://maxcdn\\.bootstrapcdn\\.com/font-awesome/([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|https://use\\.typekit\\.net/[\\w\\p{l}\\p{n}_]+\\.css',
+						'value_regex' => 'https://cdn\\.materialdesignicons\\.com/([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css|https://cloud\\.typography\\.com/[0-9]*/[0-9]*/css/fonts\\.css|https://fast\\.fonts\\.net/.*|https://fonts\\.googleapis\\.com/css\\?.*|https://fonts\\.googleapis\\.com/icon\\?.*|https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|https://maxcdn\\.bootstrapcdn\\.com/font-awesome/([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css',
 					),
 					'integrity' => array(),
 					'media' => array(),
@@ -5146,7 +5146,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp',
 							'amp4ads',
 					),
-					'spec_name' => 'link itemprop=sameas',
+					'spec_name' => 'link itemprop=sameAs',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
 
@@ -5496,7 +5496,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp4ads',
 					),
 					'mandatory_ancestor' => 'head',
-					'spec_name' => 'meta http-equiv=x-ua-compatible',
+					'spec_name' => 'meta http-equiv=X-UA-Compatible',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
 
@@ -5685,7 +5685,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp4ads',
 					),
 					'mandatory_ancestor' => 'head',
-					'spec_name' => 'meta http-equiv=content-type',
+					'spec_name' => 'meta http-equiv=Content-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
 
@@ -5774,7 +5774,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp4ads',
 					),
 					'mandatory_ancestor' => 'head',
-					'spec_name' => 'meta http-equiv=content-style-type',
+					'spec_name' => 'meta http-equiv=Content-Style-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
 
@@ -5797,7 +5797,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp4ads',
 					),
 					'mandatory_ancestor' => 'head',
-					'spec_name' => 'meta http-equiv=content-script-type',
+					'spec_name' => 'meta http-equiv=Content-Script-Type',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
 				),
 
@@ -5992,7 +5992,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]*',
 					),
 					'type' => array(
-						'value_regex' => '[1aaii]',
+						'value_regex' => '[1AaIi]',
 					),
 				),
 				'tag_spec' => array(),
@@ -6038,7 +6038,7 @@ class AMP_Allowed_Tags_Generated {
 					'for' => array(),
 					'form' => array(),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 				),
 				'tag_spec' => array(),
@@ -7041,7 +7041,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 							'amp-ad-exit',
 					),
-					'spec_name' => 'amp-ad-exit configuration json',
+					'spec_name' => 'amp-ad-exit configuration JSON',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad-exit',
 				),
 
@@ -8874,7 +8874,7 @@ class AMP_Allowed_Tags_Generated {
 					'disabled' => array(),
 					'multiple' => array(),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'required' => array(),
 					'size' => array(),
@@ -9253,7 +9253,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp4ads',
 					),
 					'mandatory_parent' => 'head',
-					'spec_name' => 'style amp-custom (amp4ads)',
+					'spec_name' => 'style amp-custom (AMP4ADS)',
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#css',
 					'unique' => true,
 				),
@@ -9811,7 +9811,7 @@ class AMP_Allowed_Tags_Generated {
 					'maxlength' => array(),
 					'minlength' => array(),
 					'name' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'placeholder' => array(),
 					'readonly' => array(),
@@ -10856,7 +10856,7 @@ class AMP_Allowed_Tags_Generated {
 		'aria-valuenow' => array(),
 		'aria-valuetext' => array(),
 		'class' => array(
-					'blacklisted_value_regex' => '(^|\\w)i-amphtml-',
+					'blacklisted_value_regex' => '(^|\\W)i-amphtml-',
 		),
 		'content' => array(),
 		'datatype' => array(),
@@ -10870,7 +10870,7 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'i-amp-access-id' => array(),
 		'id' => array(
-					'blacklisted_value_regex' => '(^|\\s)(__amp_\\s*|__count__|__definegetter__|__definesetter__|__lookupgetter__|__lookupsetter__|__nosuchmethod__|__parent__|__proto__|__amp_\\s*|\\$p|\\$proxy|acceptcharset|addeventlistener|appendchild|assignedslot|attachshadow|amp|baseuri|checkvalidity|childelementcount|childnodes|classlist|classname|clientheight|clientleft|clienttop|clientwidth|comparedocumentposition|computedname|computedrole|contenteditable|createshadowroot|enqueaction|firstchild|firstelementchild|getanimations|getattribute|getattributens|getattributenode|getattributenodens|getboundingclientrect|getclientrects|getdestinationinsertionpoints|getelementsbyclassname|getelementsbytagname|getelementsbytagnamens|getrootnode|hasattribute|hasattributens|hasattributes|haschildnodes|haspointercapture|i-amphtml-\\s*|innerhtml|innertext|inputmode|insertadjacentelement|insertadjacenthtml|insertadjacenttext|iscontenteditable|isdefaultnamespace|isequalnode|issamenode|lastchild|lastelementchild|lookupnamespaceuri|namespaceuri|nextelementsibling|nextsibling|nodename|nodetype|nodevalue|offsetheight|offsetleft|offsetparent|offsettop|offsetwidth|outerhtml|outertext|ownerdocument|parentelement|parentnode|previouselementsibling|previoussibling|queryselector|queryselectorall|releasepointercapture|removeattribute|removeattributens|removeattributenode|removechild|removeeventlistener|replacechild|reportvalidity|requestpointerlock|scrollheight|scrollintoview|scrollintoviewifneeded|scrollleft|scrollwidth|setattribute|setattributens|setattributenode|setattributenodens|setpointercapture|shadowroot|stylemap|tabindex|tagname|textcontent|tostring|valueof|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)matchesselector|(webkit|moz|ms|o)requestfullscreen|(webkit|moz|ms|o)requestfullscreen)(\\s|$)',
+					'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 		),
 		'inlist' => array(),
 		'itemid' => array(),
@@ -10899,7 +10899,7 @@ class AMP_Allowed_Tags_Generated {
 		'typeof' => array(),
 		'validation-for' => array(),
 		'visible-when-invalid' => array(
-					'value_regex' => '(badinput|customerror|patternmismatch|rangeoverflow|rangeunderflow|stepmismatch|toolong|typemismatch|valuemissing)',
+					'value_regex' => '(badInput|customError|patternMismatch|rangeOverflow|rangeUnderflow|stepMismatch|tooLong|typeMismatch|valueMissing)',
 		),
 		'vocab' => array(),
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -9764,6 +9764,22 @@ class AMP_Allowed_Tags_Generated {
 	}
 
 	/**
+	 * Get allowed tag.
+	 *
+	 * Get the rules for a single tag so that the entire data structure needn't be passed around.
+	 *
+	 * @since 0.7
+	 * @param string $node_name Tag name.
+	 * @return array|null Allowed tag, or null if the tag does not exist.
+	 */
+	public static function get_allowed_tag( $node_name ) {
+		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
+			return self::$allowed_tags[ $node_name ];
+		}
+		return null;
+	}
+
+	/**
 	 * Get list of globally-allowed attributes.
 	 *
 	 * @since 0.5

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -43,6 +43,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @var array {
 	 *      @type int $content_max_width
 	 *      @type bool $add_placeholder
+	 *      @type bool $use_document_element
 	 *      @type bool $require_https_src
 	 *      @type string[] $amp_allowed_tags
 	 *      @type string[] $amp_globally_allowed_attributes
@@ -60,6 +61,13 @@ abstract class AMP_Base_Sanitizer {
 	 * @var bool
 	 */
 	protected $did_convert_elements = false;
+
+	/**
+	 * The root element used for sanitization. Either html or body.
+	 *
+	 * @var DOMElement
+	 */
+	protected $root_element;
 
 	/**
 	 * AMP_Base_Sanitizer constructor.
@@ -81,6 +89,12 @@ abstract class AMP_Base_Sanitizer {
 	public function __construct( $dom, $args = array() ) {
 		$this->dom  = $dom;
 		$this->args = array_merge( $this->DEFAULT_ARGS, $args );
+
+		if ( ! empty( $this->args['use_document_element'] ) ) {
+			$this->root_element = $this->dom->documentElement;
+		} else {
+			$this->root_element = $this->dom->getElementsByTagName( 'body' )->item( 0 );
+		}
 	}
 
 	/**
@@ -136,10 +150,12 @@ abstract class AMP_Base_Sanitizer {
 	/**
 	 * Get HTML body as DOMElement from DOMDocument received by the constructor.
 	 *
-	 * @return DOMElement
+	 * @deprecated Just reference $root_element instead.
+	 * @return DOMElement The body or html element.
 	 */
 	protected function get_body_node() {
-		return $this->dom->getElementsByTagName( 'body' )->item( 0 );
+		_deprecated_function( __METHOD__, 'AMP_Base_Sanitizer::$root_element', '0.7' );
+		return $this->root_element;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -75,7 +75,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @since 0.2
 	 *
 	 * @param DOMDocument $dom Represents the HTML document to sanitize.
-	 * @param array       $args array {
+	 * @param array       $args {
 	 *      Args.
 	 *
 	 *      @type int $content_max_width

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -38,7 +38,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		$blacklisted_attributes = $this->get_blacklisted_attributes();
 		$blacklisted_protocols  = $this->get_blacklisted_protocols();
 
-		$body = $this->get_body_node();
+		$body = $this->root_element;
 		$this->strip_tags( $body, $blacklisted_tags );
 		$this->strip_attributes_recursive( $body, $blacklisted_attributes, $blacklisted_protocols );
 	}

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -21,6 +21,8 @@ abstract class AMP_Rule_Spec {
 
 	/**
 	 * AMP attr_spec value check results
+	 *
+	 * @todo Replacing these with integers could speed things up a bit.
 	 */
 	const PASS           = 'pass';
 	const FAIL           = 'fail';

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -20,13 +20,13 @@ abstract class AMP_Rule_Spec {
 	const CDATA          = 'cdata';
 
 	/**
-	 * AMP attr_spec value check results
+	 * AMP attr_spec value check results.
 	 *
-	 * @todo Replacing these with integers could speed things up a bit.
+	 * In 0.7 these changed from strings to integers to speed up comparisons.
 	 */
-	const PASS           = 'pass';
-	const FAIL           = 'fail';
-	const NOT_APPLICABLE = 'not_applicable';
+	const PASS           = 1;
+	const FAIL           = 0;
+	const NOT_APPLICABLE = -1;
 
 	/**
 	 * HTML Element Tag rule names
@@ -49,23 +49,8 @@ abstract class AMP_Rule_Spec {
 	const VALUE_CASEI             = 'value_casei';
 	const VALUE_REGEX             = 'value_regex';
 	const VALUE_REGEX_CASEI       = 'value_regex_casei';
-
-	/*
-	 * DispatchKeyTypes:
-	 * https://github.com/ampproject/amphtml/blob/eda1daa8c40f830207edc8d8088332b32a15c1a4/validator/validator.proto#L111-L120
-	 */
-
-	// Indicates that the attribute does not form a dispatch key.
-	const NONE_DISPATCH = 0;
-
-	// Indicates that the name of the attribute alone forms a dispatch key.
-	const NAME_DISPATCH = 1;
-
-	// Indicates that the name + value of the attribute forms a dispatch key.
-	const NAME_VALUE_DISPATCH = 2;
-
-	// Indicates that the name + value + mandatory parent forms a dispatch key.
-	const NAME_VALUE_PARENT_DISPATCH = 3;
+	const VALUE_PROPERTIES        = 'value_properties';
+	const VALUE_URL               = 'value_url';
 
 	/**
 	 * If a node type listed here is invalid, it and it's subtree will be

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -62,7 +62,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.4
 	 */
 	public function sanitize() {
-		$body = $this->get_body_node();
+		$body = $this->root_element;
 
 		$this->collect_style_elements();
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -33,6 +33,34 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $stylesheets = array();
 
 	/**
+	 * Maximum number of bytes allowed for a keyframes style.
+	 *
+	 * @since 0.7
+	 * @var int
+	 */
+	private $keyframes_max_size;
+
+	/**
+	 * AMP_Base_Sanitizer constructor.
+	 *
+	 * @since 0.7
+	 *
+	 * @param DOMDocument $dom  Represents the HTML document to sanitize.
+	 * @param array       $args Args.
+	 */
+	public function __construct( DOMDocument $dom, array $args = array() ) {
+		parent::__construct( $dom, $args );
+
+		$spec_name = 'style[amp-keyframes]';
+		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'style' ) as $spec_rule ) {
+			if ( isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) && $spec_name === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
+				$this->keyframes_max_size = $spec_rule[ AMP_Rule_Spec::CDATA ]['max_bytes'];
+				break;
+			}
+		}
+	}
+
+	/**
 	 * Get list of CSS styles in HTML content of DOMDocument ($this->dom).
 	 *
 	 * @since 0.4
@@ -122,7 +150,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return true|WP_Error Validity.
 	 */
 	private function validate_amp_keyframe( $style ) {
-		if ( strlen( $style->textContent ) > 500000 ) {
+		if ( $this->keyframes_max_size && strlen( $style->textContent ) > $this->keyframes_max_size ) {
 			return new WP_Error( 'max_bytes' );
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -112,10 +112,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * @var DOMElement $style_element
 			 */
 
-			if ( 'head' === $style_element->parentNode->nodeName && ( $style_element->hasAttribute( 'amp-boilerplate' ) || $style_element->hasAttribute( 'amp-custom' ) ) ) {
-				continue;
-			}
-
 			if ( 'body' === $style_element->parentNode->nodeName && $style_element->hasAttribute( 'amp-keyframes' ) ) {
 				$validity = $this->validate_amp_keyframe( $style_element );
 				if ( true === $validity ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -605,7 +605,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If given attribute's value is a URL with a protocol, the protocol must
 			 * be in the array specified by the rule's value to pass.
 			 */
-			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
+			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 				if ( AMP_Rule_Spec::PASS === $this->check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule ) ) {
 					$score++;
 				}
@@ -615,7 +615,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If the given attribute's value is *not* a relative path, and the rule's
 			 * value is `false`, then pass.
 			 */
-			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
+			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
 				if ( AMP_Rule_Spec::PASS === $this->check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule ) ) {
 					$score++;
 				}
@@ -625,7 +625,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If the given attribute's value exists, is non-empty and the rule's value
 			 * is false, then pass.
 			 */
-			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
+			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
 				if ( AMP_Rule_Spec::PASS === $this->check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) ) {
 					$score++;
 				}
@@ -752,13 +752,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_REGEX_CASEI ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_value_regex_casei( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) &&
+			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_RELATIVE ] ) &&
+			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
+			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
 			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::DISALLOWED_DOMAIN ] ) &&
@@ -786,8 +786,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Remove the disallowed values.
 		foreach ( $attrs_to_remove as $attr_name ) {
-			if ( isset( $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
-				( true === $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
+			if ( isset( $attr_spec_list[ $attr_name ]['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
+				( true === $attr_spec_list[ $attr_name ]['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
 				$node->setAttribute( $attr_name, '' );
 			} else {
 				$node->removeAttribute( $attr_name );
@@ -1012,7 +1012,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
+		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				$attr_value   = $node->getAttribute( $attr_name );
 				$attr_value   = preg_replace( '/\s*,\s*/', ',', $attr_value );
@@ -1024,7 +1024,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					 */
 					$url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME );
 					if ( $url_scheme ) {
-						if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
+						if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 							return AMP_Rule_Spec::FAIL;
 						}
 					}
@@ -1043,7 +1043,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 							 */
 							$url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME );
 							if ( $url_scheme ) {
-								if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
+								if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 									return AMP_Rule_Spec::FAIL;
 								}
 							}
@@ -1070,7 +1070,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_RELATIVE ] ) && ! ( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
+		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) && ! ( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				$attr_value   = $node->getAttribute( $attr_name );
 				$attr_value   = preg_replace( '/\s*,\s*/', ',', $attr_value );
@@ -1124,7 +1124,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_EMPTY ] ) && ! ( $attr_spec_rule[ AMP_Rule_Spec::ALLOW_EMPTY ] ) && $node->hasAttribute( $attr_name ) ) {
+		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && ! ( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && $node->hasAttribute( $attr_name ) ) {
 			$attr_value = $node->getAttribute( $attr_name );
 			if ( empty( $attr_value ) ) {
 				return AMP_Rule_Spec::FAIL;

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -429,6 +429,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return boolean $valid Whether the node's placement is valid.
 	 */
 	private function validate_tag_spec_for_node( $node, $tag_spec ) {
+
+		// Always skip extension spec scripts since we manage the injection of these ourselves.
+		if ( isset( $tag_spec['extension_spec'] ) ) {
+			return false;
+		}
+
 		if ( ! empty( $tag_spec[ AMP_Rule_Spec::MANDATORY_PARENT ] ) && ! $this->has_parent( $node, $tag_spec[ AMP_Rule_Spec::MANDATORY_PARENT ] ) ) {
 			return false;
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -599,7 +599,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If given attribute's value is a URL with a protocol, the protocol must
 			 * be in the array specified by the rule's value to pass.
 			 */
-			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
+			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 				$result = $this->check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule );
 				if ( AMP_Rule_Spec::PASS === $result ) {
 					$score++;
@@ -612,7 +612,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If the given attribute's value is *not* a relative path, and the rule's
 			 * value is `false`, then pass.
 			 */
-			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
+			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
 				$result = $this->check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule );
 				if ( AMP_Rule_Spec::PASS === $result ) {
 					$score++;
@@ -625,7 +625,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			 * If the given attribute's value exists, is non-empty and the rule's value
 			 * is false, then pass.
 			 */
-			if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
+			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
 				$result = $this->check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule );
 				if ( AMP_Rule_Spec::PASS === $result ) {
 					$score++;
@@ -661,7 +661,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// If the attribute's value exists and it matches the value properties spec.
-			if ( isset( $attr_spec_rule['value_properties'] ) && $node->hasAttribute( $attr_name ) ) {
+			if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_PROPERTIES ] ) && $node->hasAttribute( $attr_name ) ) {
 				$result = $this->check_attr_spec_rule_value_properties( $node, $attr_name, $attr_spec_rule );
 				if ( AMP_Rule_Spec::PASS === $result ) {
 					$score++;
@@ -771,13 +771,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_REGEX_CASEI ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_value_regex_casei( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) &&
+			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) &&
+			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
-			} elseif ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
+			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
 				AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) ) {
 				$should_remove_node = true;
 			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::DISALLOWED_DOMAIN ] ) &&
@@ -805,8 +805,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Remove the disallowed values.
 		foreach ( $attrs_to_remove as $attr_name ) {
-			if ( isset( $attr_spec_list[ $attr_name ]['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
-				( true === $attr_spec_list[ $attr_name ]['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
+			if ( isset( $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
+				( true === $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
 				$node->setAttribute( $attr_name, '' );
 			} else {
 				$node->removeAttribute( $attr_name );
@@ -1031,7 +1031,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_allowed_protocol( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
+		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				$attr_value   = $node->getAttribute( $attr_name );
 				$attr_value   = preg_replace( '/\s*,\s*/', ',', $attr_value );
@@ -1043,7 +1043,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					 */
 					$url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME );
 					if ( $url_scheme ) {
-						if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
+						if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 							return AMP_Rule_Spec::FAIL;
 						}
 					}
@@ -1062,7 +1062,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 							 */
 							$url_scheme = AMP_WP_Utils::parse_url( $url, PHP_URL_SCHEME );
 							if ( $url_scheme ) {
-								if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
+								if ( ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 									return AMP_Rule_Spec::FAIL;
 								}
 							}
@@ -1089,7 +1089,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_disallowed_relative( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) && ! ( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
+		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) && ! ( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_RELATIVE ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				$attr_value   = $node->getAttribute( $attr_name );
 				$attr_value   = preg_replace( '/\s*,\s*/', ',', $attr_value );
@@ -1143,7 +1143,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_disallowed_empty( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && ! ( $attr_spec_rule['value_url'][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && $node->hasAttribute( $attr_name ) ) {
+		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && ! ( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) && $node->hasAttribute( $attr_name ) ) {
 			$attr_value = $node->getAttribute( $attr_name );
 			if ( empty( $attr_value ) ) {
 				return AMP_Rule_Spec::FAIL;
@@ -1241,7 +1241,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_value_properties( $node, $attr_name, $attr_spec_rule ) {
-		if ( isset( $attr_spec_rule['value_properties'] ) && $node->hasAttribute( $attr_name ) ) {
+		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_PROPERTIES ] ) && $node->hasAttribute( $attr_name ) ) {
 			$properties = array();
 			foreach ( explode( ',', $node->getAttribute( $attr_name ) ) as $pair ) {
 				$pair_parts = explode( '=', $pair, 2 );
@@ -1252,11 +1252,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Fail if there are unrecognized properties.
-			if ( count( array_diff( array_keys( $properties ), array_keys( $attr_spec_rule['value_properties'] ) ) ) > 0 ) {
+			if ( count( array_diff( array_keys( $properties ), array_keys( $attr_spec_rule[ AMP_Rule_Spec::VALUE_PROPERTIES ] ) ) ) > 0 ) {
 				return AMP_Rule_Spec::FAIL;
 			}
 
-			foreach ( $attr_spec_rule['value_properties'] as $prop_name => $property_spec ) {
+			foreach ( $attr_spec_rule[ AMP_Rule_Spec::VALUE_PROPERTIES ] as $prop_name => $property_spec ) {
 
 				// Mandatory property is missing.
 				if ( ! empty( $property_spec['mandatory'] ) && ! isset( $properties[ $prop_name ] ) ) {

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -311,7 +311,7 @@ class AMP_DOM_Utils {
 	 * @todo In the future consider an AMP_DOMDocument subclass that does this automatically at saveHTML(). See <https://github.com/Automattic/amp-wp/pull/895/files#r163825513>.
 	 *
 	 * @param DOMDocument $dom  Represents an HTML document.
-	 * @param DOMNode     $node Represents an HTML element of the $dom from which to extract HTML content.
+	 * @param DOMElement  $node Represents an HTML element of the $dom from which to extract HTML content.
 	 * @return string Returns the HTML content represented in the DOMNode
 	 */
 	public static function get_content_from_dom_node( $dom, $node ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,7 +25,7 @@
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<properties>
-			<property name="customPropertiesWhitelist" value="childNodes,tagName,textContent,parentNode,nodeType,nodeName,nextSibling,firstChild,nodeValue,DEFAULT_ARGS" />
+			<property name="customPropertiesWhitelist" value="childNodes,tagName,textContent,parentNode,nodeType,nodeName,nextSibling,firstChild,nodeValue,DEFAULT_ARGS,documentElement" />
 		</properties>
 	</rule>
 

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 
 class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCase {
 
@@ -989,7 +990,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'node_tag_name' => 'div',
 					'attr_spec_list' => array(
 						'attribute1' => array(
-							'allow_relative' => false,
+							'value_url' => array(
+								'allow_relative' => false,
+							),
 						),
 					),
 				),
@@ -1001,7 +1004,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'node_tag_name' => 'div',
 					'attr_spec_list' => array(
 						'attribute1' => array(
-							'allow_relative' => false,
+							'value_url' => array(
+								'allow_relative' => false,
+							),
 						),
 					),
 				),
@@ -1013,7 +1018,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'node_tag_name' => 'div',
 					'attr_spec_list' => array(
 						'attribute1' => array(
-							'allow_empty' => false,
+							'value_url' => array(
+								'allow_empty' => false,
+							),
 						),
 					),
 				),
@@ -1025,7 +1032,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'node_tag_name' => 'div',
 					'attr_spec_list' => array(
 						'attribute1' => array(
-							'allow_empty' => false,
+							'value_url' => array(
+								'allow_empty' => false,
+							),
 						),
 					),
 				),
@@ -1445,66 +1454,74 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 
 	public function get_check_attr_spec_rule_allowed_protocol() {
 		return array(
-			'no_attributes' => array(
+			'no_attributes'             => array(
 				array(
-					'source' => '<div></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(),
 				),
 				AMP_Rule_Spec::NOT_APPLICABLE,
 			),
-			'protocol_pass' => array(
+			'protocol_pass'             => array(
 				array(
-					'source' => '<div attribute1="http://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="http://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				AMP_Rule_Spec::PASS,
 			),
-			'protocol_multiple_pass' => array(
+			'protocol_multiple_pass'    => array(
 				array(
-					'source' => '<div attribute1="http://example.com, https://domain.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="http://example.com, https://domain.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				AMP_Rule_Spec::PASS,
 			),
-			'protocol_fail' => array(
+			'protocol_fail'             => array(
 				array(
-					'source' => '<div attribute1="data://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="data://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
 				AMP_Rule_Spec::FAIL,
 			),
-			'protocol_multiple_fail' => array(
+			'protocol_multiple_fail'    => array(
 				array(
-					'source' => '<div attribute1="http://example.com, data://domain.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="http://example.com, data://domain.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url' => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
@@ -1512,16 +1529,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'protocol_alternative_pass' => array(
 				array(
-					'source' => '<div attribute1_alternative1="http://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="http://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'alternative_names' => array(
 							'attribute1_alternative1',
 						),
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url'         => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
@@ -1529,16 +1548,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'protocol_alternative_fail' => array(
 				array(
-					'source' => '<div attribute1_alternative1="data://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="data://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'alternative_names' => array(
 							'attribute1_alternative1',
 						),
-						'allowed_protocol' => array(
-							'http',
-							'https',
+						'value_url'         => array(
+							'allowed_protocol' => array(
+								'http',
+								'https',
+							),
 						),
 					),
 				),
@@ -1568,44 +1589,50 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 
 	public function get_check_attr_spec_rule_disallowed_relative() {
 		return array(
-			'no_attributes' => array(
+			'no_attributes'                                 => array(
 				array(
-					'source' => '<div></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(),
 				),
 				AMP_Rule_Spec::NOT_APPLICABLE,
 			),
-			'disallowed_relative_pass' => array(
+			'disallowed_relative_pass'                      => array(
 				array(
-					'source' => '<div attribute1="http://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="http://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url' => array(
+							'allow_relative' => false,
+						),
 					),
 				),
 				AMP_Rule_Spec::PASS,
 			),
-			'disallowed_relative_ multiple_pass' => array(
+			'disallowed_relative_multiple_pass'             => array(
 				array(
-					'source' => '<div attribute1="http://example.com, http://domain.com/path/to/resource"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="http://example.com, http://domain.com/path/to/resource"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url' => array(
+							'allow_relative' => false,
+						),
 					),
 				),
 				AMP_Rule_Spec::PASS,
 			),
-			'disallowed_relative_alternative_pass' => array(
+			'disallowed_relative_alternative_pass'          => array(
 				array(
-					'source' => '<div attribute1_alternative1="http://example.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="http://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url'         => array(
+							'allow_relative' => false,
+						),
 						'alternative_names' => array(
 							'attribute1_alternative1'
 						),
@@ -1615,11 +1642,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'disallowed_relative_alternative_multiple_pass' => array(
 				array(
-					'source' => '<div attribute1_alternative1="http://example.com, http://domain.com"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="http://example.com, http://domain.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url'         => array(
+							'allow_relative' => false,
+						),
 						'alternative_names' => array(
 							'attribute1_alternative1'
 						),
@@ -1627,35 +1656,41 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				),
 				AMP_Rule_Spec::PASS,
 			),
-			'disallowed_relative_fail' => array(
+			'disallowed_relative_fail'                      => array(
 				array(
-					'source' => '<div attribute1="/relative/path/to/resource"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="/relative/path/to/resource"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url' => array(
+							'allow_relative' => false,
+						),
 					),
 				),
 				AMP_Rule_Spec::FAIL,
 			),
-			'disallowed_relative_multiple_fail' => array(
+			'disallowed_relative_multiple_fail'             => array(
 				array(
-					'source' => '<div attribute1="//domain.com, /relative/path/to/resource"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1="//domain.com, /relative/path/to/resource"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url' => array(
+							'allow_relative' => false,
+						),
 					),
 				),
 				AMP_Rule_Spec::FAIL,
 			),
-			'disallowed_relative_alternative_fail' => array(
+			'disallowed_relative_alternative_fail'          => array(
 				array(
-					'source' => '<div attribute1_alternative1="/relative/path/to/resource"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="/relative/path/to/resource"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url'         => array(
+							'allow_relative' => false,
+						),
 						'alternative_names' => array(
 							'attribute1_alternative1'
 						),
@@ -1665,11 +1700,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'disallowed_relative_alternative_multiple_fail' => array(
 				array(
-					'source' => '<div attribute1_alternative1="http://domain.com,  /relative/path/to/resource"></div>',
-					'node_tag_name' => 'div',
-					'attr_name' => 'attribute1',
+					'source'         => '<div attribute1_alternative1="http://domain.com,  /relative/path/to/resource"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
-						'allow_relative' => false,
+						'value_url'         => array(
+							'allow_relative' => false,
+						),
 						'alternative_names' => array(
 							'attribute1_alternative1'
 						),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -150,6 +150,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_keyframe_data() {
+		$keyframes_max_size = 10;
+		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'style' ) as $spec_rule ) {
+			if ( isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) && 'style[amp-keyframes]' === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
+				$keyframes_max_size = $spec_rule[ AMP_Rule_Spec::CDATA ]['max_bytes'];
+				break;
+			}
+		}
+
 		return array(
 			'style_amp_keyframes'              => array(
 				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes foo {} }</style>',
@@ -157,7 +165,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'style_amp_keyframes_max_overflow' => array(
-				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes ' . str_repeat( 'a', 500000 ) . ' {} }</style>',
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes ' . str_repeat( 'a', $keyframes_max_size + 1 ) . ' {} }</style>',
 				'',
 			),
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -11,7 +11,7 @@
 class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 	/**
-	 * Get data.
+	 * Get data for tests.
 	 *
 	 * @return array
 	 */
@@ -116,6 +116,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'div > span { font-weight:bold; font-style: italic; }',
 				),
 			),
+
+			'styles_in_head_and_body_both_handled' => array(
+				'<html amp><head><meta charset="utf-8"><style amp-custom>b {color:red !important}</style><style amp-custom>i {color:blue}</style><style>u {color:green}</style></head><body><style>s {color:yellow}</style></body></html>',
+				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
+				array(
+					'b {color:red}',
+					'i {color:blue}',
+					'u {color:green}',
+					's {color:yellow}',
+				),
+			),
 		);
 	}
 
@@ -128,16 +139,25 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string $expected_stylesheets Expected stylesheets.
 	 */
 	public function test_sanitizer( $source, $expected_content, $expected_stylesheets ) {
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$html_doc_format = '<html amp><head><meta charset="utf-8"></head><body><!-- before -->%s<!-- after --></body></html>';
+		if ( false === strpos( $source, '<html' ) ) {
+			$source           = sprintf( $html_doc_format, $source );
+			$expected_content = sprintf( $html_doc_format, $expected_content );
+		}
 
-		$sanitizer = new AMP_Style_Sanitizer( $dom );
+		$dom = AMP_DOM_Utils::get_dom( $source );
+
+		$sanitizer = new AMP_Style_Sanitizer( $dom, array(
+			'use_document_element' => true,
+		) );
 		$sanitizer->sanitize();
 
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$whitelist_sanitizer->sanitize();
 
 		// Test content.
-		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
+		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
 		$this->assertEquals( $expected_content, $content );
 
 		// Test stylesheet.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -184,23 +184,42 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_amp_component_scripts().
+	 * Test get_amp_styles().
 	 *
-	 * @covers AMP_Theme_Support::get_amp_component_scripts()
+	 * @covers AMP_Theme_Support::get_amp_styles()
 	 */
-	public function test_get_amp_component_scripts() {
+	public function test_get_amp_styles() {
+		$styles = AMP_Theme_Support::get_amp_styles( array() );
+		$this->assertStringStartsWith( amp_get_boilerplate_code(), $styles );
+
+		$injected_css = 'b strong { color: red; }';
+		add_filter( 'amp_custom_styles', function( $css ) use ( $injected_css ) {
+			return $css . $injected_css;
+		} );
+		$styles = AMP_Theme_Support::get_amp_styles( array() );
+
+		$this->assertStringStartsWith( amp_get_boilerplate_code(), $styles );
+		$this->assertContains( $injected_css, $styles );
+	}
+
+	/**
+	 * Test get_amp_scripts().
+	 *
+	 * @covers AMP_Theme_Support::get_amp_scripts()
+	 */
+	public function test_get_amp_scripts() {
 		add_filter( 'amp_component_scripts', function( $scripts ) {
 			$scripts['amp-video'] = 'https://cdn.ampproject.org/v0/amp-video-0.1.js';
 			return $scripts;
 		} );
 
-		$scripts = AMP_Theme_Support::get_amp_component_scripts( array(
+		$scripts = AMP_Theme_Support::get_amp_scripts( array(
 			'amp-mustache' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
 			'amp-bind'     => 'https://cdn.ampproject.org/v0/amp-bind-0.1.js',
 		) );
 
 		$this->assertEquals(
-			'<script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script><script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script><script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>', // phpcs:ignore
+			'<script async src="https://cdn.ampproject.org/v0.js"></script><script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script><script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script><script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>', // phpcs:ignore
 			$scripts
 		);
 	}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -137,6 +137,26 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test finish_output_buffering to inject html[amp] attribute and ensure HTML5 doctype.
+	 *
+	 * @covers AMP_Theme_Support::finish_output_buffering()
+	 */
+	public function test_finish_output_buffering_to_add_html5_doctype_and_amp_attribute() {
+		add_theme_support( 'amp' );
+		AMP_Theme_Support::init();
+		ob_start();
+		?>
+		<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+		<html><head><?php wp_head(); ?></head><body><?php wp_footer(); ?></body></html>
+		<?php
+		$original_html  = trim( ob_get_clean() );
+		$sanitized_html = AMP_Theme_Support::finish_output_buffering( $original_html );
+
+		$this->assertStringStartsWith( '<!DOCTYPE html>', $sanitized_html );
+		$this->assertContains( '<html amp', $sanitized_html );
+	}
+
+	/**
 	 * Test purge_amp_query_vars.
 	 *
 	 * @covers AMP_Theme_Support::purge_amp_query_vars()

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -119,7 +119,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$original_html  = trim( ob_get_clean() );
 		$sanitized_html = AMP_Theme_Support::finish_output_buffering( $original_html );
 
-		$this->assertContains( '<meta charset="utf-8">', $sanitized_html );
+		$this->assertContains( '<meta charset="' . get_bloginfo( 'charset' ) . '">', $sanitized_html );
 		$this->assertContains( '<meta name="viewport" content="width=device-width,minimum-scale=1">', $sanitized_html );
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
 		$this->assertContains( '<style amp-custom>', $sanitized_html );

--- a/tests/test-class-amp-wp-styles.php
+++ b/tests/test-class-amp-wp-styles.php
@@ -136,6 +136,35 @@ class Test_AMP_WP_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests test_do_item for stylesheets.
+	 *
+	 * @covers AMP_WP_Styles::do_item()
+	 */
+	public function test_do_item_font_stylesheet() {
+		$wp_styles = AMP_Theme_Support::override_wp_styles();
+
+		$ok_styles = array(
+			'tangerine'   => 'https://fonts.googleapis.com/css?family=Tangerine',
+			'typekit'     => 'https://use.typekit.net/abc.css',
+			'fontscom'    => 'https://fast.fonts.net/abc.css',
+			'fontawesome' => 'https://maxcdn.bootstrapcdn.com/font-awesome/123/css/font-awesome.min.css',
+		);
+		foreach ( $ok_styles as $handle => $src ) {
+			$wp_styles->add( $handle, $src );
+			ob_start();
+			$this->assertTrue( $wp_styles->do_item( $handle ) );
+			$output = ob_get_clean();
+			$this->assertContains( '<link', $output );
+			$this->assertContains( $src, $output );
+		}
+
+		$this->setExpectedException( 'PHPUnit_Framework_Error_Warning', 'Unable to locate filesystem path for stylesheet fontillegal (https://illegal.example.com/forbidden.css).' );
+		$handle = 'fontillegal';
+		$wp_styles->add( $handle, 'https://illegal.example.com/forbidden.css' );
+		$this->assertFalse( $wp_styles->do_item( $handle ) );
+	}
+
+	/**
 	 * Tests do_locale_stylesheet.
 	 *
 	 * @covers AMP_WP_Styles::do_locale_stylesheet()

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -47,14 +47,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-ad' ),
 			),
 
-			'amp-ad-exit'                                               => array(
-				'<amp-ad-exit id="exit-api"><script type="application/json"></script></amp-ad-exit>',
-				null, // No change.
-				array( 'amp-ad-exit' ),
-			),
-
 			'amp-animation'                                             => array(
-				'<amp-animation layout="nodisplay"><script type="application/json"></script></amp-animation>',
+				'<amp-animation layout="nodisplay"><script type="application/json">{}</script></amp-animation>',
 				null, // No change.
 				array( 'amp-animation' ),
 			),
@@ -117,12 +111,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-gist layout="fixed-height" height="1613"></amp-gist>',
 				'',
 				array(),
-			),
-
-			'amp-gwd-animation'                                         => array(
-				'<amp-gwd-animation id="4321" layout="nodisplay"></amp-gwd-animation>',
-				null, // No change.
-				array( 'amp-gwd-animation' ),
 			),
 
 			'amp-iframe'                                                => array(

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -719,8 +719,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_html_data() {
 		$data = array(
+			// @todo Update sanitizer to validate the contents of meta[content].
 			'meta_charset_and_viewport_and_canonical' => array(
-				'<html amp lang="ar" dir="rtl"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,minimum-scale=1"><base target="_blank"><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"><link rel="canonical" href="self.html"><title>marhabaan bialealim!</title></head><body></body></html>', // phpcs:ignore
+				'<html amp lang="ar" dir="rtl"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><meta name="viewport" content="width=device-width,minimum-scale=1"><base target="_blank"><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"><link rel="canonical" href="self.html"><title>marhabaan bialealim!</title></head><body></body></html>', // phpcs:ignore
 			),
 			'script_tag_externals' => array(
 				'<html amp><head><meta charset="utf-8"><script async type="text/javascript" src="illegal.js"></script><script async src="illegal.js"></script><script src="illegal.js"></script><script type="text/javascript" src="illegal.js"></script></head><body></body></html>', // phpcs:ignore

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -299,6 +299,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'font'                                                      => array(
 				'<amp-font layout="nodisplay" font-family="Comic AMP" timeout="2000"></amp-font><amp-font layout="nodisplay" font-family="Comic AMP Bold" timeout="3000" font-weight="bold"></amp-font>',
 				'<amp-font layout="nodisplay" font-family="Comic AMP" timeout="2000"></amp-font><amp-font layout="nodisplay" font-family="Comic AMP Bold" timeout="3000" font-weight="bold"></amp-font>',
+				array( 'amp-font' ),
 			),
 
 			'form'                                                      => array(
@@ -634,9 +635,19 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<h1>Headline</h1>',
 			),
 
-			'font'                                                      => array(
+			'font_tag'                                                  => array(
 				'<font size="1">Headline</font>',
 				'Headline',
+			),
+
+			'span_with_custom_attr'                                     => array(
+				'<span class="foo" custom="not-allowed">value</span>',
+				'<span class="foo">value</span>',
+			),
+
+			'a_with_custom_protocol'                                    => array(
+				'<a class="foo" href="custom:bad">value</a>',
+				'<a class="foo" href="">value</a>',
 			),
 
 			// font is removed so we should check that other elements are checked as well.
@@ -719,7 +730,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_html_data() {
 		$data = array(
-			// @todo Update sanitizer to validate the contents of meta[content].
 			'meta_charset_and_viewport_and_canonical' => array(
 				'<html amp lang="ar" dir="rtl"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><meta name="viewport" content="width=device-width,minimum-scale=1"><base target="_blank"><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"><link rel="canonical" href="self.html"><title>marhabaan bialealim!</title></head><body></body></html>', // phpcs:ignore
 			),
@@ -742,6 +752,26 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'bad_external_font' => array(
 				'<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="https://fonts.example.com/css?family=Bad"></head><body></body></html>', // phpcs:ignore
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
+			),
+			'bad_meta_ua_compatible' => array(
+				'<html amp><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=9,chrome=1"></head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
+			),
+			'bad_meta_charset' => array(
+				'<html amp><head><meta charset="latin-1"><title>Mojibake?</title></head><body></body></html>',
+				'<html amp><head><title>Mojibake?</title></head><body></body></html>',
+			),
+			'bad_meta_viewport' => array(
+				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
+			),
+			'edge_meta_ua_compatible' => array(
+				'<html amp><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"></head><body></body></html>',
+				null, // No change.
+			),
+			'meta_viewport_extras' => array(
+				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=2,maximum-scale=3,minimum-scale=1.0,shrink-to-fit=yes,user-scalable=yes,viewport-fit=cover"></head><body></body></html>',
+				null, // No change.
 			),
 		);
 


### PR DESCRIPTION
* Add sanitization of the entire `html` document not just the `body.
* Add support for enqueueing font stylesheets from spec-allowed sources.
* Rewrite `amphtml-update.py` to use PHP for generation of array literals as opposed to using the previous buggy Python functions.
* Remove useless amp4ads from generated PHP.
* Enforce that the `<html>` element has the `amp` attribute.
* Enforce that there is a meta charset and meta viewport, after page is rendered and sanitization is complete. Wait to set rel=canonical link until page is rendered.
* De-duplicate boilerplate CSS; print boilerplate CSS in same routing that does custom CSS.
* Remove just-added dispatch_key logic from #926 since turns out to not be necessary.
* Eliminate hard-coding of keyframes max_size.
* Ensure styles in head get sanitized like styles output in body.

Todo:
- [x] Add some more unit tests.
- [x] Add validation of meta viewport..
- [x] Make tweaks for review on https://github.com/Automattic/amp-wp/pull/926

Fixes #926.