### PR TITLE
Prevent showing details link on edit post screen if validation status post type is not registered

### DIFF
--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -1143,6 +1143,9 @@ class AMP_Validation_Utils {
 	 * @return WP_Post|null The post of the existing custom post, or null.
 	 */
 	public static function get_validation_status_post( $url ) {
+		if ( ! post_type_exists( self::POST_TYPE_SLUG ) ) {
+			return null;
+		}
 		$query = new WP_Query( array(
 			'post_type'      => self::POST_TYPE_SLUG,
 			'post_status'    => 'publish',


### PR DESCRIPTION
If the theme does not have `amp` support then the `amp_validation_status` is not registered, and the admin screen is not accessible. So there should be no link to access the edit post screen attempted to be presented, since `get_edit_post_link` will return empty since the user cannot edit the post type that doesn't exist. 