### PR TITLE
Prevent schema.org duplicates

### DIFF
--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -14,6 +14,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_scripts' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_fonts' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_boilerplate_css' );
+	add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -14,7 +14,6 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_scripts' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_fonts' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_boilerplate_css' );
-	add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -829,18 +829,16 @@ class AMP_Theme_Support {
 			$head->insertBefore( $meta_viewport, $meta_charset->nextSibling );
 		}
 		// Prevent schema.org duplicates.
-		$schema_org_script = null;
+		$has_schema_org_metadata = false;
 		foreach ( $head->getElementsByTagName( 'script' ) as $script ) {
-			if ( 'application/ld+json' === $script->getAttribute( 'type' ) && preg_match( '/{"@context":"https?:[\\\]\/[\\\]\/schema\.org/', $script->nodeValue ) ) {
-				$schema_org_script = $script->nodeValue;
+			if ( 'application/ld+json' === $script->getAttribute( 'type' ) && false !== strpos( $script->nodeValue, 'schema.org' ) ) {
+				$has_schema_org_metadata = true;
 				break;
 			}
 		}
-		if ( ! $schema_org_script ) {
+		if ( ! $has_schema_org_metadata ) {
 			$script = $dom->createElement( 'script', wp_json_encode( amp_get_schemaorg_metadata() ) );
-			AMP_DOM_Utils::add_attributes_to_node( $script, array(
-				'type' => 'application/ld+json',
-			) );
+			$script->setAttribute( 'type', 'application/ld+json' );
 			$head->appendChild( $script );
 		}
 		// Ensure rel=canonical link.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -330,4 +330,49 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::handle_xhr_request();
 		$this->assertContains( 'AMP-Access-Control-Allow-Source-Origin: https://example.org', xdebug_get_headers() );
 	}
+
+	/**
+	 * Test schema_org_present().
+	 *
+	 * @dataProvider get_script_data
+	 * @covers AMP_Theme_Support::schema_org_present()
+	 * @param string  $script The value of the script.
+	 * @param boolean $expected The expected result.
+	 */
+	public function test_schema_org_present( $script, $expected ) {
+		$page = '<html><head><script>%s</script></head><body>Test</body></html>';
+		$dom  = new DOMDocument();
+		$dom->loadHTML( sprintf( $page, $script ) );
+		$this->assertEquals( $expected, AMP_Theme_Support::schema_org_present( $dom ) );
+	}
+
+	/**
+	 * Data provider for test_schema_org_present().
+	 *
+	 * @return array
+	 */
+	public function get_script_data() {
+		return array(
+			'string_schema_value'       => array(
+				'schema.org',
+				false,
+			),
+			'string_not_schema'         => array(
+				'somethinghere.org',
+				false,
+			),
+			'json_schema_present_https' => array(
+				wp_json_encode( array( '@context' => 'https://schema.org' ) ),
+				true,
+			),
+			'json_schema_present_http'  => array(
+				wp_json_encode( array( '@context' => 'http://schema.org' ) ),
+				true,
+			),
+			'json_schema_not_present'   => array(
+				wp_json_encode( array( '@anothercontext' => 'https://schema.org' ) ),
+				false,
+			),
+		);
+	}
 }

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -332,47 +332,23 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test schema_org_present().
+	 * Test ensure_required_markup().
 	 *
-	 * @dataProvider get_script_data
-	 * @covers AMP_Theme_Support::schema_org_present()
-	 * @param string  $script The value of the script.
-	 * @param boolean $expected The expected result.
+	 * @covers AMP_Theme_Support::ensure_required_markup()
 	 */
-	public function test_schema_org_present( $script, $expected ) {
-		$page = '<html><head><script>%s</script></head><body>Test</body></html>';
-		$dom  = new DOMDocument();
-		$dom->loadHTML( sprintf( $page, $script ) );
-		$this->assertEquals( $expected, AMP_Theme_Support::schema_org_present( $dom ) );
-	}
+	public function test_ensure_required_markup() {
+		$schema_test_value = '<script type="application/ld+json">{"@context":"http:\/\/schema.org"';
 
-	/**
-	 * Data provider for test_schema_org_present().
-	 *
-	 * @return array
-	 */
-	public function get_script_data() {
-		return array(
-			'string_schema_value'       => array(
-				'schema.org',
-				false,
-			),
-			'string_not_schema'         => array(
-				'somethinghere.org',
-				false,
-			),
-			'json_schema_present_https' => array(
-				wp_json_encode( array( '@context' => 'https://schema.org' ) ),
-				true,
-			),
-			'json_schema_present_http'  => array(
-				wp_json_encode( array( '@context' => 'http://schema.org' ) ),
-				true,
-			),
-			'json_schema_not_present'   => array(
-				wp_json_encode( array( '@anothercontext' => 'https://schema.org' ) ),
-				false,
-			),
-		);
+		$page = '<html><head></head><body>Test</body></html>';
+		$dom  = new DOMDocument();
+		$dom->loadHTML( $page );
+		AMP_Theme_Support::ensure_required_markup( $dom );
+		$this->assertContains( $schema_test_value, $dom->saveHTML() );
+
+		$page = '<html><head<script type="application/ld+json">{"@context":"http:\/\/schema.org","publisher":{"@type":"Organization","name":"Test Blog"}}</script>></head><body>Test</body></html>';
+		$dom  = new DOMDocument();
+		$dom->loadHTML( $page );
+		AMP_Theme_Support::ensure_required_markup( $dom );
+		$this->assertEquals( substr_count( $dom->saveHTML(), $schema_test_value ), 1 );
 	}
 }


### PR DESCRIPTION
Request For Review

Hi @westonruter,

Could you use this PR, which addresses #962?

Originally, I used json_decode( $script->nodeValue ) to convert the schema.org json data to an array. However, that brought some issues with get_mustache_tag_placeholders(), as it adds some extra markup to the schema.org script tag. 

I opted to use preg_match() as I saw the schema.org URL sometimes can either start with http or https. 

Fixes #962.