### PR TITLE
Check if  argument is empty and initialize it properly

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -373,10 +373,10 @@ function amp_get_analytics( $analytics = array() ) {
  *
  * @since 0.7
  *
- * @param array $analytics Analytics entries.
+ * @param array|string $analytics Analytics entries, or empty string when called via wp_footer action.
  */
 function amp_print_analytics( $analytics ) {
-	if ( empty( $analytics ) ) {
+	if ( '' === $analytics ) {
 		$analytics = array();
 	}
 	$analytics_entries = amp_get_analytics( $analytics );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -376,6 +376,9 @@ function amp_get_analytics( $analytics = array() ) {
  * @param array $analytics Analytics entries.
  */
 function amp_print_analytics( $analytics ) {
+	if ( empty( $analytics ) ) {
+		$analytics = array();
+	}
 	$analytics_entries = amp_get_analytics( $analytics );
 
 	if ( empty( $analytics_entries ) ) {

--- a/tests/test-amp-analytics-options.php
+++ b/tests/test-amp-analytics-options.php
@@ -257,7 +257,34 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 		amp_print_analytics( $analytics );
 		$output = ob_get_clean();
 
-		$this->assertEquals( 0, strpos( $output, '<amp-analytics' ) );
+		$this->assertStringStartsWith( '<amp-analytics', $output );
+		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
+	}
+
+	/**
+	 * Test amp_print_analytics() when empty, called via wp_footer.
+	 *
+	 * Note that wp_footer action passes empty string to any handlers.
+	 * This test asserts that an issue discovered in PHP 7.1 is fixed.
+	 *
+	 * @see AMP_Theme_Support::add_hooks() Where add_action( 'wp_footer', 'amp_print_analytics' ) is done.
+	 * @covers \amp_print_analytics()
+	 */
+	public function test_amp_print_analytics_when_empty() {
+
+		ob_start();
+		amp_print_analytics( '' );
+		$this->assertEmpty( ob_get_clean() );
+
+		$this->insert_one_option(
+			$this->vendor,
+			$this->config_one
+		);
+		ob_start();
+		amp_print_analytics( '' );
+		$output = ob_get_clean();
+		$this->assertStringStartsWith( '<amp-analytics', $output );
+		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
 	}
 
 }


### PR DESCRIPTION
Check for the edge case when the $analytics argument passed to amp_print_analytics() is empty and initialize it properly. This happened because the function is hooked into `wp_footer` (````add_action( 'wp_footer', 'amp_print_analytics' );```` and when `do_action( 'wp_footer' )` is called, it passes an empty string as the first arg to amp_print_analytics.