### PR TITLE
#933 Default stylesheet includes for theme support

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -1,0 +1,11 @@
+.amp-wp-enforced-sizes {
+	/** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
+	max-width: 100%;
+	margin: 0 auto;
+}
+
+.amp-wp-unknown-size img {
+	/** Worst case scenario when we can't figure out dimensions for an image. **/
+	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/
+	object-fit: contain;
+}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -161,6 +161,7 @@ class AMP_Theme_Support {
 		 */
 		add_action( 'wp_head', array( __CLASS__, 'add_amp_component_scripts' ), 10 );
 		add_action( 'wp_head', array( __CLASS__, 'print_amp_styles' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_amp_default_styles' ) );
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 		add_action( 'wp_head', 'amp_print_schemaorg_metadata' );
 
@@ -600,6 +601,13 @@ class AMP_Theme_Support {
 	public static function print_amp_styles() {
 		echo amp_get_boilerplate_code() . "\n"; // WPCS: XSS OK.
 		echo "<style amp-custom></style>\n"; // This will by populated by AMP_Style_Sanitizer.
+	}
+
+	/**
+	 * Adds default styles expected by sanitizer.
+	 */
+	public static function enqueue_amp_default_styles() {
+		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ) );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -160,7 +160,7 @@ class AMP_Theme_Support {
 		 */
 		add_action( 'wp_head', array( __CLASS__, 'add_amp_component_scripts' ), 10 );
 		add_action( 'wp_head', array( __CLASS__, 'print_amp_styles' ) );
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_amp_default_styles' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_amp_default_styles' ), 9 );
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 		add_action( 'wp_head', 'amp_print_schemaorg_metadata' );
 


### PR DESCRIPTION
This addresses issue #933 where some styles in the legacy stylesheet are being referenced inside of sanitizers.

After taking a look through the sanitizers and [style.php](https://github.com/Automattic/amp-wp/blob/add/933-default-stylesheet/templates/style.php), it seems those two mentioned in #933 are the important ones. 

The only other style referenced is for `.amp-wp-iframe-placeholder` as the iframe sanitizer adds this to the page when told to, but this one [doesn't appear necessary](https://github.com/Automattic/amp-wp/blob/add/933-default-stylesheet/templates/style.php#L301).

Fixes #933.