### PR TITLE
Fix the order in which ensure_required_markup() is called

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -2,6 +2,7 @@ PATH_EXCLUDES_PATTERN=includes/lib/
 DEFAULT_BASE_BRANCH=develop
 ASSETS_DIR=wp-assets
 PROJECT_SLUG=amp
+SKIP_ECHO_PATHS_SCOPE=1
 
 function after_wp_install {
     echo "Installing REST API..."

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -887,11 +887,6 @@ class AMP_Theme_Support {
 	public static function ensure_required_markup( DOMDocument $dom ) {
 		$xpath = new DOMXPath( $dom );
 
-		// First ensure the mandatory amp attribute is present on the html element, as otherwise it will be stripped entirely.
-		if ( ! $dom->documentElement->hasAttribute( 'amp' ) && ! $dom->documentElement->hasAttribute( '⚡️' ) ) {
-			$dom->documentElement->setAttribute( 'amp', '' );
-		}
-
 		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
 		if ( ! $head ) {
 			$head = $dom->createElement( 'head' );
@@ -952,15 +947,6 @@ class AMP_Theme_Support {
 				'href' => self::get_current_canonical_url(),
 			) );
 			$head->appendChild( $rel_canonical );
-		}
-
-		// Make sure scripts from the body get moved to the head.
-		$scripts = array();
-		foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
-			$scripts[] = $script;
-		}
-		foreach ( $scripts as $script ) {
-			$head->appendChild( $script );
 		}
 	}
 
@@ -1098,9 +1084,25 @@ class AMP_Theme_Support {
 		}
 		$dom = AMP_DOM_Utils::get_dom( $response );
 
-		self::ensure_required_markup( $dom );
+		$xpath = new DOMXPath( $dom );
+
+		// Make sure scripts from the body get moved to the head.
+		$scripts = array();
+		foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
+			$scripts[] = $script;
+		}
+		foreach ( $scripts as $script ) {
+			$head->appendChild( $script );
+		}
+
+		// First ensure the mandatory amp attribute is present on the html element, as otherwise it will be stripped entirely.
+		if ( ! $dom->documentElement->hasAttribute( 'amp' ) && ! $dom->documentElement->hasAttribute( '⚡️' ) ) {
+			$dom->documentElement->setAttribute( 'amp', '' );
+		}
 
 		$assets = AMP_Content_Sanitizer::sanitize_document( $dom, self::$sanitizer_classes, $args );
+
+		self::ensure_required_markup( $dom );
 
 		// @todo If 'utf-8' is not the blog charset, then we'll need to do some character encoding conversation or "entityification".
 		if ( 'utf-8' !== strtolower( get_bloginfo( 'charset' ) ) ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -885,8 +885,6 @@ class AMP_Theme_Support {
 	 * @param DOMDocument $dom Doc.
 	 */
 	public static function ensure_required_markup( DOMDocument $dom ) {
-		$xpath = new DOMXPath( $dom );
-
 		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
 		if ( ! $head ) {
 			$head = $dom->createElement( 'head' );
@@ -1086,16 +1084,20 @@ class AMP_Theme_Support {
 
 		$xpath = new DOMXPath( $dom );
 
-		// Make sure scripts from the body get moved to the head.
-		$scripts = array();
-		foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
-			$scripts[] = $script;
-		}
-		foreach ( $scripts as $script ) {
-			$head->appendChild( $script );
+		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
+
+		if ( isset( $head ) ) {
+			// Make sure scripts from the body get moved to the head.
+			$scripts = array();
+			foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
+				$scripts[] = $script;
+			}
+			foreach ( $scripts as $script ) {
+				$head->appendChild( $script );
+			}
 		}
 
-		// First ensure the mandatory amp attribute is present on the html element, as otherwise it will be stripped entirely.
+		// Ensure the mandatory amp attribute is present on the html element, as otherwise it will be stripped entirely.
 		if ( ! $dom->documentElement->hasAttribute( 'amp' ) && ! $dom->documentElement->hasAttribute( '⚡️' ) ) {
 			$dom->documentElement->setAttribute( 'amp', '' );
 		}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -253,7 +253,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// MathML script was added.
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-	}	
+	}
 
 	/**
 	 * Test prepare_response for bad/non-HTML.


### PR DESCRIPTION
The order in which `ensure_required_markup` was being called was causing the viewport meta tag to be stripped out by the sanitizer.