### PR TITLE
Set AMP_QUERY_VAR fallback when AMP is inactive

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -74,6 +74,10 @@ function amp_deactivate() {
  */
 function amp_after_setup_theme() {
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
+		// Set a fallback value to avoid constant not defined warnings
+		if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+			define( 'AMP_QUERY_VAR', false );
+		}
 		return;
 	}
 

--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -134,7 +134,7 @@ class AMP_Template_Customizer {
 
 		wp_add_inline_script( 'amp-customize-controls', sprintf( 'ampCustomizeControls.boot( %s );',
 			wp_json_encode( array(
-				'queryVar' => AMP_QUERY_VAR,
+				'queryVar' => amp_get_slug(),
 				'panelId'  => self::PANEL_ID,
 				'ampUrl'   => amp_admin_get_preview_permalink(),
 				'l10n'     => array(

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -145,7 +145,7 @@ class AMP_Post_Meta_Box {
 		);
 		wp_add_inline_script( self::ASSETS_HANDLE, sprintf( 'ampPostMetaBox.boot( %s );',
 			wp_json_encode( array(
-				'previewLink'     => esc_url_raw( add_query_arg( AMP_QUERY_VAR, '', get_preview_post_link( $post ) ) ),
+				'previewLink'     => esc_url_raw( add_query_arg( amp_get_slug(), '', get_preview_post_link( $post ) ) ),
 				'canonical'       => amp_is_canonical(),
 				'enabled'         => post_supports_amp( $post ),
 				'canSupport'      => count( AMP_Post_Type_Support::get_support_errors( $post ) ) === 0,
@@ -237,7 +237,7 @@ class AMP_Post_Meta_Box {
 		);
 
 		if ( $is_amp ) {
-			$link = add_query_arg( AMP_QUERY_VAR, true, $link );
+			$link = add_query_arg( amp_get_slug(), true, $link );
 		}
 
 		return $link;

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -48,7 +48,7 @@ function amp_admin_get_preview_permalink() {
 	 */
 	$post_type = (string) apply_filters( 'amp_customizer_post_type', 'post' );
 
-	if ( ! post_type_supports( $post_type, AMP_QUERY_VAR ) ) {
+	if ( ! post_type_supports( $post_type, amp_get_slug() ) ) {
 		return null;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -6,6 +6,36 @@
  */
 
 /**
+ * Get the slug used in AMP for the query var, endpoint, and post type support.
+ *
+ * The return value can be overridden by previously defining a AMP_QUERY_VAR
+ * constant or by adding a 'amp_query_var' filter, but *warning* this ability
+ * may be deprecated in the future. Normally the slug should be just 'amp'.
+ *
+ * @since 0.7
+ * @return string Slug used for query var, endpoint, and post type support.
+ */
+function amp_get_slug() {
+	if ( defined( 'AMP_QUERY_VAR' ) ) {
+		return AMP_QUERY_VAR;
+	}
+
+	/**
+	 * Filter the AMP query variable.
+	 *
+	 * Warning: This filter may become deprecated.
+	 *
+	 * @since 0.3.2
+	 * @param string $query_var The AMP query variable.
+	 */
+	$query_var = apply_filters( 'amp_query_var', 'amp' );
+
+	define( 'AMP_QUERY_VAR', $query_var );
+
+	return $query_var;
+}
+
+/**
  * Retrieves the full AMP-specific permalink for the given post ID.
  *
  * @since 0.1
@@ -38,9 +68,9 @@ function amp_get_permalink( $post_id ) {
 		$parsed_url = wp_parse_url( get_permalink( $post_id ) );
 		$structure  = get_option( 'permalink_structure' );
 		if ( empty( $structure ) || ! empty( $parsed_url['query'] ) || is_post_type_hierarchical( get_post_type( $post_id ) ) ) {
-			$amp_url = add_query_arg( AMP_QUERY_VAR, '', get_permalink( $post_id ) );
+			$amp_url = add_query_arg( amp_get_slug(), '', get_permalink( $post_id ) );
 		} else {
-			$amp_url = trailingslashit( get_permalink( $post_id ) ) . user_trailingslashit( AMP_QUERY_VAR, 'single_amp' );
+			$amp_url = trailingslashit( get_permalink( $post_id ) ) . user_trailingslashit( amp_get_slug(), 'single_amp' );
 		}
 	}
 
@@ -66,10 +96,10 @@ function amp_get_permalink( $post_id ) {
 function amp_remove_endpoint( $url ) {
 
 	// Strip endpoint.
-	$url = preg_replace( ':/' . preg_quote( AMP_QUERY_VAR, ':' ) . '(?=/?(\?|#|$)):', '', $url );
+	$url = preg_replace( ':/' . preg_quote( amp_get_slug(), ':' ) . '(?=/?(\?|#|$)):', '', $url );
 
 	// Strip query var.
-	$url = remove_query_arg( AMP_QUERY_VAR, $url );
+	$url = remove_query_arg( amp_get_slug(), $url );
 
 	return $url;
 }
@@ -149,7 +179,7 @@ function is_amp_endpoint() {
 		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'parse_query' hook was called. This function will always return 'false' before the 'parse_query' hook is called.", 'amp' ) ), '0.4.2' );
 	}
 
-	return false !== get_query_var( AMP_QUERY_VAR, false );
+	return false !== get_query_var( amp_get_slug(), false );
 }
 
 /**

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -54,7 +54,7 @@ class AMP_Post_Type_Support {
 			AMP_Options_Manager::get_option( 'supported_post_types', array() )
 		);
 		foreach ( $post_types as $post_type ) {
-			add_post_type_support( $post_type, AMP_QUERY_VAR );
+			add_post_type_support( $post_type, amp_get_slug() );
 		}
 	}
 
@@ -73,7 +73,7 @@ class AMP_Post_Type_Support {
 		$errors = array();
 
 		// Because `add_rewrite_endpoint` doesn't let us target specific post_types.
-		if ( isset( $post->post_type ) && ! post_type_supports( $post->post_type, AMP_QUERY_VAR ) ) {
+		if ( isset( $post->post_type ) && ! post_type_supports( $post->post_type, amp_get_slug() ) ) {
 			$errors[] = 'post-type-support';
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -130,7 +130,7 @@ class AMP_Theme_Support {
 	 * @since 0.7
 	 */
 	public static function redirect_canonical_amp() {
-		if ( false !== get_query_var( AMP_QUERY_VAR, false ) ) { // Because is_amp_endpoint() now returns true if amp_is_canonical().
+		if ( false !== get_query_var( amp_get_slug(), false ) ) { // Because is_amp_endpoint() now returns true if amp_is_canonical().
 			$url = preg_replace( '#^(https?://.+?)(/.*)$#', '$1', home_url( '/' ) );
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 				$url .= wp_unslash( $_SERVER['REQUEST_URI'] );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -153,7 +153,7 @@ class AMP_Options_Manager {
 				continue;
 			}
 
-			$post_type_supported = post_type_supports( $post_type->name, AMP_QUERY_VAR );
+			$post_type_supported = post_type_supports( $post_type->name, amp_get_slug() );
 			$is_support_elected  = in_array( $post_type->name, $supported_types, true );
 
 			$error = null;

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -94,7 +94,7 @@ class AMP_Options_Menu {
 					id="<?php echo esc_attr( $element_id ); ?>"
 					name="<?php echo esc_attr( $element_name ); ?>"
 					value="<?php echo esc_attr( $post_type->name ); ?>"
-					<?php checked( true, amp_is_canonical() || post_type_supports( $post_type->name, AMP_QUERY_VAR ) ); ?>
+					<?php checked( true, amp_is_canonical() || post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
 					<?php disabled( $is_builtin ); ?>
 					>
 				<label for="<?php echo esc_attr( $element_id ); ?>">

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -31,6 +31,15 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amp_get_slug().
+	 *
+	 * @covers amp_get_slug()
+	 */
+	public function test_amp_get_slug() {
+		$this->assertSame( 'amp', amp_get_slug() );
+	}
+
+	/**
 	 * Test amp_get_permalink() without pretty permalinks.
 	 *
 	 * @covers \amp_get_permalink()
@@ -261,7 +270,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \post_supports_amp()
 	 */
 	public function test_post_supports_amp() {
-		add_post_type_support( 'page', AMP_QUERY_VAR );
+		add_post_type_support( 'page', amp_get_slug() );
 
 		// Test disabled by default for page for posts and show on front.
 		update_option( 'show_on_front', 'page' );
@@ -282,7 +291,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertFalse( post_supports_amp( $post ) );
 
 		// Reset.
-		remove_post_type_support( 'page', AMP_QUERY_VAR );
+		remove_post_type_support( 'page', amp_get_slug() );
 	}
 
 	/**

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -93,13 +93,13 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->instance->render_status( $post );
 		$this->assertContains( $amp_status_markup, ob_get_clean() );
 
-		remove_post_type_support( 'post', AMP_QUERY_VAR );
+		remove_post_type_support( 'post', amp_get_slug() );
 
 		ob_start();
 		$this->instance->render_status( $post );
 		$this->assertEmpty( ob_get_clean() );
 
-		add_post_type_support( 'post', AMP_QUERY_VAR );
+		add_post_type_support( 'post', amp_get_slug() );
 		wp_set_current_user( $this->factory->user->create( array(
 			'role' => 'subscriber',
 		) ) );
@@ -160,7 +160,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$link = 'https://foo.bar';
 		$this->assertEquals( 'https://foo.bar', $this->instance->preview_post_link( $link ) );
 		$_POST['amp-preview'] = 'do-preview';
-		$this->assertEquals( 'https://foo.bar?' . AMP_QUERY_VAR . '=1', $this->instance->preview_post_link( $link ) );
+		$this->assertEquals( 'https://foo.bar?' . amp_get_slug() . '=1', $this->instance->preview_post_link( $link ) );
 	}
 
 }

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -171,7 +171,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEmpty( get_settings_errors() );
 
 		// Activation error.
-		remove_post_type_support( 'foo', AMP_QUERY_VAR );
+		remove_post_type_support( 'foo', amp_get_slug() );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$errors = get_settings_errors();
 		$this->assertCount( 1, $errors );
@@ -181,7 +181,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		// Deactivation error.
 		AMP_Options_Manager::update_option( 'supported_post_types', array() );
-		add_post_type_support( 'foo', AMP_QUERY_VAR );
+		add_post_type_support( 'foo', amp_get_slug() );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$errors = get_settings_errors();
 		$this->assertCount( 1, $errors );

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -73,9 +73,9 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'poem' ) );
 
 		AMP_Post_Type_Support::add_post_type_support();
-		$this->assertTrue( post_type_supports( 'post', AMP_QUERY_VAR ) );
-		$this->assertTrue( post_type_supports( 'poem', AMP_QUERY_VAR ) );
-		$this->assertFalse( post_type_supports( 'book', AMP_QUERY_VAR ) );
+		$this->assertTrue( post_type_supports( 'post', amp_get_slug() ) );
+		$this->assertTrue( post_type_supports( 'poem', amp_get_slug() ) );
+		$this->assertFalse( post_type_supports( 'book', amp_get_slug() ) );
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		// Post type support.
 		$book_id = $this->factory()->post->create( array( 'post_type' => 'book' ) );
 		$this->assertEquals( array( 'post-type-support' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
-		add_post_type_support( 'book', AMP_QUERY_VAR );
+		add_post_type_support( 'book', amp_get_slug() );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
 		// Password-protected.


### PR DESCRIPTION
If AMP is deactivated via the `amp_is_enabled` filter, the `AMP_QUERY_VAR` ends up undefined. This causes warnings when a helper function like `is_amp_endpoint()` is called. Setting a fallback value prevents this.

This was happening with a site running both `amp-wp` (but deactivated via the filter) and `lazy-load` (which calls `is_amp_endpoint()`):

```
Warning: Use of undefined constant AMP_QUERY_VAR - assumed 'AMP_QUERY_VAR' (this will throw an Error in a future version of PHP) in wp-content/plugins/amp/includes/amp-helper-functions.php
```

To reproduce:

```
add_filter( 'amp_is_enabled', '__return_false' );

add_action( 'wp_head', function() {
    is_amp_endpoint();
} );
```