### PR TITLE
Detect when ob_flush() is called prematurely in the course of output-buffering document for AMP theme support

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1034,6 +1034,15 @@ class AMP_Theme_Support {
 			return $response;
 		}
 
+		// Account for case where ob_flush() was called prematurely.
+		if ( false === strpos( $response, '<html' ) ) {
+			$error = sprintf(
+				'<div style="color:red; background: white; padding: 0.5em; position: fixed; z-index: 100000; bottom: 0; border: dashed 1px red;">%s</div>',
+				wp_kses_post( __( '<strong>AMP Plugin Error</strong>: It appears that your WordPress install prematurely flushed the output buffer. You will need to disable AMP theme support until that is fixed.', 'amp' ) )
+			);
+			return $error . $response;
+		}
+
 		$is_validation_debug_mode = ! empty( $_REQUEST[ AMP_Validation_Utils::DEBUG_QUERY_VAR ] ); // WPCS: csrf ok.
 
 		$args = array_merge(

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -912,7 +912,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// start first layer buffer.
 		ob_start();
 		AMP_Theme_Support::start_output_buffering();
-		echo '<img src="test.png"><script data-test>document.write(\'Illegal\');</script>';
+		echo '<html><img src="test.png"><script data-test>document.write(\'Illegal\');</script></html>';
 		AMP_Theme_Support::finish_output_buffering();
 		// get first layer buffer.
 		$output = ob_get_clean();
@@ -1068,6 +1068,25 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertStringStartsWith( '<!DOCTYPE html>', $sanitized_html );
 		$this->assertContains( '<html amp', $sanitized_html );
+	}
+
+	/**
+	 * Test preparing an incomplete response due to ob_flush().
+	 *
+	 * @covers AMP_Theme_Support::prepare_response()
+	 */
+	public function test_prepare_response_premature_ob_flush() {
+		add_theme_support( 'amp' );
+		AMP_Theme_Support::init();
+		ob_start();
+		wp_footer();
+		echo '</body></html>';
+		$original_html  = trim( ob_get_clean() );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
+
+		$this->assertContains( 'AMP Plugin Error', $sanitized_html );
+		$this->assertNotContains( '<!DOCTYPE html>', $sanitized_html );
+		$this->assertNotContains( '<html amp', $sanitized_html );
 	}
 
 	/**


### PR DESCRIPTION
At the moment this is a workaround to detect when the output buffer passed into `AMP_Theme_Support::finish_output_buffering()` is truncated due to a WordPress install doing `ob_flush()` prematurely. For example, on Pressable it appears that some code such as the following is running:

```php
add_action( 'get_footer', function() {
	ob_flush();
} );
```

This breaks the output buffer started in `AMP_Theme_Support::start_output_buffering()` at the `wp` action. The output buffer needs to remain intact until the `shutdown` action when `AMP_Theme_Support::finish_output_buffering()` then passes the buffer into `AMP_Theme_Support::prepare_response()`. Note that this happens at `shutdown` with a priority of 0 because `wp_ob_end_flush_all()` runs at `shutdown` priority 1.

We should try to find a better solution to ensure the integrity of the output buffer.