### PR TITLE
Facilitate using AMP components outside of AMP documents (AMP in PWA, “dirty AMP”)

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -64,6 +64,15 @@ function amp_deactivate() {
 	flush_rewrite_rules();
 }
 
+/*
+ * Register AMP scripts regardless of whether AMP is enabled or it is the AMP endpoint
+ * for the sake of being able to use AMP components on non-AMP documents ("dirty AMP").
+ */
+add_action( 'wp_default_scripts', 'amp_register_default_scripts' );
+
+// Ensure async and custom-element/custom-template attributes are present on script tags.
+add_filter( 'script_loader_tag', 'amp_filter_script_loader_tag', PHP_INT_MAX, 2 );
+
 /**
  * Set up AMP.
  *

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -167,11 +167,131 @@ function amp_get_asset_url( $file ) {
  *
  * @since 0.7
  * @link https://www.ampproject.org/docs/reference/spec#boilerplate
+ *
  * @return string Boilerplate code.
  */
 function amp_get_boilerplate_code() {
 	return '<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>'
 		. '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>';
+}
+
+/**
+ * Register default scripts for AMP components.
+ *
+ * @param WP_Scripts $wp_scripts Scripts.
+ */
+function amp_register_default_scripts( $wp_scripts ) {
+
+	// AMP Runtime.
+	$handle = 'amp-runtime';
+	$wp_scripts->add(
+		$handle,
+		'https://cdn.ampproject.org/v0.js',
+		array(),
+		null
+	);
+	$wp_scripts->add_data( $handle, 'amp_script_attributes', array(
+		'async' => true,
+	) );
+
+	// Shadow AMP API.
+	$handle = 'amp-shadow';
+	$wp_scripts->add(
+		$handle,
+		'https://cdn.ampproject.org/shadow-v0.js',
+		array(),
+		null
+	);
+	$wp_scripts->add_data( $handle, 'amp_script_attributes', array(
+		'async' => true,
+	) );
+
+	// Get all AMP components as defined in the spec.
+	$extensions = array();
+	foreach ( AMP_Allowed_Tags_Generated::get_allowed_tags() as $allowed_tag ) {
+		foreach ( $allowed_tag as $rule_spec ) {
+			if ( ! isset( $rule_spec[ AMP_Rule_Spec::TAG_SPEC ] ) ) {
+				continue;
+			}
+			$tag_spec = $rule_spec[ AMP_Rule_Spec::TAG_SPEC ];
+			if ( ! empty( $tag_spec['also_requires_tag_warning'] ) ) {
+				$extensions[] = strtok( $tag_spec['also_requires_tag_warning'][0], ' ' );
+			}
+			if ( ! empty( $tag_spec['requires_extension'] ) ) {
+				$extensions = array_merge( $extensions, $tag_spec['requires_extension'] );
+			}
+		}
+	}
+
+	/**
+	 * List of components that are custom elements.
+	 *
+	 * Per the spec, "Most extensions are custom-elements." In fact, there is only one custom template.
+	 *
+	 * @link https://github.com/ampproject/amphtml/blob/cd685d4e62153557519553ffa2183aedf8c93d62/validator/validator.proto#L326-L328
+	 * @link https://github.com/ampproject/amphtml/blob/cd685d4e62153557519553ffa2183aedf8c93d62/extensions/amp-mustache/validator-amp-mustache.protoascii#L27
+	 */
+	$custom_templates = array( 'amp-mustache' );
+
+	foreach ( $extensions as $extension ) {
+		$src = sprintf(
+			'https://cdn.ampproject.org/v0/%s-%s.js',
+			$extension,
+			'latest'
+		);
+
+		$wp_scripts->add(
+			$extension,
+			$src,
+			array( 'amp-runtime' ),
+			null
+		);
+		$attributes = array(
+			'async' => true,
+		);
+		if ( in_array( $extension, $custom_templates, true ) ) {
+			$attributes['custom-template'] = $extension;
+		} else {
+			$attributes['custom-element'] = $extension;
+		}
+		$wp_scripts->add_data( $extension, 'amp_script_attributes', $attributes );
+	}
+}
+
+/**
+ * Add AMP script attributes to enqueued scripts.
+ *
+ * @link https://core.trac.wordpress.org/ticket/12009
+ * @since 0.7
+ *
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @return string Script loader tag.
+ */
+function amp_filter_script_loader_tag( $tag, $handle ) {
+	$attributes = wp_scripts()->get_data( $handle, 'amp_script_attributes' );
+	if ( ! is_array( $attributes ) ) {
+		return $tag;
+	}
+
+	// Add each attribute (if it hasn't already been added).
+	foreach ( $attributes as $key => $value ) {
+		if ( ! preg_match( ":\s$key(=|>|\s):", $tag ) ) {
+			if ( true === $value ) {
+				$attribute_string = sprintf( ' %s', esc_attr( $key ) );
+			} else {
+				$attribute_string = sprintf( ' %s="%s"', esc_attr( $key ), esc_attr( $value ) );
+			}
+			$tag = preg_replace(
+				':(?=></script>):',
+				$attribute_string,
+				$tag,
+				1
+			);
+		}
+	}
+
+	return $tag;
 }
 
 /**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -119,6 +119,12 @@ class AMP_Theme_Support {
 			self::register_paired_hooks();
 		}
 
+		// Enqueue AMP runtime.
+		wp_enqueue_script( 'amp-runtime' );
+
+		// Enqueue default styles expected by sanitizer.
+		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ) );
+
 		self::add_hooks();
 		self::$sanitizer_classes = amp_get_content_sanitizers();
 		self::$embed_handlers    = self::register_content_embed_handlers();
@@ -212,9 +218,7 @@ class AMP_Theme_Support {
 		 * in this case too we should defer to the theme as well to output the meta charset because it is possible the
 		 * install is not on utf-8 and we may need to do a encoding conversion.
 		 */
-		add_action( 'wp_head', array( __CLASS__, 'add_amp_component_scripts' ), 10 );
 		add_action( 'wp_print_styles', array( __CLASS__, 'print_amp_styles' ), 0 ); // Print boilerplate before theme and plugin stylesheets.
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_amp_default_styles' ), 9 );
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 		add_action( 'wp_head', 'amp_print_schemaorg_metadata' );
 
@@ -567,16 +571,6 @@ class AMP_Theme_Support {
 	}
 
 	/**
-	 * Print AMP script and placeholder for others.
-	 *
-	 * @link https://www.ampproject.org/docs/reference/spec#scrpt
-	 */
-	public static function add_amp_component_scripts() {
-		// Replaced after output buffering with all AMP component scripts.
-		echo self::SCRIPTS_PLACEHOLDER; // phpcs:ignore WordPress.Security.EscapeOutput, WordPress.XSS.EscapeOutput
-	}
-
-	/**
 	 * Get canonical URL for current request.
 	 *
 	 * @see rel_canonical()
@@ -746,69 +740,6 @@ class AMP_Theme_Support {
 	public static function print_amp_styles() {
 		echo amp_get_boilerplate_code() . "\n"; // WPCS: XSS OK.
 		echo "<style amp-custom></style>\n"; // This will by populated by AMP_Style_Sanitizer.
-	}
-
-	/**
-	 * Adds default styles expected by sanitizer.
-	 */
-	public static function enqueue_amp_default_styles() {
-		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ) );
-	}
-
-	/**
-	 * Determine required AMP scripts.
-	 *
-	 * @param array $amp_scripts Initial scripts.
-	 * @return string Scripts to inject into the HEAD.
-	 */
-	public static function get_amp_scripts( $amp_scripts ) {
-
-		foreach ( self::$embed_handlers as $embed_handler ) {
-			$amp_scripts = array_merge(
-				$amp_scripts,
-				$embed_handler->get_scripts()
-			);
-		}
-
-		/**
-		 * List of components that are custom elements.
-		 *
-		 * Per the spec, "Most extensions are custom-elements." In fact, there is only one custom template.
-		 *
-		 * @link https://github.com/ampproject/amphtml/blob/cd685d4e62153557519553ffa2183aedf8c93d62/validator/validator.proto#L326-L328
-		 * @link https://github.com/ampproject/amphtml/blob/cd685d4e62153557519553ffa2183aedf8c93d62/extensions/amp-mustache/validator-amp-mustache.protoascii#L27
-		 */
-		$custom_templates = array( 'amp-mustache' );
-
-		/**
-		 * Filters AMP component scripts before they are injected onto the output buffer for the response.
-		 *
-		 * Plugins may add their own component scripts which have been rendered but which the plugin doesn't yet
-		 * recognize.
-		 *
-		 * @since 0.7
-		 *
-		 * @param array $amp_scripts AMP Component scripts, mapping component names to component source URLs.
-		 */
-		$amp_scripts = apply_filters( 'amp_component_scripts', $amp_scripts );
-
-		$scripts = '<script async src="https://cdn.ampproject.org/v0.js"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		foreach ( $amp_scripts as $amp_script_component => $amp_script_source ) {
-
-			$custom_type = 'custom-element';
-			if ( in_array( $amp_script_component, $custom_templates, true ) ) {
-				$custom_type = 'custom-template';
-			}
-
-			$scripts .= sprintf(
-				'<script async %s="%s" src="%s"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources, WordPress.XSS.EscapeOutput.OutputNotEscaped
-				$custom_type,
-				$amp_script_component,
-				$amp_script_source
-			);
-		}
-
-		return $scripts;
 	}
 
 	/**
@@ -1032,13 +963,33 @@ class AMP_Theme_Support {
 		$response  = "<!DOCTYPE html>\n";
 		$response .= AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
 
-		// Inject required scripts.
-		$response = preg_replace(
-			'#' . preg_quote( self::SCRIPTS_PLACEHOLDER, '#' ) . '#',
-			self::get_amp_scripts( $assets['scripts'] ),
-			$response,
-			1
-		);
+		$amp_scripts = $assets['scripts'];
+		foreach ( self::$embed_handlers as $embed_handler ) {
+			$amp_scripts = array_merge(
+				$amp_scripts,
+				$embed_handler->get_scripts()
+			);
+		}
+
+		// Allow for embed handlers to override the default extension version by defining a different URL.
+		foreach ( $amp_scripts as $handle => $value ) {
+			if ( is_string( $value ) && wp_script_is( $handle, 'registered' ) ) {
+				wp_scripts()->registered[ $handle ]->src = $value;
+			}
+		}
+
+		// Print all scripts, some of which may have already been printed and inject into head.
+		ob_start();
+		wp_print_scripts( array_keys( $amp_scripts ) );
+		$script_tags = ob_get_clean();
+		if ( ! empty( $script_tags ) ) {
+			$response = preg_replace(
+				'#(?=</head>)#',
+				$script_tags,
+				$response,
+				1
+			);
+		}
 
 		return $response;
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -123,7 +123,7 @@ class AMP_Theme_Support {
 		wp_enqueue_script( 'amp-runtime' );
 
 		// Enqueue default styles expected by sanitizer.
-		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ) );
+		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
 
 		self::add_hooks();
 		self::$sanitizer_classes = amp_get_content_sanitizers();

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -917,7 +917,7 @@ class AMP_Validation_Utils {
 				foreach ( array_diff( $wp_scripts->queue, $before_scripts_enqueued ) as $handle ) {
 					AMP_Validation_Utils::$enqueued_script_sources[ $handle ][] = $callback['source'];
 
-					if ( isset( $wp_scripts->registered[ $handle ] ) ) {
+					if ( ! $wp_scripts->get_data( $handle, 'amp_script_attributes' ) ) {
 						self::add_validation_error( array(
 							'code'       => self::ENQUEUED_SCRIPT_CODE,
 							'handle'     => $handle,

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -917,7 +917,8 @@ class AMP_Validation_Utils {
 				foreach ( array_diff( $wp_scripts->queue, $before_scripts_enqueued ) as $handle ) {
 					AMP_Validation_Utils::$enqueued_script_sources[ $handle ][] = $callback['source'];
 
-					if ( ! $wp_scripts->get_data( $handle, 'amp_script_attributes' ) ) {
+					// Flag all scripts not loaded from the AMP CDN as validation errors.
+					if ( isset( $wp_scripts->registered[ $handle ] ) && 0 !== strpos( $wp_scripts->registered[ $handle ]->src, 'https://cdn.ampproject.org/' ) ) {
 						self::add_validation_error( array(
 							'code'       => self::ENQUEUED_SCRIPT_CODE,
 							'handle'     => $handle,

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -134,7 +134,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 	public function test_get_scripts__did_convert() {
 		$source = '<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>';
-		$expected = array( 'amp-audio' => 'https://cdn.ampproject.org/v0/amp-audio-latest.js' );
+		$expected = array( 'amp-audio' => true );
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );

--- a/tests/test-amp-dailymotion-embed.php
+++ b/tests/test-amp-dailymotion-embed.php
@@ -50,7 +50,7 @@ class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.dailymotion.com/video/x5awwth' . PHP_EOL,
-				array( 'amp-dailymotion' => 'https://cdn.ampproject.org/v0/amp-dailymotion-latest.js' ),
+				array( 'amp-dailymotion' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -54,7 +54,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				array( 'amp-facebook' => 'https://cdn.ampproject.org/v0/amp-facebook-latest.js' ),
+				array( 'amp-facebook' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-form-sanitizer.php
+++ b/tests/test-amp-form-sanitizer.php
@@ -99,7 +99,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_scripts() {
 		$source   = '<form method="post" action-xhr="//example.org/example-page/" target="_top"></form>';
-		$expected = array( 'amp-form' => 'https://cdn.ampproject.org/v0/amp-form-latest.js' );
+		$expected = array( 'amp-form' => true );
 
 		$dom                 = AMP_DOM_Utils::get_dom_from_content( $source );
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -202,6 +202,13 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertStringStartsWith( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0.js\' async></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mathml-latest.js\' async custom-element="amp-mathml"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-0.1.js\' async custom-template="amp-mustache"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+
+		// Try some experimental component to ensure expected script attributes are added.
+		wp_register_script( 'amp-foo', 'https://cdn.ampproject.org/v0/amp-foo-0.1.js', array( 'amp-runtime' ), null );
+		ob_start();
+		wp_print_scripts( 'amp-foo' );
+		$output = ob_get_clean();
+		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-foo-0.1.js\' async custom-element="amp-foo"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 
 	/**

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -142,7 +142,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 	public function test_get_scripts__did_convert() {
 		$source = '<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>';
-		$expected = array( 'amp-iframe' => 'https://cdn.ampproject.org/v0/amp-iframe-latest.js' );
+		$expected = array( 'amp-iframe' => true );
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -152,7 +152,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 	public function test_no_gif_image_scripts() {
 		$source = '<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
-		$expected = array( 'amp-anim' => 'https://cdn.ampproject.org/v0/amp-anim-latest.js' );
+		$expected = array( 'amp-anim' => true );
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );

--- a/tests/test-amp-instagram-embed.php
+++ b/tests/test-amp-instagram-embed.php
@@ -53,7 +53,7 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
-				array( 'amp-instagram' => 'https://cdn.ampproject.org/v0/amp-instagram-latest.js' ),
+				array( 'amp-instagram' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-pinterest-embed.php
+++ b/tests/test-amp-pinterest-embed.php
@@ -37,7 +37,7 @@ class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
-				array( 'amp-pinterest' => 'https://cdn.ampproject.org/v0/amp-pinterest-latest.js' ),
+				array( 'amp-pinterest' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-playbuzz-sanitizer.php
+++ b/tests/test-amp-playbuzz-sanitizer.php
@@ -101,7 +101,7 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>';
-		$expected = array( 'amp-playbuzz' => 'https://cdn.ampproject.org/v0/amp-playbuzz-latest.js' );
+		$expected = array( 'amp-playbuzz' => true );
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Playbuzz_Sanitizer( $dom );

--- a/tests/test-amp-soundcloud-embed.php
+++ b/tests/test-amp-soundcloud-embed.php
@@ -162,7 +162,7 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted'     => array(
 				$this->oembed_url . PHP_EOL,
-				array( 'amp-soundcloud' => 'https://cdn.ampproject.org/v0/amp-soundcloud-latest.js' ),
+				array( 'amp-soundcloud' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -66,7 +66,7 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://twitter.com/altjoen/status/118252236836061184' . PHP_EOL,
-				array( 'amp-twitter' => 'https://cdn.ampproject.org/v0/amp-twitter-latest.js' ),
+				array( 'amp-twitter' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -123,7 +123,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 	public function test_get_scripts__did_convert() {
 		$source = '<video width="300" height="300" src="https://example.com/video.mp4"></video>';
-		$expected = array( 'amp-video' => 'https://cdn.ampproject.org/v0/amp-video-latest.js' );
+		$expected = array( 'amp-video' => true );
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );

--- a/tests/test-amp-vimeo-embed.php
+++ b/tests/test-amp-vimeo-embed.php
@@ -50,7 +50,7 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://vimeo.com/172355597' . PHP_EOL,
-				array( 'amp-vimeo' => 'https://cdn.ampproject.org/v0/amp-vimeo-latest.js' ),
+				array( 'amp-vimeo' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-vine-embed.php
+++ b/tests/test-amp-vine-embed.php
@@ -33,7 +33,7 @@ class AMP_Vine_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://vine.co/v/MdKjXez002d' . PHP_EOL,
-				array( 'amp-vine' => 'https://cdn.ampproject.org/v0/amp-vine-latest.js' ),
+				array( 'amp-vine' => true ),
 			),
 		);
 	}

--- a/tests/test-amp-youtube-embed.php
+++ b/tests/test-amp-youtube-embed.php
@@ -55,7 +55,7 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 			),
 			'converted' => array(
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
-				array( 'amp-youtube' => 'https://cdn.ampproject.org/v0/amp-youtube-latest.js' ),
+				array( 'amp-youtube' => true ),
 			),
 		);
 	}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -109,8 +109,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		wp_widgets_init();
 
 		add_action( 'wp_enqueue_scripts', function() {
-			wp_enqueue_script( 'amp-mathml' );
+			wp_enqueue_script( 'amp-list' );
 		} );
+		add_action( 'wp_footer', function() {
+			wp_print_scripts( 'amp-mathml' );
+			?>
+			<amp-mathml layout="container" data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"></amp-mathml>
+			<?php
+		}, 1 );
 
 		ob_start();
 		?>
@@ -150,6 +156,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
 		$this->assertContains( '<style amp-custom>body { background: black; }', $sanitized_html );
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-list-latest.js" async custom-element="amp-list"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<meta name="generator" content="AMP Plugin', $sanitized_html );
 

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -15,8 +15,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 *
+	 * @global WP_Scripts $wp_scripts
 	 */
 	public function tearDown() {
+		global $wp_scripts;
+		$wp_scripts = null;
 		parent::tearDown();
 		remove_theme_support( 'amp' );
 		$_REQUEST                = array(); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
@@ -91,15 +95,22 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Test prepare_response.
 	 *
 	 * @global WP_Widget_Factory $wp_widget_factory
+	 * @global WP_Scripts $wp_scripts
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response() {
-		global $wp_widget_factory;
+		global $wp_widget_factory, $wp_scripts;
+		$wp_scripts = null;
+
 		add_theme_support( 'amp' );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 		$wp_widget_factory = new WP_Widget_Factory();
 		wp_widgets_init();
+
+		add_action( 'wp_enqueue_scripts', function() {
+			wp_enqueue_script( 'amp-mathml' );
+		} );
 
 		ob_start();
 		?>
@@ -138,7 +149,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<meta name="viewport" content="width=device-width,minimum-scale=1">', $sanitized_html );
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
 		$this->assertContains( '<style amp-custom>body { background: black; }', $sanitized_html );
-		$this->assertContains( '<script async src="https://cdn.ampproject.org/v0.js"', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<meta name="generator" content="AMP Plugin', $sanitized_html );
 
 		$this->assertNotContains( '<img', $sanitized_html );
@@ -146,9 +158,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertNotContains( '<audio', $sanitized_html );
 		$this->assertContains( '<amp-audio', $sanitized_html );
-		$this->assertContains( '<script async custom-element="amp-audio"', $sanitized_html );
 
-		$this->assertContains( '<script async custom-element="amp-ad"', $sanitized_html );
+		// Note these are single-quoted because they are injected after the DOM has been re-serialized, so the type and src attributes come from WP_Scripts::do_item().
+		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-audio-latest.js\' async custom-element="amp-audio"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-ad-latest.js\' async custom-element="amp-ad"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		$this->assertContains( '<button>no-onclick</button>', $sanitized_html );
 		$this->assertCount( 3, $removed_nodes );
@@ -244,28 +257,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$this->assertContains( "$key=$value", $_SERVER['REQUEST_URI'] );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
-	}
-
-	/**
-	 * Test get_amp_scripts().
-	 *
-	 * @covers AMP_Theme_Support::get_amp_scripts()
-	 */
-	public function test_get_amp_scripts() {
-		add_filter( 'amp_component_scripts', function( $scripts ) {
-			$scripts['amp-video'] = 'https://cdn.ampproject.org/v0/amp-video-0.1.js';
-			return $scripts;
-		} );
-
-		$scripts = AMP_Theme_Support::get_amp_scripts( array(
-			'amp-mustache' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
-			'amp-bind'     => 'https://cdn.ampproject.org/v0/amp-bind-0.1.js',
-		) );
-
-		$this->assertEquals(
-			'<script async src="https://cdn.ampproject.org/v0.js"></script><script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script><script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script><script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>', // phpcs:ignore
-			$scripts
-		);
 	}
 
 	/**


### PR DESCRIPTION
* Add AMP scripts the WordPress way: register all AMP component scripts as defined in spec via WP_Scripts via new function `amp_register_default_scripts()`, allowing simple enqueueing via `wp_enqueue_script( 'amp-list' )`, for example.
* Also register the AMP Shadow API as a default script.
* Use `wp_print_scripts()` with filtering `script_loader_tag` to output scripts with necessary attributes. See https://core.trac.wordpress.org/ticket/12009
* Update whitelist sanitizer to allow, validate, and sanitize AMP scripts.
* Eliminate needless amp_component_scripts filter.

With this in place, you can leverage AMP components entirely outside of pages served as AMP. For example, to add the quadradic formula to the footer of a site, served as AMP or not, all that is needed is:

```php
<?php
add_action( 'wp_enqueue_scripts', function() {
	wp_enqueue_script( 'amp-mathml' );
} );

add_action( 'wp_footer', function() {
	?>
	<amp-mathml
		layout="container"
		data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"
	></amp-mathml>
	<?php
} );
```

This not only adds the `amp-mathml` component script to the `head`, but it also automatically outputs the AMP runtime script, since it is marked as a dependency of all registered AMP component scripts.

Fixes #982.