### PR TITLE
Fix handling of response when it is not HTML

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -772,6 +772,15 @@ class AMP_Theme_Support {
 	public static function prepare_response( $response, $args = array() ) {
 		global $content_width;
 
+		/*
+		 * Check if the response starts with HTML markup.
+		 * Without this check, JSON responses will be erroneously corrupted,
+		 * being wrapped in HTML documents.
+		 */
+		if ( '<' !== substr( ltrim( $response ), 0, 1 ) ) {
+			return $response;
+		}
+
 		$args = array_merge(
 			array(
 				'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -196,7 +196,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! $this->amp_custom_style_element ) {
 				$this->amp_custom_style_element = $this->dom->createElement( 'style' );
 				$this->amp_custom_style_element->setAttribute( 'amp-custom', '' );
-				$this->dom->getElementsByTagName( 'head' )->item( 0 )->appendChild( $this->amp_custom_style_element );
+				$head = $this->dom->getElementsByTagName( 'head' )->item( 0 );
+				if ( ! $head ) {
+					$head = $this->dom->createElement( 'head' );
+					$this->dom->documentElement->insertBefore( $head, $this->dom->documentElement->firstChild );
+				}
+				$head->appendChild( $this->amp_custom_style_element );
 			}
 
 			// Gather stylesheets to print as long as they don't surpass the limit.

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -160,7 +160,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					's {color:yellow}',
 				),
 			),
-			'style_eleemnts_with_link_elements' => array(
+			'style_elements_with_link_elements' => array(
 				sprintf(
 					'<html amp><head><meta charset="utf-8"><style type="text/css">strong.before-dashicon {color:green}</style><link rel="stylesheet" href="%s"><style type="text/css">strong.after-dashicon {color:green}</style></head><body><style>s {color:yellow !important}</style></body></html>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 					includes_url( 'css/dashicons.css' )
@@ -170,6 +170,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.dashicons-dashboard:before',
 					'strong.after-dashicon',
 					's {color:yellow}',
+				),
+			),
+			'style_with_no_head' => array(
+				'<html amp><body>Not good!<style>body{color:red}</style></body>',
+				array(
+					'body{color:red}',
 				),
 			),
 		);

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -139,6 +139,29 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test prepare_response for bad/non-HTML.
+	 *
+	 * @covers AMP_Theme_Support::prepare_response()
+	 */
+	public function test_prepare_response_bad_html() {
+		add_theme_support( 'amp' );
+		AMP_Theme_Support::init();
+
+		// JSON.
+		$input = '{"success":true}';
+		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
+
+		// Nothing, for redirect.
+		$input = '';
+		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
+
+		// HTML, but very stripped down.
+		$input  = '<html>Hello</html>';
+		$output = AMP_Theme_Support::prepare_response( $input );
+		$this->assertContains( '<html amp', $output );
+	}
+
+	/**
 	 * Test prepare_response to inject html[amp] attribute and ensure HTML5 doctype.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()


### PR DESCRIPTION
Amends #923.

Fixes issue where a POST form submission, such as with a Jetpack contact form, results in:

* Output buffered response is getting erroneously parsed as DOMDocument when it not HTML at all, e.g. JSON or an empty doc such as for redirect.
* 500 internal error in the style sanitizer when there is no `head` element.