### PR TITLE
Update sanitization reporting

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -314,12 +314,12 @@ abstract class AMP_Base_Sanitizer {
 	 * @since 0.7
 	 *
 	 * @param DOMElement $child The node to remove.
-	 * @return void.
+	 * @return void
 	 */
 	public function remove_invalid_child( $child ) {
 		$child->parentNode->removeChild( $child );
 		if ( isset( $this->args['remove_invalid_callback'] ) ) {
-			call_user_func( $this->args['remove_invalid_callback'], $child, AMP_Validation_Utils::NODE_REMOVED );
+			call_user_func( $this->args['remove_invalid_callback'], $child );
 		}
 	}
 
@@ -331,14 +331,23 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 0.7
 	 *
-	 * @param DOMElement $element   The node for which to remove the attribute.
-	 * @param string     $attribute The attribute to remove from the node.
-	 * @return void.
+	 * @param DOMElement     $element   The node for which to remove the attribute.
+	 * @param DOMAttr|string $attribute The attribute to remove from the element.
+	 * @return void
 	 */
 	public function remove_invalid_attribute( $element, $attribute ) {
-		$element->removeAttribute( $attribute );
 		if ( isset( $this->args['remove_invalid_callback'] ) ) {
-			call_user_func( $this->args['remove_invalid_callback'], $element, AMP_Validation_Utils::ATTRIBUTE_REMOVED, $attribute );
+			if ( is_string( $attribute ) ) {
+				$attribute = $element->getAttributeNode( $attribute );
+			}
+			if ( $attribute ) {
+				$element->removeAttributeNode( $attribute );
+				call_user_func( $this->args['remove_invalid_callback'], $attribute );
+			}
+		} elseif ( is_string( $attribute ) ) {
+			$element->removeAttribute( $attribute );
+		} else {
+			$element->removeAttributeNode( $attribute );
 		}
 	}
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -729,10 +729,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		foreach ( $attrs_to_remove as $attr ) {
-			$node->removeAttributeNode( $attr );
-			if ( isset( $this->args['remove_invalid_callback'], $attr->name ) ) {
-				call_user_func( $this->args['remove_invalid_callback'], $node, AMP_Validation_Utils::ATTRIBUTE_REMOVED, $attr->name );
-			}
+			$this->remove_invalid_attribute( $node, $attr );
 		}
 	}
 

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -254,8 +254,8 @@ class AMP_Validation_Utils {
 				$location = AMP_Validation_Utils::error_message( $location );
 				$location = add_query_arg(
 					array(
-						'removed_elements'   => array_keys( $response['removed_elements'] ),
-						'removed_attributes' => array_keys( $response['removed_attributes'] ),
+						'removed_elements'   => $response['removed_elements'],
+						'removed_attributes' => $response['removed_attributes'],
 					),
 					$location
 				);
@@ -316,19 +316,31 @@ class AMP_Validation_Utils {
 		if ( self::ERROR_QUERY_VALUE === $error ) {
 			echo '<div class="notice notice-warning">';
 			printf( '<p>%s</p>', esc_html__( 'Warning: There is content which fails AMP validation; it will be stripped when served as AMP.', 'amp' ) );
+			$removed_sets = array();
 			if ( ! empty( $_GET['removed_elements'] ) && is_array( $_GET['removed_elements'] ) ) {
-				printf(
-					'<p>%s %s</p>',
-					esc_html__( 'Invalid elements:', 'amp' ),
-					'<code>' . implode( '</code>, <code>', array_map( 'esc_html', $_GET['removed_elements'] ) ) . '</code>'
+				$removed_sets[] = array(
+					'label' => __( 'Invalid elements:', 'amp' ),
+					'names' => array_map( 'sanitize_key', $_GET['removed_elements'] ),
 				);
 			}
-			if ( ! empty( $_GET['removed_attributes'] ) ) {
-				printf(
-					'<p>%s %s</p>',
-					esc_html__( 'Invalid attributes:', 'amp' ),
-					'<code>' . implode( '</code>, <code>', array_map( 'esc_html', $_GET['removed_attributes'] ) ) . '</code>'
+			if ( ! empty( $_GET['removed_attributes'] ) && is_array( $_GET['removed_attributes'] ) ) {
+				$removed_sets[] = array(
+					'label' => __( 'Invalid attributes:', 'amp' ),
+					'names' => array_map( 'sanitize_key', $_GET['removed_attributes'] ),
 				);
+			}
+			foreach ( $removed_sets as $removed_set ) {
+				printf( '<p>%s ', esc_html( $removed_set['label'] ) );
+				$items = array();
+				foreach ( $removed_set['names'] as $name => $count ) {
+					if ( 1 === intval( $count ) ) {
+						$items[] = sprintf( '<code>%s</code>', esc_html( $name ) );
+					} else {
+						$items[] = sprintf( '<code>%s</code> (%d)', esc_html( $name ), $count );
+					}
+				}
+				echo implode( ', ', $items ); // WPCS: XSS OK.
+				echo '</p>';
 			}
 			echo '</div>';
 		}

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -72,7 +72,12 @@ class AMP_Validation_Utils {
 	 * @return void.
 	 */
 	public static function process_markup( $markup ) {
-		$args = array(
+		AMP_Theme_Support::register_content_embed_handlers();
+		remove_filter( 'the_content', 'wpautop' );
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$markup = apply_filters( 'the_content', $markup );
+		$args   = array(
 			'content_max_width' => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH,
 		);
 		if ( self::has_cap() ) {
@@ -215,6 +220,7 @@ class AMP_Validation_Utils {
 		if ( ! post_supports_amp( $post ) || ! self::has_cap() ) {
 			return;
 		}
+		AMP_Theme_Support::register_content_embed_handlers();
 		/** This filter is documented in wp-includes/post-template.php */
 		$filtered_content = apply_filters( 'the_content', $post->post_content, $post->ID );
 		$response         = self::get_response( $filtered_content );

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -72,17 +72,19 @@ class AMP_Validation_Utils {
 	 * @return void.
 	 */
 	public static function process_markup( $markup ) {
+		if ( ! self::has_cap() ) {
+			return;
+		}
+
 		AMP_Theme_Support::register_content_embed_handlers();
 		remove_filter( 'the_content', 'wpautop' );
 
 		/** This filter is documented in wp-includes/post-template.php */
 		$markup = apply_filters( 'the_content', $markup );
 		$args   = array(
-			'content_max_width' => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH,
+			'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH,
+			'remove_invalid_callback' => 'AMP_Validation_Utils::track_removed',
 		);
-		if ( self::has_cap() ) {
-			$args['remove_invalid_callback'] = 'AMP_Validation_Utils::track_removed';
-		}
 		AMP_Content_Sanitizer::sanitize( $markup, amp_get_content_sanitizers(), $args );
 	}
 

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -27,34 +27,6 @@ class AMP_Validation_Utils {
 	const ERROR_KEY = 'has_error';
 
 	/**
-	 * Key of the AMP error query var.
-	 *
-	 * @var string.
-	 */
-	const ERROR_QUERY_KEY = 'amp_error';
-
-	/**
-	 * Query arg value if there is an AMP error in the post content.
-	 *
-	 * @var string.
-	 */
-	const ERROR_QUERY_VALUE = '1';
-
-	/**
-	 * Nonce name for the editor error message.
-	 *
-	 * @var string.
-	 */
-	const ERROR_NONCE = 'amp_nonce';
-
-	/**
-	 * Nonce action for displaying the invalid AMP message.
-	 *
-	 * @var string.
-	 */
-	const ERROR_NONCE_ACTION = 'invalid_amp_message';
-
-	/**
 	 * The nodes that the sanitizer removed.
 	 *
 	 * @var DOMNode[]
@@ -68,8 +40,7 @@ class AMP_Validation_Utils {
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', array( __CLASS__, 'amp_rest_validation' ) );
-		add_action( 'save_post', array( __CLASS__, 'validate_content' ), 10, 2 );
-		add_action( 'edit_form_top', array( __CLASS__, 'display_error' ) );
+		add_action( 'edit_form_top', array( __CLASS__, 'validate_content' ), 10, 2 );
 	}
 
 	/**
@@ -104,7 +75,7 @@ class AMP_Validation_Utils {
 		$args = array(
 			'content_max_width' => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH,
 		);
-		if ( self::is_authorized() ) {
+		if ( self::has_cap() ) {
 			$args['remove_invalid_callback'] = 'AMP_Validation_Utils::track_removed';
 		}
 		AMP_Content_Sanitizer::sanitize( $markup, amp_get_content_sanitizers(), $args );
@@ -232,118 +203,65 @@ class AMP_Validation_Utils {
 	}
 
 	/**
-	 * On updating a post, this checks the AMP validity of the content.
+	 * Checks the AMP validity of the post content.
 	 *
-	 * If it's not valid AMP, it adds a query arg to the redirect URL.
-	 * This will cause an error message to appear above the 'Classic' editor.
+	 * If it's not valid AMP,
+	 * it displays an error message above the 'Classic' editor.
 	 *
-	 * @param integer $post_id The ID of the updated post.
-	 * @param WP_Post $post    The updated post.
+	 * @param WP_Post $post The updated post.
 	 * @return void.
 	 */
-	public static function validate_content( $post_id, $post ) {
-		unset( $post_id );
-		if ( ! post_supports_amp( $post ) || ! self::is_authorized() ) {
+	public static function validate_content( $post ) {
+		if ( ! post_supports_amp( $post ) || ! self::has_cap() ) {
 			return;
 		}
 		/** This filter is documented in wp-includes/post-template.php */
 		$filtered_content = apply_filters( 'the_content', $post->post_content, $post->ID );
 		$response         = self::get_response( $filtered_content );
 		if ( isset( $response[ self::ERROR_KEY ] ) && ( true === $response[ self::ERROR_KEY ] ) ) {
-			add_filter( 'redirect_post_location', function( $location ) use ( $response ) {
-				$location = AMP_Validation_Utils::error_message( $location );
-				$location = add_query_arg(
-					array(
-						'removed_elements'   => $response['removed_elements'],
-						'removed_attributes' => $response['removed_attributes'],
-					),
-					$location
-				);
-				return $location;
-			} );
+			self::display_error( $response );
 		}
 	}
 
 	/**
-	 * Whether the current user is authorized.
+	 * Displays an error message on /wp-admin/post.php.
 	 *
-	 * This checks that the user has a certain capability and the nonce is valid.
-	 * It will only return true when updating the post on:
-	 * wp-admin/post.php
-	 * Avoids using check_admin_referer().
-	 * This function might be called in different places,
-	 * and it can't cause it to die() if the nonce is invalid.
+	 * Located at the top of the 'Classic' editor.
+	 * States that the content is not valid AMP.
 	 *
-	 * @return boolean $is_valid True if the nonce is valid.
-	 */
-	public static function is_authorized() {
-		$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : ''; // WPCS: CSRF ok.
-		return ( self::has_cap() && ( false !== wp_verify_nonce( $nonce, 'update-post_' . get_the_ID() ) ) );
-	}
-
-	/**
-	 * Adds an error message to the URL if it's not valid AMP.
-	 *
-	 * When redirecting after saving a post, the content was validated for AMP compliance.
-	 * If it wasn't valid AMP, this will add a query arg to the URL.
-	 * And an error message will display on /wp-admin/post.php.
-	 *
-	 * @param string $url The URL of the redirect.
-	 * @return string $url The filtered URL, including the AMP error message query var.
-	 */
-	public static function error_message( $url ) {
-		$args = array(
-			self::ERROR_QUERY_KEY => self::ERROR_QUERY_VALUE,
-			self::ERROR_NONCE     => wp_create_nonce( self::ERROR_NONCE_ACTION ),
-		);
-		return add_query_arg( $args, $url );
-	}
-
-	/**
-	 * Displays an error message on /wp-admin/post.php if the saved content is not valid AMP.
-	 *
-	 * Use $_GET, as get_query_var won't return the value.
-	 * This displays at the top of the 'Classic' editor.
-	 *
+	 * @param array $response The validation response, an associative array.
 	 * @return void.
 	 */
-	public static function display_error() {
-		if ( ! isset( $_GET[ self::ERROR_QUERY_KEY ] ) ) {
-			return;
+	public static function display_error( $response ) {
+		echo '<div class="notice notice-warning">';
+		printf( '<p>%s</p>', esc_html__( 'Warning: There is content which fails AMP validation; it will be stripped when served as AMP.', 'amp' ) );
+		$removed_sets = array();
+		if ( ! empty( $response['removed_elements'] ) && is_array( $response['removed_elements'] ) ) {
+			$removed_sets[] = array(
+				'label' => __( 'Invalid elements:', 'amp' ),
+				'names' => array_map( 'sanitize_key', $response['removed_elements'] ),
+			);
 		}
-		check_admin_referer( self::ERROR_NONCE_ACTION, self::ERROR_NONCE );
-		$error = isset( $_GET[ self::ERROR_QUERY_KEY ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::ERROR_QUERY_KEY ] ) ) : ''; // WPCS: CSRF ok.
-		if ( self::ERROR_QUERY_VALUE === $error ) {
-			echo '<div class="notice notice-warning">';
-			printf( '<p>%s</p>', esc_html__( 'Warning: There is content which fails AMP validation; it will be stripped when served as AMP.', 'amp' ) );
-			$removed_sets = array();
-			if ( ! empty( $_GET['removed_elements'] ) && is_array( $_GET['removed_elements'] ) ) {
-				$removed_sets[] = array(
-					'label' => __( 'Invalid elements:', 'amp' ),
-					'names' => array_map( 'sanitize_key', $_GET['removed_elements'] ),
-				);
-			}
-			if ( ! empty( $_GET['removed_attributes'] ) && is_array( $_GET['removed_attributes'] ) ) {
-				$removed_sets[] = array(
-					'label' => __( 'Invalid attributes:', 'amp' ),
-					'names' => array_map( 'sanitize_key', $_GET['removed_attributes'] ),
-				);
-			}
-			foreach ( $removed_sets as $removed_set ) {
-				printf( '<p>%s ', esc_html( $removed_set['label'] ) );
-				$items = array();
-				foreach ( $removed_set['names'] as $name => $count ) {
-					if ( 1 === intval( $count ) ) {
-						$items[] = sprintf( '<code>%s</code>', esc_html( $name ) );
-					} else {
-						$items[] = sprintf( '<code>%s</code> (%d)', esc_html( $name ), $count );
-					}
+		if ( ! empty( $response['removed_attributes'] ) && is_array( $response['removed_attributes'] ) ) {
+			$removed_sets[] = array(
+				'label' => __( 'Invalid attributes:', 'amp' ),
+				'names' => array_map( 'sanitize_key', $response['removed_attributes'] ),
+			);
+		}
+		foreach ( $removed_sets as $removed_set ) {
+			printf( '<p>%s ', esc_html( $removed_set['label'] ) );
+			$items = array();
+			foreach ( $removed_set['names'] as $name => $count ) {
+				if ( 1 === intval( $count ) ) {
+					$items[] = sprintf( '<code>%s</code>', esc_html( $name ) );
+				} else {
+					$items[] = sprintf( '<code>%s</code> (%d)', esc_html( $name ), $count );
 				}
-				echo implode( ', ', $items ); // WPCS: XSS OK.
-				echo '</p>';
 			}
-			echo '</div>';
+			echo implode( ', ', $items ); // WPCS: XSS OK.
+			echo '</p>';
 		}
+		echo '</div>';
 	}
 
 }

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -245,18 +245,14 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 	/**
 	 * Tests remove_child.
 	 *
-	 * @see AMP_Base_Sanitizer::remove_invalid_child()
+	 * @covers AMP_Base_Sanitizer::remove_invalid_child()
 	 */
 	public function test_remove_child() {
 		$parent_tag_name = 'div';
-		$child_tag_name  = 'h1';
 		$dom_document    = new DOMDocument( '1.0', 'utf-8' );
 		$parent          = $dom_document->createElement( $parent_tag_name );
 		$child           = $dom_document->createElement( 'h1' );
 		$parent->appendChild( $child );
-
-		// To ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar.
-		// @codingStandardsIgnoreStart
 
 		$this->assertEquals( $child, $parent->firstChild );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom_document, array(
@@ -264,7 +260,8 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 		) );
 		$sanitizer->remove_invalid_child( $child );
 		$this->assertEquals( null, $parent->firstChild );
-		$this->assertEquals( 1, AMP_Validation_Utils::$removed_nodes[ $child_tag_name ] );
+		$this->assertCount( 1, AMP_Validation_Utils::$removed_nodes );
+		$this->assertEquals( $child, AMP_Validation_Utils::$removed_nodes[0] );
 
 		$parent->appendChild( $child );
 		$this->assertEquals( $child, $parent->firstChild );
@@ -272,14 +269,13 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 
 		$this->assertEquals( null, $parent->firstChild );
 		$this->assertEquals( null, $child->parentNode );
-		// @codingStandardsIgnoreEnd
 		AMP_Validation_Utils::$removed_nodes = null;
 	}
 
 	/**
 	 * Tests remove_child.
 	 *
-	 * @see AMP_Base_Sanitizer::remove_invalid_child()
+	 * @covers AMP_Base_Sanitizer::remove_invalid_child()
 	 */
 	public function test_remove_attribute() {
 		AMP_Validation_Utils::reset_removed();
@@ -288,20 +284,15 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 		$dom_document = new DOMDocument( '1.0', 'utf-8' );
 		$video        = $dom_document->createElement( $video_name );
 		$video->setAttribute( $attribute, 'someFunction()' );
+		$attr_node = $video->getAttributeNode( $attribute );
 
-		// To ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar.
-		// @codingStandardsIgnoreStart
 		$args = array(
 			'remove_invalid_callback' => 'AMP_Validation_Utils::track_removed',
-		);
-		$expected_removed = array(
-			$attribute => 1,
 		);
 		$sanitizer = new AMP_Video_Sanitizer( $dom_document, $args );
 		$sanitizer->remove_invalid_attribute( $video, $attribute );
 		$this->assertEquals( null, $video->getAttribute( $attribute ) );
-		$this->assertEquals( $expected_removed, AMP_Validation_Utils::$removed_attributes );
-		// @codingStandardsIgnoreEnd
+		$this->assertEquals( array( $attr_node ), AMP_Validation_Utils::$removed_nodes );
 		AMP_Validation_Utils::reset_removed();
 	}
 

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -286,7 +286,7 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 		$video->setAttribute( $attribute, 'someFunction()' );
 		$attr_node = $video->getAttributeNode( $attribute );
 
-		$args = array(
+		$args      = array(
 			'remove_invalid_callback' => 'AMP_Validation_Utils::track_removed',
 		);
 		$sanitizer = new AMP_Video_Sanitizer( $dom_document, $args );

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -277,8 +277,6 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		$this->assertNotContains( 'notice notice-warning', $output );
 		$this->assertNotContains( 'Warning:', $output );
 
-		$post_id            = $this->factory()->post->create();
-		$post               = get_post( $post_id );
 		$post->post_content = $this->disallowed_tag;
 		ob_start();
 		AMP_Validation_Utils::validate_content( $post );
@@ -287,6 +285,18 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		$this->assertContains( 'notice notice-warning', $output );
 		$this->assertContains( 'Warning:', $output );
 		$this->assertContains( '<code>script</code>', $output );
+		AMP_Validation_Utils::reset_removed();
+
+		$youtube            = 'https://www.youtube.com/watch?v=GGS-tKTXw4Y';
+		$post->post_content = $youtube;
+		ob_start();
+		AMP_Validation_Utils::validate_content( $post );
+		$output = ob_get_clean();
+
+		// The YouTube embed handler should convert the URL into a valid AMP element.
+		$this->assertNotContains( 'notice notice-warning', $output );
+		$this->assertNotContains( 'Warning:', $output );
+		AMP_Validation_Utils::reset_removed();
 	}
 
 	/**


### PR DESCRIPTION
Follow-up on #912 for #843.

- [x] Eliminate sanitization reporting during `save_post` action in favor of doing it inline when loading the edit post screen.
- [x] Make sure that AMP embeds are run prior to sanitization.

This PR could also include parts from #842 if we want.
