### PR TITLE
Prevent New Relic script from being injected in AMP responses

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -316,6 +316,11 @@ function amp_render_post( $post ) {
 		$wp_query->query_vars[ AMP_QUERY_VAR ] = true;
 	}
 
+	// Prevent New Relic from causing invalid AMP responses due the NREUM script it injects after the meta charset.
+	if ( extension_loaded( 'newrelic' ) ) {
+		newrelic_disable_autorum();
+	}
+
 	/**
 	 * Fires before rendering a post in AMP.
 	 *

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -796,6 +796,17 @@ class AMP_Theme_Support {
 	 * @see AMP_Theme_Support::finish_output_buffering()
 	 */
 	public static function start_output_buffering() {
+		/*
+		 * Disable the New Relic Browser agent on AMP responses.
+		 * This prevents th New Relic from causing invalid AMP responses due the NREUM script it injects after the meta charset:
+		 * https://docs.newrelic.com/docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
+		 * Sites with New Relic will need to specially configure New Relic for AMP:
+		 * https://docs.newrelic.com/docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
+		 */
+		if ( extension_loaded( 'newrelic' ) ) {
+			newrelic_disable_autorum();
+		}
+
 		ob_start();
 
 		// Note that the following must be at 0 because wp_ob_end_flush_all() runs at shutdown:1.


### PR DESCRIPTION
Note that to [Monitor AMP pages with New Relic Browser](https://docs.newrelic.com/docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser) you must apparently generate a license key, so there's nothing we can do to automate that. We'll need to add docs in the wiki for how to set that up. Perhaps we could add a UI for supplying the license ID later.

In the mean time, the important thing is to prevent New Relic from causing AMP pages to be invalid.

Fixes #808.