### PR TITLE
Ensure layout attributes are only allowed on supporting elements

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -469,6 +469,15 @@ def GetTagRules(tag_spec):
 	if tag_spec.HasField('unique_warning'):
 		tag_rules['unique_warning'] = tag_spec.unique_warning
 
+	if tag_spec.HasField('amp_layout'):
+		amp_layout = {}
+		for field in tag_spec.amp_layout.ListFields():
+			if 'supported_layouts' == field[0].name:
+				amp_layout['supported_layouts'] = [ val for val in field[1] ]
+			else:
+				amp_layout[ field[0].name ] = field[1]
+		tag_rules['amp_layout'] = amp_layout
+
 	logging.info('... done')
 	return tag_rules
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -105,6 +105,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-3q-player',
 					),
@@ -122,6 +130,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
 					'requires_extension' => array(
 						'amp-accordion',
 					),
@@ -156,6 +169,18 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
 						'amp-ad extension .js script',
+					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
 					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
@@ -196,6 +221,18 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
 						'amp-ad extension .js script',
+					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
 					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
@@ -240,6 +277,18 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'also_requires_tag_warning' => array(
 						'amp-ad extension .js script',
+					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
 					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
@@ -304,6 +353,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-anim',
 					),
@@ -323,6 +383,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-animation',
 					),
@@ -344,6 +409,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-apester-media',
 					),
@@ -363,6 +438,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-app-banner',
@@ -407,6 +487,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'defines_default_height' => true,
+						'defines_default_width' => true,
+						'supported_layouts' => array(
+							2,
+							3,
+							1,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-story',
 					),
@@ -448,6 +537,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'defines_default_height' => true,
+						'defines_default_width' => true,
+						'supported_layouts' => array(
+							2,
+							3,
+							1,
+						),
+					),
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
 						'amp-audio',
@@ -497,6 +595,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-beopinion',
 					),
@@ -542,6 +651,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-bodymovin-animation',
 					),
@@ -576,6 +695,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-brid-player',
 					),
@@ -601,6 +730,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-brightcove',
 					),
@@ -623,6 +762,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-byside-content',
 					),
@@ -648,6 +797,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-call-tracking',
 					),
@@ -691,6 +850,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-carousel',
 					),
@@ -707,6 +877,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-consent',
 					),
@@ -749,6 +924,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-dailymotion',
 					),
@@ -810,6 +994,17 @@ class AMP_Allowed_Tags_Generated {
 					'week-day-format' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-date-picker',
 					),
@@ -867,6 +1062,12 @@ class AMP_Allowed_Tags_Generated {
 					'week-day-format' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-date-picker',
 					),
@@ -928,6 +1129,17 @@ class AMP_Allowed_Tags_Generated {
 					'week-day-format' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-date-picker',
 					),
@@ -987,6 +1199,12 @@ class AMP_Allowed_Tags_Generated {
 					'week-day-format' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-date-picker',
 					),
@@ -1034,6 +1252,18 @@ class AMP_Allowed_Tags_Generated {
 					'also_requires_tag_warning' => array(
 						'amp-ad extension .js script',
 					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
 					),
@@ -1074,6 +1304,18 @@ class AMP_Allowed_Tags_Generated {
 					'also_requires_tag_warning' => array(
 						'amp-ad extension .js script',
 					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
 						'amp-carousel',
@@ -1113,6 +1355,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-facebook',
 					),
@@ -1131,6 +1383,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-facebook-comments',
 					),
@@ -1156,6 +1418,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-facebook-like',
 					),
@@ -1181,6 +1453,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-facebook-page',
 					),
@@ -1198,6 +1480,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-fit-text',
 					),
@@ -1226,6 +1519,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-font',
 					),
@@ -1265,6 +1563,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-gfycat',
 					),
@@ -1284,6 +1591,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							3,
+						),
+					),
 					'requires_extension' => array(
 						'amp-gist',
 					),
@@ -1303,6 +1615,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-hulu',
 					),
@@ -1352,6 +1673,17 @@ class AMP_Allowed_Tags_Generated {
 					'srcdoc' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-iframe',
 					),
@@ -1388,6 +1720,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-ima-video',
 					),
@@ -1405,6 +1746,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-image-lightbox',
 					),
@@ -1449,6 +1795,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
 				),
 			),
@@ -1465,6 +1822,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-imgur',
 					),
@@ -1484,6 +1851,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-instagram',
 					),
@@ -1514,6 +1891,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-install-serviceworker',
 					),
@@ -1533,6 +1915,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-izlesene',
 					),
@@ -1554,6 +1945,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-jwplayer',
 					),
@@ -1572,6 +1973,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-kaltura-player',
 					),
@@ -1587,6 +1998,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-layout',
 				),
 			),
@@ -1603,6 +2025,11 @@ class AMP_Allowed_Tags_Generated {
 					'scrollable' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-lightbox',
 					),
@@ -1638,6 +2065,16 @@ class AMP_Allowed_Tags_Generated {
 					'template' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-list',
 					),
@@ -1668,6 +2105,16 @@ class AMP_Allowed_Tags_Generated {
 					'template' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-list',
 					),
@@ -1696,6 +2143,12 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							3,
+						),
+					),
 					'requires_extension' => array(
 						'amp-live-list',
 					),
@@ -1715,6 +2168,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
 					'requires_extension' => array(
 						'amp-mathml',
 					),
@@ -1752,6 +2210,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-nexxtv-player',
 					),
@@ -1773,6 +2241,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-o2-player',
 					),
@@ -1797,6 +2275,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-ooyala-player',
 					),
@@ -1816,6 +2302,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-pinterest',
 					),
@@ -1847,6 +2343,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'defines_default_height' => true,
+						'defines_default_width' => true,
+						'supported_layouts' => array(
+							2,
+							1,
+						),
+					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pixel',
 				),
 			),
@@ -1871,6 +2375,12 @@ class AMP_Allowed_Tags_Generated {
 					'src' => array(),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							4,
+							3,
+						),
+					),
 					'requires_extension' => array(
 						'amp-playbuzz',
 					),
@@ -1893,6 +2403,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-position-observer',
 					),
@@ -1912,6 +2427,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-reach-player',
 					),
@@ -1940,6 +2464,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-reddit',
 					),
@@ -1959,6 +2493,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-riddle-quiz',
 					),
@@ -1990,6 +2529,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							1,
+							4,
+							5,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-selector',
 					),
@@ -2011,6 +2560,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-sidebar',
@@ -2054,6 +2608,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-social-share',
 					),
@@ -2084,6 +2649,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							3,
+						),
+					),
 					'requires_extension' => array(
 						'amp-soundcloud',
 					),
@@ -2120,6 +2690,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-springboard-player',
 					),
@@ -2163,6 +2741,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-app-banner',
 					),
@@ -2280,6 +2863,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-timeago',
 					),
@@ -2299,6 +2889,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-twitter',
 					),
@@ -2335,6 +2936,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-user-notification',
 					),
@@ -2408,6 +3014,16 @@ class AMP_Allowed_Tags_Generated {
 					'also_requires_tag_warning' => array(
 						'amp-video extension .js script',
 					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'disallowed_ancestor' => array(
 						'amp-story',
 					),
@@ -2472,6 +3088,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'mandatory_ancestor' => 'amp-story',
 					'requires_extension' => array(
 						'amp-video',
@@ -2494,6 +3120,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-vimeo',
 					),
@@ -2512,6 +3147,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-vine',
 					),
@@ -2530,6 +3175,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-vk',
 					),
@@ -2576,6 +3228,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
 					'requires_extension' => array(
 						'amp-web-push',
 					),
@@ -2596,6 +3253,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+						),
+					),
 					'requires_extension' => array(
 						'amp-web-push',
 					),
@@ -2616,6 +3278,15 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-wistia-player',
 					),
@@ -2649,6 +3320,16 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
 					'requires_extension' => array(
 						'amp-youtube',
 					),

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -53,6 +53,24 @@ abstract class AMP_Rule_Spec {
 	const VALUE_URL               = 'value_url';
 
 	/**
+	 * Supported layout values.
+	 *
+	 * @since 1.0
+	 * @var array
+	 */
+	public static $layout_enum = array(
+		1 => 'nodisplay',
+		2 => 'fixed',
+		3 => 'fixed-height',
+		4 => 'responsive',
+		5 => 'container',
+		6 => 'fill',
+		7 => 'flex-item',
+		8 => 'fluid',
+		9 => 'intrinsic',
+	);
+
+	/**
 	 * If a node type listed here is invalid, it and it's subtree will be
 	 * removed if it is invalid. This is mainly  because any children will be
 	 * non-functional without this parent.

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -433,6 +433,17 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			$attr_spec_list
 		);
 
+		// Amend spec list with layout.
+		if ( isset( $tag_spec['amp_layout'] ) ) {
+			$merged_attr_spec_list = array_merge( $merged_attr_spec_list, $this->layout_allowed_attributes );
+
+			if ( isset( $tag_spec['amp_layout']['supported_layouts'] ) ) {
+				$layouts = wp_array_slice_assoc( AMP_Rule_Spec::$layout_enum, $tag_spec['amp_layout']['supported_layouts'] );
+
+				$merged_attr_spec_list['layout'][ AMP_Rule_Spec::VALUE_REGEX_CASEI ] = '(' . implode( '|', $layouts ) . ')';
+			}
+		}
+
 		// Identify any remaining disallowed attributes.
 		$disallowed_attributes = $this->get_disallowed_attributes_in_node( $node, $merged_attr_spec_list );
 
@@ -1465,13 +1476,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return bool Return true if attribute name is valid for this attr_spec_list, false otherwise.
 	 */
 	private function is_amp_allowed_attribute( $attr_name, $attr_spec_list ) {
-		if ( isset( $this->globally_allowed_attributes[ $attr_name ] ) || isset( $this->layout_allowed_attributes[ $attr_name ] ) || isset( $attr_spec_list[ $attr_name ] ) ) {
+		if ( isset( $attr_spec_list[ $attr_name ] ) ) {
 			return true;
-		} else {
-			foreach ( AMP_Rule_Spec::$whitelisted_attr_regex as $whitelisted_attr_regex ) {
-				if ( preg_match( $whitelisted_attr_regex, $attr_name ) ) {
-					return true;
-				}
+		}
+		foreach ( AMP_Rule_Spec::$whitelisted_attr_regex as $whitelisted_attr_regex ) {
+			if ( preg_match( $whitelisted_attr_regex, $attr_name ) ) {
+				return true;
 			}
 		}
 

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -8,9 +8,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	protected $layout_allowed_attrs;
 
 	public function setUp() {
-		$this->allowed_tags = AMP_Allowed_Tags_Generated::get_allowed_tags();
-		$this->globally_allowed_attributes = AMP_Allowed_Tags_Generated::get_allowed_attributes();
-		$this->layout_allowed_attributes = AMP_Allowed_Tags_Generated::get_allowed_attributes();
+		$this->allowed_tags           = AMP_Allowed_Tags_Generated::get_allowed_tags();
+		$this->globally_allowed_attrs = AMP_Allowed_Tags_Generated::get_allowed_attributes();
+		$this->layout_allowed_attrs   = AMP_Allowed_Tags_Generated::get_layout_attributes();
 	}
 
 	public function get_attr_spec_rule_data() {
@@ -551,10 +551,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		}
 		$source = '<' . $data['tag_name'] . ' ' . $attribute . '>Some test content</' . $data['tag_name'] . '>';
 
-		$attr_spec_list = $this->allowed_tags[ $data['tag_name'] ][$data['rule_spec_index']]['attr_spec_list'];
-		foreach( $attr_spec_list as $attr_name => $attr_val ) {
-			if ( isset( $attr_spec_list[ $attr_name ][AMP_Rule_Spec::ALTERNATIVE_NAMES] ) ) {
-				foreach( $attr_spec_list[ $attr_name ][AMP_Rule_Spec::ALTERNATIVE_NAMES] as $attr_alt_name ) {
+		$attr_spec_list = $this->allowed_tags[ $data['tag_name'] ][ $data['rule_spec_index'] ]['attr_spec_list'];
+		if ( isset( $this->allowed_tags[ $data['tag_name'] ][ $data['rule_spec_index'] ]['tag_spec']['amp_layout'] ) ) {
+			$attr_spec_list = array_merge( $attr_spec_list, $this->layout_allowed_attrs );
+		}
+		foreach ( $attr_spec_list as $attr_name => $attr_val ) {
+			if ( isset( $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::ALTERNATIVE_NAMES ] ) ) {
+				foreach ( $attr_spec_list[ $attr_name ][ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $attr_alt_name ) {
 					$attr_spec_list[ $attr_alt_name ] = $attr_spec_list[ $attr_name ];
 				}
 			}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -739,6 +739,44 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null, // No change.
 				array( 'amp-date-picker' ),
 			),
+
+			'amp-img-layout-allowed'                                    => array(
+				implode( '', array(
+					'<amp-img src="/img1.png" width="50" height="50" layout="fill"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="fixed"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="fixed-height"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="flex-item"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="intrinsic"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="nodisplay"></amp-img>',
+					'<amp-img src="/img1.png" width="50" height="50" layout="responsive"></amp-img>',
+				) ),
+				null, // No change.
+				array(),
+			),
+
+			'amp-img-layout-illegal'                                    => array(
+				'<amp-img src="/img1.png" width="50" height="50" layout="container"></amp-img>',
+				'<amp-img src="/img1.png" width="50" height="50"></amp-img>',
+				array(),
+			),
+
+			'amp-img-layout-unknown'                                    => array(
+				'<amp-img src="/img1.png" width="50" height="50" layout="bogus-value"></amp-img>',
+				'<amp-img src="/img1.png" width="50" height="50"></amp-img>',
+				array(),
+			),
+
+			'non-layout-span-element-attrs'                             => array(
+				'<span id="test" width="1" height="1" heights="(min-width:500px) 200px, 80%" sizes="(min-width: 650px) 50vw, 100vw" layout="nodisplay" [height]="1" [width]="1">Test</span>',
+				'<span id="test">Test</span>',
+				array(),
+			),
+
+			'non-layout-col-element-attrs'                              => array(
+				'<table><col class="foo" width="123" style="background:red;"><col class="bar" style="background:green;" width="12%"><col class="baz" style="background:blue;" width="2*"><tr><td>1</td><td>2</td><td>3</td></tr></table>',
+				'<table><col class="foo"><col class="bar"><col class="baz"><tr><td>1</td><td>2</td><td>3</td></tr></table>',
+				array(),
+			),
 		);
 	}
 


### PR DESCRIPTION
The whitelist sanitizer is currently incorrectly allowing layout attributes (`layout`, `width`, `height`, etc) on all elements. This PR ensures that the list of layout attributes are only merged into the attribute list for tag specs that actually declare they have `amp_layout`. Additionally, the value of the `layout` attribute itself is validated against the tag spec's `supported_layouts`.

This is a companion PR with #1064 to fix #1062.