### PR TITLE
improve sanitization in jetpack_amp_build_stats_pixel_url()

### DIFF
--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -63,7 +63,7 @@ function jetpack_amp_build_stats_pixel_url() {
 		$data = compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
 	}
 
-	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? rawurlencode( $_SERVER['HTTP_HOST'] ) : ''; // input var ok
+	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var ok
 	$data['rand'] = 'RANDOM'; // amp placeholder
 	$data['ref'] = 'DOCUMENT_REFERRER'; // amp placeholder
 	$data = array_map( 'rawurlencode' , $data );


### PR DESCRIPTION
* avoid double-calling `rawurlencode()` on `$data` — `array_map()` already does this
* sanitize HTTP_HOST