### PR TITLE
Move enqueuing of assets to 'wp_enqueue_scripts'

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -171,6 +171,10 @@ function post_supports_amp( $post ) {
  * @return bool Whether it is the AMP endpoint.
  */
 function is_amp_endpoint() {
+	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		return false;
+	}
+
 	if ( amp_is_canonical() ) {
 		return true;
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -100,6 +100,8 @@ class AMP_Theme_Support {
 		 * action to template_redirect--the wp action--is used instead.
 		 */
 		add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
+
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 	}
 
 	/**
@@ -118,12 +120,6 @@ class AMP_Theme_Support {
 		} else {
 			self::register_paired_hooks();
 		}
-
-		// Enqueue AMP runtime.
-		wp_enqueue_script( 'amp-runtime' );
-
-		// Enqueue default styles expected by sanitizer.
-		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
 
 		self::add_hooks();
 		self::$sanitizer_classes = amp_get_content_sanitizers();
@@ -1015,5 +1011,21 @@ class AMP_Theme_Support {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Enqueue AMP assets if this is an AMP endpoint.
+	 *
+	 * @since 0.7
+	 *
+	 * @return void
+	 */
+	public static function enqueue_assets() {
+		if ( is_amp_endpoint() ) {
+			// Enqueue AMP runtime.
+			wp_enqueue_script( 'amp-runtime' );
+			// Enqueue default styles expected by sanitizer.
+			wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
+		}
 	}
 }

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1021,11 +1021,9 @@ class AMP_Theme_Support {
 	 * @return void
 	 */
 	public static function enqueue_assets() {
-		if ( is_amp_endpoint() ) {
-			// Enqueue AMP runtime.
-			wp_enqueue_script( 'amp-runtime' );
-			// Enqueue default styles expected by sanitizer.
-			wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
-		}
+		// Enqueue AMP runtime.
+		wp_enqueue_script( 'amp-runtime' );
+		// Enqueue default styles expected by sanitizer.
+		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
 	}
 }

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -56,6 +56,18 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->assertFalse( $before_is_amp_endpoint, 'is_amp_endpoint was not defaulting to false before amp_render_post' );
 		$this->assertTrue( $this->was_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
 		$this->assertFalse( $after_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
+
+		add_theme_support( 'amp' );
+		$this->assertTrue( is_amp_endpoint() );
+
+		// Make is_admin() true, as requests for an admin page aren't for AMP endpoints.
+		set_current_screen( 'edit.php' );
+		$this->assertFalse( is_amp_endpoint() );
+		unset( $GLOBALS['current_screen'] );
+
+		$GLOBALS['wp_query']->is_feed = true;
+		$this->assertFalse( is_amp_endpoint() );
+		$GLOBALS['wp_query']->is_feed = false;
 	}
 
 	/**

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -67,6 +67,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// Test inline script boot.
 		$this->assertTrue( false !== stripos( wp_json_encode( $script_data ), 'ampPostMetaBox.boot(' ) );
 		unset( $GLOBALS['post'] );
+		unset( $GLOBALS['current_screen'] );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -384,11 +384,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		wp_dequeue_script( $script_slug );
 		wp_dequeue_style( $style_slug );
 		AMP_Theme_Support::enqueue_assets();
-		$this->assertFalse( in_array( $script_slug, wp_scripts()->queue, true ) );
-		$this->assertFalse( in_array( $style_slug, wp_styles()->queue, true ) );
-
-		add_theme_support( 'amp' );
-		AMP_Theme_Support::enqueue_assets();
 		$this->assertTrue( in_array( $script_slug, wp_scripts()->queue, true ) );
 		$this->assertTrue( in_array( $style_slug, wp_styles()->queue, true ) );
 	}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -346,6 +346,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::ensure_required_markup( $dom );
 		$this->assertEquals( $expected, substr_count( $dom->saveHTML(), 'schema.org' ) );
 	}
+
 	/**
 	 * Data provider for test_ensure_required_markup.
 	 *
@@ -370,5 +371,25 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				1,
 			),
 		);
+	}
+
+	/**
+	 * Test enqueue_assets().
+	 *
+	 * @covers AMP_Theme_Support::enqueue_assets()
+	 */
+	public function test_enqueue_assets() {
+		$script_slug = 'amp-runtime';
+		$style_slug  = 'amp-default';
+		wp_dequeue_script( $script_slug );
+		wp_dequeue_style( $style_slug );
+		AMP_Theme_Support::enqueue_assets();
+		$this->assertFalse( in_array( $script_slug, wp_scripts()->queue, true ) );
+		$this->assertFalse( in_array( $style_slug, wp_styles()->queue, true ) );
+
+		add_theme_support( 'amp' );
+		AMP_Theme_Support::enqueue_assets();
+		$this->assertTrue( in_array( $script_slug, wp_scripts()->queue, true ) );
+		$this->assertTrue( in_array( $style_slug, wp_styles()->queue, true ) );
 	}
 }

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -372,7 +372,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Utils::wrap_widget_callbacks()
 	 */
 	public function test_wrap_widget_callbacks() {
-		global $wp_registered_widgets;
+		global $wp_registered_widgets, $_wp_sidebars_widgets;
 
 		$widget_id = 'search-2';
 		$this->assertArrayHasKey( $widget_id, $wp_registered_widgets );
@@ -387,9 +387,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 			'id'           => $sidebar_id,
 			'after_widget' => '</li>',
 		) );
-		update_option( 'sidebars_widgets', array(
-			$sidebar_id => array( $widget_id ),
-		) );
+		$_wp_sidebars_widgets[ $sidebar_id ] = array( $widget_id ); // WPCS: global override ok.
 
 		ob_start();
 		dynamic_sidebar( $sidebar_id );
@@ -1145,6 +1143,8 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		ob_start();
 		AMP_Validation_Utils::remaining_error_notice();
 		$this->assertContains( 'The rechecked URL has no validation error', ob_get_clean() );
+
+		unset( $GLOBALS['current_screen'] );
 	}
 
 	/**


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter,
@kopepasah found an issue where the `amp-runtime` script appeared in the `wp-admin/edit.php` page.

As you mentioned, this should be enqueued on the action `wp_enqeue_scripts`.

So this does that, and wraps the enqueuing in `if ( is_amp_endpoint() )` This also appeared where they were enqueued before.