### PR TITLE
Defer attribute removal until after deciding whether to remove element; report node & parent to callback

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -313,13 +313,17 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 0.7
 	 *
-	 * @param DOMElement $child The node to remove.
+	 * @param DOMNode|DOMElement $child The node to remove.
 	 * @return void
 	 */
 	public function remove_invalid_child( $child ) {
+		$parent = $child->parentNode;
 		$child->parentNode->removeChild( $child );
 		if ( isset( $this->args['remove_invalid_callback'] ) ) {
-			call_user_func( $this->args['remove_invalid_callback'], $child );
+			call_user_func( $this->args['remove_invalid_callback'], array(
+				'node'   => $child,
+				'parent' => $parent,
+			) );
 		}
 	}
 
@@ -342,7 +346,10 @@ abstract class AMP_Base_Sanitizer {
 			}
 			if ( $attribute ) {
 				$element->removeAttributeNode( $attribute );
-				call_user_func( $this->args['remove_invalid_callback'], $attribute );
+				call_user_func( $this->args['remove_invalid_callback'], array(
+					'node'   => $attribute,
+					'parent' => $element,
+				) );
 			}
 		} elseif ( is_string( $attribute ) ) {
 			$element->removeAttribute( $attribute );

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -29,7 +29,7 @@ class AMP_Validation_Utils {
 	/**
 	 * The nodes that the sanitizer removed.
 	 *
-	 * @var DOMNode[]
+	 * @var array[][]
 	 */
 	public static $removed_nodes = array();
 
@@ -153,7 +153,8 @@ class AMP_Validation_Utils {
 
 		$removed_elements   = array();
 		$removed_attributes = array();
-		foreach ( self::$removed_nodes as $node ) {
+		foreach ( self::$removed_nodes as $removed ) {
+			$node = $removed['node'];
 			if ( $node instanceof DOMAttr ) {
 				if ( ! isset( $removed_attributes[ $node->nodeName ] ) ) {
 					$removed_attributes[ $node->nodeName ] = 1;

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -261,7 +261,7 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 		$sanitizer->remove_invalid_child( $child );
 		$this->assertEquals( null, $parent->firstChild );
 		$this->assertCount( 1, AMP_Validation_Utils::$removed_nodes );
-		$this->assertEquals( $child, AMP_Validation_Utils::$removed_nodes[0] );
+		$this->assertEquals( $child, AMP_Validation_Utils::$removed_nodes[0]['node'] );
 
 		$parent->appendChild( $child );
 		$this->assertEquals( $child, $parent->firstChild );
@@ -292,7 +292,13 @@ class AMP_Base_Sanitizer__Sanitize_Dimension__Test extends WP_UnitTestCase {
 		$sanitizer = new AMP_Video_Sanitizer( $dom_document, $args );
 		$sanitizer->remove_invalid_attribute( $video, $attribute );
 		$this->assertEquals( null, $video->getAttribute( $attribute ) );
-		$this->assertEquals( array( $attr_node ), AMP_Validation_Utils::$removed_nodes );
+		$this->assertEquals(
+			array(
+				'node'   => $attr_node,
+				'parent' => $video,
+			),
+			AMP_Validation_Utils::$removed_nodes[0]
+		);
 		AMP_Validation_Utils::reset_removed();
 	}
 

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -123,8 +123,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$original_html  = trim( ob_get_clean() );
 		$removed_nodes  = array();
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, array(
-			'remove_invalid_callback' => function( $node ) use ( &$removed_nodes ) {
-				$removed_nodes[ $node->nodeName ] = $node;
+			'remove_invalid_callback' => function( $removed ) use ( &$removed_nodes ) {
+				$removed_nodes[ $removed['node']->nodeName ] = $removed['node'];
 			},
 		) );
 

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -120,7 +120,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 
 		AMP_Validation_Utils::process_markup( $this->disallowed_tag );
 		$this->assertCount( 1, AMP_Validation_Utils::$removed_nodes );
-		$this->assertEquals( 'script', AMP_Validation_Utils::$removed_nodes[0]->nodeName );
+		$this->assertEquals( 'script', AMP_Validation_Utils::$removed_nodes[0]['node']->nodeName );
 
 		AMP_Validation_Utils::reset_removed();
 		$disallowed_style = '<div style="display:none"></div>';
@@ -131,12 +131,12 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		$invalid_video = '<video width="200" height="100"></video>';
 		AMP_Validation_Utils::process_markup( $invalid_video );
 		$this->assertCount( 1, AMP_Validation_Utils::$removed_nodes );
-		$this->assertEquals( 'video', AMP_Validation_Utils::$removed_nodes[0]->nodeName );
+		$this->assertEquals( 'video', AMP_Validation_Utils::$removed_nodes[0]['node']->nodeName );
 
 		AMP_Validation_Utils::reset_removed();
 		AMP_Validation_Utils::process_markup( '<button onclick="evil()">Do it</button>' );
 		$this->assertCount( 1, AMP_Validation_Utils::$removed_nodes );
-		$this->assertEquals( 'onclick', AMP_Validation_Utils::$removed_nodes[0]->nodeName );
+		$this->assertEquals( 'onclick', AMP_Validation_Utils::$removed_nodes[0]['node']->nodeName );
 		AMP_Validation_Utils::reset_removed();
 	}
 


### PR DESCRIPTION
Before this change, when the sanitizer came across the following:

```html
<script type="text/javascript" src="https://src.wordpress-develop.test/wp-includes/js/wp-embed.js?ver=4.9.4-src"></script>
```

It would report two separate removals when in calling the `remove_invalid_callback`:

* `src` attribute
* `<script type="text/javascript"></script>` element

Notice how for the reported element removal lacks the `src` for context, which is confusing. By waiting to remove attributes until after it is decided the element should be removed, we can reduce the number of times `remove_invalid_callback` is called, and the full context for the removal will be retained.

This PR also changes the format of the arg passed to the `remove_invalid_callback` so that instead of a `DOMNode` being passed it now passes an array which contains a `node` and a `parent`. This is useful in reporting in order to have the context for where the node was located when it was removed.