### PR TITLE
Ensure amphtml link is properly output in theme support paired mode on non-singular queries

### DIFF
--- a/includes/amp-frontend-actions.php
+++ b/includes/amp-frontend-actions.php
@@ -10,23 +10,31 @@ add_action( 'wp_head', 'amp_frontend_add_canonical' );
 /**
  * Add amphtml link to frontend.
  *
+ * @todo This function's name is incorrect. It's not about adding a canonical link but adding the amphtml link.
+ *
  * @since 0.2
  */
 function amp_frontend_add_canonical() {
 
-	// Prevent showing amphtml link if theme supports AMP but paired mode is not available.
-	if ( current_theme_supports( 'amp' ) && ! AMP_Theme_Support::is_paired_available() ) {
-		return;
-	}
-
 	/**
 	 * Filters whether to show the amphtml link on the frontend.
 	 *
+	 * @todo This filter's name is incorrect. It's not about adding a canonical link but adding the amphtml link.
 	 * @since 0.2
 	 */
 	if ( false === apply_filters( 'amp_frontend_show_canonical', true ) ) {
 		return;
 	}
 
-	printf( '<link rel="amphtml" href="%s">', esc_url( amp_get_permalink( get_queried_object_id() ) ) );
+	$amp_url = null;
+	if ( is_singular() ) {
+		$amp_url = amp_get_permalink( get_queried_object_id() );
+	} elseif ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		$host_url = preg_replace( '#(^https?://[^/]+)/.*#', '$1', home_url( '/' ) );
+		$self_url = esc_url_raw( $host_url . wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$amp_url  = add_query_arg( amp_get_slug(), '', $self_url );
+	}
+	if ( $amp_url ) {
+		printf( '<link rel="amphtml" href="%s">', esc_url( $amp_url ) );
+	}
 }

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -117,7 +117,13 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_init() {
 		if ( ! is_amp_endpoint() ) {
-			amp_add_frontend_actions();
+			// Add amphtml link when paired mode is available.
+			if ( self::is_paired_available() ) {
+				amp_add_frontend_actions(); // @todo This function is poor in how it requires a file that then does add_action().
+				if ( ! has_action( 'wp_head', 'amp_frontend_add_canonical' ) ) {
+					add_action( 'wp_head', 'amp_frontend_add_canonical' );
+				}
+			}
 			return;
 		}
 

--- a/tests/test-amp-frontend-actions.php
+++ b/tests/test-amp-frontend-actions.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Test AMP frontend actions.
+ *
+ * @package AMP
+ */
+
+/**
+ * Test functions in includes/amp-frontend-actions.php
+ */
+class Test_AMP_Frontend_Actions extends WP_UnitTestCase {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+		amp_add_frontend_actions();
+	}
+
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		remove_theme_support( 'amp' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that hook is added.
+	 *
+	 * @covers \amp_add_frontend_actions()
+	 */
+	public function test_has_hook() {
+		$this->assertEquals( 10, has_action( 'wp_head', 'amp_frontend_add_canonical' ) );
+	}
+
+	/**
+	 * URLs to test amphtml link.
+	 *
+	 * @return array
+	 */
+	public function get_amphtml_urls() {
+		$post_id = $this->factory()->post->create();
+		return array(
+			'home' => array(
+				home_url( '/' ),
+				add_query_arg( amp_get_slug(), '', home_url( '/' ) ),
+			),
+			'404'  => array(
+				home_url( '/no-existe/' ),
+				add_query_arg( amp_get_slug(), '', home_url( '/no-existe/' ) ),
+			),
+			'post' => array(
+				get_permalink( $post_id ),
+				amp_get_permalink( $post_id ),
+			),
+		);
+	}
+
+	/**
+	 * Adding link when theme support is not present.
+	 *
+	 * @dataProvider get_amphtml_urls
+	 * @covers \amp_frontend_add_canonical()
+	 * @param string $canonical_url Canonical URL.
+	 * @param string $amphtml_url   The amphtml URL.
+	 */
+	public function test_amp_frontend_add_canonical( $canonical_url, $amphtml_url ) {
+		$this->go_to( $canonical_url );
+		ob_start();
+		amp_frontend_add_canonical();
+		$output = ob_get_clean();
+		$this->assertEquals(
+			sprintf( '<link rel="amphtml" href="%s">', esc_url( $amphtml_url ) ),
+			$output
+		);
+
+		// Make sure adding the filter hides the amphtml link.
+		add_filter( 'amp_frontend_show_canonical', '__return_false' );
+		ob_start();
+		amp_frontend_add_canonical();
+		$output = ob_get_clean();
+		$this->assertEmpty( $output );
+	}
+}


### PR DESCRIPTION
How to reproduce the problem: enable AMP paired mode theme support and add a `404.php` paired mode template and make AMP available for 404 responses:

```php
add_action( 'after_setup_theme', function() {
	add_theme_support( 'amp', array(
		'template_dir'       => 'amp',
		'available_callback' => function() {
			return is_singular() || is_404();
		},
	) );
} );
```

Now try going to a 404 URL on your site and notice the erroneous `amphtml` link:

```html
<link rel="amphtml" href="/amp/">
```

This PR ensures the `href` points to the current URL with `?amp` added to it.