### PR TITLE
Fix handling of font stylesheets with non-HTTPS scheme or scheme-less URLs

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -319,7 +319,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$pattern = sprintf( '/\.(%s)$/i', implode( '|', $allowed_extensions ) );
 			if ( ! preg_match( $pattern, $url ) ) {
 				/* translators: %s is the file URL */
-				return new WP_Error( 'amp_disallowed_file_extension', sprintf( __( 'Skipped file which does not have an allowed file extension (%s).', 'amp' ), $url ) );
+				return new WP_Error( 'disallowed_file_extension', sprintf( __( 'Skipped file which does not have an allowed file extension (%s).', 'amp' ), $url ) );
 			}
 		}
 
@@ -337,7 +337,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		if ( ! $file_path || false !== strpos( '../', $file_path ) || 0 !== validate_file( $file_path ) || ! file_exists( $file_path ) ) {
 			/* translators: %s is file URL */
-			return new WP_Error( 'amp_file_path_not_found', sprintf( __( 'Unable to locate filesystem path for %s.', 'amp' ), $url ) );
+			return new WP_Error( 'file_path_not_found', sprintf( __( 'Unable to locate filesystem path for %s.', 'amp' ), $url ) );
 		}
 
 		return $file_path;
@@ -406,6 +406,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$css_file_path = $this->get_validated_url_file_path( $href, array( 'css', 'less', 'scss', 'sass' ) );
 		if ( is_wp_error( $css_file_path ) ) {
 			$this->remove_invalid_child( $element, array(
+				'code'    => $css_file_path->get_error_code(),
 				'message' => $css_file_path->get_error_message(),
 			) );
 			return;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -394,8 +394,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_link_element( DOMElement $element ) {
 		$href = $element->getAttribute( 'href' );
 
-		// Allow font URLs.
-		if ( $this->allowed_font_src_regex && preg_match( $this->allowed_font_src_regex, $href ) ) {
+		// Allow font URLs, including protocol-less URLs and recognized URLs that use HTTP instead of HTTPS.
+		$normalized_font_href = preg_replace( '#^(http:)?(?=//)#', 'https:', $href );
+		if ( $this->allowed_font_src_regex && preg_match( $this->allowed_font_src_regex, $normalized_font_href ) ) {
+			if ( $href !== $normalized_font_href ) {
+				$element->setAttribute( 'href', $normalized_font_href );
+			}
 			return;
 		}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -536,6 +536,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				admin_url( 'css/common.css' ),
 				ABSPATH . 'wp-admin/css/common.css',
 			),
+			'admin_with_host_https' => array(
+				set_url_scheme( admin_url( 'css/common.css' ), 'https' ),
+				ABSPATH . 'wp-admin/css/common.css',
+			),
+			'admin_with_host_http' => array(
+				set_url_scheme( admin_url( 'css/common.css' ), 'http' ),
+				ABSPATH . 'wp-admin/css/common.css',
+			),
+			'admin_with_no_host_scheme' => array(
+				preg_replace( '#^\w+:(?=//)#', '', admin_url( 'css/common.css' ) ),
+				ABSPATH . 'wp-admin/css/common.css',
+			),
 			'amp_disallowed_file_extension' => array(
 				content_url( 'themes/twentyseventeen/index.php' ),
 				null,
@@ -602,6 +614,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'fontawesome' => array(
 				'https://maxcdn.bootstrapcdn.com/font-awesome/123/css/font-awesome.min.css',
 				array(),
+			),
+			'bad_host'    => array(
+				'https://bad.example.com/font.css',
+				array( 'disallowed_external_file_url' ),
 			),
 			'bad_ext'    => array(
 				home_url( '/bad.php' ),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -583,6 +583,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'https://fonts.googleapis.com/css?family=Tangerine',
 				true,
 			),
+			'tangerine2'  => array(
+				'//fonts.googleapis.com/css?family=Tangerine',
+				true,
+			),
+			'tangerine3'  => array(
+				'http://fonts.googleapis.com/css?family=Tangerine',
+				true,
+			),
 			'typekit'     => array(
 				'https://use.typekit.net/abc.css',
 				true,
@@ -620,7 +628,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$link = $dom->getElementsByTagName( 'link' )->item( 0 );
 		if ( $pass ) {
 			$this->assertInstanceOf( 'DOMElement', $link );
-			$this->assertEquals( $url, $link->getAttribute( 'href' ) );
+			$this->assertEquals(
+				preg_replace( '#^(http:)?(?=//)#', 'https:', $url ),
+				$link->getAttribute( 'href' )
+			);
 		} else {
 			$this->assertEmpty( $link );
 		}


### PR DESCRIPTION
* When someone enqueues a font CDN stylesheet without the required HTTPS scheme, automatically supply it before checking against the regex and ensure the link has the HTTPS URL set during processing.
* Improve URL checking by first ensuring the host name matches.
* Ignore differences for URL scheme (even scheme-less URLs) when comparing URLs since the scheme is irrelevant.

Fixes #1072