### PR TITLE
Update versions tested in Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,9 @@ language: php
 # Opt to use Travis container-based environment.
 sudo: false
 
-# PHP version used in first build configuration.
-php:
-    - "7.1"
-
-# WordPress version used in first build configuration.
-env:
-    - WP_VERSION=latest
-
 # Newer versions like trusty don't have PHP 5.2 or 5.3
 # https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
 dist: precise
-
-# Next we define our matrix of additional build configurations to test against.
-# The versions listed above will automatically create our first configuration,
-# so it doesn't need to be re-defined below.
-
-# WP_VERSION specifies the tag to use. The way these tests are configured to run
-# requires at least WordPress 3.8. Specify "latest" to test against SVN trunk.
-
-# Note that Travis CI supports listing these above to automatically build a
-# matrix of configurations, but we're being nice here by manually building a
-# total of four configurations even though we're testing 4 versions of PHP
-# along with 2 versions of WordPress (which would build 8 configs otherwise).
-# This takes half as long to run while still providing adequate coverage.
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,10 @@ matrix:
      env: WP_VERSION=latest
    - php: "7.0"
      env: WP_VERSION=4.7
-     # 7.1 / latest already included above as first build.
    - php: "7.1"
-     env: WP_VERSION=4.7
+     env: WP_VERSION=latest
+   - php: "7.2"
+     env: WP_VERSION=trunk
 
 install:
   - nvm install 6 && nvm use 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,18 @@ matrix:
   include:
    - php: "5.3"
      env: WP_VERSION=latest DEV_LIB_SKIP=composer,phpcs
-   - php: "5.3"
-     env: WP_VERSION=4.7 DEV_LIB_SKIP=composer,phpcs
    - php: "5.4"
-     env: WP_VERSION=latest
-   - php: "5.4"
-     env: WP_VERSION=4.7
+     env: WP_VERSION=4.7    DEV_LIB_SKIP=composer,phpcs
+   - php: "5.5"
+     env: WP_VERSION=latest DEV_LIB_SKIP=phpcs
+   - php: "5.6"
+     env: WP_VERSION=4.8    DEV_LIB_SKIP=phpcs
+   - php: "5.6"
+     env: WP_VERSION=latest DEV_LIB_SKIP=phpcs
    - php: "7.0"
-     env: WP_VERSION=latest
-   - php: "7.0"
-     env: WP_VERSION=4.7
+     env: WP_VERSION=latest DEV_LIB_SKIP=phpcs
    - php: "7.1"
-     env: WP_VERSION=latest
+     env: WP_VERSION=latest DEV_LIB_SKIP=phpcs
    - php: "7.2"
      env: WP_VERSION=trunk
 

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -45,14 +45,15 @@ add_filter( 'amp_post_template_metadata', 'jetpack_amp_post_template_metadata', 
 /**
  * Add publisher and image metadata.
  *
+ * @since 0.3
+ *
  * @param array   $metadata Metadata array.
  * @param WP_Post $post     Post.
- *
  * @return array Modified metadata array.
  */
 function jetpack_amp_post_template_metadata( $metadata, $post ) {
 	if ( isset( $metadata['publisher'] ) && ! isset( $metadata['publisher']['logo'] ) ) {
-		$metadata = wpcom_amp_add_blavatar_to_metadata( $metadata, $post );
+		$metadata = wpcom_amp_add_blavatar_to_metadata( $metadata );
 	}
 
 	if ( ! isset( $metadata['image'] ) ) {

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,17 +1,22 @@
 <?php
+/**
+ * WPCOM-specific things.
+ *
+ * @todo Move this into Jetpack. See https://github.com/Automattic/amp-wp/issues/1021
+ * @package AMP
+ */
 
-// WPCOM-specific things
 add_action( 'pre_amp_render_post', 'jetpack_amp_disable_the_content_filters' );
 
-// Disable admin menu
+// Disable admin menu.
 add_filter( 'amp_options_menu_is_enabled', '__return_false', 9999 );
 
 /**
  * Disable the_content filters for Jetpack.
  *
- * @param int $post_id Post ID.
+ * @since 0.3
  */
-function jetpack_amp_disable_the_content_filters( $post_id ) {
+function jetpack_amp_disable_the_content_filters() {
 	add_filter( 'post_flair_disable', '__return_true', 99 );
 	add_filter( 'videopress_show_2015_player', '__return_true' );
 	add_filter( 'protected_embeds_use_form_post', '__return_false' );
@@ -24,7 +29,12 @@ function jetpack_amp_disable_the_content_filters( $post_id ) {
 
 add_action( 'amp_post_template_head', 'jetpack_amp_add_og_tags' );
 
-function jetpack_amp_add_og_tags( $amp_template ) {
+/**
+ * Add Open Graph tags.
+ *
+ * @since 0.3
+ */
+function jetpack_amp_add_og_tags() {
 	if ( function_exists( 'jetpack_og_tags' ) ) {
 		jetpack_og_tags();
 	}
@@ -32,6 +42,14 @@ function jetpack_amp_add_og_tags( $amp_template ) {
 
 add_filter( 'amp_post_template_metadata', 'jetpack_amp_post_template_metadata', 10, 2 );
 
+/**
+ * Add publisher and image metadata.
+ *
+ * @param array   $metadata Metadata array.
+ * @param WP_Post $post     Post.
+ *
+ * @return array Modified metadata array.
+ */
 function jetpack_amp_post_template_metadata( $metadata, $post ) {
 	if ( isset( $metadata['publisher'] ) && ! isset( $metadata['publisher']['logo'] ) ) {
 		$metadata = wpcom_amp_add_blavatar_to_metadata( $metadata, $post );
@@ -44,22 +62,40 @@ function jetpack_amp_post_template_metadata( $metadata, $post ) {
 	return $metadata;
 }
 
-function wpcom_amp_add_blavatar_to_metadata( $metadata, $post ) {
+/**
+ * Add blavatar to metadata.
+ *
+ * @since 0.3
+ *
+ * @param array $metadata Metadata.
+ * @return array Metadata.
+ */
+function wpcom_amp_add_blavatar_to_metadata( $metadata ) {
 	if ( ! function_exists( 'blavatar_domain' ) ) {
 		return $metadata;
 	}
 
 	$size = 60;
+
 	$metadata['publisher']['logo'] = array(
-		'@type' => 'ImageObject',
-		'url' => blavatar_url( blavatar_domain( site_url() ), 'img', $size, staticize_subdomain( 'https://wordpress.com/i/favicons/apple-touch-icon-60x60.png' ) ),
-		'width' => $size,
+		'@type'  => 'ImageObject',
+		'url'    => blavatar_url( blavatar_domain( site_url() ), 'img', $size, staticize_subdomain( 'https://wordpress.com/i/favicons/apple-touch-icon-60x60.png' ) ),
+		'width'  => $size,
 		'height' => $size,
 	);
 
 	return $metadata;
 }
 
+/**
+ * Add image to metadata.
+ *
+ * @since 0.3.2
+ *
+ * @param array   $metadata Metadata.
+ * @param WP_Post $post     Post.
+ * @return array Metadata.
+ */
 function wpcom_amp_add_image_to_metadata( $metadata, $post ) {
 	if ( ! class_exists( 'Jetpack_PostImages' ) ) {
 		return wpcom_amp_add_fallback_image_to_metadata( $metadata );
@@ -67,10 +103,10 @@ function wpcom_amp_add_image_to_metadata( $metadata, $post ) {
 
 	$image = Jetpack_PostImages::get_image( $post->ID, array(
 		'fallback_to_avatars' => true,
-		'avatar_size' => 200,
-		// AMP already attempts these
-		'from_thumbnail' => false,
-		'from_attachment' => false,
+		'avatar_size'         => 200,
+		// AMP already attempts these.
+		'from_thumbnail'      => false,
+		'from_attachment'     => false,
 	) );
 
 	if ( empty( $image ) ) {
@@ -80,30 +116,37 @@ function wpcom_amp_add_image_to_metadata( $metadata, $post ) {
 	if ( ! isset( $image['src_width'] ) ) {
 		$dimensions = wpcom_amp_extract_image_dimensions_from_getimagesize( array(
 			$image['src'] => false,
-			)
-		);
+		) );
 
 		if ( false !== $dimensions[ $image['src'] ] ) {
-			$image['src_width'] = $dimensions['width'];
+			$image['src_width']  = $dimensions['width'];
 			$image['src_height'] = $dimensions['height'];
 		}
 	}
 
 	$metadata['image'] = array(
-		'@type' => 'ImageObject',
-		'url' => $image['src'],
-		'width' => $image['src_width'],
+		'@type'  => 'ImageObject',
+		'url'    => $image['src'],
+		'width'  => $image['src_width'],
 		'height' => $image['src_height'],
 	);
 
 	return $metadata;
 }
 
+/**
+ * Add fallback image to metadata.
+ *
+ * @since 0.3.2
+ *
+ * @param array $metadata Metadata.
+ * @return array Metadata.
+ */
 function wpcom_amp_add_fallback_image_to_metadata( $metadata ) {
 	$metadata['image'] = array(
-		'@type' => 'ImageObject',
-		'url' => staticize_subdomain( 'https://wordpress.com/i/blank.jpg' ),
-		'width' => 200,
+		'@type'  => 'ImageObject',
+		'url'    => staticize_subdomain( 'https://wordpress.com/i/blank.jpg' ),
+		'width'  => 200,
 		'height' => 200,
 	);
 
@@ -111,36 +154,50 @@ function wpcom_amp_add_fallback_image_to_metadata( $metadata ) {
 }
 
 add_action( 'amp_extract_image_dimensions_batch_callbacks_registered', 'wpcom_amp_extract_image_dimensions_batch_add_custom_callbacks' );
+
+/**
+ * Add hooks to extract image dimensions.
+ *
+ * @since 0.5
+ */
 function wpcom_amp_extract_image_dimensions_batch_add_custom_callbacks() {
 	// If images are being served from Photon or WP.com files, try extracting the size using querystring.
 	add_action( 'amp_extract_image_dimensions_batch', 'wpcom_amp_extract_image_dimensions_from_querystring', 9, 1 ); // Hook in before the default extractors.
 
 	// Uses a special wpcom lib (wpcom_getimagesize) to extract dimensions as a last resort if we weren't able to figure them out.
-	add_action( 'amp_extract_image_dimensions_batch', 'wpcom_amp_extract_image_dimensions_from_getimagesize', 99, 1 ); // Our last resort, so run late
+	add_action( 'amp_extract_image_dimensions_batch', 'wpcom_amp_extract_image_dimensions_from_getimagesize', 99, 1 ); // Our last resort, so run late.
 
 	// The wpcom override obviates this one, so take it out.
-	remove_filter( 'amp_extract_image_dimensions_batch', array( 'AMP_Image_Dimension_Extractor', 'extract_by_downloading_images' ), 999, 1 );
+	remove_filter( 'amp_extract_image_dimensions_batch', array( 'AMP_Image_Dimension_Extractor', 'extract_by_downloading_images' ), 999 );
 }
 
+/**
+ * Extract image dimensions from query string.
+ *
+ * @since 0.5
+ *
+ * @param array $dimensions Dimensions.
+ * @return array Dimensions.
+ */
 function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions ) {
-	foreach ( $dimensions as $url => $value  ) {
+	foreach ( $dimensions as $url => $value ) {
 
 		if ( is_array( $value ) ) {
 			continue;
 		}
 
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( ! wp_endswith( $host, '.wp.com' ) || ! wp_endswith( $host, '.files.wordpress.com' ) ) {
 			continue;
 		}
 
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $query );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query );
 		$w = isset( $query['w'] ) ? absint( $query['w'] ) : false;
 		$h = isset( $query['h'] ) ? absint( $query['h'] ) : false;
 
 		if ( false !== $w && false !== $h ) {
 			$dimensions[ $url ] = array(
-				'width' => $w,
+				'width'  => $w,
 				'height' => $h,
 			);
 		}
@@ -148,6 +205,14 @@ function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions ) {
 	return $dimensions;
 }
 
+/**
+ * Extract image dimensions via wpcom/imagesize.
+ *
+ * @since 0.5
+ *
+ * @param array $dimensions Dimensions.
+ * @return array Dimensions.
+ */
 function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions ) {
 	if ( ! function_exists( 'require_lib' ) ) {
 		return $dimensions;
@@ -161,7 +226,7 @@ function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions ) {
 		$result = wpcom_getimagesize( $url );
 		if ( is_array( $result ) ) {
 			$dimensions[ $url ] = array(
-				'width' => $result[0],
+				'width'  => $result[0],
 				'height' => $result[1],
 			);
 		}


### PR DESCRIPTION
* Add PHP 7.2 to Travis test matrix; WordPress currently recommends PHP 7.2.
* Include testing PHP 5.6 (the most popular PHP version), as well as 5.5.
* Include testing WP 4.8 and trunk.
* Skip running PHPCS on every build; only needs to be run once.
* Clean up some PHPCS issues along the way to cause PHP to be checked in the build.