### PR TITLE
Fix domain check for WP.com hosted files

### DIFF
--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -188,7 +188,7 @@ function wpcom_amp_extract_image_dimensions_from_querystring( $dimensions ) {
 		}
 
 		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! wp_endswith( $host, '.wp.com' ) || ! wp_endswith( $host, '.files.wordpress.com' ) ) {
+		if ( ! wp_endswith( $host, '.wp.com' ) && ! wp_endswith( $host, '.files.wordpress.com' ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
We want the querystring extraction to apply to either `*.wp.com` or `*.files.wordpress.com` domains. Previously, this would only apply for `*.wp.com` due to the incorrect conditional.

This change is in the `wpcom-helper.php` file and only applies to WP.com-hosted sites.

props @vortfu