### PR TITLE
remove amp_last_check_time

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -288,6 +288,7 @@ class AMP_Theme_Support {
 			'__amp_source_origin',
 			'_wp_amp_action_xhr_converted',
 			'amp_latest_update_time',
+			'amp_last_check_time',
 		);
 
 		// Scrub input vars.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -296,6 +296,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
 		$bad_query_vars = array(
 			'amp_latest_update_time' => '1517199956',
+			'amp_last_check_time'    => '1517599126',
 			'__amp_source_origin'    => home_url(),
 		);
 		$ok_query_vars  = array(


### PR DESCRIPTION
Removes the new query var `amp_last_check_time` - which addressed #14662

fixes #939
