### PR TITLE
Output admin notice if persistent object caching is not present

### DIFF
--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -214,7 +214,7 @@ class AMP_Validation_Utils {
 		add_filter( 'bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'add_bulk_action' ), 10, 2 );
 		add_filter( 'handle_bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'handle_bulk_action' ), 10, 3 );
 		add_action( 'admin_notices', array( __CLASS__, 'remaining_error_notice' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'persistent_caching_object_notice' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'persistent_object_caching_notice' ) );
 		add_action( 'post_action_' . self::RECHECK_ACTION, array( __CLASS__, 'handle_inline_recheck' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'remove_publish_meta_box' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu_validation_status_count' ) );
@@ -1797,18 +1797,17 @@ class AMP_Validation_Utils {
 	 *
 	 * @return void
 	 */
-	public static function persistent_caching_object_notice() {
-		$screen = get_current_screen();
-		if ( 'toplevel_page_amp-options' === $screen->id ) {
-			if ( ! wp_using_ext_object_cache() ) {
-				?>
-				<div class="notice notice-warning">
-					<p><?php esc_html_e( 'The AMP plugin performs at its best when persistent object cache is enabled.', 'amp' ); ?></p>
-					<p><a href="<?php echo esc_url( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching' ); ?>">More details</a></p>
-				</div>
-				<?php
-			}
+	public static function persistent_object_caching_notice() {
+		if ( ! wp_using_ext_object_cache() && 'toplevel_page_amp-options' === get_current_screen()->id ) {
+			printf(
+				'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+				esc_html__( 'The AMP plugin performs at its best when persistent object cache is enabled.', 'amp' ),
+				esc_url( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching' ),
+				esc_html__( 'More details', 'amp' ),
+				esc_html__( 'Dismiss this notice.', 'amp' )
+			);
 		}
 	}
 
 }
+

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -1800,11 +1800,10 @@ class AMP_Validation_Utils {
 	public static function persistent_object_caching_notice() {
 		if ( ! wp_using_ext_object_cache() && 'toplevel_page_amp-options' === get_current_screen()->id ) {
 			printf(
-				'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+				'<div class="notice notice-warning"><p>%s <a href="%s">%s</a></p></div>',
 				esc_html__( 'The AMP plugin performs at its best when persistent object cache is enabled.', 'amp' ),
 				esc_url( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching' ),
-				esc_html__( 'More details', 'amp' ),
-				esc_html__( 'Dismiss this notice.', 'amp' )
+				esc_html__( 'More details', 'amp' )
 			);
 		}
 	}

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -214,6 +214,7 @@ class AMP_Validation_Utils {
 		add_filter( 'bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'add_bulk_action' ), 10, 2 );
 		add_filter( 'handle_bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'handle_bulk_action' ), 10, 3 );
 		add_action( 'admin_notices', array( __CLASS__, 'remaining_error_notice' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'persistent_caching_object_notice' ) );
 		add_action( 'post_action_' . self::RECHECK_ACTION, array( __CLASS__, 'handle_inline_recheck' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'remove_publish_meta_box' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu_validation_status_count' ) );
@@ -1789,6 +1790,25 @@ class AMP_Validation_Utils {
 			esc_html__( 'Recheck the URL for AMP validity', 'amp' ),
 			esc_html__( 'Recheck', 'amp' )
 		);
+	}
+
+	/**
+	 * Outputs an admin notice if persistent object cache is not present.
+	 *
+	 * @return void
+	 */
+	public static function persistent_caching_object_notice() {
+		$screen = get_current_screen();
+		if ( 'toplevel_page_amp-options' === $screen->id ) {
+			if ( ! wp_using_ext_object_cache() ) {
+				?>
+				<div class="notice notice-warning">
+					<p><?php esc_html_e( 'The AMP plugin performs at its best when persistent object cache is enabled.', 'amp' ); ?></p>
+					<p><a href="<?php echo esc_url( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching' ); ?>">More details</a></p>
+				</div>
+				<?php
+			}
+		}
 	}
 
 }

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -94,6 +94,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		$GLOBALS['wp_registered_widgets'] = $this->original_wp_registered_widgets; // WPCS: override ok.
+		unset( $GLOBALS['current_screen'] );
 		parent::tearDown();
 	}
 
@@ -114,7 +115,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'bulk_actions-edit-' . AMP_Validation_Utils::POST_TYPE_SLUG, self::TESTED_CLASS . '::add_bulk_action' ) );
 		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validation_Utils::POST_TYPE_SLUG, self::TESTED_CLASS . '::handle_bulk_action' ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', self::TESTED_CLASS . '::remaining_error_notice' ) );
-		$this->assertEquals( 10, has_action( 'admin_notices', self::TESTED_CLASS . '::persistent_caching_object_notice' ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', self::TESTED_CLASS . '::persistent_object_caching_notice' ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', self::TESTED_CLASS . '::remove_publish_meta_box' ) );
 		$this->assertEquals( 10, has_action( 'add_meta_boxes', self::TESTED_CLASS . '::add_meta_boxes' ) );
 	}
@@ -1361,41 +1362,36 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test for persistent_caching_object_notice()
+	 * Test for persistent_object_caching_notice()
 	 *
-	 * @covers AMP_Validation_Utils::persistent_caching_object_notice()
+	 * @covers AMP_Validation_Utils::persistent_object_caching_notice()
 	 */
-	public function test_persistent_caching_object_notice() {
+	public function test_persistent_object_caching_notice() {
 		set_current_screen( 'toplevel_page_amp-options' );
-		$needle = 'The AMP plugin performs at its best when persistent object cache is enabled.';
+		$text = 'The AMP plugin performs at its best when persistent object cache is enabled.';
 
-		$using = null;
-		wp_using_ext_object_cache( $using );
+		wp_using_ext_object_cache( null );
 		ob_start();
-		AMP_Validation_Utils::persistent_caching_object_notice();
-		$this->assertContains( $needle, ob_get_clean() );
+		AMP_Validation_Utils::persistent_object_caching_notice();
+		$this->assertContains( $text, ob_get_clean() );
 
-		$using = true;
-		wp_using_ext_object_cache( $using );
+		wp_using_ext_object_cache( true );
 		ob_start();
-		AMP_Validation_Utils::persistent_caching_object_notice();
-		$this->assertNotContains( $needle, ob_get_clean() );
+		AMP_Validation_Utils::persistent_object_caching_notice();
+		$this->assertNotContains( $text, ob_get_clean() );
 
 		set_current_screen( 'edit.php' );
 
-		$using = null;
-		wp_using_ext_object_cache( $using );
+		wp_using_ext_object_cache( null );
 		ob_start();
-		AMP_Validation_Utils::persistent_caching_object_notice();
-		$this->assertNotContains( $needle, ob_get_clean() );
+		AMP_Validation_Utils::persistent_object_caching_notice();
+		$this->assertNotContains( $text, ob_get_clean() );
 
-		$using = true;
-		wp_using_ext_object_cache( $using );
+		wp_using_ext_object_cache( true );
 		ob_start();
-		AMP_Validation_Utils::persistent_caching_object_notice();
-		$this->assertNotContains( $needle, ob_get_clean() );
+		AMP_Validation_Utils::persistent_object_caching_notice();
+		$this->assertNotContains( $text, ob_get_clean() );
 
-		unset( $GLOBALS['current_screen'] );
 	}
 
 }

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -114,6 +114,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'bulk_actions-edit-' . AMP_Validation_Utils::POST_TYPE_SLUG, self::TESTED_CLASS . '::add_bulk_action' ) );
 		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validation_Utils::POST_TYPE_SLUG, self::TESTED_CLASS . '::handle_bulk_action' ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', self::TESTED_CLASS . '::remaining_error_notice' ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', self::TESTED_CLASS . '::persistent_caching_object_notice' ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', self::TESTED_CLASS . '::remove_publish_meta_box' ) );
 		$this->assertEquals( 10, has_action( 'add_meta_boxes', self::TESTED_CLASS . '::add_meta_boxes' ) );
 	}
@@ -1357,6 +1358,44 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Test for persistent_caching_object_notice()
+	 *
+	 * @covers AMP_Validation_Utils::persistent_caching_object_notice()
+	 */
+	public function test_persistent_caching_object_notice() {
+		set_current_screen( 'toplevel_page_amp-options' );
+		$needle = 'The AMP plugin performs at its best when persistent object cache is enabled.';
+
+		$using = null;
+		wp_using_ext_object_cache( $using );
+		ob_start();
+		AMP_Validation_Utils::persistent_caching_object_notice();
+		$this->assertContains( $needle, ob_get_clean() );
+
+		$using = true;
+		wp_using_ext_object_cache( $using );
+		ob_start();
+		AMP_Validation_Utils::persistent_caching_object_notice();
+		$this->assertNotContains( $needle, ob_get_clean() );
+
+		set_current_screen( 'edit.php' );
+
+		$using = null;
+		wp_using_ext_object_cache( $using );
+		ob_start();
+		AMP_Validation_Utils::persistent_caching_object_notice();
+		$this->assertNotContains( $needle, ob_get_clean() );
+
+		$using = true;
+		wp_using_ext_object_cache( $using );
+		ob_start();
+		AMP_Validation_Utils::persistent_caching_object_notice();
+		$this->assertNotContains( $needle, ob_get_clean() );
+
+		unset( $GLOBALS['current_screen'] );
 	}
 
 }


### PR DESCRIPTION
Hi @westonruter,

Could you use this PR which addresses #960 ?

I was not sure where it was best to write the method in, so I opted to write it in **class-amp-validation-utils** but i'm open to your suggestions.

I'm also not sure if the output message would be good as it is now. I opted to include a link to [https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching](url) since users might not know what persistent object cache is and how to enable it.


![git](https://user-images.githubusercontent.com/31049169/38168323-0b9f4fa4-3506-11e8-9e58-dfcc971de98a.png)

Fixes #960.