### PR TITLE
Disable AMP admin menu option when AMP customizer not enabled or Theme Support enabled.

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -73,6 +73,7 @@ function amp_admin_get_preview_permalink() {
  * Registers a submenu page to access the AMP template editor panel in the Customizer.
  */
 function amp_add_customizer_link() {
+	/** This filter is documented in includes/settings/class-amp-customizer-design-settings.php **/
 	if ( ! apply_filters( 'amp_customizer_is_enabled', true ) || current_theme_supports( 'amp' ) ) {
 		return;
 	}

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -73,6 +73,10 @@ function amp_admin_get_preview_permalink() {
  * Registers a submenu page to access the AMP template editor panel in the Customizer.
  */
 function amp_add_customizer_link() {
+	if ( ! apply_filters( 'amp_customizer_is_enabled', true ) || current_theme_supports( 'amp' ) ) {
+		return;
+	}
+
 	$menu_slug = add_query_arg( array(
 		'autofocus[panel]' => AMP_Template_Customizer::PANEL_ID,
 		'url'              => rawurlencode( amp_admin_get_preview_permalink() ),


### PR DESCRIPTION
Hi @westonruter, @kienstra,

Could you use this PR to solve: https://github.com/Automattic/amp-wp/issues/1069 ?

I hope I understood the issue correctly. Glad to hear any feedback. Thanks!

Fixes #1069.