### PR TITLE
Issue #841: Native AMP audio and video playlists.

### DIFF
--- a/assets/css/amp-playlist-shortcode.css
+++ b/assets/css/amp-playlist-shortcode.css
@@ -1,5 +1,5 @@
 /**
-* For the custom AMP implementation of audio 'playlist' shortcode.
+* For the custom AMP implementation of the 'playlist' shortcode.
 */
 .wp-playlist .wp-playlist-current-item img {
 	margin-right: 0;
@@ -12,4 +12,8 @@
 
 .wp-playlist audio {
 	display: block;
+}
+
+.wp-playlist .amp-carousel-button {
+	visibility: hidden;
 }

--- a/assets/css/amp-playlist-shortcode.css
+++ b/assets/css/amp-playlist-shortcode.css
@@ -1,0 +1,15 @@
+/**
+* For the custom AMP implementation of audio 'playlist' shortcode.
+*/
+.wp-playlist .wp-playlist-current-item img {
+	margin-right: 0;
+}
+
+.wp-playlist .wp-playlist-current-item amp-img {
+	float: left;
+	margin-right: 10px;
+}
+
+.wp-playlist audio {
+	display: block;
+}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -260,6 +260,7 @@ function amp_get_content_embed_handlers( $post = null ) {
 			'AMP_Vine_Embed_Handler'        => array(),
 			'AMP_Facebook_Embed_Handler'    => array(),
 			'AMP_Pinterest_Embed_Handler'   => array(),
+			'AMP_Playlist_Embed_Handler'    => array(),
 			'AMP_Reddit_Embed_Handler'      => array(),
 			'AMP_Tumblr_Embed_Handler'      => array(),
 			'AMP_Gallery_Embed_Handler'     => array(),

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -42,6 +42,7 @@ class AMP_Autoloader {
 		'AMP_Issuu_Embed_Handler'                     => 'includes/embeds/class-amp-issuu-embed-handler',
 		'AMP_Meetup_Embed_Handler'                    => 'includes/embeds/class-amp-meetup-embed-handler',
 		'AMP_Pinterest_Embed_Handler'                 => 'includes/embeds/class-amp-pinterest-embed',
+		'AMP_Playlist_Embed_Handler'                  => 'includes/embeds/class-amp-playlist-embed-handler',
 		'AMP_Reddit_Embed_Handler'                    => 'includes/embeds/class-amp-reddit-embed-handler',
 		'AMP_SoundCloud_Embed_Handler'                => 'includes/embeds/class-amp-soundcloud-embed',
 		'AMP_Tumblr_Embed_Handler'                    => 'includes/embeds/class-amp-tumblr-embed-handler',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -147,6 +147,7 @@ class AMP_Theme_Support {
 		remove_action( 'wp_head', 'wp_post_preview_js', 1 );
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		remove_action( 'wp_head', 'wp_oembed_add_host_js' );
 
 		/*
 		 * Add additional markup required by AMP <https://www.ampproject.org/docs/reference/spec#required-markup>.
@@ -181,6 +182,7 @@ class AMP_Theme_Support {
 		add_filter( 'comment_reply_link', array( __CLASS__, 'filter_comment_reply_link' ), 10, 4 );
 		add_filter( 'cancel_comment_reply_link', array( __CLASS__, 'filter_cancel_comment_reply_link' ), 10, 3 );
 		add_action( 'comment_form', array( __CLASS__, 'add_amp_comment_form_templates' ), 100 );
+		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 
 		// @todo Add character conversion.
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -146,8 +146,6 @@ class AMP_Theme_Support {
 		// Remove core actions which are invalid AMP.
 		remove_action( 'wp_head', 'wp_post_preview_js', 1 );
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-		remove_action( 'wp_head', 'wp_print_head_scripts', 9 );
-		remove_action( 'wp_footer', 'wp_print_footer_scripts', 20 );
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 		/*

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -118,11 +118,11 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Gets an AMP-compliant audio playlist.
 	 *
-	 * @return string Playlist shortcode markup.
+	 * @return string Playlist shortcode markup, or an empty string.
 	 */
 	public function audio_playlist() {
 		if ( ! isset( $this->data['tracks'] ) ) {
-			return;
+			return '';
 		}
 		$container_id   = 'ampPlaylistCarousel' . self::$playlist_id;
 		$selected_slide = $container_id . '.selectedSlide';
@@ -164,7 +164,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * This uses similar markup to the native playlist shortcode output.
 	 * So the styles from wp-mediaelement.min.css will apply to it.
 	 *
-	 * @global content_width.
+	 * @global int content_width.
 	 * @return string $video_playlist Markup for the video playlist.
 	 */
 	public function video_playlist() {

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -44,7 +44,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @var string.
 	 */
-	const PLAYLIST_REGEX = '/(?s)\<script [^>]* class="wp-playlist-script"\>[^<]*?(.*).*?\<\/script\>/';
+	const PLAYLIST_REGEX = ':<script type="application/json" class="wp-playlist-script">(.+?)</script>:s';
 
 	/**
 	 * The ID of individual playlist.
@@ -71,7 +71,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Unregisters the playlist shortcode.
 	 *
-	 * @return void.
+	 * @return void
 	 */
 	public function unregister_embed() {
 		remove_shortcode( self::SHORTCODE );
@@ -80,7 +80,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Enqueues the playlist styling.
 	 *
-	 * @return void.
+	 * @return void
 	 */
 	public function styling() {
 		global $post;
@@ -241,7 +241,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param string $type         The type of tracks: 'audio' or 'video'.
 	 * @param string $container_id The ID of the container.
-	 * @return void.
+	 * @return void
 	 */
 	public function tracks( $type, $container_id ) {
 		?>

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -162,7 +162,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 								<span class="wp-playlist-item-meta wp-playlist-item-title"><?php echo esc_html( $title ); ?></span>
 							</div>
 						</div>
-						<amp-audio width="auto" height="50" src="<?php echo esc_url( isset( $track['src'] ) ? $track['src'] : '' ); ?>"></amp-audio>
+						<amp-audio width="auto" height="50" src="<?php echo esc_url( $track['src'] ); ?>"></amp-audio>
 					</div>
 				<?php endforeach; ?>
 			</amp-carousel>
@@ -194,7 +194,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		);
 		foreach ( $this->data['tracks'] as $index => $track ) {
 			$amp_state[ $index ] = array(
-				'videoUrl' => isset( $track['src'] ) ? $track['src'] : '',
+				'videoUrl' => $track['src'],
 				'thumb'    => isset( $track['thumb']['src'] ) ? $track['thumb']['src'] : '',
 			);
 		}

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -18,7 +18,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * The tag of the shortcode.
 	 *
-	 * @var string.
+	 * @var string
 	 */
 	const SHORTCODE = 'playlist';
 
@@ -28,21 +28,21 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * This corresponds to the max-width in wp-mediaelement.css:
 	 * .wp-playlist .wp-playlist-current-item img
 	 *
-	 * @var string.
+	 * @var string
 	 */
 	const THUMB_MAX_WIDTH = 60;
 
 	/**
 	 * The height of the carousel.
 	 *
-	 * @var string.
+	 * @var string
 	 */
 	const CAROUSEL_HEIGHT = 160;
 
 	/**
 	 * The pattern to get the playlist data.
 	 *
-	 * @var string.
+	 * @var string
 	 */
 	const PLAYLIST_REGEX = ':<script type="application/json" class="wp-playlist-script">(.+?)</script>:s';
 
@@ -54,6 +54,13 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	public static $playlist_id = 0;
 
 	/**
+	 * The removed shortcode callback.
+	 *
+	 * @var string|array
+	 */
+	public $removed_shortcode;
+
+	/**
 	 * The parsed data for the playlist.
 	 *
 	 * @var array
@@ -62,8 +69,15 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	/**
 	 * Registers the playlist shortcode.
+
+	 * @global array $shortcode_tags
+	 * @return void
 	 */
 	public function register_embed() {
+		global $shortcode_tags;
+		if ( shortcode_exists( self::SHORTCODE ) ) {
+			$this->removed_shortcode = $shortcode_tags[ self::SHORTCODE ];
+		}
 		add_shortcode( self::SHORTCODE, array( $this, 'shortcode' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'styling' ) );
 	}
@@ -74,7 +88,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return void
 	 */
 	public function unregister_embed() {
-		remove_shortcode( self::SHORTCODE );
+		add_shortcode( self::SHORTCODE, $this->removed_shortcode );
 	}
 
 	/**

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -162,8 +162,8 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 			<amp-carousel id="<?php echo esc_attr( $container_id ); ?>" [slide]="<?php echo esc_attr( $selected_slide ); ?>" height="<?php echo esc_attr( self::CAROUSEL_HEIGHT ); ?>" width="auto" type="slides">
 				<?php
 				foreach ( $this->data['tracks'] as $track ) :
-					$title            = $this->get_title( $track );
-					$image_url        = isset( $track['thumb']['src'] ) ? esc_url( $track['thumb']['src'] ) : '';
+					$title                              = $this->get_title( $track );
+					$image_url                          = isset( $track['thumb']['src'] ) ? esc_url( $track['thumb']['src'] ) : '';
 					list( $image_height, $image_width ) = $this->get_thumb_dimensions( $track );
 
 					?>

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -145,10 +145,10 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 						<div class="wp-playlist-current-item">
 							<amp-img src="<?php echo esc_url( $image_url ); ?>" height="<?php echo esc_attr( $image_height ); ?>" width="<?php echo esc_attr( $image_width ); ?>"></amp-img>
 							<div class="wp-playlist-caption">
-								<span class="wp-playlist-item-meta wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
+								<span class="wp-playlist-item-meta wp-playlist-item-title"><?php echo esc_html( $title ); ?></span>
 							</div>
 						</div>
-						<amp-audio width="auto" height="50" src="<?php echo isset( $track['src'] ) ? esc_url( $track['src'] ) : ''; ?>"></amp-audio>
+						<amp-audio width="auto" height="50" src="<?php echo esc_url( isset( $track['src'] ) ? $track['src'] : '' ); ?>"></amp-audio>
 					</div>
 				<?php endforeach; ?>
 			</amp-carousel>
@@ -197,7 +197,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 					<?php echo wp_unslash( wp_json_encode( $amp_state ) ); // WPCS: XSS ok. ?>
 				</script>
 			</amp-state>
-			<amp-video id="amp-video" src="<?php echo esc_url( $this->data['tracks'][0]['src'] ); ?>" [src]="<?php echo esc_attr( $playlist ); ?>[<?php echo esc_attr( $playlist ); ?>.currentVideo].videoUrl" width="<?php echo esc_attr( $width ); ?>" height="<?php echo isset( $height ) ? esc_attr( $height ) : ''; ?>" controls></amp-video>
+			<amp-video id="amp-video" src="<?php echo esc_url( $this->data['tracks'][0]['src'] ); ?>" [src]="<?php echo esc_attr( $playlist ); ?>[<?php echo esc_attr( $playlist ); ?>.currentVideo].videoUrl" width="<?php echo esc_attr( $width ); ?>" height="<?php echo esc_attr( isset( $height ) ? $height : '' ); ?>" controls></amp-video>
 			<?php $this->tracks( 'video', $playlist ); ?>
 		</div>
 		<?php
@@ -259,9 +259,9 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 				}
 
 				?>
-				<div class="wp-playlist-item" [class]="<?php echo isset( $item_class ) ? esc_attr( $item_class ) : ''; ?>">
-					<a class="wp-playlist-caption" on="<?php echo isset( $on ) ? esc_attr( $on ) : ''; ?>">
-						<?php echo esc_html( strval( $i + 1 ) . '.' ); ?> <span class="wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
+				<div class="wp-playlist-item" [class]="<?php echo esc_attr( isset( $item_class ) ? $item_class : '' ); ?>">
+					<a class="wp-playlist-caption" on="<?php echo esc_attr( isset( $on ) ? $on : '' ); ?>">
+						<?php echo esc_html( strval( $i + 1 ) . '.' ); ?> <span class="wp-playlist-item-title"><?php echo esc_html( $title ); ?></span>
 					</a>
 					<?php if ( isset( $track['meta']['length_formatted'] ) ) : ?>
 						<div class="wp-playlist-item-length"><?php echo esc_html( $track['meta']['length_formatted'] ); ?></div>

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -23,6 +23,20 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	const SHORTCODE = 'playlist';
 
 	/**
+	 * The default height of the thumbnail image for 'audio' playlist tracks.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_THUMB_HEIGHT = 64;
+
+	/**
+	 * The default width of the thumbnail image for 'audio' playlist tracks.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_THUMB_WIDTH = 48;
+
+	/**
 	 * The max width of the audio thumbnail image.
 	 *
 	 * This corresponds to the max-width in wp-mediaelement.css:
@@ -150,9 +164,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 				foreach ( $this->data['tracks'] as $track ) :
 					$title            = $this->get_title( $track );
 					$image_url        = isset( $track['thumb']['src'] ) ? esc_url( $track['thumb']['src'] ) : '';
-					$thumb_dimensions = $this->get_thumb_dimensions( $track );
-					$image_height     = isset( $thumb_dimensions['height'] ) ? $thumb_dimensions['height'] : '';
-					$image_width      = isset( $thumb_dimensions['width'] ) ? $thumb_dimensions['width'] : '';
+					list( $image_height, $image_width ) = $this->get_thumb_dimensions( $track );
 
 					?>
 					<div>
@@ -229,21 +241,18 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return array $dimensions The height and width of the thumbnail image.
 	 */
 	public function get_thumb_dimensions( $track ) {
-		if ( ! isset( $track['thumb']['width'], $track['thumb']['height'] ) ) {
-			return array();
-		}
-		$original_width  = intval( $track['thumb']['width'] );
-		$original_height = intval( $track['thumb']['height'] );
+		$original_height = isset( $track['thumb']['height'] ) ? intval( $track['thumb']['height'] ) : self::DEFAULT_THUMB_HEIGHT;
+		$original_width  = isset( $track['thumb']['width'] ) ? intval( $track['thumb']['width'] ) : self::DEFAULT_THUMB_WIDTH;
 		$image_width     = min( self::THUMB_MAX_WIDTH, $original_width );
 		if ( $original_width > self::THUMB_MAX_WIDTH ) {
 			$ratio        = $original_width / self::THUMB_MAX_WIDTH;
-			$image_height = floor( $original_height / $ratio );
+			$image_height = intval( $original_height / $ratio );
 		} else {
 			$image_height = $original_height;
 		}
 		return array(
-			'height' => $image_height,
-			'width'  => $image_width,
+			$image_height,
+			$image_width,
 		);
 	}
 
@@ -299,7 +308,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		$markup = wp_playlist_shortcode( $attr );
 		preg_match( self::PLAYLIST_REGEX, $markup, $matches );
 		if ( empty( $matches[1] ) ) {
-			return;
+			return array();
 		}
 		return json_decode( $matches[1], true );
 	}

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -211,7 +211,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * These typically appear below the player.
 	 * Clicking a track triggers the player to appear with its src.
 	 *
-	 * @param string $type The type of tracks: 'audio' or 'video'.
+	 * @param string $type         The type of tracks: 'audio' or 'video'.
 	 * @param string $container_id The ID of the container.
 	 * @return void.
 	 */

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Class AMP_Playlist_Embed_Handler
+ *
+ * @package AMP
+ * @since 0.7
+ */
+
+/**
+ * Class AMP_Playlist_Embed_Handler
+ */
+class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
+
+	/**
+	 * The ID of the individual playlist.
+	 *
+	 * @var int
+	 */
+	public static $playlist_id = 0;
+
+	/**
+	 * Registers the playlist shortcode.
+	 */
+	public function register_embed() {
+		add_shortcode( 'playlist', array( $this, 'shortcode' ) );
+	}
+
+	/**
+	 * Unregisters the playlist shortcode.
+	 *
+	 * @return void.
+	 */
+	public function unregister_embed() {
+		remove_shortcode( 'playlist' );
+	}
+
+	/**
+	 * Outputs an AMP-compliant playlist shortcode.
+	 *
+	 * Uses the JSON that wp_playlist_shortcode() produces.
+	 * But outputs an <amp-video>, and an <amp-state> to change the current video.
+	 *
+	 * @global content_width.
+	 * @param array $attr The playlist attributes.
+	 * @return string Playlist shortcode markup.
+	 */
+	public function shortcode( $attr ) {
+		global $content_width;
+
+		$markup = wp_playlist_shortcode( $attr );
+		preg_match( '/(?s)\<script [^>]* class="wp-playlist-script"\>[^<]*?(.*).*?\<\/script\>/', $markup, $matches );
+		if ( empty( $matches[1] ) ) {
+			return;
+		}
+		$data = json_decode( $matches[1], true );
+		if ( ! isset( $data['tracks'], $data['tracks'][0]['src'] ) ) {
+			return;
+		}
+
+		$amp_state = array(
+			'currentVideo' => '0',
+		);
+		foreach ( $data['tracks'] as $index => $track ) {
+			$amp_state[ $index ] = array(
+				'videoUrl' => isset( $track['src'] ) ? $track['src'] : '',
+				'thumb'    => isset( $track['thumb']['src'] ) ? $track['thumb']['src'] : '',
+			);
+		}
+		$playlist   = 'playlist' . self::$playlist_id++;
+		$dimensions = isset( $data['tracks'][0]['dimensions']['resized'] ) ? $data['tracks'][0]['dimensions']['resized'] : null;
+		$width      = isset( $dimensions['width'] ) ? $dimensions['width'] : $content_width;
+		$height     = isset( $dimensions['height'] ) ? $dimensions['height'] : null;
+
+		ob_start();
+		?>
+		<div class="wp-playlist wp-video-playlist wp-playlist-light">
+			<amp-state id="<?php echo esc_attr( $playlist ); ?>">
+				<script type="application/json">
+					<?php echo wp_unslash( wp_json_encode( $amp_state ) ); // WPCS: XSS ok. ?>
+				</script>
+			</amp-state>
+			<amp-video id="amp-video" src="<?php echo esc_url( $data['tracks'][0]['src'] ); ?>" [src]="<?php echo esc_attr( $playlist ); ?>[<?php echo esc_attr( $playlist ); ?>.currentVideo].videoUrl" width="<?php echo esc_attr( $width ); ?>" height="<?php echo isset( $height ) ? esc_attr( $height ) : ''; ?>" controls></amp-video>
+			<div class="wp-playlist-tracks">
+				<?php
+				$i = 1;
+				foreach ( $data['tracks'] as $index => $track ) {
+					if ( ! empty( $track['caption'] ) ) {
+						$title = $track['caption'];
+					} elseif ( ! empty( $track['title'] ) ) {
+						$title = $track['title'];
+					}
+					?>
+					<div class="wp-playlist-item">
+						<a class="wp-playlist-caption" on="tap:AMP.setState({<?php echo esc_attr( $playlist ); ?>: {currentVideo: <?php echo esc_attr( $index ); ?>}})">
+							<?php echo esc_html( $i . '.' ); ?> <span class="wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
+						</a>
+						<?php if ( isset( $track['meta']['length_formatted'] ) ) : ?>
+							<div class="wp-playlist-item-length"><?php echo esc_html( $track['meta']['length_formatted'] ); ?></div>
+						<?php endif; ?>
+					</div>
+					<?php
+					$i++;
+				}
+			?>
+			</div>
+		</div>
+		<?php
+		return ob_get_clean(); // WPCS: XSS ok.
+	}
+
+}
+

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -230,7 +230,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function get_thumb_dimensions( $track ) {
 		if ( ! isset( $track['thumb']['width'], $track['thumb']['height'] ) ) {
-			return;
+			return array();
 		}
 		$original_width  = intval( $track['thumb']['width'] );
 		$original_height = intval( $track['thumb']['height'] );

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -8,15 +8,50 @@
 
 /**
  * Class AMP_Playlist_Embed_Handler
+ *
+ * Creates AMP-compatible markup for the WordPress 'playlist' shortcode.
+ *
+ * @package AMP
  */
 class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	/**
-	 * The ID of the individual playlist.
+	 * The max width of the audio thumbnail image.
+	 *
+	 * This corresponds to the max-width in wp-mediaelement.css:
+	 * .wp-playlist .wp-playlist-current-item img
+	 *
+	 * @var string.
+	 */
+	const THUMB_MAX_WIDTH = 60;
+
+	/**
+	 * The height of the carousel.
+	 *
+	 * @var string.
+	 */
+	const CAROUSEL_HEIGHT = 160;
+
+	/**
+	 * The pattern to get the playlist data.
+	 *
+	 * @var string.
+	 */
+	const PLAYLIST_REGEX = '/(?s)\<script [^>]* class="wp-playlist-script"\>[^<]*?(.*).*?\<\/script\>/';
+
+	/**
+	 * The ID of individual playlist.
 	 *
 	 * @var int
 	 */
 	public static $playlist_id = 0;
+
+	/**
+	 * The parsed data for the playlist.
+	 *
+	 * @var array
+	 */
+	public $data;
 
 	/**
 	 * Registers the playlist shortcode.
@@ -35,39 +70,94 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	/**
-	 * Outputs an AMP-compliant playlist shortcode.
+	 * Gets AMP-compliant markup for the playlist shortcode.
 	 *
 	 * Uses the JSON that wp_playlist_shortcode() produces.
-	 * But outputs an <amp-video>, and an <amp-state> to change the current video.
+	 * Gets the markup, based on the type of playlist.
 	 *
-	 * @global content_width.
 	 * @param array $attr The playlist attributes.
 	 * @return string Playlist shortcode markup.
 	 */
 	public function shortcode( $attr ) {
-		global $content_width;
+		$this->data = $this->get_data( $attr );
+		if ( isset( $this->data['type'] ) && ( 'audio' === $this->data['type'] ) ) {
+			return $this->audio_playlist();
+		} elseif ( isset( $this->data['type'] ) && ( 'video' === $this->data['type'] ) ) {
+			return $this->video_playlist();
+		}
+	}
 
-		$markup = wp_playlist_shortcode( $attr );
-		preg_match( '/(?s)\<script [^>]* class="wp-playlist-script"\>[^<]*?(.*).*?\<\/script\>/', $markup, $matches );
-		if ( empty( $matches[1] ) ) {
+	/**
+	 * Gets an AMP-compliant audio playlist.
+	 *
+	 * @return string Playlist shortcode markup.
+	 */
+	public function audio_playlist() {
+		if ( ! isset( $this->data['tracks'] ) ) {
 			return;
 		}
-		$data = json_decode( $matches[1], true );
-		if ( ! isset( $data['tracks'], $data['tracks'][0]['src'] ) ) {
+		$container_id   = 'ampPlaylistCarousel' . self::$playlist_id;
+		$selected_slide = $container_id . '.selectedSlide';
+		self::$playlist_id++;
+
+		ob_start();
+		?>
+		<div class="wp-playlist wp-audio-playlist wp-playlist-light">
+			<amp-carousel id="<?php echo esc_attr( $container_id ); ?>" [slide]="<?php echo esc_attr( $selected_slide ); ?>" height="<?php echo esc_attr( self::CAROUSEL_HEIGHT ); ?>" width="auto" type="slides">
+				<?php
+				foreach ( $this->data['tracks'] as $track ) :
+					$title            = $this->get_title( $track );
+					$image_url        = isset( $track['thumb']['src'] ) ? esc_url( $track['thumb']['src'] ) : '';
+					$thumb_dimensions = $this->get_thumb_dimensions( $track );
+					$image_height     = isset( $thumb_dimensions['height'] ) ? $thumb_dimensions['height'] : '';
+					$image_width      = isset( $thumb_dimensions['width'] ) ? $thumb_dimensions['width'] : '';
+
+					?>
+					<div>
+						<div class="wp-playlist-current-item">
+							<amp-img src="<?php echo esc_url( $image_url ); ?>" height="<?php echo esc_attr( $image_height ); ?>" width="<?php echo esc_attr( $image_width ); ?>"></amp-img>
+							<div class="wp-playlist-caption">
+								<span class="wp-playlist-item-meta wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
+							</div>
+						</div>
+						<amp-audio width="auto" height="50" src="<?php echo isset( $track['src'] ) ? esc_url( $track['src'] ) : ''; ?>"></amp-audio>
+					</div>
+				<?php endforeach; ?>
+			</amp-carousel>
+			<?php $this->tracks( 'audio', $container_id ); ?>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Gets an AMP-compliant video playlist.
+	 *
+	 * This uses similar markup to the native playlist shortcode output.
+	 * So the styles from wp-mediaelement.min.css will apply to it.
+	 *
+	 * @global content_width.
+	 * @return string $video_playlist Markup for the video playlist.
+	 */
+	public function video_playlist() {
+		global $content_width;
+		if ( ! isset( $this->data['tracks'], $this->data['tracks'][0]['src'] ) ) {
 			return;
 		}
+		$playlist = 'playlist' . self::$playlist_id;
+		self::$playlist_id++;
 
 		$amp_state = array(
 			'currentVideo' => '0',
 		);
-		foreach ( $data['tracks'] as $index => $track ) {
+		foreach ( $this->data['tracks'] as $index => $track ) {
 			$amp_state[ $index ] = array(
 				'videoUrl' => isset( $track['src'] ) ? $track['src'] : '',
 				'thumb'    => isset( $track['thumb']['src'] ) ? $track['thumb']['src'] : '',
 			);
 		}
-		$playlist   = 'playlist' . self::$playlist_id++;
-		$dimensions = isset( $data['tracks'][0]['dimensions']['resized'] ) ? $data['tracks'][0]['dimensions']['resized'] : null;
+
+		$dimensions = isset( $this->data['tracks'][0]['dimensions']['resized'] ) ? $this->data['tracks'][0]['dimensions']['resized'] : null;
 		$width      = isset( $dimensions['width'] ) ? $dimensions['width'] : $content_width;
 		$height     = isset( $dimensions['height'] ) ? $dimensions['height'] : null;
 
@@ -79,34 +169,111 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 					<?php echo wp_unslash( wp_json_encode( $amp_state ) ); // WPCS: XSS ok. ?>
 				</script>
 			</amp-state>
-			<amp-video id="amp-video" src="<?php echo esc_url( $data['tracks'][0]['src'] ); ?>" [src]="<?php echo esc_attr( $playlist ); ?>[<?php echo esc_attr( $playlist ); ?>.currentVideo].videoUrl" width="<?php echo esc_attr( $width ); ?>" height="<?php echo isset( $height ) ? esc_attr( $height ) : ''; ?>" controls></amp-video>
-			<div class="wp-playlist-tracks">
-				<?php
-				$i = 1;
-				foreach ( $data['tracks'] as $index => $track ) {
-					if ( ! empty( $track['caption'] ) ) {
-						$title = $track['caption'];
-					} elseif ( ! empty( $track['title'] ) ) {
-						$title = $track['title'];
-					}
-					?>
-					<div class="wp-playlist-item">
-						<a class="wp-playlist-caption" on="tap:AMP.setState({<?php echo esc_attr( $playlist ); ?>: {currentVideo: <?php echo esc_attr( $index ); ?>}})">
-							<?php echo esc_html( $i . '.' ); ?> <span class="wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
-						</a>
-						<?php if ( isset( $track['meta']['length_formatted'] ) ) : ?>
-							<div class="wp-playlist-item-length"><?php echo esc_html( $track['meta']['length_formatted'] ); ?></div>
-						<?php endif; ?>
-					</div>
-					<?php
-					$i++;
-				}
-			?>
-			</div>
+			<amp-video id="amp-video" src="<?php echo esc_url( $this->data['tracks'][0]['src'] ); ?>" [src]="<?php echo esc_attr( $playlist ); ?>[<?php echo esc_attr( $playlist ); ?>.currentVideo].videoUrl" width="<?php echo esc_attr( $width ); ?>" height="<?php echo isset( $height ) ? esc_attr( $height ) : ''; ?>" controls></amp-video>
+			<?php $this->tracks( 'video', $playlist ); ?>
 		</div>
 		<?php
 		return ob_get_clean(); // WPCS: XSS ok.
 	}
 
-}
+	/**
+	 * Gets the thumbnail image dimensions, including height and width.
+	 *
+	 * If the width is higher than the maximum width,
+	 * reduces it to the maximum width.
+	 * And it proportionally reduces the height.
+	 *
+	 * @param array $track The data for the track.
+	 * @return array $dimensions The height and width of the thumbnail image.
+	 */
+	public function get_thumb_dimensions( $track ) {
+		if ( ! isset( $track['thumb']['width'], $track['thumb']['height'] ) ) {
+			return;
+		}
+		$original_width  = intval( $track['thumb']['width'] );
+		$original_height = intval( $track['thumb']['height'] );
+		$image_width     = min( self::THUMB_MAX_WIDTH, $original_width );
+		if ( $original_width > self::THUMB_MAX_WIDTH ) {
+			$ratio        = $original_width / self::THUMB_MAX_WIDTH;
+			$image_height = floor( $original_height / $ratio );
+		} else {
+			$image_height = $original_height;
+		}
+		return array(
+			'height' => $image_height,
+			'width'  => $image_width,
+		);
+	}
 
+	/**
+	 * Outputs the playlist tracks, based on the type of playlist.
+	 *
+	 * These typically appear below the player.
+	 * Clicking a track triggers the player to appear with its src.
+	 *
+	 * @param string $type The type of tracks: 'audio' or 'video'.
+	 * @param string $container_id The ID of the container.
+	 * @return void.
+	 */
+	public function tracks( $type, $container_id ) {
+		?>
+		<div class="wp-playlist-tracks">
+			<?php
+			$i = 0;
+			foreach ( $this->data['tracks'] as $index => $track ) {
+				$title = $this->get_title( $track );
+				if ( 'audio' === $type ) {
+					$on         = 'tap:AMP.setState({' . $container_id . ': {selectedSlide: ' . $i . '}})';
+					$item_class = esc_attr( $i ) . ' == ' . esc_attr( $container_id ) . '.selectedSlide ? "wp-playlist-item wp-playlist-playing" : "wp-playlist-item"';
+				} elseif ( 'video' === $type ) {
+					$on         = 'tap:AMP.setState({' . $container_id . ': {currentVideo: ' . $index . '}})';
+					$item_class = esc_attr( $index ) . ' == ' . esc_attr( $container_id ) . '.currentVideo ? "wp-playlist-item wp-playlist-playing" : "wp-playlist-item"';
+				}
+
+				?>
+				<div class="wp-playlist-item" [class]="<?php echo isset( $item_class ) ? esc_attr( $item_class ) : ''; ?>">
+					<a class="wp-playlist-caption" on="<?php echo isset( $on ) ? esc_attr( $on ) : ''; ?>">
+						<?php echo esc_html( strval( $i + 1 ) . '.' ); ?> <span class="wp-playlist-item-title"><?php echo isset( $title ) ? esc_html( $title ) : ''; ?></span>
+					</a>
+					<?php if ( isset( $track['meta']['length_formatted'] ) ) : ?>
+						<div class="wp-playlist-item-length"><?php echo esc_html( $track['meta']['length_formatted'] ); ?></div>
+					<?php endif; ?>
+				</div>
+				<?php
+				$i++;
+			}
+		?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Gets the data for the playlist.
+	 *
+	 * @param array $attr The shortcode attributes.
+	 * @return array $data The data for the playlist.
+	 */
+	public function get_data( $attr ) {
+		$markup = wp_playlist_shortcode( $attr );
+		preg_match( self::PLAYLIST_REGEX, $markup, $matches );
+		if ( empty( $matches[1] ) ) {
+			return;
+		}
+		return json_decode( $matches[1], true );
+	}
+
+	/**
+	 * Gets the title for the track.
+	 *
+	 * @param array $track The track data.
+	 * @return string $title The title of the track.
+	 */
+	public function get_title( $track ) {
+		if ( ! empty( $track['caption'] ) ) {
+			return $track['caption'];
+		} elseif ( ! empty( $track['title'] ) ) {
+			return $track['title'];
+		}
+	}
+
+}

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -16,6 +16,13 @@
 class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	/**
+	 * The tag of the shortcode.
+	 *
+	 * @var string.
+	 */
+	const SHORTCODE = 'playlist';
+
+	/**
 	 * The max width of the audio thumbnail image.
 	 *
 	 * This corresponds to the max-width in wp-mediaelement.css:
@@ -57,7 +64,8 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers the playlist shortcode.
 	 */
 	public function register_embed() {
-		add_shortcode( 'playlist', array( $this, 'shortcode' ) );
+		add_shortcode( self::SHORTCODE, array( $this, 'shortcode' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'styling' ) );
 	}
 
 	/**
@@ -66,7 +74,27 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return void.
 	 */
 	public function unregister_embed() {
-		remove_shortcode( 'playlist' );
+		remove_shortcode( self::SHORTCODE );
+	}
+
+	/**
+	 * Enqueues the playlist styling.
+	 *
+	 * @return void.
+	 */
+	public function styling() {
+		global $post;
+		if ( ! isset( $post->post_content ) || ! has_shortcode( $post->post_content, self::SHORTCODE ) ) {
+			return;
+		}
+
+		wp_enqueue_style( 'wp-mediaelement' );
+		wp_enqueue_style(
+			'amp-playlist-shortcode',
+			amp_get_asset_url( 'css/amp-playlist-shortcode.css' ),
+			array(),
+			AMP__VERSION
+		);
 	}
 
 	/**

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -93,6 +93,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 			$this->removed_shortcode_callback = $shortcode_tags[ self::SHORTCODE ];
 		}
 		add_shortcode( self::SHORTCODE, array( $this, 'shortcode' ) );
+		remove_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 	}
 
 	/**
@@ -105,6 +106,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 			add_shortcode( self::SHORTCODE, $this->removed_shortcode_callback );
 			$this->removed_shortcode_callback = null;
 		}
+		add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 	}
 
 	/**
@@ -113,11 +115,10 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return void
 	 */
 	public function enqueue_styles() {
-		wp_enqueue_style( 'wp-mediaelement' );
 		wp_enqueue_style(
 			'amp-playlist-shortcode',
 			amp_get_asset_url( 'css/amp-playlist-shortcode.css' ),
-			array(),
+			array( 'wp-mediaelement' ),
 			AMP__VERSION
 		);
 	}
@@ -299,6 +300,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Gets the data for the playlist.
 	 *
+	 * @see wp_playlist_shortcode()
 	 * @param array $attr The shortcode attributes.
 	 * @return array $data The data for the playlist.
 	 */

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -251,10 +251,10 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 			foreach ( $this->data['tracks'] as $index => $track ) {
 				$title = $this->get_title( $track );
 				if ( 'audio' === $type ) {
-					$on         = 'tap:AMP.setState({' . $container_id . ': {selectedSlide: ' . $i . '}})';
+					$on         = 'tap:AMP.setState(' . wp_json_encode( array( $container_id => array( 'selectedSlide' => $i ) ) ) . ')';
 					$item_class = esc_attr( $i ) . ' == ' . esc_attr( $container_id ) . '.selectedSlide ? "wp-playlist-item wp-playlist-playing" : "wp-playlist-item"';
 				} elseif ( 'video' === $type ) {
-					$on         = 'tap:AMP.setState({' . $container_id . ': {currentVideo: ' . $index . '}})';
+					$on         = 'tap:AMP.setState(' . wp_json_encode( array( $container_id => array( 'currentVideo' => $index ) ) ) . ')';
 					$item_class = esc_attr( $index ) . ' == ' . esc_attr( $container_id ) . '.currentVideo ? "wp-playlist-item wp-playlist-playing" : "wp-playlist-item"';
 				}
 

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -45,8 +45,13 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 
 	/**
 	 * Tear down test.
+	 *
+	 * @global WP_Styles $wp_styles
 	 */
 	public function tearDown() {
+		global $wp_styles;
+		$wp_styles = null;
+
 		wp_dequeue_style( 'wp-mediaelement' );
 		AMP_Playlist_Embed_Handler::$playlist_id = 0;
 	}
@@ -96,9 +101,8 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$post->post_content = '[playlist ids="5,3"]';
 		$this->instance->enqueue_styles();
 		$style = wp_styles()->registered[ $playlist_shortcode ];
-		$this->assertTrue( in_array( 'wp-mediaelement', wp_styles()->queue, true ) );
-		$this->assertTrue( in_array( $playlist_shortcode, wp_styles()->queue, true ) );
-		$this->assertEquals( array(), $style->deps );
+		$this->assertContains( $playlist_shortcode, wp_styles()->queue );
+		$this->assertEquals( array( 'wp-mediaelement' ), $style->deps );
 		$this->assertEquals( $playlist_shortcode, $style->handle );
 		$this->assertEquals( amp_get_asset_url( 'css/amp-playlist-shortcode.css' ), $style->src );
 		$this->assertEquals( AMP__VERSION, $style->ver );

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -135,7 +135,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->assertContains( $this->file_1, $playlist );
 		$this->assertContains( $this->file_2, $playlist );
 		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
-		$this->assertContains( 'on="tap:AMP.setState({playlist0: {currentVideo: 0}})"', $playlist );
+		$this->assertContains( 'on="tap:AMP.setState({&quot;playlist0&quot;:{&quot;currentVideo&quot;:0}})"', $playlist );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->assertContains( '<amp-audio', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
 		$this->assertContains( $this->file_2, $playlist );
-		$this->assertContains( 'tap:AMP.setState({ampPlaylistCarousel0: {selectedSlide: 0}})"', $playlist );
+		$this->assertContains( 'tap:AMP.setState({&quot;ampPlaylistCarousel0&quot;:{&quot;selectedSlide&quot;:0}})"', $playlist );
 	}
 
 	/**
@@ -205,7 +205,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$attr                 = $this->get_attributes( $type );
 		$this->instance->data = $this->instance->get_data( $attr );
 		$container_id         = 'fooContainerId0';
-		$expected_on          = 'tap:AMP.setState({' . $container_id . ': {currentVideo: 0}})';
+		$expected_on          = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;currentVideo&quot;:0}})';
 
 		ob_start();
 		$this->instance->tracks( $type, $container_id );
@@ -217,7 +217,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$type                 = 'audio';
 		$attr                 = $this->get_attributes( $type );
 		$this->instance->data = $this->instance->get_data( $attr );
-		$expected_on          = 'tap:AMP.setState({' . $container_id . ': {selectedSlide: 0}})';
+		$expected_on          = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;selectedSlide&quot;:0}})';
 
 		ob_start();
 		$this->instance->tracks( $type, $container_id );

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -176,6 +176,11 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 			'thumb' => $dimensions,
 		);
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
+
+		$track = array(
+			'thumb' => array(),
+		);
+		$this->assertEquals( array(), $this->instance->get_thumb_dimensions( $track ) );
 	}
 
 	/**

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -52,7 +52,6 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		global $wp_styles;
 		$wp_styles = null;
 
-		wp_dequeue_style( 'wp-mediaelement' );
 		AMP_Playlist_Embed_Handler::$playlist_id = 0;
 	}
 
@@ -136,8 +135,8 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->assertContains( '<amp-state', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
 		$this->assertContains( $this->file_2, $playlist );
-		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
-		$this->assertContains( 'on="tap:AMP.setState({&quot;playlist0&quot;:{&quot;currentVideo&quot;:0}})"', $playlist );
+		$this->assertContains( '[src]="wpPlaylist1[wpPlaylist1.selectedIndex].videoUrl"', $playlist );
+		$this->assertContains( 'on="tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
 	}
 
 	/**
@@ -217,35 +216,35 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->assertContains( '<amp-audio', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
 		$this->assertContains( $this->file_2, $playlist );
-		$this->assertContains( 'tap:AMP.setState({&quot;ampPlaylistCarousel0&quot;:{&quot;selectedSlide&quot;:0}})"', $playlist );
+		$this->assertContains( 'tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
 	}
 
 	/**
 	 * Test tracks.
 	 *
-	 * @covers AMP_Playlist_Embed_Handler::tracks()
+	 * @covers AMP_Playlist_Embed_Handler::print_tracks()
 	 */
 	public function test_tracks() {
 		$type         = 'video';
 		$attr         = $this->get_attributes( $type );
 		$data         = $this->instance->get_data( $attr );
-		$container_id = 'fooContainerId0';
-		$expected_on  = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;currentVideo&quot;:0}})';
+		$container_id = 'fooContainerId1';
+		$state_id     = 'fooId1';
+		$expected_on  = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
 		ob_start();
-		$this->instance->tracks( $type, $container_id, $data['tracks'] );
+		$this->instance->print_tracks( $state_id, $data['tracks'] );
 		$tracks = ob_get_clean();
 		$this->assertContains( '<div class="wp-playlist-tracks">', $tracks );
-		$this->assertContains( $container_id, $tracks );
+		$this->assertContains( $state_id, $tracks );
 		$this->assertContains( $expected_on, $tracks );
 
-		$type                 = 'audio';
-		$attr                 = $this->get_attributes( $type );
-		$this->instance->data = $this->instance->get_data( $attr );
-		$expected_on          = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;selectedSlide&quot;:0}})';
+		$attr        = $this->get_attributes( $type );
+		$data        = $this->instance->get_data( $attr );
+		$expected_on = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
 		ob_start();
-		$this->instance->tracks( $type, $container_id, $data['tracks'] );
+		$this->instance->print_tracks( $state_id, $data['tracks'] );
 		$tracks = ob_get_clean();
 		$this->assertContains( $expected_on, $tracks );
 	}

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -65,17 +65,29 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	/**
 	 * Test shortcode.
 	 *
-	 * Logic for creating the upload object copied from Tests_Media.
+	 * Logic for creating the videos copied from Tests_Media.
 	 *
 	 * @covers AMP_Playlist_Embed_Handler::shortcode()
 	 */
 	public function test_shortcode() {
-		$id_mp4   = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
-		$id_mkv   = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mkv' );
-		$ids      = array(
-			$id_mp4,
-			$id_mkv,
+		$file_1 = 'example-video-1.mp4';
+		$file_2 = 'example-video-2.mkv';
+		$files  = array(
+			$file_1,
+			$file_2,
 		);
+
+		$ids = array();
+		foreach ( $files as $file ) {
+			$ids[] = $this->factory()->attachment->create_object(
+				$file,
+				0,
+				array(
+					'post_mime_type' => 'video/mp4',
+					'post_type'      => 'attachment',
+				)
+			);
+		}
 		$attr     = array(
 			'ids'  => implode( ',', $ids ),
 			'type' => 'video',
@@ -83,7 +95,8 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$playlist = $this->instance->shortcode( $attr );
 		$this->assertContains( '<amp-video', $playlist );
 		$this->assertContains( '<amp-state', $playlist );
-		$this->assertContains( 'small-video', $playlist );
+		$this->assertContains( $file_1, $playlist );
+		$this->assertContains( $file_2, $playlist );
 		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
 		$this->assertContains( 'on="tap:AMP.setState({playlist0: {currentVideo: 0}})"', $playlist );
 	}

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -189,7 +189,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		);
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
-		$track = array(
+		$track               = array(
 			'thumb' => array(),
 		);
 		$expected_dimensions = array(

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests for AMP_Playlist_Embed_Handler.
+ *
+ * @package AMP
+ * @since 0.7
+ */
+
+/**
+ * Tests for AMP_Playlist_Embed_Handler.
+ *
+ * @covers AMP_Playlist_Embed_Handler
+ */
+class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
+
+	/**
+	 * Instance of the tested class.
+	 *
+	 * @var AMP_Playlist_Embed_Handler.
+	 */
+	public $instance;
+
+	/**
+	 * Set up test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new AMP_Playlist_Embed_Handler();
+	}
+
+	/**
+	 * Tear down test.
+	 */
+	public function tearDown() {
+		wp_dequeue_style( 'wp-mediaelement' );
+	}
+
+	/**
+	 * Test register_embed.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::register_embed()
+	 */
+	public function test_register_embed() {
+		global $shortcode_tags;
+		$shortcode = 'playlist';
+		$this->assertFalse( isset( $shortcode_tags[ $shortcode ] ) );
+		$this->instance->register_embed();
+		$this->assertEquals( 'AMP_Playlist_Embed_Handler', get_class( $shortcode_tags[ $shortcode ][0] ) );
+		$this->assertEquals( 'shortcode', $shortcode_tags[ $shortcode ][1] );
+		$this->instance->unregister_embed();
+	}
+
+	/**
+	 * Test unregister_embed.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::unregister_embed()
+	 */
+	public function test_unregister_embed() {
+		global $shortcode_tags;
+		$shortcode = 'playlist';
+		$this->instance->unregister_embed();
+		$this->assertFalse( isset( $shortcode_tags[ $shortcode ] ) );
+	}
+
+	/**
+	 * Test shortcode.
+	 *
+	 * Logic for creating the upload object copied from Tests_Media.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::shortcode()
+	 */
+	public function test_shortcode() {
+		$id_mp4   = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
+		$id_mkv   = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mkv' );
+		$ids      = array(
+			$id_mp4,
+			$id_mkv,
+		);
+		$attr     = array(
+			'ids'  => implode( ',', $ids ),
+			'type' => 'video',
+		);
+		$playlist = $this->instance->shortcode( $attr );
+		$this->assertContains( '<amp-video', $playlist );
+		$this->assertContains( '<amp-state', $playlist );
+		$this->assertContains( 'small-video', $playlist );
+		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
+		$this->assertContains( 'on="tap:AMP.setState({playlist0: {currentVideo: 0}})"', $playlist );
+	}
+
+}

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -121,7 +121,6 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->assertContains( '<amp-state', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
 		$this->assertContains( $this->file_2, $playlist );
-		$this->assertEquals( $this->instance->data, $this->instance->get_data( $attr ) );
 	}
 
 	/**
@@ -130,9 +129,9 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @covers AMP_Playlist_Embed_Handler::video_playlist()
 	 */
 	public function test_video_playlist() {
-		$attr                 = $this->get_attributes( 'video' );
-		$this->instance->data = $this->instance->get_data( $attr );
-		$playlist             = $this->instance->video_playlist( $attr );
+		$attr     = $this->get_attributes( 'video' );
+		$data     = $this->instance->get_data( $attr );
+		$playlist = $this->instance->video_playlist( $data );
 		$this->assertContains( '<amp-video', $playlist );
 		$this->assertContains( '<amp-state', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
@@ -208,13 +207,12 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @covers AMP_Playlist_Embed_Handler::audio_playlist()
 	 */
 	public function test_audio_playlist() {
-		$attr                 = $this->get_attributes( 'audio' );
-		$this->instance->data = array();
-		$playlist             = $this->instance->audio_playlist();
+		$attr     = $this->get_attributes( 'audio' );
+		$playlist = $this->instance->audio_playlist( array() );
 		$this->assertEquals( '', $playlist );
 
-		$this->instance->data = $this->instance->get_data( $attr );
-		$playlist             = $this->instance->audio_playlist();
+		$data     = $this->instance->get_data( $attr );
+		$playlist = $this->instance->audio_playlist( $data );
 		$this->assertContains( '<amp-carousel', $playlist );
 		$this->assertContains( '<amp-audio', $playlist );
 		$this->assertContains( $this->file_1, $playlist );
@@ -228,14 +226,14 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @covers AMP_Playlist_Embed_Handler::tracks()
 	 */
 	public function test_tracks() {
-		$type                 = 'video';
-		$attr                 = $this->get_attributes( $type );
-		$this->instance->data = $this->instance->get_data( $attr );
-		$container_id         = 'fooContainerId0';
-		$expected_on          = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;currentVideo&quot;:0}})';
+		$type         = 'video';
+		$attr         = $this->get_attributes( $type );
+		$data         = $this->instance->get_data( $attr );
+		$container_id = 'fooContainerId0';
+		$expected_on  = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;currentVideo&quot;:0}})';
 
 		ob_start();
-		$this->instance->tracks( $type, $container_id );
+		$this->instance->tracks( $type, $container_id, $data['tracks'] );
 		$tracks = ob_get_clean();
 		$this->assertContains( '<div class="wp-playlist-tracks">', $tracks );
 		$this->assertContains( $container_id, $tracks );
@@ -247,7 +245,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$expected_on          = 'tap:AMP.setState({&quot;' . $container_id . '&quot;:{&quot;selectedSlide&quot;:0}})';
 
 		ob_start();
-		$this->instance->tracks( $type, $container_id );
+		$this->instance->tracks( $type, $container_id, $data['tracks'] );
 		$tracks = ob_get_clean();
 		$this->assertContains( $expected_on, $tracks );
 	}

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -153,7 +153,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$track      = array(
 			'thumb' => $dimensions,
 		);
-		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
+		$this->assertEquals( array_values( $dimensions ), $this->instance->get_thumb_dimensions( $track ) );
 
 		$dimensions = array(
 			'height' => 68,
@@ -162,25 +162,41 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$track      = array(
 			'thumb' => $dimensions,
 		);
-		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
+		$this->assertEquals( array_values( $dimensions ), $this->instance->get_thumb_dimensions( $track ) );
 
 		$dimensions          = array(
 			'height' => 70,
 			'width'  => 80.5,
 		);
 		$expected_dimensions = array(
-			'height' => 52,
-			'width'  => 60,
+			52,
+			60,
 		);
 		$track               = array(
 			'thumb' => $dimensions,
 		);
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
+		$dimensions          = array(
+			'width' => 80.5,
+		);
+		$track               = array(
+			'thumb' => $dimensions,
+		);
+		$expected_dimensions = array(
+			48,
+			60,
+		);
+		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
+
 		$track = array(
 			'thumb' => array(),
 		);
-		$this->assertEquals( array(), $this->instance->get_thumb_dimensions( $track ) );
+		$expected_dimensions = array(
+			AMP_Playlist_Embed_Handler::DEFAULT_THUMB_HEIGHT,
+			AMP_Playlist_Embed_Handler::DEFAULT_THUMB_WIDTH,
+		);
+		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 	}
 
 	/**

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -9,6 +9,7 @@
 /**
  * Tests for AMP_Playlist_Embed_Handler.
  *
+ * @package AMP
  * @covers AMP_Playlist_Embed_Handler
  */
 class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
@@ -19,6 +20,20 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @var AMP_Playlist_Embed_Handler.
 	 */
 	public $instance;
+
+	/**
+	 * The first tested file.
+	 *
+	 * @var string.
+	 */
+	public $file_1;
+
+	/**
+	 * The second tested file.
+	 *
+	 * @var string.
+	 */
+	public $file_2;
 
 	/**
 	 * Set up test.
@@ -33,6 +48,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		wp_dequeue_style( 'wp-mediaelement' );
+		AMP_Playlist_Embed_Handler::$playlist_id = 0;
 	}
 
 	/**
@@ -65,40 +81,213 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	/**
 	 * Test shortcode.
 	 *
-	 * Logic for creating the videos copied from Tests_Media.
-	 *
 	 * @covers AMP_Playlist_Embed_Handler::shortcode()
+	 * @covers AMP_Playlist_Embed_Handler::video_playlist()
 	 */
 	public function test_shortcode() {
-		$file_1 = 'example-video-1.mp4';
-		$file_2 = 'example-video-2.mkv';
-		$files  = array(
-			$file_1,
-			$file_2,
+		$attr     = $this->get_attributes( 'video' );
+		$playlist = $this->instance->shortcode( $attr );
+		$this->assertContains( '<amp-video', $playlist );
+		$this->assertContains( '<amp-state', $playlist );
+		$this->assertContains( $this->file_1, $playlist );
+		$this->assertContains( $this->file_2, $playlist );
+		$this->assertEquals( $this->instance->data, $this->instance->get_data( $attr ) );
+	}
+
+	/**
+	 * Test video_playlist.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::video_playlist()
+	 */
+	public function test_video_playlist() {
+		$attr                 = $this->get_attributes( 'video' );
+		$this->instance->data = $this->instance->get_data( $attr );
+		$playlist             = $this->instance->video_playlist( $attr );
+		$this->assertContains( '<amp-video', $playlist );
+		$this->assertContains( '<amp-state', $playlist );
+		$this->assertContains( $this->file_1, $playlist );
+		$this->assertContains( $this->file_2, $playlist );
+		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
+		$this->assertContains( 'on="tap:AMP.setState({playlist0: {currentVideo: 0}})"', $playlist );
+	}
+
+	/**
+	 * Test get_thumb_dimensions.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::get_thumb_dimensions()
+	 */
+	public function test_get_thumb_dimensions() {
+		$dimensions = array(
+			'height' => 60,
+			'width'  => 60,
+		);
+		$track      = array(
+			'thumb' => $dimensions,
+		);
+		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
+
+		$dimensions = array(
+			'height' => 68,
+			'width'  => 59,
+		);
+		$track      = array(
+			'thumb' => $dimensions,
+		);
+		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
+
+		$dimensions          = array(
+			'height' => 70,
+			'width'  => 80.5,
+		);
+		$expected_dimensions = array(
+			'height' => 52,
+			'width'  => 60,
+		);
+		$track               = array(
+			'thumb' => $dimensions,
+		);
+		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
+	}
+
+	/**
+	 * Test audio_playlist.
+	 *
+	 * Logic for creating the videos copied from Tests_Media.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::audio_playlist()
+	 */
+	public function test_audio_playlist() {
+		$attr                 = $this->get_attributes( 'audio' );
+		$this->instance->data = $this->instance->get_data( $attr );
+		$playlist             = $this->instance->audio_playlist();
+
+		$this->assertContains( '<amp-carousel', $playlist );
+		$this->assertContains( '<amp-audio', $playlist );
+		$this->assertContains( $this->file_1, $playlist );
+		$this->assertContains( $this->file_2, $playlist );
+		$this->assertContains( 'tap:AMP.setState({ampPlaylistCarousel0: {selectedSlide: 0}})"', $playlist );
+	}
+
+	/**
+	 * Test tracks.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::tracks()
+	 */
+	public function test_tracks() {
+		$type                 = 'video';
+		$attr                 = $this->get_attributes( $type );
+		$this->instance->data = $this->instance->get_data( $attr );
+		$container_id         = 'fooContainerId0';
+		$expected_on          = 'tap:AMP.setState({' . $container_id . ': {currentVideo: 0}})';
+
+		ob_start();
+		$this->instance->tracks( $type, $container_id );
+		$tracks = ob_get_clean();
+		$this->assertContains( '<div class="wp-playlist-tracks">', $tracks );
+		$this->assertContains( $container_id, $tracks );
+		$this->assertContains( $expected_on, $tracks );
+
+		$type                 = 'audio';
+		$attr                 = $this->get_attributes( $type );
+		$this->instance->data = $this->instance->get_data( $attr );
+		$expected_on          = 'tap:AMP.setState({' . $container_id . ': {selectedSlide: 0}})';
+
+		ob_start();
+		$this->instance->tracks( $type, $container_id );
+		$tracks = ob_get_clean();
+		$this->assertContains( $expected_on, $tracks );
+	}
+
+	/**
+	 * Test get_data.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::get_data()
+	 */
+	public function test_get_data() {
+		$type = 'audio';
+		$data = $this->instance->get_data( $this->get_attributes( $type ) );
+		$this->assertEquals( $type, $data['type'] );
+		$this->assertContains( $this->file_1, $data['tracks'][0]['src'] );
+		$this->assertContains( $this->file_2, $data['tracks'][1]['src'] );
+	}
+
+	/**
+	 * Test get_title.
+	 *
+	 * @covers AMP_Playlist_Embed_Handler::get_data()
+	 */
+	public function test_get_title() {
+		$caption = 'Example caption';
+		$title   = 'Media Title';
+		$track   = array(
+			'caption' => $caption,
 		);
 
+		$this->assertEquals( $caption, $this->instance->get_title( $track ) );
+
+		$track = array(
+			'title' => $title,
+		);
+		$this->assertEquals( $title, $this->instance->get_title( $track ) );
+
+		$track = array(
+			'caption' => $caption,
+			'title'   => $title,
+		);
+		$this->assertEquals( $caption, $this->instance->get_title( $track ) );
+		$this->assertEquals( null, $this->instance->get_title( array() ) );
+	}
+
+	/**
+	 * Gets the shortcode attributes.
+	 *
+	 * @param string $type The type of shortcode attributes: 'audio' or 'video'.
+	 * @return array $attrs The shortcode attributes.
+	 */
+	public function get_attributes( $type ) {
+		if ( 'audio' === $type ) {
+			$this->file_1 = 'example-audio-1.mp3';
+			$this->file_2 = 'example-audio-2.mp3';
+			$mime_type    = 'audio/mp3';
+		} elseif ( 'video' === $type ) {
+			$this->file_1 = 'example-video-1.mp4';
+			$this->file_2 = 'example-video-2.mkv';
+			$mime_type    = 'video/mp4';
+		} else {
+			return;
+		}
+
+		$files = array(
+			$this->file_1,
+			$this->file_2,
+		);
+		$ids   = $this->get_file_ids( $files, $mime_type );
+		return array(
+			'ids'  => implode( ',', $ids ),
+			'type' => $type,
+		);
+	}
+
+	/**
+	 * Gets test file IDs.
+	 *
+	 * @param array  $files     The file names to create.
+	 * @param string $mime_type The type of file.
+	 * @return array $ids The IDs of the test files.
+	 */
+	public function get_file_ids( $files, $mime_type ) {
 		$ids = array();
 		foreach ( $files as $file ) {
 			$ids[] = $this->factory()->attachment->create_object(
 				$file,
 				0,
 				array(
-					'post_mime_type' => 'video/mp4',
+					'post_mime_type' => $mime_type,
 					'post_type'      => 'attachment',
 				)
 			);
 		}
-		$attr     = array(
-			'ids'  => implode( ',', $ids ),
-			'type' => 'video',
-		);
-		$playlist = $this->instance->shortcode( $attr );
-		$this->assertContains( '<amp-video', $playlist );
-		$this->assertContains( '<amp-state', $playlist );
-		$this->assertContains( $file_1, $playlist );
-		$this->assertContains( $file_2, $playlist );
-		$this->assertContains( '[src]="playlist0[playlist0.currentVideo].videoUrl"', $playlist );
-		$this->assertContains( 'on="tap:AMP.setState({playlist0: {currentVideo: 0}})"', $playlist );
+		return $ids;
 	}
 
 }

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -185,9 +185,12 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function test_audio_playlist() {
 		$attr                 = $this->get_attributes( 'audio' );
+		$this->instance->data = array();
+		$playlist             = $this->instance->audio_playlist();
+		$this->assertEquals( '', $playlist );
+
 		$this->instance->data = $this->instance->get_data( $attr );
 		$playlist             = $this->instance->audio_playlist();
-
 		$this->assertContains( '<amp-carousel', $playlist );
 		$this->assertContains( '<amp-audio', $playlist );
 		$this->assertContains( $this->file_1, $playlist );

--- a/tests/test-class-amp-playlist-embed-handler.php
+++ b/tests/test-class-amp-playlist-embed-handler.php
@@ -58,12 +58,13 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function test_register_embed() {
 		global $shortcode_tags;
-		$shortcode = 'playlist';
-		$this->assertFalse( isset( $shortcode_tags[ $shortcode ] ) );
+		$removed_shortcode = 'wp_playlist_shortcode';
+		add_shortcode( 'playlist', $removed_shortcode );
 		$this->instance->register_embed();
-		$this->assertEquals( 'AMP_Playlist_Embed_Handler', get_class( $shortcode_tags[ $shortcode ][0] ) );
-		$this->assertEquals( 'shortcode', $shortcode_tags[ $shortcode ][1] );
+		$this->assertEquals( 'AMP_Playlist_Embed_Handler', get_class( $shortcode_tags[ AMP_Playlist_Embed_Handler::SHORTCODE ][0] ) );
+		$this->assertEquals( 'shortcode', $shortcode_tags[ AMP_Playlist_Embed_Handler::SHORTCODE ][1] );
 		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', array( $this->instance, 'styling' ) ) );
+		$this->assertEquals( $removed_shortcode, $this->instance->removed_shortcode );
 		$this->instance->unregister_embed();
 	}
 
@@ -74,9 +75,10 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function test_unregister_embed() {
 		global $shortcode_tags;
-		$shortcode = 'playlist';
+		$expected_removed_shortcode        = 'wp_playlist_shortcode';
+		$this->instance->removed_shortcode = $expected_removed_shortcode;
 		$this->instance->unregister_embed();
-		$this->assertFalse( isset( $shortcode_tags[ $shortcode ] ) );
+		$this->assertEquals( $expected_removed_shortcode, $shortcode_tags[ AMP_Playlist_Embed_Handler::SHORTCODE ] );
 	}
 
 	/**


### PR DESCRIPTION
This WIP pull request adds a custom shortcode handler for video playlists. It uses `<amp-video>` and `<amp-state>`, on Weston's suggestion.

Here's a [screencast](https://drive.google.com/file/d/1l6E5pVuCJ_nXk9sbzYq24ItYsS-JudSE/view?usp=sharing). It uses much of the same markup as the native shortcode, so it appears styled when adding [wp-mediaelement.min.css](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/mediaelement/wp-mediaelement.min.css).

Fixes #841.