### PR TITLE
Add runtime CSS minification, !important replacement, and tree shaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
      env: WP_VERSION=4.7
 
 install:
+  - if [[ $DEV_LIB_SKIP =~ composer ]]; then composer install --no-dev; fi
   - nvm install 6 && nvm use 6
   - export DEV_LIB_PATH=dev-lib
   - source $DEV_LIB_PATH/travis.install.sh

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,15 +84,21 @@ module.exports = function( grunt ) {
 				args: [ 'ls-files' ]
 			},
 			function( err, res ) {
+				var paths;
 				if ( err ) {
 					throw new Error( err.message );
 				}
 
+				paths = res.stdout.trim().split( /\n/ ).filter( function( file ) {
+					return ! /^(\.|bin|([^/]+)+\.(md|json|xml)|Gruntfile\.js|tests|wp-assets|dev-lib|readme\.md|composer\..*)/.test( file );
+				} );
+				paths.push( 'vendor/autoload.php' );
+				paths.push( 'vendor/composer/**' );
+				paths.push( 'vendor/sabberworm/php-css-parser/lib/**' );
+
 				grunt.config.set( 'copy', {
 					build: {
-						src: res.stdout.trim().split( /\n/ ).filter( function( file ) {
-							return ! /^(\.|bin|([^/]+)+\.(md|json|xml)|Gruntfile\.js|tests|wp-assets|dev-lib|readme\.md|composer\..*)/.test( file );
-						} ),
+						src: paths,
 						dest: 'build',
 						expand: true
 					}

--- a/amp.php
+++ b/amp.php
@@ -59,6 +59,12 @@ require_once AMP__DIR__ . '/includes/amp-helper-functions.php';
 require_once AMP__DIR__ . '/includes/admin/functions.php';
 
 register_activation_hook( __FILE__, 'amp_activate' );
+
+/**
+ * Handle activation of plugin.
+ *
+ * @since 0.2
+ */
 function amp_activate() {
 	amp_after_setup_theme();
 	if ( ! did_action( 'amp_init' ) ) {
@@ -68,8 +74,14 @@ function amp_activate() {
 }
 
 register_deactivation_hook( __FILE__, 'amp_deactivate' );
+
+/**
+ * Handle deactivation of plugin.
+ *
+ * @since 0.2
+ */
 function amp_deactivate() {
-	// We need to manually remove the amp endpoint
+	// We need to manually remove the amp endpoint.
 	global $wp_rewrite;
 	foreach ( $wp_rewrite->endpoints as $index => $endpoint ) {
 		if ( amp_get_slug() === $endpoint[1] ) {
@@ -147,8 +159,16 @@ function amp_init() {
 	add_action( 'wp', 'amp_maybe_add_actions' );
 }
 
-// Make sure the `amp` query var has an explicit value.
-// Avoids issues when filtering the deprecated `query_string` hook.
+/**
+ * Make sure the `amp` query var has an explicit value.
+ *
+ * This avoids issues when filtering the deprecated `query_string` hook.
+ *
+ * @since 0.3.3
+ *
+ * @param array $query_vars Query vars.
+ * @return array Query vars.
+ */
 function amp_force_query_var_value( $query_vars ) {
 	if ( isset( $query_vars[ amp_get_slug() ] ) && '' === $query_vars[ amp_get_slug() ] ) {
 		$query_vars[ amp_get_slug() ] = 1;
@@ -267,20 +287,41 @@ function amp_is_canonical() {
 	return false;
 }
 
+/**
+ * Load classes.
+ *
+ * @since 0.2
+ * @deprecated As of 0.6 since autoloading is now employed.
+ */
 function amp_load_classes() {
 	_deprecated_function( __FUNCTION__, '0.6' );
 }
 
+/**
+ * Add frontend actions.
+ *
+ * @since 0.2
+ */
 function amp_add_frontend_actions() {
 	require_once AMP__DIR__ . '/includes/amp-frontend-actions.php';
 }
 
+/**
+ * Add post template actions.
+ *
+ * @since 0.2
+ */
 function amp_add_post_template_actions() {
 	require_once AMP__DIR__ . '/includes/amp-post-template-actions.php';
 	require_once AMP__DIR__ . '/includes/amp-post-template-functions.php';
 	amp_post_template_init_hooks();
 }
 
+/**
+ * Add action to do post template rendering at template_redirect action.
+ *
+ * @since 0.2
+ */
 function amp_prepare_render() {
 	add_action( 'template_redirect', 'amp_render' );
 }

--- a/amp.php
+++ b/amp.php
@@ -21,12 +21,29 @@
 function _amp_print_php_version_admin_notice() {
 	?>
 	<div class="notice notice-error">
-			<p><?php esc_html_e( 'The AMP plugin requires PHP 5.3+. Please contact your host to update your PHP version.', 'amp' ); ?></p>
-		</div>
+		<p><?php esc_html_e( 'The AMP plugin requires PHP 5.3+. Please contact your host to update your PHP version.', 'amp' ); ?></p>
+	</div>
 	<?php
 }
 if ( version_compare( phpversion(), '5.3', '<' ) ) {
 	add_action( 'admin_notices', '_amp_print_php_version_admin_notice' );
+	return;
+}
+
+/**
+ * Print admin notice when composer install has not been performed.
+ *
+ * @since 1.0
+ */
+function _amp_print_composer_install_admin_notice() {
+	?>
+	<div class="notice notice-error">
+		<p><?php esc_html_e( 'You appear to be running the AMP plugin from source. Please do `composer install` to finish installation.', 'amp' ); ?></p>
+	</div>
+	<?php
+}
+if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) || ! file_exists( __DIR__ . '/vendor/sabberworm/php-css-parser' ) ) {
+	add_action( 'admin_notices', '_amp_print_composer_install_admin_notice' );
 	return;
 }
 

--- a/amp.php
+++ b/amp.php
@@ -25,7 +25,7 @@ function _amp_print_php_version_admin_notice() {
 	</div>
 	<?php
 }
-if ( version_compare( phpversion(), '5.3', '<' ) ) {
+if ( version_compare( phpversion(), '5.3.2', '<' ) ) {
 	add_action( 'admin_notices', '_amp_print_php_version_admin_notice' );
 	return;
 }

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -356,12 +356,37 @@ def GetTagSpec(tag_spec, attr_lists):
 		for (field_descriptor, field_value) in tag_spec.cdata.ListFields():
 			if isinstance(field_value, (unicode, str, bool, int)):
 				cdata_dict[ field_descriptor.name ] = field_value
-			else:
-				if hasattr( field_value, '_values' ):
-					cdata_dict[ field_descriptor.name ] = {}
-					for _value in field_value._values:
-						for (key,val) in _value.ListFields():
-							cdata_dict[ field_descriptor.name ][ key.name ] = val
+			elif hasattr( field_value, '_values' ):
+				cdata_dict[ field_descriptor.name ] = {}
+				for _value in field_value._values:
+					for (key,val) in _value.ListFields():
+						cdata_dict[ field_descriptor.name ][ key.name ] = val
+			elif 'css_spec' == field_descriptor.name:
+				css_spec = {}
+
+				css_spec['at_rules'] = []
+				for at_rule_spec in field_value.at_rule_spec:
+					if '$DEFAULT' == at_rule_spec.name:
+						continue
+					css_spec['at_rules'].append( at_rule_spec.name )
+
+				for css_spec_field_name in ( 'allowed_declarations', 'font_url_spec', 'image_url_spec', 'validate_keyframes' ):
+					if not hasattr( field_value, css_spec_field_name ):
+						continue
+					css_spec_field_value = getattr( field_value, css_spec_field_name )
+					if isinstance(css_spec_field_value, (list, collections.Sequence, google.protobuf.internal.containers.RepeatedScalarFieldContainer)):
+						css_spec[ css_spec_field_name ] = [ val for val in css_spec_field_value ]
+					elif hasattr( css_spec_field_value, 'ListFields' ):
+						css_spec[ css_spec_field_name ] = {}
+						for (css_spec_field_item_descriptor, css_spec_field_item_value) in getattr( field_value, css_spec_field_name ).ListFields():
+							if isinstance(css_spec_field_item_value, (list, collections.Sequence, google.protobuf.internal.containers.RepeatedScalarFieldContainer)):
+								css_spec[ css_spec_field_name ][ css_spec_field_item_descriptor.name ] = [ val for val in css_spec_field_item_value ]
+							else:
+								css_spec[ css_spec_field_name ][ css_spec_field_item_descriptor.name ] = css_spec_field_item_value
+					else:
+						css_spec[ css_spec_field_name ] = css_spec_field_value
+
+				cdata_dict['css_spec'] = css_spec
 		if len( cdata_dict ) > 0:
 			tag_spec_dict['cdata'] = cdata_dict
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -364,11 +364,11 @@ def GetTagSpec(tag_spec, attr_lists):
 			elif 'css_spec' == field_descriptor.name:
 				css_spec = {}
 
-				css_spec['at_rules'] = []
+				css_spec['allowed_at_rules'] = []
 				for at_rule_spec in field_value.at_rule_spec:
 					if '$DEFAULT' == at_rule_spec.name:
 						continue
-					css_spec['at_rules'].append( at_rule_spec.name )
+					css_spec['allowed_at_rules'].append( at_rule_spec.name )
 
 				for css_spec_field_name in ( 'allowed_declarations', 'font_url_spec', 'image_url_spec', 'validate_keyframes' ):
 					if not hasattr( field_value, css_spec_field_name ):

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "type": "wordpress-plugin",
     "license": "GPL-2.0",
     "version": "1.0.0",
+    "require": {
+        "sabberworm/php-css-parser": "*"
+    },
     "require-dev": {
         "wp-coding-standards/wpcs": "^0.14.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,14 @@
     "type": "wordpress-plugin",
     "license": "GPL-2.0",
     "version": "1.0.0",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/xwp/PHP-CSS-Parser"
+        }
+    ],
     "require": {
-        "sabberworm/php-css-parser": "*"
+        "sabberworm/php-css-parser": "dev-master"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4859d4cee2cb9fec9dc6e86f80459837",
+    "content-hash": "3e2682fa9441981321b1f903b75abb25",
     "packages": [
         {
             "name": "sabberworm/php-css-parser",
-            "version": "8.1.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
-                "reference": "850cbbcbe7fbb155387a151ea562897a67e242ef"
+                "url": "https://github.com/xwp/PHP-CSS-Parser.git",
+                "reference": "e3204589287c28396b3db16b92ec30dab19ac2e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/850cbbcbe7fbb155387a151ea562897a67e242ef",
-                "reference": "850cbbcbe7fbb155387a151ea562897a67e242ef",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/e3204589287c28396b3db16b92ec30dab19ac2e9",
+                "reference": "e3204589287c28396b3db16b92ec30dab19ac2e9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "autoload": {
@@ -32,7 +32,6 @@
                     "Sabberworm\\CSS": "lib/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -48,7 +47,10 @@
                 "parser",
                 "stylesheet"
             ],
-            "time": "2016-07-19T19:14:21+00:00"
+            "support": {
+                "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
+            },
+            "time": "2018-04-01 07:35:36"
         }
     ],
     "packages-dev": [
@@ -266,7 +268,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "sabberworm/php-css-parser": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,53 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "984ff0ea17c1c8dff71e6e2e2e9dc8a0",
-    "packages": [],
+    "content-hash": "4859d4cee2cb9fec9dc6e86f80459837",
+    "packages": [
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
+                "reference": "850cbbcbe7fbb155387a151ea562897a67e242ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/850cbbcbe7fbb155387a151ea562897a67e242ef",
+                "reference": "850cbbcbe7fbb155387a151ea562897a67e242ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sabberworm\\CSS": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "http://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "time": "2016-07-19T19:14:21+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -77,16 +122,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
-                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
                 "shasum": ""
             },
             "require": {
@@ -96,7 +141,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -124,7 +169,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-19T21:44:46+00:00"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "wimg/php-compatibility",
@@ -180,16 +225,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c"
+                "reference": "cf6b310caad735816caef7573295f8a534374706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8cadf48fa1c70b2381988e0a79e029e011a8f41c",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "reference": "cf6b310caad735816caef7573295f8a534374706",
                 "shasum": ""
             },
             "require": {
@@ -216,7 +261,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-11-01T15:10:46+00:00"
+            "time": "2018-02-16T01:57:48+00:00"
         }
     ],
     "aliases": [],

--- a/contributing.md
+++ b/contributing.md
@@ -2,10 +2,21 @@
 
 Thanks for taking the time to contribute!
 
-To clone this repository
-``` bash
-$ git clone --recursive git@github.com:Automattic/amp-wp.git
+To start, clone this repository into your WordPress install being used for development:
+
+```bash
+cd wp-content/plugins && git clone --recursive git@github.com:Automattic/amp-wp.git amp
 ```
+
+If you happened to have cloned without `--recursive` previously, please do `git submodule update --init` to ensure the [dev-lib](https://github.com/xwp/wp-dev-lib/) submodule is available for development.
+
+Lastly, to get the plugin running in your WordPress install, run `composer install` and then activate the plugin via the WordPress dashboard or `wp plugin activate amp`.
+
+To install the `pre-commit` hook, do `bash dev-lib/install-pre-commit-hook.sh`.
+
+Note that pull requests will be checked against [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) with PHPCS, and for JavaScript linting is done with ESLint and (for now) JSCS and JSHint.
+
+To run the Grunt commands, please first `npm install -g grunt-cli` and then `npm install`.
 
 ## Updating Allowed Tags And Attributes
 
@@ -72,6 +83,7 @@ When you push a commit to your PR, Travis CI will run the PHPUnit tests and snif
 
 Contributors who want to make a new release, follow these steps:
 
+0. Do `grunt build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
 1. Bump plugin versions in `package.json` (×1), `package-lock.json` (×1, just do `npm install` first), `composer.json` (×1), and in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
 2. Add changelog entry to readme.
 3. Merge release branch into `master`.

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -107,6 +107,12 @@ function amp_post_template_add_schemaorg_metadata() {
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_styles( $amp_template ) {
+	$stylesheets = $amp_template->get( 'post_amp_stylesheets' );
+	if ( ! empty( $stylesheets ) ) {
+		echo '/* Inline stylesheets */' . PHP_EOL; // WPCS: XSS OK.
+		echo implode( '', $stylesheets ); // WPCS: XSS OK.
+	}
+
 	$styles = $amp_template->get( 'post_amp_styles' );
 	if ( ! empty( $styles ) ) {
 		echo '/* Inline styles */' . PHP_EOL; // WPCS: XSS OK.

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -131,6 +131,10 @@ class AMP_Autoloader {
 	 * Called at the end of this file; calling a second time has no effect.
 	 */
 	public static function register() {
+		if ( file_exists( AMP__DIR__ . '/vendor/autoload.php' ) ) {
+			require_once AMP__DIR__ . '/vendor/autoload.php';
+		}
+
 		if ( ! self::$is_registered ) {
 			spl_autoload_register( array( __CLASS__, 'autoload' ) );
 			self::$is_registered = true;

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -30,6 +30,7 @@ class AMP_Autoloader {
 	 */
 	private static $_classmap = array(
 		'AMP_Theme_Support'                           => 'includes/class-amp-theme-support',
+		'AMP_Response_Headers'                        => 'includes/class-amp-response-headers',
 		'AMP_Comment_Walker'                          => 'includes/class-amp-comment-walker',
 		'AMP_Template_Customizer'                     => 'includes/admin/class-amp-customizer',
 		'AMP_Post_Meta_Box'                           => 'includes/admin/class-amp-post-meta-box',

--- a/includes/class-amp-response-headers.php
+++ b/includes/class-amp-response-headers.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Class AMP_Response_Headers
+ *
+ * @since 1.0
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Response_Headers
+ */
+class AMP_Response_Headers {
+
+	/**
+	 * Headers sent (or attempted to be sent).
+	 *
+	 * @since 1.0
+	 * @see AMP_Theme_Support::send_header()
+	 * @var array[]
+	 */
+	public static $headers_sent = array();
+
+	/**
+	 * Send an HTTP response header.
+	 *
+	 * This largely exists to facilitate unit testing but it also provides a better interface for sending headers.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param string $name  Header name.
+	 * @param string $value Header value.
+	 * @param array  $args {
+	 *     Args to header().
+	 *
+	 *     @type bool $replace     Whether to replace a header previously sent. Default true.
+	 *     @type int  $status_code Status code to send with the sent header.
+	 * }
+	 * @return bool Whether the header was sent.
+	 */
+	public static function send_header( $name, $value, $args = array() ) {
+		$args = array_merge(
+			array(
+				'replace'     => true,
+				'status_code' => null,
+			),
+			$args
+		);
+
+		self::$headers_sent[] = array_merge( compact( 'name', 'value' ), $args );
+		if ( headers_sent() ) {
+			return false;
+		}
+
+		header(
+			sprintf( '%s: %s', $name, $value ),
+			$args['replace'],
+			$args['status_code']
+		);
+		return true;
+	}
+
+	/**
+	 * Send Server-Timing header.
+	 *
+	 * @since 1.0
+	 * @todo What is the ordering in Chrome dev tools? What are the colors about?
+	 * @todo Is there a better name standardization?
+	 * @todo Is there a way to indicate nested server timings, so an outer method's own time can be seen separately from the inner method's time?
+	 *
+	 * @param string $name        Name.
+	 * @param float  $duration    Duration. If negative, will be added to microtime( true ). Optional.
+	 * @param string $description Description. Optional.
+	 * @return bool Return value of send_header call.
+	 */
+	public static function send_server_timing( $name, $duration = null, $description = null ) {
+		$value = $name;
+		if ( isset( $description ) ) {
+			$value .= sprintf( ';desc=%s', wp_json_encode( $description ) );
+		}
+		if ( isset( $duration ) ) {
+			if ( $duration < 0 ) {
+				$duration = microtime( true ) + $duration;
+			}
+			$value .= sprintf( ';dur=%f', $duration * 1000 );
+		}
+		return self::send_header( 'Server-Timing', $value, array( 'replace' => false ) );
+	}
+}

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -8422,6 +8422,35 @@ class AMP_Allowed_Tags_Generated {
 						'error_message' => 'CSS !important',
 						'regex' => '!important',
 					),
+					'css_spec' => array(
+						'allowed_declarations' => array(),
+						'at_rules' => array(
+							'font-face',
+							'keyframes',
+							'media',
+							'supports',
+						),
+						'font_url_spec' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+								'http',
+								'data',
+							),
+						),
+						'image_url_spec' => array(
+							'allow_empty' => true,
+							'allow_relative' => true,
+							'allowed_protocol' => array(
+								'https',
+								'http',
+								'data',
+								'absolute',
+							),
+						),
+						'validate_keyframes' => false,
+					),
 					'max_bytes' => 50000,
 					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#maximum-size',
 				),
@@ -8482,6 +8511,23 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'cdata' => array(
+					'css_spec' => array(
+						'allowed_declarations' => array(
+							'animation-timing-function',
+							'offset-distance',
+							'opacity',
+							'transform',
+							'visibility',
+						),
+						'at_rules' => array(
+							'keyframes',
+							'media',
+							'supports',
+						),
+						'font_url_spec' => array(),
+						'image_url_spec' => array(),
+						'validate_keyframes' => true,
+					),
 					'max_bytes' => 500000,
 					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#keyframes-stylesheet',
 				),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -8423,13 +8423,13 @@ class AMP_Allowed_Tags_Generated {
 						'regex' => '!important',
 					),
 					'css_spec' => array(
-						'allowed_declarations' => array(),
-						'at_rules' => array(
+						'allowed_at_rules' => array(
 							'font-face',
 							'keyframes',
 							'media',
 							'supports',
 						),
+						'allowed_declarations' => array(),
 						'font_url_spec' => array(
 							'allow_empty' => true,
 							'allow_relative' => true,
@@ -8512,17 +8512,17 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'cdata' => array(
 					'css_spec' => array(
+						'allowed_at_rules' => array(
+							'keyframes',
+							'media',
+							'supports',
+						),
 						'allowed_declarations' => array(
 							'animation-timing-function',
 							'offset-distance',
 							'opacity',
 							'transform',
 							'visibility',
-						),
-						'at_rules' => array(
-							'keyframes',
-							'media',
-							'supports',
 						),
 						'font_url_spec' => array(),
 						'image_url_spec' => array(),

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -55,7 +55,7 @@ abstract class AMP_Base_Sanitizer {
 	 *      @type bool $allow_dirty_styles
 	 *      @type bool $allow_dirty_scripts
 	 *      @type bool $disable_invalid_removal
-	 *      @type callable $remove_invalid_callback
+	 *      @type callable $validation_error_callback
 	 * }
 	 */
 	protected $args;

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -130,6 +130,7 @@ abstract class AMP_Base_Sanitizer {
 	 * Return array of values that would be valid as an HTML `style` attribute.
 	 *
 	 * @since 0.4
+	 * @deprecated As of 1.0, use get_stylesheets().
 	 *
 	 * @return array[][] Mapping of CSS selectors to arrays of properties.
 	 */

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -603,9 +603,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 					$selectors_parsed = array();
 					foreach ( $selectors as $selector ) {
-						$classes = array();
-						// @todo There could be a false negative here, such as when :not(body.home) is used. Nots should be first removed prior to matching.
-						if ( preg_match_all( '/(?<=\.)([a-zA-Z0-9_-]+)/', $selector, $matches ) ) {
+						$classes          = array();
+						$reduced_selector = preg_replace( '/:not\(.+?\)/', '', $selector ); // Remove :not() to eliminate false negatives.
+						if ( preg_match_all( '/(?<=\.)([a-zA-Z0-9_-]+)/', $reduced_selector, $matches ) ) {
 							$classes = $matches[0];
 						}
 						$selectors_parsed[ $selector ] = $classes;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1286,7 +1286,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'code'    => 'excessive_css',
 						'message' => sprintf(
 							/* translators: %d is the number of bytes over the limit */
-							__( 'Too much CSS enqueued (by %d bytes).', 'amp' ),
+							__( 'Too much CSS output (by %d bytes).', 'amp' ),
 							( $final_size + $sheet_size ) - $stylesheet_set['cdata_spec']['max_bytes']
 						),
 					);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -592,18 +592,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Remove properties that have illegal values. See <https://www.ampproject.org/docs/fundamentals/spec#properties>.
 		// @todo Limit transition to opacity, transform and -vendorPrefix-transform. See https://www.ampproject.org/docs/design/responsive/style_pages#restricted-styles.
-		$properties = $ruleset->getRules( 'overflow-' );
-		foreach ( $properties as $property ) {
-			if ( in_array( $property->getValue(), array( 'auto', 'scroll' ), true ) ) {
-				$validation_errors[] = array(
-					'code'           => 'illegal_css_property_value',
-					'property_name'  => $property->getRule(),
-					'property_value' => $property->getValue(),
-				);
-				$ruleset->removeRule( $property->getRule() );
-			}
-		}
-
 		$this->transform_important_qualifiers( $ruleset, $css_list );
 
 		// Delete illegal properties. See <https://www.ampproject.org/docs/design/responsive/style_pages#disallowed-styles>.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -493,6 +493,23 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
+			// Delete illegal properties. See <https://www.ampproject.org/docs/design/responsive/style_pages#disallowed-styles>.
+			$property_blacklist = array(
+				'behavior',
+				'-moz-binding',
+			);
+			foreach ( $property_blacklist as $illegal_property_name ) {
+				$properties = $ruleset->getRules( $illegal_property_name );
+				foreach ( $properties as $property ) {
+					$validation_errors[] = array(
+						'code'           => 'illegal_css_property',
+						'property_name'  => $property->getRule(),
+						'property_value' => $property->getValue(),
+					);
+					$ruleset->removeRule( $property->getRule() );
+				}
+			}
+
 			// Convert width to max-width when requested. See <https://github.com/Automattic/amp-wp/issues/494>.
 			if ( $args['convert_width_to_max_width'] ) {
 				$properties = $ruleset->getRules( 'width' );

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -603,8 +603,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 					$selectors_parsed = array();
 					foreach ( $selectors as $selector ) {
-						$classes          = array();
-						$reduced_selector = preg_replace( '/:not\(.+?\)/', '', $selector ); // Remove :not() to eliminate false negatives.
+						$classes = array();
+
+						// Remove :not() to eliminate false negatives, such as with `body:not(.title-tagline-hidden) .site-branding-text`.
+						$reduced_selector = preg_replace( '/:not\(.+?\)/', '', $selector );
+
+						// Remove attribute selectors to eliminate false negative, such as with `.social-navigation a[href*="example.com"]:before`.
+						$reduced_selector = preg_replace( '/\[\w.*?\]/', '', $reduced_selector );
+
 						if ( preg_match_all( '/(?<=\.)([a-zA-Z0-9_-]+)/', $reduced_selector, $matches ) ) {
 							$classes = $matches[0];
 						}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -71,9 +71,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 1.0
 	 * @var array[] {
-	 * @type array              $stylesheet Array of stylesheet chunked, with declaration blocks being represented as arrays.
-	 * @type DOMElement|DOMAttr $node       Origin for styles.
-	 * @type array $sources
+	 *     @type array              $stylesheet Array of stylesheet chunked, with declaration blocks being represented as arrays.
+	 *     @type DOMElement|DOMAttr $node       Origin for styles.
+	 *     @type array              $sources    Sources for the node.
+	 *     @type bool               $keyframes  Whether an amp-keyframes.
 	 * }
 	 */
 	private $pending_stylesheets = array();
@@ -92,14 +93,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var DOMElement
 	 */
 	private $amp_custom_style_element;
-
-	/**
-	 * The found style[amp-keyframe] stylesheets.
-	 *
-	 * @since 1.0
-	 * @var string[]
-	 */
-	private $keyframes_stylesheets = array();
 
 	/**
 	 * Spec for style[amp-keyframes] cdata.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -509,11 +509,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $parsed['stylesheet'] as $stylesheet_part ) {
 			if ( is_array( $stylesheet_part ) ) {
 				list( $selectors_parsed, $declaration_block ) = $stylesheet_part;
-
-				$selectors = array();
 				if ( $should_tree_shake ) {
+					$selectors = array();
 					foreach ( $selectors_parsed as $selector => $class_names ) {
-						if ( count( $class_names ) === count( array_intersect( $class_names, $this->used_class_names ) ) ) {
+						if ( 0 === count( array_diff( $class_names, $this->used_class_names ) ) ) { // If all class names are used in the doc.
 							$selectors[] = $selector;
 						}
 					}

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -17,6 +17,7 @@ class AMP_Content_Sanitizer {
 	 *
 	 * @since 0.4.1
 	 * @since 0.7 Passing return_styles=false in $global_args causes stylesheets to be returned instead of styles.
+	 * @deprecated Since 1.0
 	 *
 	 * @param string   $content HTML content string or DOM document.
 	 * @param string[] $sanitizer_classes Sanitizer classes.

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -63,6 +63,7 @@ class AMP_Content_Sanitizer {
 		$return_styles = ! empty( $args['return_styles'] );
 		unset( $args['return_styles'] );
 		foreach ( $sanitizer_classes as $sanitizer_class => $sanitizer_args ) {
+			$sanitize_class_start = microtime( true );
 			if ( ! class_exists( $sanitizer_class ) ) {
 				/* translators: %s is sanitizer class */
 				_doing_it_wrong( __METHOD__, sprintf( esc_html__( 'Sanitizer (%s) class does not exist', 'amp' ), esc_html( $sanitizer_class ) ), '0.4.1' );
@@ -90,6 +91,8 @@ class AMP_Content_Sanitizer {
 			} else {
 				$stylesheets = array_merge( $stylesheets, $sanitizer->get_stylesheets() );
 			}
+
+			AMP_Response_Headers::send_server_timing( 'amp_sanitize', -$sanitize_class_start, $sanitizer_class );
 		}
 
 		return compact( 'scripts', 'styles', 'stylesheets' );

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -34,9 +34,18 @@ class AMP_Content {
 	/**
 	 * AMP styles.
 	 *
+	 * @deprecated
 	 * @var array
 	 */
 	private $amp_styles = array();
+
+	/**
+	 * AMP stylesheets.
+	 *
+	 * @since 1.0
+	 * @var array
+	 */
+	private $amp_stylesheets = array();
 
 	/**
 	 * Args.
@@ -97,10 +106,22 @@ class AMP_Content {
 	/**
 	 * Get AMP styles.
 	 *
-	 * @return array
+	 * @deprecated Since 1.0 in favor of the get_amp_stylesheets method.
+	 * @return array Empty list.
 	 */
 	public function get_amp_styles() {
-		return $this->amp_styles;
+		_deprecated_function( __METHOD__, '1.0', __CLASS__ . '::get_amp_stylesheets' );
+		return array();
+	}
+
+	/**
+	 * Get AMP styles.
+	 *
+	 * @since 1.0
+	 * @return array
+	 */
+	public function get_amp_stylesheets() {
+		return $this->amp_stylesheets;
 	}
 
 	/**
@@ -130,12 +151,13 @@ class AMP_Content {
 	}
 
 	/**
-	 * Add styles.
+	 * Add stylesheets.
 	 *
-	 * @param array $styles Styles.
+	 * @since 1.0
+	 * @param array $stylesheets Styles.
 	 */
-	private function add_styles( $styles ) {
-		$this->amp_styles = array_merge( $this->amp_styles, $styles );
+	private function add_stylesheets( $stylesheets ) {
+		$this->amp_stylesheets = array_merge( $this->amp_stylesheets, $stylesheets );
 	}
 
 	/**
@@ -179,14 +201,16 @@ class AMP_Content {
 	 *
 	 * @see AMP_Content_Sanitizer::sanitize()
 	 * @param string $content Content.
-	 * @return array Sanitized content.
+	 * @return string Sanitized content.
 	 */
 	private function sanitize( $content ) {
-		list( $sanitized_content, $scripts, $styles ) = AMP_Content_Sanitizer::sanitize( $content, $this->sanitizer_classes, $this->args );
+		$dom = AMP_DOM_Utils::get_dom_from_content( $content );
 
-		$this->add_scripts( $scripts );
-		$this->add_styles( $styles );
+		$results = AMP_Content_Sanitizer::sanitize_document( $dom, $this->sanitizer_classes, $this->args );
 
-		return $sanitized_content;
+		$this->add_scripts( $results['scripts'] );
+		$this->add_stylesheets( $results['stylesheets'] );
+
+		return AMP_DOM_Utils::get_content_from_dom( $dom );
 	}
 }

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -129,7 +129,8 @@ class AMP_Post_Template {
 				'merriweather' => 'https://fonts.googleapis.com/css?family=Merriweather:400,400italic,700,700italic',
 			),
 
-			'post_amp_styles'       => array(),
+			'post_amp_stylesheets'  => array(),
+			'post_amp_styles'       => array(), // Deprecated.
 
 			'amp_analytics'         => amp_add_custom_analytics(),
 		);
@@ -319,7 +320,7 @@ class AMP_Post_Template {
 
 		$this->add_data_by_key( 'post_amp_content', $amp_content->get_amp_content() );
 		$this->merge_data_for_key( 'amp_component_scripts', $amp_content->get_amp_scripts() );
-		$this->merge_data_for_key( 'post_amp_styles', $amp_content->get_amp_styles() );
+		$this->add_data_by_key( 'post_amp_stylesheets', $amp_content->get_amp_stylesheets() );
 	}
 
 	/**
@@ -347,13 +348,16 @@ class AMP_Post_Template {
 
 		$featured_image = get_post( $featured_id );
 
-		list( $sanitized_html, $featured_scripts, $featured_styles ) = AMP_Content_Sanitizer::sanitize(
-			$featured_html,
+		$dom    = AMP_DOM_Utils::get_dom_from_content( $featured_html );
+		$assets = AMP_Content_Sanitizer::sanitize_document(
+			$dom,
 			array( 'AMP_Img_Sanitizer' => array() ),
 			array(
 				'content_max_width' => $this->get( 'content_max_width' ),
 			)
 		);
+
+		$sanitized_html = AMP_DOM_Utils::get_content_from_dom( $dom );
 
 		$this->add_data_by_key(
 			'featured_image', array(
@@ -362,12 +366,12 @@ class AMP_Post_Template {
 			)
 		);
 
-		if ( $featured_scripts ) {
-			$this->merge_data_for_key( 'amp_component_scripts', $featured_scripts );
+		if ( $assets['scripts'] ) {
+			$this->merge_data_for_key( 'amp_component_scripts', $assets['scripts'] );
 		}
 
-		if ( $featured_styles ) {
-			$this->merge_data_for_key( 'post_amp_styles', $featured_styles );
+		if ( $assets['stylesheets'] ) {
+			$this->merge_data_for_key( 'post_amp_stylesheets', $assets['stylesheets'] );
 		}
 	}
 

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -411,7 +411,9 @@ class AMP_Validation_Utils {
 			$node = $data['node'];
 			unset( $data['node'] );
 			$data['node_name'] = $node->nodeName;
-			$data['sources']   = self::locate_sources( $node );
+			if ( ! isset( $data['sources'] ) ) {
+				$data['sources'] = self::locate_sources( $node );
+			}
 			if ( $node->parentNode ) {
 				$data['parent_name'] = $node->parentNode->nodeName;
 			}

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 **Tested up to:** 4.9  
 **Stable tag:** 0.6.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
-**Requires PHP:** 5.3  
+**Requires PHP:** 5.3.2  
 
 [![Build Status](https://travis-ci.org/Automattic/amp-wp.svg?branch=master)](https://travis-ci.org/Automattic/amp-wp) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) 
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 4.9
 Stable tag: 0.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Requires PHP: 5.3
+Requires PHP: 5.3.2
 
 Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -265,6 +265,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, array(
 			'use_document_element' => true,
+			'remove_unused_rules'  => 'always',
 		) );
 		$sanitizer->sanitize();
 
@@ -299,6 +300,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, array(
 			'use_document_element' => true,
+			'remove_unused_rules'  => 'always',
 		) );
 		$sanitizer->sanitize();
 		AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
@@ -386,7 +388,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	public function test_keyframe_sanitizer( $source, $expected = null ) {
 		$expected  = isset( $expected ) ? $expected : $source;
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Style_Sanitizer( $dom );
+		$sanitizer = new AMP_Style_Sanitizer( $dom, array(
+			'use_document_element' => true,
+		) );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$content = preg_replace( '#\s+(?=@keyframes)#', '', $content );

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -209,6 +209,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'body.foo:not(.bar) > p{color:blue;}body.foo:not(.bar) p:not(.baz){color:green;}body.foo p{color:yellow;}',
 				),
 			),
+			'style_with_attribute_selectors' => array(
+				'<html amp><head><meta charset="utf-8"><style amp-custom>.social-navigation a[href*="example.com"] { color:red; } .social-navigation a.examplecom { color:blue; }</style></head><body class="foo"><nav class="social-navigation"><a href="https://example.com/">Example</a></nav></body>',
+				array(
+					'.social-navigation a[href*="example.com"]{color:red;}',
+				),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -110,7 +110,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'.amp-wp-2864855{background:#000;}',
 				),
-
 			),
 
 			'inline_style_element_with_multiple_rules_containing_selectors_is_removed' => array(
@@ -118,6 +117,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<div><span>bold!</span></div>',
 				array(
 					'div > span{font-weight:bold;font-style:italic;}',
+				),
+			),
+
+			'illegal_unsafe_properties' => array(
+				'<style>button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ }</style><button>Click</button>',
+				'<button>Click</button>',
+				array(
+					'button{font-weight:bold;}',
 				),
 			),
 		);

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -122,6 +122,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'illegal_at_rule_in_style_attribute' => array(
+				'<span style="color:brown; @media screen { color:green }">Parse error.</span>',
+				'<span>Parse error.</span>',
+				array(),
+			),
+
 			'illegal_at_rules_removed' => array(
 				'<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { width: device-width; } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>',
 				'',
@@ -249,8 +255,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		return array(
 			'style_amp_keyframes'              => array(
-				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) {@keyframes foo {} }</style>',
-				null, // No Change.
+				'<style amp-keyframes>@keyframes anim1 { from { opacity:0.0 } to { opacity:0.5 } } @media (min-width: 600px) {@keyframes anim1 { from { opacity:0.5 } to { opacity:1.0 } } }</style>',
+				'<style amp-keyframes="">@keyframes anim1{from{opacity:0;}to{opacity:.5;}}@media (min-width: 600px){@keyframes anim1{from{opacity:.5;}to{opacity:1;}}}</style>',
 			),
 
 			'style_amp_keyframes_max_overflow' => array(
@@ -260,7 +266,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'style_amp_keyframes_last_child'   => array(
 				'<b>before</b> <style amp-keyframes>@keyframes anim1 {}</style> between <style amp-keyframes>@keyframes anim2 {}</style> as <b>after</b>',
-				'<b>before</b> between  as <b>after</b><style amp-keyframes>@keyframes anim1 {}@keyframes anim2 {}</style>',
+				'<b>before</b> between  as <b>after</b><style amp-keyframes="">@keyframes anim1{}@keyframes anim2{}</style>',
+			),
+
+			'blacklisted_and_whitelisted_keyframe_properties' => array(
+				'<style amp-keyframes>@keyframes anim1 { 50% { width: 50%; animation-timing-function: ease; opacity: 0.5; height:10%; offset-distance: 50%; visibility: visible; transform: rotate(0.5turn); -webkit-transform: rotate(0.5turn); color:red; } }</style>',
+				'<style amp-keyframes="">@keyframes anim1{50%{animation-timing-function:ease;opacity:.5;offset-distance:50%;visibility:visible;transform:rotate(.5 turn);-webkit-transform:rotate(.5 turn);}}</style>',
+			),
+
+			'style_amp_keyframes_with_disallowed_rules' => array(
+				'<style amp-keyframes>body { color:red; opacity:1; } @keyframes anim1 { 50% { opacity:0.5 !important; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); }</style>',
+				'<style amp-keyframes="">@keyframes anim1{50%{opacity:.5;}}</style>',
 			),
 		);
 	}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -113,10 +113,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'inline_style_element_with_multiple_rules_containing_selectors_is_removed' => array(
-				'<style>div > span { font-weight:bold !important; overflow: scroll; font-style: italic; }</style><div><span>bold!</span></div>',
+				'<style>div > span { font-weight:bold !important; overflow: scroll; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; overflow: auto; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				array(
-					'div > span{font-style:italic;}:root:not(#FK_ID) div > span{font-weight:bold;}',
+					'div > span{font-style:italic;}@media screen and ( max-width: 640px ){div > span{font-style:normal;}:root:not(#FK_ID) div > span{font-weight:normal;}}:root:not(#FK_ID) div > span{font-weight:bold;}',
 				),
 			),
 
@@ -125,6 +125,22 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<button>Click</button>',
 				array(
 					'button{font-weight:bold;}',
+				),
+			),
+
+			'illegal_at_rules_removed' => array(
+				'<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { width: device-width; } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>',
+				'',
+				array(
+					'body{color:black;}',
+				),
+			),
+
+			'allowed_at_rules_retained' => array(
+				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style>',
+				'',
+				array(
+					'@media screen and ( max-width: 640px ){body{font-size:small;}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2");}@supports (display: grid){div{display:grid;}}@-moz-keyframes appear{from{opacity:0;}to{opacity:1;}}@keyframes appear{from{opacity:0;}to{opacity:1;}}',
 				),
 			),
 		);

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -29,7 +29,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color: #00ff00;">This is green.</span>',
 				'<span class="amp-wp-bb01159">This is green.</span>',
 				array(
-					'.amp-wp-bb01159{color:#0f0;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0;}',
 				),
 			),
 
@@ -37,7 +37,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color  :   #00ff00">This is green.</span>',
 				'<span class="amp-wp-0837823">This is green.</span>',
 				array(
-					'.amp-wp-0837823{color:#0f0;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-0837823{color:#0f0;}',
 				),
 			),
 
@@ -45,7 +45,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color: #00ff00; background-color: #000; ">This is green.</span>',
 				'<span class="amp-wp-c71affe">This is green.</span>',
 				array(
-					'.amp-wp-c71affe{color:#0f0;background-color:#000;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c71affe{color:#0f0;background-color:#000;}',
 				),
 			),
 
@@ -53,7 +53,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure style="width: 300px"></figure>',
 				'<figure class="amp-wp-343bce0"></figure>',
 				array(
-					'.amp-wp-343bce0{max-width:300px;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-343bce0{max-width:300px;}',
 				),
 			),
 
@@ -61,7 +61,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				'<span class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				array(
-					'.amp-wp-224b51a{display:none;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none;}',
 				),
 			),
 
@@ -69,7 +69,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="padding:1px; margin: 2px !important; outline: 3px;">!important is converted.</span>',
 				'<span class="amp-wp-6a75598">!important is converted.</span>',
 				array(
-					'.amp-wp-6a75598{padding:1px;outline:3px;}:root:not(#FK_ID) .amp-wp-6a75598{margin:2px;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{padding:1px;outline:3px;}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{margin:2px;}',
 				),
 			),
 
@@ -77,7 +77,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color: red  !  important;">!important is converted.</span>',
 				'<span class="amp-wp-952600b">!important is converted.</span>',
 				array(
-					':root:not(#FK_ID) .amp-wp-952600b{color:red;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-952600b{color:red;}',
 				),
 			),
 
@@ -85,7 +85,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color: red !important; background: blue!important;">!important is converted.</span>',
 				'<span class="amp-wp-1e2bfaa">!important is converted.</span>',
 				array(
-					':root:not(#FK_ID) .amp-wp-1e2bfaa{color:red;background:blue;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-1e2bfaa{color:red;background:blue;}',
 				),
 			),
 
@@ -93,8 +93,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
 				'<span class="amp-wp-bb01159"><span class="amp-wp-cc68ddc">This is red.</span></span>',
 				array(
-					'.amp-wp-bb01159{color:#0f0;}',
-					'.amp-wp-cc68ddc{color:#f00;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cc68ddc{color:#f00;}',
 				),
 			),
 
@@ -102,7 +102,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure class="alignleft" style="background: #000"></figure>',
 				'<figure class="alignleft amp-wp-2864855"></figure>',
 				array(
-					'.amp-wp-2864855{background:#000;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-2864855{background:#000;}',
 				),
 			),
 
@@ -110,7 +110,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<style>div > span { font-weight:bold !important; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				array(
-					'div > span{font-style:italic;}@media screen and ( max-width: 640px ){div > span{font-style:normal;}:root:not(#FK_ID) div > span{font-weight:normal;}}:root:not(#FK_ID) div > span{font-weight:bold;}',
+					'div > span{font-style:italic;}@media screen and ( max-width: 640px ){div > span{font-style:normal;}:root:not(#_):not(#_) div > span{font-weight:normal;}}:root:not(#_):not(#_) div > span{font-weight:bold;}',
 				),
 			),
 
@@ -141,6 +141,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'',
 				array(
 					'@media screen and ( max-width: 640px ){body{font-size:small;}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2");}@supports (display: grid){div{display:grid;}}@-moz-keyframes appear{from{opacity:0;}to{opacity:1;}}@keyframes appear{from{opacity:0;}to{opacity:1;}}',
+				),
+			),
+
+			'selector_specificity' => array(
+				'<style>#child {color:red !important;} #parent #child {color:pink !important;} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div>',
+				'<div id="parent"><span id="child" class="foo bar baz">one</span><span class="amp-wp-64b4fd4">two</span><span class="amp-wp-ab79d9e">three</span></div>',
+				array(
+					':root:not(#_) #child{color:red;}:root:not(#_):not(#_) #parent #child{color:pink;}:root:not(#_) .foo{color:blue;}:root:not(#_):not(#_) #me .foo{color:green;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-ab79d9e{color:purple;}',
 				),
 			),
 		);
@@ -179,9 +189,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'multiple_amp_custom_and_other_styles' => array(
 				'<html amp><head><meta charset="utf-8"><style amp-custom>b {color:red !important}</style><style amp-custom>i {color:blue}</style><style type="text/css">u {color:green; text-decoration: underline !important;}</style></head><body><style>s {color:yellow} /* So !important! */</style></body></html>',
 				array(
-					':root:not(#FK_ID) b{color:red;}',
+					':root:not(#_):not(#_) b{color:red;}',
 					'i{color:blue;}',
-					'u{color:green;}:root:not(#FK_ID) u{text-decoration:underline;}',
+					'u{color:green;}:root:not(#_):not(#_) u{text-decoration:underline;}',
 					's{color:yellow;}',
 				),
 			),
@@ -194,7 +204,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'strong.before-dashicon',
 					'.dashicons-dashboard:before',
 					'strong.after-dashicon',
-					':root:not(#FK_ID) s{color:yellow;}',
+					':root:not(#_):not(#_) s{color:yellow;}',
 				),
 			),
 			'style_with_no_head' => array(
@@ -213,6 +223,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<html amp><head><meta charset="utf-8"><style amp-custom>.social-navigation a[href*="example.com"] { color:red; } .social-navigation a.examplecom { color:blue; }</style></head><body class="foo"><nav class="social-navigation"><a href="https://example.com/">Example</a></nav></body></html>',
 				array(
 					'.social-navigation a[href*="example.com"]{color:red;}',
+				),
+			),
+			'style_on_root_element' => array(
+				'<html amp style="color:red;"><head><meta charset="utf-8"><style amp-custom>html { background-color: blue !important; }</style></head><body>Hi</body></html>',
+				array(
+					'html:not(#_):not(#_){background-color:blue;}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-10b06ba{color:red;}',
 				),
 			),
 		);

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -430,33 +430,34 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				admin_url( 'css/common.css' ),
 				ABSPATH . 'wp-admin/css/common.css',
 			),
-			'amp_css_bad_file_extension' => array(
+			'amp_disallowed_file_extension' => array(
 				content_url( 'themes/twentyseventeen/index.php' ),
 				null,
-				'amp_css_bad_file_extension',
+				'amp_disallowed_file_extension',
 			),
-			'amp_css_path_not_found' => array(
+			'amp_file_path_not_found' => array(
 				content_url( 'themes/twentyseventeen/404.css' ),
 				null,
-				'amp_css_path_not_found',
+				'amp_file_path_not_found',
 			),
 		);
 	}
 
 	/**
-	 * Tests get_validated_css_file_path.
+	 * Tests get_validated_url_file_path.
 	 *
 	 * @dataProvider get_stylesheet_urls
-	 * @covers AMP_Style_Sanitizer::get_validated_css_file_path()
+	 * @covers AMP_Style_Sanitizer::get_validated_url_file_path()
+	 *
 	 * @param string      $source     Source URL.
 	 * @param string|null $expected   Expected path or null if error.
 	 * @param string      $error_code Error code. Optional.
 	 */
-	public function test_get_validated_css_file_path( $source, $expected, $error_code = null ) {
+	public function test_get_validated_url_file_path( $source, $expected, $error_code = null ) {
 		$dom = AMP_DOM_Utils::get_dom( '<html></html>' );
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom );
-		$actual    = $sanitizer->get_validated_css_file_path( $source );
+		$actual    = $sanitizer->get_validated_url_file_path( $source, array( 'css' ) );
 		if ( isset( $error_code ) ) {
 			$this->assertInstanceOf( 'WP_Error', $actual );
 			$this->assertEquals( $error_code, $actual->get_error_code() );

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -203,6 +203,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'body{color:red;}',
 				),
 			),
+			'style_with_not_selectors' => array(
+				'<html amp><head><meta charset="utf-8"><style amp-custom>body.bar > p:not(.baz) { color:red; } body.foo:not(.bar) > p { color:blue; } body.foo:not(.bar) p:not(.baz) { color:green; } body.foo p { color:yellow; }</style></head><body class="foo"><p>Hello</p></body>',
+				array(
+					'body.foo:not(.bar) > p{color:blue;}body.foo:not(.bar) p:not(.baz){color:green;}body.foo p{color:yellow;}',
+				),
+			),
 		);
 	}
 
@@ -233,7 +239,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			if ( false === strpos( $expected_stylesheet, '{' ) ) {
 				$this->assertContains( $expected_stylesheet, $actual_stylesheets[ $i ] );
 			} else {
-				$this->assertStringStartsWith( $expected_stylesheet, $actual_stylesheets[ $i ] );
+				$this->assertEquals( $expected_stylesheet, $actual_stylesheets[ $i ] );
 			}
 			$this->assertContains( $expected_stylesheet, $sanitized_html );
 		}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -295,6 +295,28 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test handling of stylesheets with relative background-image URLs.
+	 *
+	 * @covers AMP_Style_Sanitizer::real_path_urls()
+	 */
+	public function test_relative_background_url_handling() {
+		$html = '<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="' . esc_url( admin_url( 'css/common.css' ) ) . '"></head><body><span class="spinner"></span></body></html>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+
+		$sanitizer = new AMP_Style_Sanitizer( $dom, array(
+			'use_document_element' => true,
+		) );
+		$sanitizer->sanitize();
+		AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
+		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
+		$this->assertCount( 1, $actual_stylesheets );
+		$stylesheet = $actual_stylesheets[0];
+
+		$this->assertNotContains( '../images/spinner', $stylesheet );
+		$this->assertContains( sprintf( '.spinner{background-image:url("%s");', admin_url( 'images/spinner-2x.gif' ) ), $stylesheet );
+	}
+
+	/**
 	 * Get amp-keyframe styles.
 	 *
 	 * @return array

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -65,12 +65,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'div_amp_banned_style' => array(
-				'<span style="overflow: scroll;">Scrollbars not allowed.</span>',
-				'<span>Scrollbars not allowed.</span>',
-				array(),
-			),
-
 			'!important_is_ok' => array(
 				'<span style="padding:1px; margin: 2px !important; outline: 3px;">!important is converted.</span>',
 				'<span class="amp-wp-6a75598">!important is converted.</span>',
@@ -113,7 +107,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'inline_style_element_with_multiple_rules_containing_selectors_is_removed' => array(
-				'<style>div > span { font-weight:bold !important; overflow: scroll; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; overflow: auto; font-style: normal; } }</style><div><span>bold!</span></div>',
+				'<style>div > span { font-weight:bold !important; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				array(
 					'div > span{font-style:italic;}@media screen and ( max-width: 640px ){div > span{font-style:normal;}:root:not(#FK_ID) div > span{font-weight:normal;}}:root:not(#FK_ID) div > span{font-weight:bold;}',
@@ -121,10 +115,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'illegal_unsafe_properties' => array(
-				'<style>button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ }</style><button>Click</button>',
+				'<style>button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ } @media screen { button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ } }</style><button>Click</button>',
 				'<button>Click</button>',
 				array(
-					'button{font-weight:bold;}',
+					'button{font-weight:bold;}@media screen{button{font-weight:bold;}}',
 				),
 			),
 
@@ -198,7 +192,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 			),
 			'style_with_no_head' => array(
-				'<html amp><body>Not good!<style>body{color:red;overflow:auto;overflow-x:scroll;overflow-y:scroll;}</style></body>',
+				'<html amp><body>Not good!<style>body{color:red;}</style></body>',
 				array(
 					'body{color:red;}',
 				),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -27,41 +27,41 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => array(
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e">This is green.</span>',
+				'<span class="amp-wp-bb01159">This is green.</span>',
 				array(
-					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e { color:#00ff00; }',
+					'.amp-wp-bb01159{color:#0f0;}',
 				),
 			),
 
 			'span_one_style_bad_format' => array(
 				'<span style="color  :   #00ff00">This is green.</span>',
-				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e">This is green.</span>',
+				'<span class="amp-wp-0837823">This is green.</span>',
 				array(
-					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e { color:#00ff00; }',
+					'.amp-wp-0837823{color:#0f0;}',
 				),
 			),
 
 			'span_two_styles_reversed' => array(
 				'<span style="color: #00ff00; background-color: #000; ">This is green.</span>',
-				'<span class="amp-wp-inline-58550689c128f3d396444313296e4c47">This is green.</span>',
+				'<span class="amp-wp-c71affe">This is green.</span>',
 				array(
-					'.amp-wp-inline-58550689c128f3d396444313296e4c47 { background-color:#000; color:#00ff00; }',
+					'.amp-wp-c71affe{color:#0f0;background-color:#000;}',
 				),
 			),
 
 			'width_to_max-width' => array(
 				'<figure style="width: 300px"></figure>',
-				'<figure class="amp-wp-inline-2676cd1bfa7e8feb4f0e0e8086ae9ce4"></figure>',
+				'<figure class="amp-wp-343bce0"></figure>',
 				array(
-					'.amp-wp-inline-2676cd1bfa7e8feb4f0e0e8086ae9ce4 { max-width:300px; }',
+					'.amp-wp-343bce0{max-width:300px;}',
 				),
 			),
 
 			'span_display_none' => array(
 				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
-				'<span class="amp-wp-inline-0f1bf07c72fdf1784fff2e164d9dca98">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
+				'<span class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				array(
-					'.amp-wp-inline-0f1bf07c72fdf1784fff2e164d9dca98 { display:none; }',
+					'.amp-wp-224b51a{display:none;}',
 				),
 			),
 
@@ -73,42 +73,42 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'!important_not_allowed' => array(
 				'<span style="margin: 1px!important;">!important not allowed.</span>',
-				'<span class="amp-wp-inline-b370df7c42957a3192cac40a8ddcff79">!important not allowed.</span>',
+				'<span class="amp-wp-416ccd3">!important not allowed.</span>',
 				array(
-					'.amp-wp-inline-b370df7c42957a3192cac40a8ddcff79 { margin:1px; }',
+					'.amp-wp-416ccd3{margin:1px;}',
 				),
 			),
 
 			'!important_with_spaces_not_allowed' => array(
 				'<span style="color: red  !  important;">!important not allowed.</span>',
-				'<span class="amp-wp-inline-5b88d03e432f20476a218314084d3a05">!important not allowed.</span>',
+				'<span class="amp-wp-952600b">!important not allowed.</span>',
 				array(
-					'.amp-wp-inline-5b88d03e432f20476a218314084d3a05 { color:red; }',
+					'.amp-wp-952600b{color:red;}',
 				),
 			),
 
 			'!important_multiple_not_allowed' => array(
 				'<span style="color: red !important; background: blue!important;">!important not allowed.</span>',
-				'<span class="amp-wp-inline-ef4329d562b6b3486a8a661df5c5280f">!important not allowed.</span>',
+				'<span class="amp-wp-1e2bfaa">!important not allowed.</span>',
 				array(
-					'.amp-wp-inline-ef4329d562b6b3486a8a661df5c5280f { background:blue; color:red; }',
+					'.amp-wp-1e2bfaa{color:red;background:blue;}',
 				),
 			),
 
 			'two_nodes' => array(
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span class="amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e"><span class="amp-wp-inline-f146f9bb819d875bbe5cf83e36368b44">This is red.</span></span>',
+				'<span class="amp-wp-bb01159"><span class="amp-wp-cc68ddc">This is red.</span></span>',
 				array(
-					'.amp-wp-inline-ad0e57ab02197f7023aa5b93bcf6c97e { color:#00ff00; }',
-					'.amp-wp-inline-f146f9bb819d875bbe5cf83e36368b44 { color:#ff0000; }',
+					'.amp-wp-bb01159{color:#0f0;}',
+					'.amp-wp-cc68ddc{color:#f00;}',
 				),
 			),
 
 			'existing_class_attribute' => array(
 				'<figure class="alignleft" style="background: #000"></figure>',
-				'<figure class="alignleft amp-wp-inline-3be9b2f79873ad78941ba2b3c03025a3"></figure>',
+				'<figure class="alignleft amp-wp-2864855"></figure>',
 				array(
-					'.amp-wp-inline-3be9b2f79873ad78941ba2b3c03025a3 { background:#000; }',
+					'.amp-wp-2864855{background:#000;}',
 				),
 
 			),
@@ -117,7 +117,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<style>div > span { font-weight:bold !important; overflow: scroll; font-style: italic; }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				array(
-					'div > span { font-weight:bold; font-style: italic; }',
+					'div > span{font-weight:bold;font-style:italic;}',
 				),
 			),
 		);
@@ -156,10 +156,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'multiple_amp_custom_and_other_styles' => array(
 				'<html amp><head><meta charset="utf-8"><style amp-custom>b {color:red !important}</style><style amp-custom>i {color:blue}</style><style type="text/css">u {color:green}</style></head><body><style>s {color:yellow} /* So !important! */</style></body></html>',
 				array(
-					'b {color:red}',
-					'i {color:blue}',
-					'u {color:green}',
-					's {color:yellow}',
+					'b{color:red;}',
+					'i{color:blue;}',
+					'u{color:green;}',
+					's{color:yellow;}',
 				),
 			),
 			'style_elements_with_link_elements' => array(
@@ -171,7 +171,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'strong.before-dashicon',
 					'.dashicons-dashboard:before',
 					'strong.after-dashicon',
-					's {color:yellow}',
+					's{color:yellow;}',
 				),
 			),
 			'style_with_no_head' => array(

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -232,6 +232,24 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-10b06ba{color:red;}',
 				),
 			),
+			'styles_with_dynamic_elements' => array(
+				implode( '', array(
+					'<html amp><head><meta charset="utf-8">',
+					'<style amp-custom>b.foo, form [submit-success] b, div[submit-failure] b, form.unused b { color: green }</style>',
+					'<style amp-custom>.dead-list li .highlighted, amp-live-list li .highlighted { background: yellow }</style>',
+					'<style amp-custom>body amp-list .portland { color:blue; }</style>',
+					'</head><body>',
+					'<form method="post" action-xhr="https://example.com/subscribe" target="_top"><div submit-success><template type="amp-mustache"><b>Thanks</b>, {{name}}}</template></div></form>',
+					'<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"><button update on="tap:my-live-list.update">You have updates!</button><ul items><li id="live-list-2-item-2" data-sort-time="1464281932879">Hello</li></ul></amp-live-list>',
+					'<amp-list width="auto" height="100" layout="fixed-height" src="https://ampproject-b5f4c.firebaseapp.com/examples/data/amp-list-urls.json"> <template type="amp-mustache"> <div class="url-entry"> <a href="{{url}}" class="{{class}}">{{title}}</a> </div> </template> </amp-list>',
+					'</body></html>',
+				) ),
+				array(
+					'form [submit-success] b,div[submit-failure] b{color:green;}',
+					'amp-live-list li .highlighted{background:yellow;}',
+					'body amp-list .portland{color:blue;}',
+				),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -187,7 +187,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'style_elements_with_link_elements' => array(
 				sprintf(
-					'<html amp><head><meta charset="utf-8"><style type="text/css">strong.before-dashicon {color:green}</style><link rel="stylesheet" href="%s"><style type="text/css">strong.after-dashicon {color:green}</style></head><body><style>s {color:yellow !important}</style></body></html>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+					'<html amp><head><meta charset="utf-8"><style type="text/css">strong.before-dashicon {color:green}</style><link rel="stylesheet" href="%s"><style type="text/css">strong.after-dashicon {color:green}</style></head><body><style>s {color:yellow !important}</style><s class="before-dashicon"></s><strong class="dashicons-dashboard"></strong><strong class="after-dashicon"></strong></body></html>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 					includes_url( 'css/dashicons.css' )
 				),
 				array(

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -235,18 +235,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		return array(
 			'style_amp_keyframes'              => array(
-				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes foo {} }</style>',
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) {@keyframes foo {} }</style>',
 				null, // No Change.
 			),
 
 			'style_amp_keyframes_max_overflow' => array(
-				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes ' . str_repeat( 'a', $keyframes_max_size + 1 ) . ' {} }</style>',
+				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) {@keyframes ' . str_repeat( 'a', $keyframes_max_size + 1 ) . ' {} }</style>',
 				'',
 			),
 
 			'style_amp_keyframes_last_child'   => array(
-				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) { @keyframes foo {} }</style> as <b>after</b>',
-				' as <b>after</b>',
+				'<b>before</b> <style amp-keyframes>@keyframes anim1 {}</style> between <style amp-keyframes>@keyframes anim2 {}</style> as <b>after</b>',
+				'<b>before</b> between  as <b>after</b><style amp-keyframes>@keyframes anim1 {}@keyframes anim2 {}</style>',
 			),
 		);
 	}
@@ -264,6 +264,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer = new AMP_Style_Sanitizer( $dom );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content = preg_replace( '#\s+(?=@keyframes)#', '', $content );
+		$content = preg_replace( '#\s+(?=</style>)#', '', $content );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
 		$this->assertEquals( $expected, $content );
 	}

--- a/tests/test-class-amp-response-headers.php
+++ b/tests/test-class-amp-response-headers.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for Theme Support.
+ *
+ * @package AMP
+ * @since 1.0
+ */
+
+/**
+ * Tests for Theme Support.
+ *
+ * @covers AMP_Response_Headers
+ */
+class Test_AMP_Response_Headers extends WP_UnitTestCase {
+
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 *
+	 * @global WP_Scripts $wp_scripts
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		AMP_Response_Headers::$headers_sent = array();
+	}
+
+	/**
+	 * Test \AMP_Response_Headers::send_header() when no args are passed.
+	 *
+	 * @covers \AMP_Response_Headers::send_header()
+	 */
+	public function test_send_header_no_args() {
+		AMP_Response_Headers::send_header( 'Foo', 'Bar' );
+		$this->assertContains(
+			array(
+				'name'        => 'Foo',
+				'value'       => 'Bar',
+				'replace'     => true,
+				'status_code' => null,
+			),
+			AMP_Response_Headers::$headers_sent
+		);
+	}
+
+	/**
+	 * Test \AMP_Response_Headers::send_header() when replace arg is passed.
+	 *
+	 * @covers \AMP_Response_Headers::send_header()
+	 */
+	public function test_send_header_replace_arg() {
+		AMP_Response_Headers::send_header( 'Foo', 'Bar', array(
+			'replace' => false,
+		) );
+		$this->assertContains(
+			array(
+				'name'        => 'Foo',
+				'value'       => 'Bar',
+				'replace'     => false,
+				'status_code' => null,
+			),
+			AMP_Response_Headers::$headers_sent
+		);
+	}
+
+	/**
+	 * Test \AMP_Response_Headers::send_header() when status code is passed.
+	 *
+	 * @covers \AMP_Response_Headers::send_header()
+	 */
+	public function test_send_header_status_code() {
+		AMP_Response_Headers::send_header( 'Foo', 'Bar', array(
+			'status_code' => 400,
+		) );
+		$this->assertContains(
+			array(
+				'name'        => 'Foo',
+				'value'       => 'Bar',
+				'replace'     => true,
+				'status_code' => 400,
+			),
+			AMP_Response_Headers::$headers_sent
+		);
+	}
+
+	/**
+	 * Test \AMP_Response_Headers::send_server_timing() when positive duration passed.
+	 *
+	 * @covers \AMP_Response_Headers::send_server_timing()
+	 */
+	public function test_send_server_timing_positive_duration() {
+		AMP_Response_Headers::send_server_timing( 'name', 123, 'Description' );
+		$this->assertCount( 1, AMP_Response_Headers::$headers_sent );
+		$this->assertEquals( 'Server-Timing', AMP_Response_Headers::$headers_sent[0]['name'] );
+		$values = preg_split( '/\s*;\s*/', AMP_Response_Headers::$headers_sent[0]['value'] );
+		$this->assertEquals( 'name', $values[0] );
+		$this->assertEquals( 'desc="Description"', $values[1] );
+		$this->assertStringStartsWith( 'dur=123000.', $values[2] );
+		$this->assertFalse( AMP_Response_Headers::$headers_sent[0]['replace'] );
+		$this->assertNull( AMP_Response_Headers::$headers_sent[0]['status_code'] );
+	}
+
+	/**
+	 * Test \AMP_Response_Headers::send_server_timing() when positive duration passed.
+	 *
+	 * @covers \AMP_Response_Headers::send_server_timing()
+	 */
+	public function test_send_server_timing_negative_duration() {
+		AMP_Response_Headers::send_server_timing( 'name', -microtime( true ) );
+		$this->assertCount( 1, AMP_Response_Headers::$headers_sent );
+		$this->assertEquals( 'Server-Timing', AMP_Response_Headers::$headers_sent[0]['name'] );
+		$values = preg_split( '/\s*;\s*/', AMP_Response_Headers::$headers_sent[0]['value'] );
+		$this->assertEquals( 'name', $values[0] );
+		$this->assertStringStartsWith( 'dur=0.', $values[1] );
+		$this->assertFalse( AMP_Response_Headers::$headers_sent[0]['replace'] );
+		$this->assertNull( AMP_Response_Headers::$headers_sent[0]['status_code'] );
+	}
+}

--- a/tests/test-class-amp-response-headers.php
+++ b/tests/test-class-amp-response-headers.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Tests for Theme Support.
+ * Tests for AMP_Response_Headers.
  *
  * @package AMP
  * @since 1.0
  */
 
 /**
- * Tests for Theme Support.
+ * Tests for AMP_Response_Headers.
  *
  * @covers AMP_Response_Headers
  */

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -190,7 +190,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<meta charset="' . get_bloginfo( 'charset' ) . '">', $sanitized_html );
 		$this->assertContains( '<meta name="viewport" content="width=device-width,minimum-scale=1">', $sanitized_html );
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
-		$this->assertContains( '<style amp-custom>body { background: black; }', $sanitized_html );
+		$this->assertContains( '<style amp-custom>body{background:black;}', $sanitized_html );
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-list-latest.js" async custom-element="amp-list"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -27,7 +27,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$_SERVER['QUERY_STRING'] = '';
 		unset( $_SERVER['REQUEST_URI'] );
 		unset( $_SERVER['REQUEST_METHOD'] );
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 	}
 
 	/**
@@ -349,7 +349,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_handle_xhr_request() {
 		AMP_Theme_Support::purge_amp_query_vars();
 		AMP_Theme_Support::handle_xhr_request();
-		$this->assertEmpty( AMP_Theme_Support::$headers_sent );
+		$this->assertEmpty( AMP_Response_Headers::$headers_sent );
 
 		$_GET['_wp_amp_action_xhr_converted'] = '1';
 
@@ -358,14 +358,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$_SERVER['REQUEST_METHOD']   = 'POST';
 		AMP_Theme_Support::purge_amp_query_vars();
 		AMP_Theme_Support::handle_xhr_request();
-		$this->assertEmpty( AMP_Theme_Support::$headers_sent );
+		$this->assertEmpty( AMP_Response_Headers::$headers_sent );
 
 		// Try home source origin.
 		$_GET['__amp_source_origin'] = home_url();
 		$_SERVER['REQUEST_METHOD']   = 'POST';
 		AMP_Theme_Support::purge_amp_query_vars();
 		AMP_Theme_Support::handle_xhr_request();
-		$this->assertCount( 1, AMP_Theme_Support::$headers_sent );
+		$this->assertCount( 1, AMP_Response_Headers::$headers_sent );
 		$this->assertEquals(
 			array(
 				'name'        => 'AMP-Access-Control-Allow-Source-Origin',
@@ -373,7 +373,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent[0]
+			AMP_Response_Headers::$headers_sent[0]
 		);
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', array( 'AMP_Theme_Support', 'intercept_post_request_redirect' ) ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_post_redirect', array( 'AMP_Theme_Support', 'filter_comment_post_redirect' ) ) );
@@ -476,7 +476,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		} );
 
 		// Test redirecting to full URL with HTTPS protocol.
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 		ob_start();
 		AMP_Theme_Support::intercept_post_request_redirect( $url );
 		$this->assertEquals( '{"success":true}', ob_get_clean() );
@@ -487,7 +487,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 		$this->assertContains(
 			array(
@@ -496,11 +496,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 
 		// Test redirecting to non-HTTPS URL.
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 		ob_start();
 		$url = home_url( '/', 'http' );
 		AMP_Theme_Support::intercept_post_request_redirect( $url );
@@ -512,7 +512,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 		$this->assertContains(
 			array(
@@ -521,11 +521,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 
 		// Test redirecting to host-less location.
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 		ob_start();
 		AMP_Theme_Support::intercept_post_request_redirect( '/new-location/' );
 		$this->assertEquals( '{"success":true}', ob_get_clean() );
@@ -536,11 +536,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 
 		// Test redirecting to scheme-less location.
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 		ob_start();
 		$url = home_url( '/new-location/' );
 		AMP_Theme_Support::intercept_post_request_redirect( substr( $url, strpos( $url, ':' ) + 1 ) );
@@ -552,11 +552,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 
 		// Test redirecting to empty location.
-		AMP_Theme_Support::$headers_sent = array();
+		AMP_Response_Headers::$headers_sent = array();
 		ob_start();
 		AMP_Theme_Support::intercept_post_request_redirect( '' );
 		$this->assertEquals( '{"success":true}', ob_get_clean() );
@@ -567,7 +567,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'replace'     => true,
 				'status_code' => null,
 			),
-			AMP_Theme_Support::$headers_sent
+			AMP_Response_Headers::$headers_sent
 		);
 	}
 


### PR DESCRIPTION
- [x] Add support for [Server Timing](https://w3c.github.io/server-timing/) to reveal the time required for the plugin to render a response. Move header-sending logic to `AMP_Response_Headers` class. See #990.
- [x] Minify CSS to remove whitespace and comments. See #688.
- [x] Sanitize CSS by means of a CSS parser instead of relying on regular expressions.
- [x] Remove illegal CSS properties (`-moz-binding` and `behavior`).
- [x] Reduce length of CSS class names generated for `style` attributes.
- [x] If `amp-keyframes` appears anywhere but end of `body`, just move it to the end of the `body`.
- [x] Implement the [replace-important](https://www.npmjs.com/package/replace-important) approach to eliminating `!important` qualifiers.
- [x] Delete illegal CSS @-rules.
- [x] Make sure css_spec gets parsed and included in AMP_Allowed_Tags_Generated.
- [x] Limit `@keyframes` to opacity, transform and -vendorPrefix-transform. 
- [x] Make sure legacy post template still renders properly with stylesheet changes.
- [x] Delete CSS rules that don't apply to the current page based on the class names used, if the total CSS size would otherwise be greater than 50KB. (CSS tree shaking.)
- [x] Delete selectors that reference class names that don't exist.
- [x] Handle case of false negatives when a selector contains `:not(.classname)`. Also strip strings.
- [x] Figure out how to gracefully deal with Genericons and Dashicons.
- [x] Use expiring transient instead of indefinite cache when external cache is not available.
- [x] Improve handling of specificity, including giving higher selector specificity to rules from inline styles. Reduce length of fake ID.
- [x] Address relative URLs, such as for background images.

Fixes #990.
Fixes #930.
Fixes #688.
Closes #610.

Ideas for later:
* Look at other tree-shaking methods beyond class names.
* Add tree-shaking based on IDs.