### PR TITLE
Fix enqueueing amp-runtime and handling comment submissions in paired mode

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -109,8 +109,6 @@ class AMP_Theme_Support {
 		 * action to template_redirect--the wp action--is used instead.
 		 */
 		add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
-
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 	}
 
 	/**
@@ -226,6 +224,7 @@ class AMP_Theme_Support {
 		add_action( 'wp_print_styles', array( __CLASS__, 'print_amp_styles' ), 0 ); // Print boilerplate before theme and plugin stylesheets.
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		if ( is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( __CLASS__, 'dequeue_customize_preview_scripts' ), 1000 );
 		}
@@ -1146,8 +1145,8 @@ class AMP_Theme_Support {
 	 * @return void
 	 */
 	public static function enqueue_assets() {
-		// Enqueue AMP runtime.
 		wp_enqueue_script( 'amp-runtime' );
+
 		// Enqueue default styles expected by sanitizer.
 		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -363,7 +363,14 @@ class AMP_Theme_Support {
 	 * @since 0.7.0
 	 */
 	public static function handle_xhr_request() {
-		if ( empty( self::$purged_amp_query_vars['__amp_source_origin'] ) || empty( $_SERVER['REQUEST_METHOD'] ) || 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
+		$is_amp_xhr = (
+			! empty( self::$purged_amp_query_vars['_wp_amp_action_xhr_converted'] )
+			&&
+			! empty( self::$purged_amp_query_vars['__amp_source_origin'] )
+			&&
+			( ! empty( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] )
+		);
+		if ( ! $is_amp_xhr ) {
 			return;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -249,7 +249,7 @@ class AMP_Theme_Support {
 		add_filter( 'comment_form_defaults', array( __CLASS__, 'filter_comment_form_defaults' ) );
 		add_filter( 'comment_reply_link', array( __CLASS__, 'filter_comment_reply_link' ), 10, 4 );
 		add_filter( 'cancel_comment_reply_link', array( __CLASS__, 'filter_cancel_comment_reply_link' ), 10, 3 );
-		add_action( 'comment_form', array( __CLASS__, 'add_amp_comment_form_templates' ), 100 );
+		add_action( 'comment_form', array( __CLASS__, 'amend_comment_form' ), 100 );
 		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 
 		if ( AMP_Validation_Utils::should_validate_response() ) {
@@ -444,7 +444,7 @@ class AMP_Theme_Support {
 		 */
 		$message = apply_filters( 'amp_comment_posted_message', $message, $comment );
 
-		// Message will be shown in template defined by AMP_Theme_Support::add_amp_comment_form_templates().
+		// Message will be shown in template defined by AMP_Theme_Support::amend_comment_form().
 		wp_send_json( array(
 			'message' => self::wp_kses_amp_mustache( $message ),
 		) );
@@ -484,7 +484,7 @@ class AMP_Theme_Support {
 			$error = $error->get_error_message();
 		}
 
-		// Message will be shown in template defined by AMP_Theme_Support::add_amp_comment_form_templates().
+		// Message will be shown in template defined by AMP_Theme_Support::amend_comment_form().
 		wp_send_json( array(
 			'error' => self::wp_kses_amp_mustache( $error ),
 		) );
@@ -643,8 +643,12 @@ class AMP_Theme_Support {
 	/**
 	 * Adds the form submit success and fail templates.
 	 */
-	public static function add_amp_comment_form_templates() {
+	public static function amend_comment_form() {
 		?>
+		<?php if ( is_singular() && ! amp_is_canonical() ) : ?>
+			<input type="hidden" name="redirect_to" value="<?php echo esc_url( amp_get_permalink( get_the_ID() ) ); ?>">
+		<?php endif; ?>
+
 		<div submit-success>
 			<template type="amp-mustache">
 				<p>{{{message}}}</p>

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -95,6 +95,39 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amend_comment_form().
+	 *
+	 * @covers AMP_Theme_Support::amend_comment_form()
+	 */
+	public function test_amend_comment_form() {
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertTrue( is_singular() );
+
+		// Test native AMP.
+		add_theme_support( 'amp' );
+		$this->assertTrue( amp_is_canonical() );
+		ob_start();
+		AMP_Theme_Support::amend_comment_form();
+		$output = ob_get_clean();
+		$this->assertNotContains( '<input type="hidden" name="redirect_to"', $output );
+		$this->assertContains( '<div submit-success>', $output );
+		$this->assertContains( '<div submit-error>', $output );
+
+		// Test paired AMP.
+		add_theme_support( 'amp', array(
+			'template_dir' => 'amp-templates',
+		) );
+		$this->assertFalse( amp_is_canonical() );
+		ob_start();
+		AMP_Theme_Support::amend_comment_form();
+		$output = ob_get_clean();
+		$this->assertContains( '<input type="hidden" name="redirect_to"', $output );
+		$this->assertContains( '<div submit-success>', $output );
+		$this->assertContains( '<div submit-error>', $output );
+	}
+
+	/**
 	 * Test prepare_response.
 	 *
 	 * @global WP_Widget_Factory $wp_widget_factory

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -279,6 +279,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::handle_xhr_request();
 		$this->assertEmpty( AMP_Theme_Support::$headers_sent );
 
+		$_GET['_wp_amp_action_xhr_converted'] = '1';
+
 		// Try bad source origin.
 		$_GET['__amp_source_origin'] = 'http://evil.example.com/';
 		$_SERVER['REQUEST_METHOD']   = 'POST';


### PR DESCRIPTION
Fixes #1028:

1. When in paired mode, if I submit the comment at https://paired-ampconfdemo.pantheonsite.io/2018/02/06/are-you-there-lebron-its-me-lebron-a-superstars-ultimate-pep-talk/amp/ then it will redirect me to the non-AMP article. The `comment_post_redirect` filter should be making sure that if paired mode is enabled that it redirects to the AMP version of the post instead. 

2. Related: when in non-paired mode such as at https://paired-ampconfdemo.pantheonsite.io/2018/02/06/are-you-there-lebron-its-me-lebron-a-superstars-ultimate-pep-talk/#respond I cannot submit the form. Why? Because the `amp-runtime` script is erroneously getting enqueued. This results in:

![image](https://user-images.githubusercontent.com/134745/37738257-a12ae16e-2d13-11e8-9b5e-dde6721d8b17.png)

This regression was introduced in https://github.com/Automattic/amp-wp/pull/1023

3. When submitting a comment from a site I can see now that `_wp_amp_action_xhr_converted` really should be used to determine whether the logic in `AMP_Theme_Support::handle_xhr_request()` runs. 