### PR TITLE
Issue #845: Script to create Gutenberg test page

### DIFF
--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -59,7 +59,7 @@ function amp_get_block_permutations() {
 		),
 		array(
 			'title'   => 'Columns, With 2 Columns',
-			'content' => '<!-- wp:columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:paragraph {"layout":"column-1"} -->	<p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:paragraph --></div><!-- /wp:columns -->',
+			'content' => '<!-- wp:columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:paragraph --></div><!-- /wp:columns -->',
 		),
 		array(
 			'title'   => 'Cover Image With Fixed Background',

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -104,14 +104,15 @@ function amp_get_block_permutations() {
  */
 function amp_create_gutenberg_test_post( $content ) {
 	$slug            = 'amp-test-gutenberg-blocks';
-	$page            = get_page_by_path( $slug );
+	$title           = 'AMP Test Gutenberg Blocks';
+	$page            = get_page_by_path( "/{$slug}/" );
 	$failure_message = 'The test page could not be added, please try again.';
 	if ( $page ) {
 		$page_id = $page->ID;
 	} else {
 		$page_id = wp_insert_post( array(
 			'post_name'  => $slug,
-			'post_title' => 'Test Gutenberg Blocks',
+			'post_title' => $title,
 			'post_type'  => 'page',
 		) );
 

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Create post to test all Gutenberg blocks.
+ * Creates a post to test all Gutenberg blocks.
  *
  * @codeCoverageIgnore
  * @package AMP
  */
 
 /**
- * Gets many of the Gutenberg fixture blocks in /blocks/tests/fixtures.
+ * Gets many of the Gutenberg fixture blocks in blocks/tests/fixtures/.
  *
  * @throws Exception If this is script is not run inside the plugin directory.
  * @return string $content Post content with all Gutenberg blocks.
@@ -25,7 +25,7 @@ function amp_get_blocks() {
 	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
 		if ( ! preg_match( '/(serialized|embed|custom-text-teaser)/', $file ) ) {
 			// Add the block's title.
-			if ( preg_match( ':core__(<block>.+)\.html:s', basename( $file ), $matches ) ) {
+			if ( preg_match( ':core__(?P<block>.+)\.html:s', basename( $file ), $matches ) ) {
 				$content .= sprintf( '<h1>%s</h1>', $matches['block'] );
 			}
 			$content .= file_get_contents( $file ); // @codingStandardsIgnoreLine: file_get_contents_file_get_contents and file_system_read_file_get_contents.

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -14,7 +14,7 @@
  */
 function amp_get_blocks() {
 	$fixtures_dir = dirname( dirname( __DIR__ ) ) . '/gutenberg/blocks/test/fixtures';
-	$content      = '';
+	$content      = amp_get_block_permutations();
 	if ( ! is_dir( $fixtures_dir ) ) {
 		$fixtures_dir = dirname( $fixtures_dir );
 		if ( ! is_dir( $fixtures_dir ) ) {
@@ -23,14 +23,75 @@ function amp_get_blocks() {
 	}
 
 	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
-		if ( ! preg_match( '/(serialized|embed|custom-text-teaser)/', $file ) ) {
+		if ( ! preg_match( '/(serialized|embed|shortcode|custom-text-teaser)/', $file ) ) {
 			// Add the block's title.
 			if ( preg_match( ':core__(?P<block>.+)\.html:s', basename( $file ), $matches ) ) {
 				$content .= sprintf( '<h1>%s</h1>', $matches['block'] );
 			}
-			$content .= file_get_contents( $file ); // @codingStandardsIgnoreLine: file_get_contents_file_get_contents and file_system_read_file_get_contents.
+			$content .= file_get_contents( $file ); // @codingStandardsIgnoreLine: file_get_contents_file_get_contents, file_system_read_file_get_contents.
 		}
 	}
+
+	// Replace broken URLs in fixture files.
+	$content = str_replace( 'http://google.com/hi.png', 'https://cldup.com/-3VMmmrPm9.jpg', $content );
+	$content = str_replace( 'https://awesome-fake.video/file.mp4', 'https://videos.files.wordpress.com/DK5mLrbr/video-ca6dc0ab4a_hd.mp4', $content );
+	return $content;
+}
+
+/**
+ * Gets the Gutenberg block permutations.
+ *
+ * These are mostly copied from gutenberg/blocks/test/fixtures, and slightly modified.
+ * Embeds and shortcodes are tested in a separate script, so this does not have have many.
+ *
+ * @return string $content The blocks as HTML.
+ */
+function amp_get_block_permutations() {
+	$blocks = array(
+		array(
+			'title'   => 'Categories With Dropdown',
+			'content' => '<!-- wp:core/categories {"showPostCounts":false,"displayAsDropdown":true,"showHierarchy":false} /-->',
+		),
+		array(
+			'title'   => 'Columns, With 2 Columns',
+			'content' => '<!-- wp:columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:paragraph {"layout":"column-1"} -->	<p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:paragraph --></div><!-- /wp:columns -->',
+		),
+		array(
+			'title'   => 'Cover Image With Fixed Background',
+			'content' => '<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} --><section class="wp-block-cover-image has-background-dim-40 has-background-dim has-parallax" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><h2>Guten Berg!</h2></section><!-- /wp:core/cover-image -->',
+		),
+		array(
+			'title'   => 'WordPress Embed',
+			'content' => '<!-- wp:core-embed/wordpress {"url":"https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/"} --><figure class="wp-block-embed-wordpress wp-block-embed">https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/<figcaption>Embedded content from WordPress</figcaption></figure><!-- /wp:core-embed/wordpress -->',
+		),
+		array(
+			'title'   => 'YouTube Embed',
+			'content' => '<!-- wp:core-embed/youtube {"url":"https://www.youtube.com/watch?v=GGS-tKTXw4Y"} --><figure class="wp-block-embed-youtube wp-block-embed">https://www.youtube.com/watch?v=GGS-tKTXw4Y<figcaption>Embedded content from youtube</figcaption></figure><!-- /wp:core-embed/youtube -->',
+		),
+		array(
+			'title'   => 'Twitter Embed',
+			'content' => '<!-- wp:core-embed/twitter {"url":"https://twitter.com/AMPhtml/status/963443140005957632"} --><figure class="wp-block-embed-twitter wp-block-embed">https://twitter.com/AMPhtml/status/963443140005957632<figcaption>We are Automattic</figcaption></figure><!-- /wp:core-embed/twitter -->',
+		),
+		array(
+			'title'   => 'Gallery With 3 Columns',
+			'content' => '<!-- wp:core/gallery --><ul class="wp-block-gallery alignnone columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/-3VMmmrPm9.jpg" alt="title" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/aMbxBM0zAi.jpg" alt="title" /></figure></li></ul><!-- /wp:core/gallery -->',
+		),
+		array(
+			'title'   => 'Audio Shortcode',
+			'content' => '<!-- wp:core/shortcode -->[audio src=https://wptavern.com/wp-content/uploads/2017/11/EPISODE-296-Gutenberg-Telemetry-Calypso-and-More-With-Matt-Mullenweg.mp3]<!-- /wp:core/shortcode -->',
+		),
+		array(
+			'title'   => 'Caption Shortcode',
+			'content' => '<!-- wp:core/shortcode -->[caption width=150]This is a caption[/caption]<!-- /wp:core/shortcode -->',
+		),
+	);
+
+	$content = '';
+	foreach ( $blocks as $block ) {
+		$content .= sprintf( '<h1>%s</h1>', $block['title'] );
+		$content .= $block['content'];
+	}
+
 	return $content;
 }
 

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -6,25 +6,27 @@
  * @package AMP
  */
 
+namespace AMP;
+
 /**
  * Gets many of the Gutenberg fixture blocks in blocks/tests/fixtures/.
  *
- * @throws Exception If this is script is not run inside the plugin directory, or if it doesn't have .html fixtures.
+ * @throws \Exception If this is script is not run inside the plugin directory, or if it doesn't have .html fixtures.
  * @return string $content Post content with all Gutenberg blocks.
  */
-function amp_get_blocks() {
+function get_test_block_fixtures() {
 	$gutenberg_dir = dirname( dirname( __DIR__ ) ) . '/gutenberg';
-	$content       = amp_get_block_permutations();
+	$content       = get_test_block_permutations();
 	if ( ! is_dir( $gutenberg_dir ) ) {
 		$gutenberg_dir = dirname( $gutenberg_dir );
 		if ( ! is_dir( $gutenberg_dir ) ) {
-			throw new Exception( 'Please run this script from the AMP plugin root.' );
+			throw new \Exception( 'Please run this script from the AMP plugin root.' );
 		}
 	}
 
 	$fixtures_dir = $gutenberg_dir . '/blocks/test/fixtures';
 	if ( ! is_dir( $fixtures_dir ) ) {
-		throw new Exception( "Test files not found in the Gutenberg plugin. You may need to clone the plugin repo: \nhttps://github.com/WordPress/gutenberg.git" );
+		throw new \Exception( "Test files not found in the Gutenberg plugin. You may need to clone the plugin repo: \nhttps://github.com/WordPress/gutenberg.git" );
 	}
 
 	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
@@ -52,11 +54,11 @@ function amp_get_blocks() {
  *
  * @return string $content The blocks as HTML.
  */
-function amp_get_block_permutations() {
+function get_test_block_permutations() {
 	$blocks = array(
 		array(
 			'title'   => '(Reusable) Block With Video',
-			'content' => sprintf( '<!-- wp:block {"ref":%d} /-->', amp_create_reusable_block() ),
+			'content' => sprintf( '<!-- wp:block {"ref":%d} /-->', create_test_reusable_block() ),
 		),
 		array(
 			'title'   => 'Categories With Dropdown',
@@ -111,9 +113,9 @@ function amp_get_block_permutations() {
  * Reusable blocks are stored in custom post types.
  * This creates one, and returns the ID on success.
  *
- * @return int|WP_Error $post_id The post ID where the reusable block is stored, and 0 or WP_Error in case of failure.
+ * @return int|\WP_Error $post_id The post ID where the reusable block is stored, and 0 or WP_Error in case of failure.
  */
-function amp_create_reusable_block() {
+function create_test_reusable_block() {
 	return wp_insert_post( array(
 		'post_type'    => 'wp_block',
 		'post_title'   => 'Test Reusable Block',
@@ -125,11 +127,11 @@ function amp_create_reusable_block() {
 /**
  * Creates a Gutenberg test post (page).
  *
- * @throws Exception If there is an error in creating the test page.
+ * @throws \Exception If there is an error in creating the test page.
  * @param string $content The content to add to the post.
  * @return int Page ID.
  */
-function amp_create_gutenberg_test_post( $content ) {
+function create_gutenberg_test_post( $content ) {
 	$slug            = 'amp-test-gutenberg-blocks';
 	$title           = 'AMP Test Gutenberg Blocks';
 	$page            = get_page_by_path( "/{$slug}/" );
@@ -144,7 +146,7 @@ function amp_create_gutenberg_test_post( $content ) {
 		) );
 
 		if ( ! $page_id || is_wp_error( $page_id ) ) {
-			throw new Exception( $failure_message );
+			throw new \Exception( $failure_message );
 		}
 	}
 
@@ -154,7 +156,7 @@ function amp_create_gutenberg_test_post( $content ) {
 	) );
 
 	if ( ! $update ) {
-		throw new Exception( $failure_message );
+		throw new \Exception( $failure_message );
 	}
 	return $update;
 }
@@ -162,10 +164,10 @@ function amp_create_gutenberg_test_post( $content ) {
 // Bootstrap.
 if ( defined( 'WP_CLI' ) ) {
 	try {
-		$post_id = amp_create_gutenberg_test_post( amp_get_blocks() );
-		WP_CLI::success( sprintf( 'The test page is at: %s', amp_get_permalink( $post_id ) . '#development=1' ) );
-	} catch ( Exception $e ) {
-		WP_CLI::error( $e->getMessage() );
+		$post_id = create_gutenberg_test_post( get_test_block_fixtures() );
+		\WP_CLI::success( sprintf( 'The test page is at: %s', \amp_get_permalink( $post_id ) . '#development=1' ) );
+	} catch ( \Exception $e ) {
+		\WP_CLI::error( $e->getMessage() );
 	}
 } else {
 	echo "This script should be run WP-CLI via: wp eval-file bin/create-gutenberg-test-post.php\n";

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Create post to test all Gutenberg blocks.
+ *
+ * @codeCoverageIgnore
+ * @package AMP
+ */
+
+/**
+ * Gets many of the Gutenberg fixture blocks in /blocks/tests/fixtures.
+ *
+ * @throws Exception If this is script is not run inside the plugin directory.
+ * @return string $content Post content with all Gutenberg blocks.
+ */
+function amp_get_blocks() {
+	$fixtures_dir = dirname( dirname( __DIR__ ) ) . '/gutenberg/blocks/test/fixtures';
+	$content      = '';
+	if ( ! is_dir( $fixtures_dir ) ) {
+		$fixtures_dir = dirname( $fixtures_dir );
+		if ( ! is_dir( $fixtures_dir ) ) {
+			throw new Exception( 'Please run this script from the AMP plugin root.' );
+		}
+	}
+
+	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
+		if ( ! preg_match( '/(serialized|embed|custom-text-teaser)/', $file ) ) {
+			// Add the block's title.
+			if ( preg_match( ':core__(<block>.+)\.html:s', basename( $file ), $matches ) ) {
+				$content .= sprintf( '<h1>%s</h1>', $matches['block'] );
+			}
+			$content .= file_get_contents( $file ); // @codingStandardsIgnoreLine: file_get_contents_file_get_contents and file_system_read_file_get_contents.
+		}
+	}
+	return $content;
+}
+
+/**
+ * Creates a Gutenberg test post (page).
+ *
+ * @throws Exception If there is an error in creating the test page.
+ * @param string $content The content to add to the post.
+ * @return int Page ID.
+ */
+function amp_create_gutenberg_test_post( $content ) {
+	$slug            = 'amp-test-gutenberg-blocks';
+	$page            = get_page_by_path( $slug );
+	$failure_message = 'The test page could not be added, please try again.';
+	if ( $page ) {
+		$page_id = $page->ID;
+	} else {
+		$page_id = wp_insert_post( array(
+			'post_name'  => $slug,
+			'post_title' => 'Test Gutenberg Blocks',
+			'post_type'  => 'page',
+		) );
+
+		if ( ! $page_id || is_wp_error( $page_id ) ) {
+			throw new Exception( $failure_message );
+		}
+	}
+
+	$update = wp_update_post( array(
+		'ID'           => $page_id,
+		'post_content' => $content,
+	) );
+
+	if ( ! $update ) {
+		throw new Exception( $failure_message );
+	}
+	return $update;
+}
+
+// Bootstrap.
+if ( defined( 'WP_CLI' ) ) {
+	try {
+		$post_id = amp_create_gutenberg_test_post( amp_get_blocks() );
+		WP_CLI::success( sprintf( 'The test page is at: %s', amp_get_permalink( $post_id ) . '#development=1' ) );
+	} catch ( Exception $e ) {
+		WP_CLI::error( $e->getMessage() );
+	}
+} else {
+	echo "This script should be run WP-CLI via: wp eval-file bin/create-gutenberg-test-post.php\n";
+	exit( 1 );
+}

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -23,9 +23,10 @@ function amp_get_blocks() {
 	}
 
 	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
-		if ( ! preg_match( '/(serialized|embed|shortcode|custom-text-teaser)/', $file ) ) {
+		if ( ! preg_match( '/(serialized|embed|shortcode|custom-text-teaser|core__block)/', $file ) ) {
 			// Add the block's title.
-			if ( preg_match( ':core__(?P<block>.+)\.html:s', basename( $file ), $matches ) ) {
+			preg_match( ':core__(?P<block>.+)\.html:s', basename( $file ), $matches );
+			if ( isset( $matches['block'] ) ) {
 				$content .= sprintf( '<h1>%s</h1>', $matches['block'] );
 			}
 			$content .= file_get_contents( $file ); // @codingStandardsIgnoreLine: file_get_contents_file_get_contents, file_system_read_file_get_contents.
@@ -41,13 +42,17 @@ function amp_get_blocks() {
 /**
  * Gets the Gutenberg block permutations.
  *
- * These are mostly copied from gutenberg/blocks/test/fixtures, and slightly modified.
+ * These are mostly copied from gutenberg/blocks/test/fixtures/, and slightly modified.
  * Embeds and shortcodes are tested in a separate script, so this does not have have many.
  *
  * @return string $content The blocks as HTML.
  */
 function amp_get_block_permutations() {
 	$blocks = array(
+		array(
+			'title'   => '(Reusable) Block With Video',
+			'content' => sprintf( '<!-- wp:block {"ref":%d} /-->', amp_create_reusable_block() ),
+		),
 		array(
 			'title'   => 'Categories With Dropdown',
 			'content' => '<!-- wp:core/categories {"showPostCounts":false,"displayAsDropdown":true,"showHierarchy":false} /-->',
@@ -88,11 +93,28 @@ function amp_get_block_permutations() {
 
 	$content = '';
 	foreach ( $blocks as $block ) {
-		$content .= sprintf( '<h1>%s</h1>', $block['title'] );
+		$content .= sprintf( '<h2>%s</h2>', $block['title'] );
 		$content .= $block['content'];
 	}
 
 	return $content;
+}
+
+/**
+ * Creates a reusable block with a video.
+ *
+ * Reusable blocks are stored in custom post types.
+ * This creates one, and returns the ID on success.
+ *
+ * @return int|WP_Error $post_id The post ID where the reusable block is stored, and 0 or WP_Error in case of failure.
+ */
+function amp_create_reusable_block() {
+	return wp_insert_post( array(
+		'post_type'    => 'wp_block',
+		'post_title'   => 'Test Reusable Block',
+		'post_content' => '<!-- wp:core/video --><figure class="wp-block-video"><video src="https://videos.files.wordpress.com/DK5mLrbr/video-ca6dc0ab4a_hd.mp4" controls=""></video></figure><!-- /wp:core/video -->',
+		'post_status'  => 'publish',
+	) );
 }
 
 /**

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -9,17 +9,22 @@
 /**
  * Gets many of the Gutenberg fixture blocks in blocks/tests/fixtures/.
  *
- * @throws Exception If this is script is not run inside the plugin directory.
+ * @throws Exception If this is script is not run inside the plugin directory, or if it doesn't have .html fixtures.
  * @return string $content Post content with all Gutenberg blocks.
  */
 function amp_get_blocks() {
-	$fixtures_dir = dirname( dirname( __DIR__ ) ) . '/gutenberg/blocks/test/fixtures';
-	$content      = amp_get_block_permutations();
-	if ( ! is_dir( $fixtures_dir ) ) {
-		$fixtures_dir = dirname( $fixtures_dir );
-		if ( ! is_dir( $fixtures_dir ) ) {
+	$gutenberg_dir = dirname( dirname( __DIR__ ) ) . '/gutenberg';
+	$content       = amp_get_block_permutations();
+	if ( ! is_dir( $gutenberg_dir ) ) {
+		$gutenberg_dir = dirname( $gutenberg_dir );
+		if ( ! is_dir( $gutenberg_dir ) ) {
 			throw new Exception( 'Please run this script from the AMP plugin root.' );
 		}
+	}
+
+	$fixtures_dir = $gutenberg_dir . '/blocks/test/fixtures';
+	if ( ! is_dir( $fixtures_dir ) ) {
+		throw new Exception( "Test files not found in the Gutenberg plugin. You may need to clone the plugin repo: \nhttps://github.com/WordPress/gutenberg.git" );
 	}
 
 	foreach ( glob( $fixtures_dir . '/*.html' ) as $file ) {
@@ -59,7 +64,7 @@ function amp_get_block_permutations() {
 		),
 		array(
 			'title'   => 'Columns, With 2 Columns',
-			'content' => '<!-- wp:columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:paragraph --><!-- wp:paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:paragraph --></div><!-- /wp:columns -->',
+			'content' => '<!-- wp:core/columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:core/paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:core/paragraph --><!-- wp:core/paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:core/paragraph --><!-- wp:core/paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:core/paragraph --></div><!-- /wp:core/columns -->',
 		),
 		array(
 			'title'   => 'Cover Image With Fixed Background',

--- a/bin/create-gutenberg-test-post.sh
+++ b/bin/create-gutenberg-test-post.sh
@@ -12,7 +12,6 @@ if [[ ! -e $GUTENBERG_PATH ]]; then
 	cd $PLUGINS_PATH
 	echo "This needs to clone the Gutenberg plugin into your plugins directory, as it looks like it's not there."
 	read -p "Is that alright? y/n " -r
-	printf "\n"
 	if [[ $REPLY =~ [Yy] ]]; then
 		git clone https://github.com/WordPress/gutenberg.git
 	else
@@ -26,5 +25,5 @@ else
 	fi
 fi
 
-cd $PROJECT_PATH/bin
-wp eval-file create-gutenberg-test-post.php
+cd $PROJECT_PATH
+wp eval-file bin/create-gutenberg-test-post.php

--- a/bin/create-gutenberg-test-post.sh
+++ b/bin/create-gutenberg-test-post.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+cd "$(dirname "$0")"
 
 BIN_PATH="$(pwd)"
 PROJECT_PATH=$(dirname $PWD)

--- a/bin/create-gutenberg-test-post.sh
+++ b/bin/create-gutenberg-test-post.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+BIN_PATH="$(pwd)"
+PROJECT_PATH=$(dirname $PWD)
+PLUGINS_PATH=$(dirname $PROJECT_PATH)
+GUTENBERG_PATH=$PLUGINS_PATH/gutenberg
+
+# Clone the Gutenberg plugin, or pull the master branch if it's already present.
+if [[ ! -e $GUTENBERG_PATH ]]; then
+	cd $PLUGINS_PATH
+	echo "This needs to clone the Gutenberg plugin into your plugins directory, as it looks like it's not there."
+	read -p "Is that alright? y/n " -r
+	printf "\n"
+	if [[ $REPLY =~ [Yy] ]]; then
+		git clone https://github.com/WordPress/gutenberg.git
+	else
+		echo "Exiting script."
+		exit 1
+	fi
+else
+	cd $GUTENBERG_PATH
+	if [ 'master' == $( git rev-parse --abbrev-ref HEAD ) ]; then
+		git pull origin master
+	fi
+fi
+
+cd $PROJECT_PATH/bin
+wp eval-file create-gutenberg-test-post.php

--- a/bin/create-gutenberg-test-post.sh
+++ b/bin/create-gutenberg-test-post.sh
@@ -14,6 +14,9 @@ if [[ ! -e $GUTENBERG_PATH ]]; then
 	read -p "Is that alright? y/n " -r
 	if [[ $REPLY =~ [Yy] ]]; then
 		git clone https://github.com/WordPress/gutenberg.git
+		wp plugin activate gutenberg
+		echo "The Gutenberg plugin is cloned. Please follow the build steps:"
+		echo "https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md"
 	else
 		echo "Exiting script."
 		exit 1

--- a/contributing.md
+++ b/contributing.md
@@ -42,6 +42,14 @@ To run it:
 3. run `wp eval-file bin/create-comments-on-test-post.php`
 4. go to the URL that is output in the command line
 
+## Testing Gutenberg Block Support
+
+The following script creates a post with all core Gutenberg blocks. To run it:
+1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+2. `cd` to the root of this plugin
+3. run `bash bin/create-gutenberge-test-post.sh`
+4. go to the URL that is output in the command line
+
 ## PHPUnit Testing
 
 Please run these tests in an environment with WordPress unit tests installed, like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV).


### PR DESCRIPTION
**Pull Request**

This PR for Issue #845 uses the [test fixtures](https://github.com/WordPress/gutenberg/tree/master/blocks/test/fixtures) in Gutenberg, but excludes the embeds. Those fixtures usually don't have actual URLs.

From the plugin root, run this command from inside an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV/):

`bash bin/create-gutenberg-test-post.sh`

This clones Gutenberg if it's not present, or pulls the master branch. Then, it runs the `wp-cli` script to create the test page, based on the [test fixtures](https://github.com/WordPress/gutenberg/tree/master/blocks/test/fixtures).


- [x] Add some permutations (see #845)
- [x] Add documentation in [contributing.md](https://github.com/Automattic/amp-wp/blob/develop/contributing.md)
- [x] Create a test [reusable block](https://github.com/WordPress/gutenberg/tree/master/blocks/library/block)
- [x] Test this more

This uses logic from [create-embed-test-post.php](https://github.com/Automattic/amp-wp/blob/develop/bin/create-embed-test-post.php) and [amphtml-update.sh](https://github.com/Automattic/amp-wp/blob/develop/bin/amphtml-update.sh)