### PR TITLE
[WIP] Add dynamic handling of validation errors

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -139,7 +139,9 @@ function amp_init() {
 
 	add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
 
-	AMP_Validation_Utils::init();
+	AMP_Validation_Utils::init( array(
+		'debug' => isset( $_REQUEST[ AMP_Validation_Utils::DEBUG_QUERY_VAR ] ), // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+	) );
 	AMP_Theme_Support::init();
 	AMP_Post_Type_Support::add_post_type_support();
 	add_filter( 'request', 'amp_force_query_var_value' );

--- a/includes/class-amp-response-headers.php
+++ b/includes/class-amp-response-headers.php
@@ -63,9 +63,6 @@ class AMP_Response_Headers {
 	 * Send Server-Timing header.
 	 *
 	 * @since 1.0
-	 * @todo What is the ordering in Chrome dev tools? What are the colors about?
-	 * @todo Is there a better name standardization?
-	 * @todo Is there a way to indicate nested server timings, so an outer method's own time can be seen separately from the inner method's time?
 	 *
 	 * @param string $name        Name.
 	 * @param float  $duration    Duration. If negative, will be added to microtime( true ). Optional.
@@ -75,7 +72,7 @@ class AMP_Response_Headers {
 	public static function send_server_timing( $name, $duration = null, $description = null ) {
 		$value = $name;
 		if ( isset( $description ) ) {
-			$value .= sprintf( ';desc=%s', wp_json_encode( $description ) );
+			$value .= sprintf( ';desc="%s"', str_replace( array( '\\', '"' ), '', substr( $description, 0, 100 ) ) );
 		}
 		if ( isset( $duration ) ) {
 			if ( $duration < 0 ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -604,7 +604,7 @@ class AMP_Theme_Support {
 	 * @see get_query_template()
 	 *
 	 * @param array $templates Template hierarchy.
-	 * @returns array Templates.
+	 * @return array Templates.
 	 */
 	public static function filter_paired_template_hierarchy( $templates ) {
 		$support = get_theme_support( 'amp' );
@@ -991,15 +991,12 @@ class AMP_Theme_Support {
 			return $response;
 		}
 
-		$is_validation_debug_mode = ! empty( $_REQUEST[ AMP_Validation_Utils::DEBUG_QUERY_VAR ] ); // WPCS: csrf ok.
-
 		$args = array_merge(
 			array(
-				'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
-				'use_document_element'    => true,
-				'allow_dirty_styles'      => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
-				'allow_dirty_scripts'     => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
-				'disable_invalid_removal' => $is_validation_debug_mode,
+				'content_max_width'    => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
+				'use_document_element' => true,
+				'allow_dirty_styles'   => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
+				'allow_dirty_scripts'  => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
 			),
 			$args
 		);
@@ -1051,9 +1048,7 @@ class AMP_Theme_Support {
 		}
 
 		if ( AMP_Validation_Utils::should_validate_response() ) {
-			AMP_Validation_Utils::finalize_validation( $dom, array(
-				'remove_source_comments' => ! $is_validation_debug_mode,
-			) );
+			AMP_Validation_Utils::finalize_validation( $dom );
 		}
 
 		$response  = "<!DOCTYPE html>\n";

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -367,7 +367,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'stylesheet' => $stylesheet,
 				'node'       => $element,
 			);
-			if ( ! empty( $this->args['validation_error_callback'] ) ) {
+			if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo This needs to be capture_sources.
 				$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
 			}
 			$this->pending_stylesheets[] = $pending_stylesheet;
@@ -402,6 +402,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$css_file_path = $this->get_validated_url_file_path( $href, array( 'css', 'less', 'scss', 'sass' ) );
 		if ( is_wp_error( $css_file_path ) ) {
 			$this->remove_invalid_child( $element, array(
+				'code'    => $css_file_path->get_error_code(),
 				'message' => $css_file_path->get_error_message(),
 			) );
 			return;
@@ -411,6 +412,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$stylesheet = file_get_contents( $css_file_path ); // phpcs:ignore -- It's a local filesystem path not a remote request.
 		if ( false === $stylesheet ) {
 			$this->remove_invalid_child( $element, array(
+				'code'    => 'stylesheet_file_missing',
 				'message' => __( 'Unable to load stylesheet from filesystem.', 'amp' ),
 			) );
 			return;
@@ -434,7 +436,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'stylesheet' => $stylesheet,
 			'node'       => $element,
 		);
-		if ( ! empty( $this->args['validation_error_callback'] ) ) {
+		if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo This needs to be capture_sources.
 			$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
 		}
 		$this->pending_stylesheets[] = $pending_stylesheet;
@@ -470,6 +472,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $node, $options = array() ) {
 		$cache_impacting_options = wp_array_slice_assoc(
 			$options,
+			// @todo Needs to be a debug flag here because stored validation_errors will vary based on whether sources are being captured.
 			array( 'property_whitelist', 'property_blacklist', 'convert_width_to_max_width', 'stylesheet_url', 'allowed_at_rules' )
 		);
 
@@ -489,9 +492,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				// The expiration is to ensure transient doesn't stick around forever since no LRU flushing like with external object cache.
 				set_transient( $cache_key . $cache_group, $parsed, MONTH_IN_SECONDS );
 			}
-		}
+		} elseif ( ! empty( $this->args['validation_error_callback'] ) && ! empty( $parsed['validation_errors'] ) ) {
 
-		if ( ! empty( $this->args['validation_error_callback'] ) && ! empty( $parsed['validation_errors'] ) ) {
+			// Report cached validation errors.
 			foreach ( $parsed['validation_errors'] as $validation_error ) {
 				call_user_func( $this->args['validation_error_callback'], array_merge( $validation_error, compact( 'node' ) ) );
 			}
@@ -609,15 +612,34 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 		} catch ( Exception $exception ) {
-			$validation_errors[] = array(
+			$validation_error = array(
 				'code'    => 'css_parse_error',
 				'message' => $exception->getMessage(),
 			);
+			if ( ! empty( $this->args['validation_error_callback'] ) ) {
+				call_user_func( $this->args['validation_error_callback'], $validation_error );
+			}
+			$validation_error[] = $validation_error;
 		}
 
 		$this->parse_css_duration += ( microtime( true ) - $start_time );
 
 		return compact( 'stylesheet', 'validation_errors' );
+	}
+
+	/**
+	 * Check whether or not sanitization should occur in response to validation error.
+	 *
+	 * @since 1.0
+	 *
+	 * @param array $validation_error Validation error.
+	 * @return bool Whether to sanitize.
+	 */
+	private function should_sanitize( $validation_error ) {
+		if ( empty( $this->args['validation_error_callback'] ) ) {
+			return true;
+		}
+		return false !== call_user_func( $this->args['validation_error_callback'], $validation_error );
 	}
 
 	/**
@@ -633,70 +655,87 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$validation_errors = array();
 
 		foreach ( $css_list->getContents() as $css_item ) {
+			$should_remove_item = false;
 			if ( $css_item instanceof DeclarationBlock && empty( $options['validate_keyframes'] ) ) {
 				$validation_errors = array_merge(
 					$validation_errors,
 					$this->process_css_declaration_block( $css_item, $css_list, $options )
 				);
 			} elseif ( $css_item instanceof AtRuleBlockList ) {
-				if ( in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
+				if ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
+					$validation_error    = array(
+						'code'    => 'illegal_css_at_rule',
+						/* translators: %s is the CSS at-rule name. */
+						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
+					);
+					$validation_errors[] = $validation_error;
+					$should_remove_item  = $this->should_sanitize( $validation_error );
+				}
+				if ( ! $should_remove_item ) {
 					$validation_errors = array_merge(
 						$validation_errors,
 						$this->process_css_list( $css_item, $options )
 					);
-				} else {
-					$validation_errors[] = array(
+				}
+			} elseif ( $css_item instanceof Import ) {
+				$validation_error    = array(
+					'code'    => 'illegal_css_import_rule',
+					'message' => __( 'CSS @import is currently disallowed.', 'amp' ),
+				);
+				$validation_errors[] = $validation_error;
+				$should_remove_item  = $this->should_sanitize( $validation_error );
+			} elseif ( $css_item instanceof AtRuleSet ) {
+				if ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
+					$validation_error    = array(
 						'code'    => 'illegal_css_at_rule',
 						/* translators: %s is the CSS at-rule name. */
 						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 					);
-					$css_list->remove( $css_item );
+					$validation_errors[] = $validation_errors;
+					$should_remove_item  = $this->should_sanitize( $validation_error );
 				}
-			} elseif ( $css_item instanceof Import ) {
-				$validation_errors[] = array(
-					'code'    => 'illegal_css_import_rule',
-					'message' => __( 'CSS @import is currently disallowed.', 'amp' ),
-				);
-				$css_list->remove( $css_item );
-			} elseif ( $css_item instanceof AtRuleSet ) {
-				if ( in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
+
+				if ( ! $should_remove_item ) {
 					$validation_errors = array_merge(
 						$validation_errors,
 						$this->process_css_declaration_block( $css_item, $css_list, $options )
 					);
-				} else {
-					$validation_errors[] = array(
+				}
+			} elseif ( $css_item instanceof KeyFrame ) {
+				if ( ! in_array( 'keyframes', $options['allowed_at_rules'], true ) ) {
+					$validation_error    = array(
 						'code'    => 'illegal_css_at_rule',
 						/* translators: %s is the CSS at-rule name. */
 						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 					);
-					$css_list->remove( $css_item );
+					$validation_errors[] = $validation_errors;
+					$should_remove_item  = $this->should_sanitize( $validation_error );
 				}
-			} elseif ( $css_item instanceof KeyFrame ) {
-				if ( in_array( 'keyframes', $options['allowed_at_rules'], true ) ) {
+
+				if ( ! $should_remove_item ) {
 					$validation_errors = array_merge(
 						$validation_errors,
 						$this->process_css_keyframes( $css_item, $options )
 					);
-				} else {
-					$validation_errors[] = array(
-						'code'    => 'illegal_css_at_rule',
-						/* translators: %s is the CSS at-rule name. */
-						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
-					);
 				}
 			} elseif ( $css_item instanceof AtRule ) {
-				$validation_errors[] = array(
+				$validation_error    = array(
 					'code'    => 'illegal_css_at_rule',
 					/* translators: %s is the CSS at-rule name. */
 					'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 				);
-				$css_list->remove( $css_item );
+				$validation_errors[] = $validation_errors;
+				$should_remove_item  = $this->should_sanitize( $validation_error );
 			} else {
-				$validation_errors[] = array(
+				$validation_error    = array(
 					'code'    => 'unrecognized_css',
 					'message' => __( 'Unrecognized CSS removed.', 'amp' ),
 				);
+				$validation_errors[] = $validation_errors;
+				$should_remove_item  = $this->should_sanitize( $validation_error );
+			}
+
+			if ( $should_remove_item ) {
 				$css_list->remove( $css_item );
 			}
 		}
@@ -758,24 +797,30 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $properties as $property ) {
 				$vendorless_property_name = preg_replace( '/^-\w+-/', '', $property->getRule() );
 				if ( ! in_array( $vendorless_property_name, $options['property_whitelist'], true ) ) {
-					$validation_errors[] = array(
+					$validation_error = array(
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => $property->getValue(),
 					);
-					$ruleset->removeRule( $property->getRule() );
+					if ( $this->should_sanitize( $validation_error ) ) {
+						$ruleset->removeRule( $property->getRule() );
+					}
+					$validation_errors[] = $validation_error;
 				}
 			}
 		} else {
 			foreach ( $options['property_blacklist'] as $illegal_property_name ) {
 				$properties = $ruleset->getRules( $illegal_property_name );
 				foreach ( $properties as $property ) {
-					$validation_errors[] = array(
+					$validation_error = array(
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => $property->getValue(),
 					);
-					$ruleset->removeRule( $property->getRule() );
+					if ( $this->should_sanitize( $validation_error ) ) {
+						$ruleset->removeRule( $property->getRule() );
+					}
+					$validation_errors[] = $validation_error;
 				}
 			}
 		}
@@ -937,11 +982,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( ! empty( $options['property_whitelist'] ) ) {
 			foreach ( $css_list->getContents() as $rules ) {
 				if ( ! ( $rules instanceof DeclarationBlock ) ) {
-					$validation_errors[] = array(
+					$validation_error = array(
 						'code'    => 'unrecognized_css',
 						'message' => __( 'Unrecognized CSS removed.', 'amp' ),
 					);
-					$css_list->remove( $rules );
+					if ( $this->should_sanitize( $validation_error ) ) {
+						$css_list->remove( $rules );
+					}
+					$validation_errors[] = $validation_error;
 					continue;
 				}
 
@@ -954,12 +1002,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $properties as $property ) {
 					$vendorless_property_name = preg_replace( '/^-\w+-/', '', $property->getRule() );
 					if ( ! in_array( $vendorless_property_name, $options['property_whitelist'], true ) ) {
-						$validation_errors[] = array(
+						$validation_error = array(
 							'code'           => 'illegal_css_property',
 							'property_name'  => $property->getRule(),
 							'property_value' => $property->getValue(),
 						);
-						$rules->removeRule( $property->getRule() );
+						if ( $this->should_sanitize( $validation_error ) ) {
+							$rules->removeRule( $property->getRule() );
+						}
+						$validation_errors[] = $validation_error;
 					}
 				}
 			}
@@ -979,7 +1030,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation errors.
 	 */
 	private function transform_important_qualifiers( RuleSet $ruleset, CSSList $css_list ) {
-		$validation_errors    = array();
+		$validation_errors = array();
+
+		// An !important only makes sense for rulesets that have selectors.
 		$allow_transformation = (
 			$ruleset instanceof DeclarationBlock
 			&&
@@ -990,17 +1043,19 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$importants = array();
 		foreach ( $properties as $property ) {
 			if ( $property->getIsImportant() ) {
-				$property->setIsImportant( false );
-
-				// An !important doesn't make sense for rulesets that don't have selectors.
 				if ( $allow_transformation ) {
 					$importants[] = $property;
+					$property->setIsImportant( false );
 					$ruleset->removeRule( $property->getRule() );
 				} else {
-					$validation_errors[] = array(
+					$validation_error = array(
 						'code'    => 'illegal_css_important',
 						'message' => __( 'Illegal CSS !important qualifier.', 'amp' ),
 					);
+					if ( $this->should_sanitize( $validation_error ) ) {
+						$property->setIsImportant( false );
+					}
+					$validation_errors[] = $validation_error;
 				}
 			}
 		}
@@ -1087,7 +1142,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'node'       => $element,
 			'keyframes'  => false,
 		);
-		if ( ! empty( $this->args['validation_error_callback'] ) ) {
+		if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo Needs to be capture_sources or something, like debug.
 			$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
 		}
 
@@ -1281,25 +1336,25 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			// Report validation error if size is now too big.
 			$sheet_size = strlen( $stylesheet );
 			if ( $final_size + $sheet_size > $stylesheet_set['cdata_spec']['max_bytes'] ) {
-				if ( ! empty( $this->args['validation_error_callback'] ) ) {
-					$validation_error = array(
-						'code'    => 'excessive_css',
-						'message' => sprintf(
-							/* translators: %d is the number of bytes over the limit */
-							__( 'Too much CSS output (by %d bytes).', 'amp' ),
-							( $final_size + $sheet_size ) - $stylesheet_set['cdata_spec']['max_bytes']
-						),
-					);
-					if ( isset( $pending_stylesheet['sources'] ) ) {
-						$validation_error['sources'] = $pending_stylesheet['sources'];
-					}
-					call_user_func( $this->args['validation_error_callback'], $validation_error );
+				$validation_error = array(
+					'code'    => 'excessive_css',
+					'message' => sprintf(
+						/* translators: %d is the number of bytes over the limit */
+						__( 'Too much CSS output (by %d bytes).', 'amp' ),
+						( $final_size + $sheet_size ) - $stylesheet_set['cdata_spec']['max_bytes']
+					),
+				);
+				if ( isset( $pending_stylesheet['sources'] ) ) {
+					$validation_error['sources'] = $pending_stylesheet['sources'];
 				}
-			} else {
-				$final_size += $sheet_size;
-
-				$stylesheet_set['final_stylesheets'][ $hash ] = $stylesheet;
+				if ( $this->should_sanitize( $validation_error ) ) {
+					continue;
+				}
 			}
+
+			$final_size += $sheet_size;
+
+			$stylesheet_set['final_stylesheets'][ $hash ] = $stylesheet;
 		}
 
 		return $stylesheet_set;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -35,6 +35,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type bool     $require_https_src          Require HTTPS URLs.
 	 *      @type bool     $allow_dirty_styles         Allow dirty styles. This short-circuits the sanitize logic; it is used primarily in Customizer preview.
 	 *      @type callable $validation_error_callback  Function to call when a validation error is encountered.
+	 *      @type bool     $locate_sources             Whether to locate the sources when reporting validation errors.
 	 * }
 	 */
 	protected $args;
@@ -52,6 +53,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'[submit-error]',
 			'[submit-success]',
 		),
+		'locate_sources'            => false,
 	);
 
 	/**
@@ -148,6 +150,20 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var float
 	 */
 	private $parse_css_duration = 0.0;
+
+	/**
+	 * Current node being processed.
+	 *
+	 * @var DOMElement|DOMAttr
+	 */
+	private $current_node;
+
+	/**
+	 * Current sources for a given node.
+	 *
+	 * @var array
+	 */
+	private $current_sources;
 
 	/**
 	 * AMP_Base_Sanitizer constructor.
@@ -344,34 +360,49 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Set the current node (and its sources when required).
+	 *
+	 * @since 1.0
+	 * @param DOMElement|DOMAttr|null $node Current node, or null to reset.
+	 */
+	private function set_current_node( $node ) {
+		if ( $this->current_node === $node ) {
+			return;
+		}
+
+		$this->current_node = $node;
+		if ( empty( $node ) ) {
+			$this->current_sources = null;
+		} elseif ( ! empty( $this->args['locate_sources'] ) ) {
+			$this->current_sources = AMP_Validation_Utils::locate_sources( $node );
+		}
+	}
+
+	/**
 	 * Process style element.
 	 *
 	 * @param DOMElement $element Style element.
 	 */
 	private function process_style_element( DOMElement $element ) {
+		$this->set_current_node( $element ); // And sources when needing to be located.
 
 		// @todo Any @keyframes rules could be removed from amp-custom and instead added to amp-keyframes.
 		$is_keyframes = $element->hasAttribute( 'amp-keyframes' );
 		$stylesheet   = trim( $element->textContent );
 		$cdata_spec   = $is_keyframes ? $this->style_keyframes_cdata_spec : $this->style_custom_cdata_spec;
-		if ( $stylesheet ) {
 
-			$stylesheet = $this->process_stylesheet( $stylesheet, $element, array(
-				'allowed_at_rules'   => $cdata_spec['css_spec']['allowed_at_rules'],
-				'property_whitelist' => $cdata_spec['css_spec']['allowed_declarations'],
-				'validate_keyframes' => $cdata_spec['css_spec']['validate_keyframes'],
-			) );
+		$stylesheet = $this->process_stylesheet( $stylesheet, array(
+			'allowed_at_rules'   => $cdata_spec['css_spec']['allowed_at_rules'],
+			'property_whitelist' => $cdata_spec['css_spec']['allowed_declarations'],
+			'validate_keyframes' => $cdata_spec['css_spec']['validate_keyframes'],
+		) );
 
-			$pending_stylesheet = array(
-				'keyframes'  => $is_keyframes,
-				'stylesheet' => $stylesheet,
-				'node'       => $element,
-			);
-			if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo This needs to be capture_sources.
-				$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
-			}
-			$this->pending_stylesheets[] = $pending_stylesheet;
-		}
+		$this->pending_stylesheets[] = array(
+			'keyframes'  => $is_keyframes,
+			'stylesheet' => $stylesheet,
+			'node'       => $element,
+			'sources'    => $this->current_sources,
+		);
 
 		if ( $element->hasAttribute( 'amp-custom' ) ) {
 			if ( ! $this->amp_custom_style_element ) {
@@ -384,6 +415,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			// Remove from DOM since we'll be adding it to amp-custom.
 			$element->parentNode->removeChild( $element );
 		}
+
+		$this->set_current_node( null );
 	}
 
 	/**
@@ -424,25 +457,26 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$stylesheet = sprintf( '@media %s { %s }', $media, $stylesheet );
 		}
 
-		$stylesheet = $this->process_stylesheet( $stylesheet, $element, array(
+		$this->set_current_node( $element ); // And sources when needing to be located.
+
+		$stylesheet = $this->process_stylesheet( $stylesheet, array(
 			'allowed_at_rules'   => $this->style_custom_cdata_spec['css_spec']['allowed_at_rules'],
 			'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['allowed_declarations'],
 			'stylesheet_url'     => $href,
 			'stylesheet_path'    => $css_file_path,
 		) );
 
-		$pending_stylesheet = array(
+		$this->pending_stylesheets[] = array(
 			'keyframes'  => false,
 			'stylesheet' => $stylesheet,
 			'node'       => $element,
+			'sources'    => $this->current_sources, // Needed because node is removed below.
 		);
-		if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo This needs to be capture_sources.
-			$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
-		}
-		$this->pending_stylesheets[] = $pending_stylesheet;
 
 		// Remove now that styles have been processed.
 		$element->parentNode->removeChild( $element );
+
+		$this->set_current_node( null );
 	}
 
 	/**
@@ -453,12 +487,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 1.0
 	 *
-	 * @param string             $stylesheet Stylesheet.
-	 * @param DOMElement|DOMAttr $node       Element (link/style) or style attribute where the stylesheet came from.
-	 * @param array              $options {
+	 * @param string $stylesheet Stylesheet.
+	 * @param array  $options {
 	 *     Options.
 	 *
-	 *     @type bool     $class_selector_tree_shaking Whether to perform tree shaking to delete rules that reference class names not extant in the current document.
 	 *     @type string[] $property_whitelist          Exclusively-allowed properties.
 	 *     @type string[] $property_blacklist          Disallowed properties.
 	 *     @type bool     $convert_width_to_max_width  Convert width to max-width.
@@ -469,12 +501,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * }
 	 * @return array Processed stylesheet parts.
 	 */
-	private function process_stylesheet( $stylesheet, $node, $options = array() ) {
+	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$cache_impacting_options = wp_array_slice_assoc(
 			$options,
-			// @todo Needs to be a debug flag here because stored validation_errors will vary based on whether sources are being captured.
 			array( 'property_whitelist', 'property_blacklist', 'convert_width_to_max_width', 'stylesheet_url', 'allowed_at_rules' )
 		);
+
+		$cache_impacting_options['locate_sources'] = ! empty( $this->args['locate_sources'] );
 
 		$cache_key = md5( $stylesheet . serialize( $cache_impacting_options ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
@@ -492,11 +525,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				// The expiration is to ensure transient doesn't stick around forever since no LRU flushing like with external object cache.
 				set_transient( $cache_key . $cache_group, $parsed, MONTH_IN_SECONDS );
 			}
-		} elseif ( ! empty( $this->args['validation_error_callback'] ) && ! empty( $parsed['validation_errors'] ) ) {
+		} elseif ( ! empty( $parsed['validation_errors'] ) ) {
 
 			// Report cached validation errors.
 			foreach ( $parsed['validation_errors'] as $validation_error ) {
-				call_user_func( $this->args['validation_error_callback'], array_merge( $validation_error, compact( 'node' ) ) );
+				$this->handle_validation_error( $validation_error );
 			}
 		}
 
@@ -616,9 +649,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'code'    => 'css_parse_error',
 				'message' => $exception->getMessage(),
 			);
-			if ( ! empty( $this->args['validation_error_callback'] ) ) {
-				call_user_func( $this->args['validation_error_callback'], $validation_error );
-			}
+			$this->handle_validation_error( $validation_error );
 			$validation_error[] = $validation_error;
 		}
 
@@ -628,6 +659,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Call the validation_error_callback.
+	 *
 	 * Check whether or not sanitization should occur in response to validation error.
 	 *
 	 * @since 1.0
@@ -635,9 +668,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array $validation_error Validation error.
 	 * @return bool Whether to sanitize.
 	 */
-	private function should_sanitize( $validation_error ) {
-		if ( empty( $this->args['validation_error_callback'] ) ) {
+	private function handle_validation_error( $validation_error ) {
+		if ( empty( $this->args['validation_error_callback'] ) || ! is_callable( $this->args['validation_error_callback'] ) ) {
 			return true;
+		}
+		if ( ! isset( $validation_error['node'] ) ) {
+			$validation_error['node'] = $this->current_node;
+		}
+		if ( ! isset( $validation_error['sources'] ) ) {
+			$validation_error['sources'] = $this->current_sources;
 		}
 		return false !== call_user_func( $this->args['validation_error_callback'], $validation_error );
 	}
@@ -669,7 +708,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 					);
 					$validation_errors[] = $validation_error;
-					$should_remove_item  = $this->should_sanitize( $validation_error );
+					$should_remove_item  = $this->handle_validation_error( $validation_error );
 				}
 				if ( ! $should_remove_item ) {
 					$validation_errors = array_merge(
@@ -683,7 +722,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					'message' => __( 'CSS @import is currently disallowed.', 'amp' ),
 				);
 				$validation_errors[] = $validation_error;
-				$should_remove_item  = $this->should_sanitize( $validation_error );
+				$should_remove_item  = $this->handle_validation_error( $validation_error );
 			} elseif ( $css_item instanceof AtRuleSet ) {
 				if ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
 					$validation_error    = array(
@@ -692,7 +731,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 					);
 					$validation_errors[] = $validation_errors;
-					$should_remove_item  = $this->should_sanitize( $validation_error );
+					$should_remove_item  = $this->handle_validation_error( $validation_error );
 				}
 
 				if ( ! $should_remove_item ) {
@@ -709,7 +748,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 					);
 					$validation_errors[] = $validation_errors;
-					$should_remove_item  = $this->should_sanitize( $validation_error );
+					$should_remove_item  = $this->handle_validation_error( $validation_error );
 				}
 
 				if ( ! $should_remove_item ) {
@@ -725,14 +764,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					'message' => sprintf( __( 'CSS @%s rules are currently disallowed.', 'amp' ), $css_item->atRuleName() ),
 				);
 				$validation_errors[] = $validation_errors;
-				$should_remove_item  = $this->should_sanitize( $validation_error );
+				$should_remove_item  = $this->handle_validation_error( $validation_error );
 			} else {
 				$validation_error    = array(
 					'code'    => 'unrecognized_css',
 					'message' => __( 'Unrecognized CSS removed.', 'amp' ),
 				);
 				$validation_errors[] = $validation_errors;
-				$should_remove_item  = $this->should_sanitize( $validation_error );
+				$should_remove_item  = $this->handle_validation_error( $validation_error );
 			}
 
 			if ( $should_remove_item ) {
@@ -802,7 +841,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'property_name'  => $property->getRule(),
 						'property_value' => $property->getValue(),
 					);
-					if ( $this->should_sanitize( $validation_error ) ) {
+					if ( $this->handle_validation_error( $validation_error ) ) {
 						$ruleset->removeRule( $property->getRule() );
 					}
 					$validation_errors[] = $validation_error;
@@ -815,9 +854,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$validation_error = array(
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
-						'property_value' => $property->getValue(),
+						'property_value' => (string) $property->getValue(),
 					);
-					if ( $this->should_sanitize( $validation_error ) ) {
+					if ( $this->handle_validation_error( $validation_error ) ) {
 						$ruleset->removeRule( $property->getRule() );
 					}
 					$validation_errors[] = $validation_error;
@@ -986,7 +1025,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'code'    => 'unrecognized_css',
 						'message' => __( 'Unrecognized CSS removed.', 'amp' ),
 					);
-					if ( $this->should_sanitize( $validation_error ) ) {
+					if ( $this->handle_validation_error( $validation_error ) ) {
 						$css_list->remove( $rules );
 					}
 					$validation_errors[] = $validation_error;
@@ -1005,9 +1044,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						$validation_error = array(
 							'code'           => 'illegal_css_property',
 							'property_name'  => $property->getRule(),
-							'property_value' => $property->getValue(),
+							'property_value' => (string) $property->getValue(),
 						);
-						if ( $this->should_sanitize( $validation_error ) ) {
+						if ( $this->handle_validation_error( $validation_error ) ) {
 							$rules->removeRule( $property->getRule() );
 						}
 						$validation_errors[] = $validation_error;
@@ -1052,7 +1091,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'code'    => 'illegal_css_important',
 						'message' => __( 'Illegal CSS !important qualifier.', 'amp' ),
 					);
-					if ( $this->should_sanitize( $validation_error ) ) {
+					if ( $this->handle_validation_error( $validation_error ) ) {
 						$property->setIsImportant( false );
 					}
 					$validation_errors[] = $validation_error;
@@ -1126,34 +1165,31 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$root  = ':root' . str_repeat( ':not(#_)', 5 ); // @todo The correctness of using "5" should be validated.
 		$rule  = sprintf( '%s .%s { %s }', $root, $class, $style_attribute->nodeValue );
 
-		$stylesheet = $this->process_stylesheet( $rule, $style_attribute, array(
+		$this->set_current_node( $element ); // And sources when needing to be located.
+
+		$stylesheet = $this->process_stylesheet( $rule, array(
 			'convert_width_to_max_width' => true,
 			'allowed_at_rules'           => array(),
 			'property_whitelist'         => $this->style_custom_cdata_spec['css_spec']['allowed_declarations'],
 		) );
 
-		if ( empty( $stylesheet ) ) {
-			$element->removeAttribute( 'style' );
-			return;
-		}
-
-		$pending_stylesheet = array(
-			'stylesheet' => $stylesheet,
-			'node'       => $element,
-			'keyframes'  => false,
-		);
-		if ( ! empty( $this->args['validation_error_callback'] ) ) { // @todo Needs to be capture_sources or something, like debug.
-			$pending_stylesheet['sources'] = AMP_Validation_Utils::locate_sources( $element ); // Needed because node is removed below.
-		}
-
-		$this->pending_stylesheets[] = $pending_stylesheet;
-
 		$element->removeAttribute( 'style' );
-		if ( $element->hasAttribute( 'class' ) ) {
-			$element->setAttribute( 'class', $element->getAttribute( 'class' ) . ' ' . $class );
-		} else {
-			$element->setAttribute( 'class', $class );
+
+		if ( $stylesheet ) {
+			$this->pending_stylesheets[] = array(
+				'stylesheet' => $stylesheet,
+				'node'       => $element,
+				'sources'    => $this->current_sources, // Needed because node is removed below.
+			);
+
+			if ( $element->hasAttribute( 'class' ) ) {
+				$element->setAttribute( 'class', $element->getAttribute( 'class' ) . ' ' . $class );
+			} else {
+				$element->setAttribute( 'class', $class );
+			}
 		}
+
+		$this->set_current_node( null );
 	}
 
 	/**
@@ -1247,12 +1283,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( ! empty( $stylesheet_sets['keyframes']['final_stylesheets'] ) ) {
 			$body = $this->dom->getElementsByTagName( 'body' )->item( 0 );
 			if ( ! $body ) {
-				if ( ! empty( $this->args['validation_error_callback'] ) ) {
-					call_user_func( $this->args['validation_error_callback'], array(
-						'code'    => 'missing_body_element',
-						'message' => __( 'amp-keyframes must be last child of body element.', 'amp' ),
-					) );
-				}
+				$this->handle_validation_error( array(
+					'code'    => 'missing_body_element',
+					'message' => __( 'amp-keyframes must be last child of body element.', 'amp' ),
+				) );
 			} else {
 				$style_element = $this->dom->createElement( 'style' );
 				$style_element->setAttribute( 'amp-keyframes', '' );
@@ -1280,8 +1314,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			)
 		);
 
-		if ( $is_too_much_css && $should_tree_shake && ! empty( $this->args['validation_error_callback'] ) ) {
-			call_user_func( $this->args['validation_error_callback'], array(
+		if ( $is_too_much_css && $should_tree_shake ) {
+			$this->handle_validation_error( array(
 				'code'    => 'removed_unused_css_rules',
 				'message' => __( 'Too much CSS is enqueued and so seemingly irrelevant rules have been removed.', 'amp' ),
 			) );
@@ -1338,6 +1372,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $final_size + $sheet_size > $stylesheet_set['cdata_spec']['max_bytes'] ) {
 				$validation_error = array(
 					'code'    => 'excessive_css',
+					'node'    => $pending_stylesheet['node'],
 					'message' => sprintf(
 						/* translators: %d is the number of bytes over the limit */
 						__( 'Too much CSS output (by %d bytes).', 'amp' ),
@@ -1347,7 +1382,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( isset( $pending_stylesheet['sources'] ) ) {
 					$validation_error['sources'] = $pending_stylesheet['sources'];
 				}
-				if ( $this->should_sanitize( $validation_error ) ) {
+				if ( $this->handle_validation_error( $validation_error ) ) {
 					continue;
 				}
 			}

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -205,10 +205,22 @@ class AMP_Validation_Utils {
 	/**
 	 * Add the actions.
 	 *
+	 * @param array $args {
+	 *     Args.
+	 *
+	 *     @type bool $debug Whether validation should be done in debug mode, where validation errors are not sanitized and source comments are not removed.
+	 * }
 	 * @return void
 	 */
-	public static function init() {
-		self::$debug = isset( $_REQUEST[ self::DEBUG_QUERY_VAR ] ); // WPCS: csrf ok.
+	public static function init( $args = array() ) {
+		$args = array_merge(
+			array(
+				'debug' => false,
+			),
+			$args
+		);
+
+		self::$debug = $args['debug'];
 
 		if ( current_theme_supports( 'amp' ) ) {
 			add_action( 'init', array( __CLASS__, 'register_post_type' ) );
@@ -314,7 +326,7 @@ class AMP_Validation_Utils {
 		}
 
 		add_filter( 'do_shortcode_tag', array( __CLASS__, 'decorate_shortcode_source' ), -1, 2 );
-		add_filter( 'amp_content_sanitizers', array( __CLASS__, 'add_validation_callback' ) );
+		add_filter( 'amp_content_sanitizers', array( __CLASS__, 'add_validation_callback' ), 1000 );
 	}
 
 	/**
@@ -1100,14 +1112,28 @@ class AMP_Validation_Utils {
 	 * @return array $sanitizers The filtered AMP sanitizers.
 	 */
 	public static function add_validation_callback( $sanitizers ) {
-		foreach ( $sanitizers as $sanitizer => $args ) {
-			$sanitizers[ $sanitizer ] = array_merge(
-				$args,
-				array(
-					'validation_error_callback' => __CLASS__ . '::add_validation_error',
-				)
-			);
+		foreach ( $sanitizers as $sanitizer => &$args ) {
+
+			if ( isset( $args['validation_error_callback'] ) ) {
+				$original_validation_error_callback = $args['validation_error_callback'];
+				$args['validation_error_callback']  = function( $validation_error ) use ( $original_validation_error_callback ) {
+					AMP_Validation_Utils::add_validation_error( $validation_error );
+					$result = call_user_func( $original_validation_error_callback, $validation_error );
+					if ( self::$debug ) {
+						return false;
+					}
+					return $result;
+				};
+			} else {
+				$args['validation_error_callback'] = __CLASS__ . '::add_validation_error';
+			}
 		}
+
+		// @todo Pass this into all sanitizers?
+		if ( isset( $sanitizers['AMP_Style_Sanitizer'] ) ) {
+			$sanitizers['AMP_Style_Sanitizer']['locate_sources'] = true;
+		}
+
 		return $sanitizers;
 	}
 

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -194,11 +194,22 @@ class AMP_Validation_Utils {
 	protected static $current_hook_source_stack = array();
 
 	/**
+	 * Whether in debug mode.
+	 *
+	 * This means that sanitization will not be applied for validation errors.
+	 *
+	 * @var bool
+	 */
+	public static $debug = false;
+
+	/**
 	 * Add the actions.
 	 *
 	 * @return void
 	 */
 	public static function init() {
+		self::$debug = isset( $_REQUEST[ self::DEBUG_QUERY_VAR ] ); // WPCS: csrf ok.
+
 		if ( current_theme_supports( 'amp' ) ) {
 			add_action( 'init', array( __CLASS__, 'register_post_type' ) );
 			add_filter( 'dashboard_glance_items', array( __CLASS__, 'filter_dashboard_glance_items' ) );
@@ -403,6 +414,7 @@ class AMP_Validation_Utils {
 	 *     @type string $code Error code.
 	 *     @type DOMElement|DOMNode $node The removed node.
 	 * }
+	 * @return bool Whether the validation error should result in sanitization.
 	 */
 	public static function add_validation_error( array $data ) {
 		$node = null;
@@ -455,6 +467,8 @@ class AMP_Validation_Utils {
 		}
 
 		self::$validation_errors[] = $data;
+
+		return ! self::$debug;
 	}
 
 	/**
@@ -1051,7 +1065,7 @@ class AMP_Validation_Utils {
 		$args = array_merge(
 			array(
 				'send_validation_errors_header'    => true,
-				'remove_source_comments'           => true,
+				'remove_source_comments'           => ! self::$debug,
 				'append_validation_status_comment' => true,
 			),
 			$args

--- a/tests/test-class-amp-validation-utils.php
+++ b/tests/test-class-amp-validation-utils.php
@@ -129,7 +129,7 @@ class Test_AMP_Validation_Utils extends \WP_UnitTestCase {
 		AMP_Validation_Utils::add_validation_hooks();
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_content', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_excerpt', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
-		$this->assertEquals( 10, has_action( 'amp_content_sanitizers', array( self::TESTED_CLASS, 'add_validation_callback' ) ) );
+		$this->assertEquals( 1000, has_action( 'amp_content_sanitizers', array( self::TESTED_CLASS, 'add_validation_callback' ) ) );
 		$this->assertEquals( -1, has_action( 'do_shortcode_tag', array( self::TESTED_CLASS, 'decorate_shortcode_source' ) ) );
 	}
 


### PR DESCRIPTION
Follow up on https://github.com/Automattic/amp-wp/pull/1048#issuecomment-379167176

> I want to follow up later with some more improvements including the added ability to knowingly bypass removal of elements, attributes, and styles that are invalid but which a given site cannot afford to be removed. I'm thinking we'd want CSS over the 50KB limit to default to not be removed, even if that means it is invalid AMP. In terms of implementation here, I think this can be implemented by allowing the `validation_error_callback` to return `false` as a way to prevent removal from happening. That would allow a theme/plugin to decide on a case-by-case basis which things should get removed. This is in regards to https://github.com/Automattic/amp-wp/pull/1048#pullrequestreview-108681682 and https://github.com/Automattic/amp-wp/pull/1048#discussion_r178599928

There are a few validation errors that should specifically be not sanitized by default since they could seriously impact a site:

* Keyframe properties that aren't hardware accelerated.
* CSS exceeding 50KB.
* External stylesheets that can't be inlined.
* …

In addition to allowing the user to manually acknowledge whether a given validation error should be considered critical or be ignored (#1003), there also needs to be a way to dynamically make this decision based on a user-supplied validation callback, a capability which would also be used in #1087 to check whether a validation error is a deal breaker for serving AMP for the current page.

# Todo

- [ ] When a deal-breaker validation error occurs, prevent AMP from being served from a given URL.
- [ ] Make sure that error codes are distinct enough to be differentiated.
- [ ] Make sure that validation errors still display when editing a post.
- [x] Make sure that sources are located when not serving validation errors from cache (pass `$node` to methods).
- [ ] 🚫 ~Decide on which validation errors should not result in sanitization by default (if any).~
- [ ] 🚫 ~Consider having a AMP admin setting for whether to allow select validation errors when they occur.~
- [ ] 🚫 ~Look at factoring in sanitization-skipping to paired mode, to serve `canonical` dirty AMP documents but valid non-canonical (`amphtml`) ones. This is similar to incorporating prerendering into the postprocessing flow (#958).~

Closes #956 