### PR TITLE
Focus first radio button in AMP status

### DIFF
--- a/assets/js/amp-post-meta-box.js
+++ b/assets/js/amp-post-meta-box.js
@@ -161,6 +161,8 @@ var ampPostMetaBox = ( function( $ ) {
 		editAmpStatus.fadeToggle( component.toggleSpeed, function() {
 			if ( editAmpStatus.is( ':visible' ) ) {
 				editAmpStatus.focus();
+			} else {
+				$container.find( 'input[type="radio"]' ).first().focus();
 			}
 		} );
 		$container.slideToggle( component.toggleSpeed );


### PR DESCRIPTION
The usual behaviour of toggles in the post meta box is to focus the first form element after clicking the Edit link.