### PR TITLE
Discuss: Remove enforcement of 50KB limit on CSS

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -960,6 +960,7 @@ class AMP_Theme_Support {
 				'remove_invalid_callback' => null,
 				'allow_dirty_styles'      => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
 				'allow_dirty_scripts'     => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
+				'unlimited_custom_style'  => true,
 			),
 			$args
 		);

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -54,6 +54,7 @@ abstract class AMP_Base_Sanitizer {
 	 *      @type array $amp_bind_placeholder_prefix
 	 *      @type bool $allow_dirty_styles
 	 *      @type bool $allow_dirty_scripts
+	 *      @type bool $unlimited_custom_style
 	 *      @type callable $remove_invalid_callback
 	 * }
 	 */

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -215,7 +215,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$total_size = 0;
 			foreach ( $this->get_stylesheets() as $key => $stylesheet ) {
 				$sheet_size = strlen( $stylesheet );
-				if ( $total_size + $sheet_size > $this->custom_max_size ) {
+				if ( empty( $this->args['unlimited_custom_style'] ) && $total_size + $sheet_size > $this->custom_max_size ) {
 					$skipped[] = $key;
 				} else {
 					if ( $total_size ) {
@@ -237,7 +237,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 			$this->amp_custom_style_element->appendChild( $this->dom->createTextNode( $css ) );
 
-			// @todo This would be a candidate for sanitization reporting.
+			// @todo This would be a candidate for sanitization reporting, when ! empty( $skipped ) || $total_size > $this->custom_max_size.
 			// Add comments to indicate which sheets were not included.
 			foreach ( array_reverse( $skipped ) as $skip ) {
 				$this->amp_custom_style_element->parentNode->insertBefore(

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -103,6 +103,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		parent::__construct( $dom, $args );
 
+		if ( ! empty( $this->args['unlimited_custom_style'] ) ) {
+			foreach ( $this->args['amp_allowed_tags']['style'] as &$style ) {
+				if ( isset( $style[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['amp-custom'] ) ) {
+					unset( $style[ AMP_Rule_Spec::CDATA ]['max_bytes'] );
+					unset( $style[ AMP_Rule_Spec::CDATA ]['max_bytes_spec_url'] );
+					break;
+				}
+			}
+		}
+
 		if ( ! empty( $this->args['allow_dirty_styles'] ) ) {
 
 			// Allow style attribute on all elements.


### PR DESCRIPTION
Currently the plugin will truncate custom CSS that goes beyond 50KB. This immediately becomes a problem when Gutenberg is activated since the limit is overrun. This could become irrelevant with “tree shaking” in #930, but I wanted to open a PR to discuss at least. Having a site exclude CSS makes it look broken. Preventing a site from looking broken might be more important than maintaining strict AMP validity, but then it becomes a slippery slope. See also #956.