### PR TITLE
Bump 0.6.1

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/automattic/amp-wp
  * Author: Automattic
  * Author URI: https://automattic.com
- * Version: 0.6.0
+ * Version: 0.6.1
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -15,7 +15,7 @@
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '0.6.0' );
+define( 'AMP__VERSION', '0.6.1' );
 
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,5 @@
     "homepage": "https://github.com/Automattic/amp-wp",
     "type": "wordpress-plugin",
     "license": "GPL-2.0",
-    "version": "0.6.0"
+    "version": "0.6.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-wp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "git",
   "url": "https://github.com/Automattic/amp-wp.git"
  },
- "version": "0.6.0",
+ "version": "0.6.1",
  "license": "GPL-2.0+",
  "private": true,
  "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 **Tags:** [amp](https://wordpress.org/plugins/tags/amp), [mobile](https://wordpress.org/plugins/tags/mobile)  
 **Requires at least:** 4.7  
 **Tested up to:** 4.9  
-**Stable tag:** 0.6.0  
+**Stable tag:** 0.6.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.2  
 
@@ -55,6 +55,9 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 1. You may need to refresh your permalinks by going to `Settings > Permalinks` and tapping the `Save` button.
 
 ## Changelog ##
+
+### 0.6.1 (2018-02-09) ###
+Bump version to re-release to ensure temporarily-broken 0.6.0 ZIP build is permanently fixed, without requiring a site to re-install the plugin.
 
 ### 0.6.0 (2018-01-23) ###
 - Add support for the "page" post type. A new `page.php` is introduced with template parts factored out (`html-start.php`, `header.php`, `footer.php`, `html-end.php`) and re-used from `single.php`. Note that AMP URLs will end in `?amp` instead of `/amp/`. See [#825](https://github.com/Automattic/amp-wp/pull/825). Props technosailor, ThierryA, westonruter.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: batmoo, joen, automattic, potatomaster, albertomedina, google, xwp
 Tags: amp, mobile
 Requires at least: 4.7
 Tested up to: 4.9
-Stable tag: 0.6.0
+Stable tag: 0.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP: 5.2
@@ -37,6 +37,10 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 1. You may need to refresh your permalinks by going to `Settings > Permalinks` and tapping the `Save` button.
 
 == Changelog ==
+
+= 0.6.1 (2018-02-09) =
+
+Bump version to re-release to ensure temporarily-broken 0.6.0 ZIP build is permanently fixed, without requiring a site to re-install the plugin.
 
 = 0.6.0 (2018-01-23) =
 


### PR DESCRIPTION
Bump version to re-release to ensure temporarily-broken 0.6.0 ZIP build is permanently fixed, without requiring a site to re-install the plugin.

See https://wordpress.org/support/topic/dysfunction-latest-version-0-6-0/