### PR TITLE
Prevent MediaElement.js scripts and styles from being enqueued

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -217,6 +217,14 @@ class AMP_Theme_Support {
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		remove_action( 'wp_head', 'wp_oembed_add_host_js' );
 
+		// Prevent MediaElement.js scripts/styles from being enqueued.
+		add_filter( 'wp_video_shortcode_library', function() {
+			return 'amp';
+		} );
+		add_filter( 'wp_audio_shortcode_library', function() {
+			return 'amp';
+		} );
+
 		/*
 		 * Add additional markup required by AMP <https://www.ampproject.org/docs/reference/spec#required-markup>.
 		 * Note that the meta[name=viewport] is not added here because a theme may want to define one with additional


### PR DESCRIPTION
I noticed that when using an audio/video media widget that MediaElement.js scripts and styles are getting enqueued erroneously. Since we're using AMP components for playing media instead of MediaElement.js it doesn't make sense for these to be enqueued to begin with.

See:

* https://github.com/WordPress/wordpress-develop/blob/da6b1b64aea6ac0de3200bed02b79a2855e05ba7/src/wp-includes/media.php#L2395-L2399
* https://github.com/WordPress/wordpress-develop/blob/da6b1b64aea6ac0de3200bed02b79a2855e05ba7/src/wp-includes/media.php#L2634-L2639