### PR TITLE
Eliminate use of safecss_filter_attr() in processing style attributes since redundant and lossy

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -483,27 +483,20 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 0.4
 	 *
-	 * @param string $string Style string.
+	 * @param string $css Style string.
 	 * @return array Style properties.
 	 */
-	private function process_style( $string ) {
-		/*
-		 * Filter properties
-		 *
-		 * @todo Removed values are not reported.
-		 */
-		$string = safecss_filter_attr( esc_html( $string ) );
+	private function process_style( $css ) {
 
-		if ( ! $string ) {
-			return array();
-		}
+		// Normalize whitespace.
+		$css = str_replace( array( "\n", "\r", "\t" ), '', $css );
 
 		/*
-		 * safecss returns a string but we want individual rules.
 		 * Use preg_split to break up rules by `;` but only if the
 		 * semi-colon is not inside parens (like a data-encoded image).
 		 */
-		$styles = array_map( 'trim', preg_split( '/;(?![^(]*\))/', $string ) );
+		$styles = preg_split( '/\s*;\s*(?![^(]*\))/', trim( $css, '; ' ) );
+		$styles = array_filter( $styles );
 
 		// Normalize the order of the styles.
 		sort( $styles );
@@ -512,12 +505,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Normalize whitespace and filter rules.
 		foreach ( $styles as $index => $rule ) {
-			$arr2 = array_map( 'trim', explode( ':', $rule, 2 ) );
-			if ( 2 !== count( $arr2 ) ) {
+			$tuple = preg_split( '/\s*:\s*/', $rule, 2 );
+			if ( 2 !== count( $tuple ) ) {
 				continue;
 			}
 
-			list( $property, $value ) = $this->filter_style( $arr2[0], $arr2[1] );
+			list( $property, $value ) = $this->filter_style( $tuple[0], $tuple[1] );
 			if ( empty( $property ) || empty( $value ) ) {
 				continue;
 			}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -57,10 +57,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'div_kses_banned_style' => array(
-				'<span style="overflow-x: hidden;">Specific overflow axis not allowed.</span>',
-				'<span>Specific overflow axis not allowed.</span>',
-				array(),
+			'span_display_none' => array(
+				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
+				'<span class="amp-wp-inline-0f1bf07c72fdf1784fff2e164d9dca98">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
+				array(
+					'.amp-wp-inline-0f1bf07c72fdf1784fff2e164d9dca98 { display:none; }',
+				),
 			),
 
 			'div_amp_banned_style' => array(


### PR DESCRIPTION
Fixes #613.

There is a problem with the use of `safecss_filter_attr()` in `\AMP_Style_Sanitizer::process_style()` introduced via https://github.com/Automattic/amp-wp/blob/23eced628815e169ca9831b2ccb460b49adc53c1/includes/sanitizers/class-amp-style-sanitizer.php#L456

This is what is removing the `display` property. It was introduced in https://github.com/Automattic/amp-wp/commit/de2a303563afba4132c317d94324bdfaf793d444 with the comment:

> Filter the styles using `safecss_filter_attr()` to make sure there
> aren't any funky properties. Also alphabetize the valid properties so
> that variable order doesn't cause unnecessary duplication.

The logic in `safecss_filter_attr()` is already being run on post save to strip out `display`, if the user doesn't have `unfiltered_html`. So this is preventing `safecss_filter_attr()` from being called a second time when displaying the post, resulting in a plugin that outputs a Kses-illegal style property to be also erroneously stripped. Otherwise, if a user _does_ have `unfiltered_html` then they currently aren't able to do so in AMP even in spite of the sanitizer.