### PR TITLE
Sanitize <img> tags when src attribute contains only spaces. 

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -73,7 +73,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			if ( ! $node->hasAttribute( 'src' ) || '' === $node->getAttribute( 'src' ) ) {
+			if ( ! $node->hasAttribute( 'src' ) || '' === trim( $node->getAttribute( 'src' ) ) ) {
 				$this->remove_invalid_child( $node );
 				continue;
 			}

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -27,6 +27,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<p></p>',
 			),
 
+			'image_with_spaces_only_src'               => array(
+				'<p><img src="    " width="300" height="300" /></p>',
+				'<p></p>',
+			),
+
 			'image_with_empty_width_and_height'        => array(
 				'<p><img src="http://placehold.it/300x300" width="" height="" /></p>',
 				'<p><amp-img src="http://placehold.it/300x300" width="600" height="400" class="amp-wp-unknown-size amp-wp-enforced-sizes" sizes="(min-width: 600px) 600px, 100vw"></amp-img></p>',


### PR DESCRIPTION
This PR fixes issue #1030. 