### PR TITLE
Account for ob_start() being called during page execution

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1035,15 +1035,6 @@ class AMP_Theme_Support {
 			return $response;
 		}
 
-		// Account for case where ob_flush() was called prematurely.
-		if ( false === strpos( $response, '<html' ) ) {
-			$error = sprintf(
-				'<div style="color:red; background: white; padding: 0.5em; position: fixed; z-index: 100000; bottom: 0; border: dashed 1px red;">%s</div>',
-				wp_kses_post( __( '<strong>AMP Plugin Error</strong>: It appears that your WordPress install prematurely flushed the output buffer. You will need to disable AMP theme support until that is fixed.', 'amp' ) )
-			);
-			return $error . $response;
-		}
-
 		$is_validation_debug_mode = ! empty( $_REQUEST[ AMP_Validation_Utils::DEBUG_QUERY_VAR ] ); // WPCS: csrf ok.
 
 		$args = array_merge(

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -77,6 +77,14 @@ class AMP_Theme_Support {
 	public static $headers_sent = array();
 
 	/**
+	 * Output buffering level when starting.
+	 *
+	 * @since 0.7
+	 * @var int
+	 */
+	protected static $initial_ob_level = 0;
+
+	/**
 	 * Initialize.
 	 */
 	public static function init() {
@@ -969,6 +977,7 @@ class AMP_Theme_Support {
 		}
 
 		ob_start();
+		self::$initial_ob_level = ob_get_level();
 
 		// Note that the following must be at 0 because wp_ob_end_flush_all() runs at shutdown:1.
 		add_action( 'shutdown', array( __CLASS__, 'finish_output_buffering' ), 0 );
@@ -981,6 +990,12 @@ class AMP_Theme_Support {
 	 * @see AMP_Theme_Support::start_output_buffering()
 	 */
 	public static function finish_output_buffering() {
+
+		// Flush output buffer stack until we get to the output buffer we started.
+		while ( ob_get_level() > self::$initial_ob_level ) {
+			ob_end_flush();
+		}
+
 		echo self::prepare_response( ob_get_clean() ); // WPCS: xss ok.
 	}
 

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -913,7 +913,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// start first layer buffer.
 		ob_start();
 		AMP_Theme_Support::start_output_buffering();
-		echo '<html><img src="test.png"><script data-test>document.write(\'Illegal\');</script></html>';
+		echo '<img src="test.png"><script data-test>document.write(\'Illegal\');</script>';
 		AMP_Theme_Support::finish_output_buffering();
 		// get first layer buffer.
 		$output = ob_get_clean();
@@ -1069,25 +1069,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertStringStartsWith( '<!DOCTYPE html>', $sanitized_html );
 		$this->assertContains( '<html amp', $sanitized_html );
-	}
-
-	/**
-	 * Test preparing an incomplete response due to ob_flush().
-	 *
-	 * @covers AMP_Theme_Support::prepare_response()
-	 */
-	public function test_prepare_response_premature_ob_flush() {
-		add_theme_support( 'amp' );
-		AMP_Theme_Support::init();
-		ob_start();
-		wp_footer();
-		echo '</body></html>';
-		$original_html  = trim( ob_get_clean() );
-		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
-
-		$this->assertContains( 'AMP Plugin Error', $sanitized_html );
-		$this->assertNotContains( '<!DOCTYPE html>', $sanitized_html );
-		$this->assertNotContains( '<html amp', $sanitized_html );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -894,6 +894,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, has_action( 'shutdown', array( self::TESTED_CLASS, 'finish_output_buffering' ) ) );
 		$this->assertTrue( ob_get_level() > $ob_level );
+
 		// End output buffer.
 		if ( ob_get_level() > $ob_level ) {
 			ob_get_clean();
@@ -913,12 +914,24 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// start first layer buffer.
 		ob_start();
 		AMP_Theme_Support::start_output_buffering();
+
 		echo '<img src="test.png"><script data-test>document.write(\'Illegal\');</script>';
+
+		// Additional nested output bufferings which aren't getting closed.
+		ob_start();
+		echo 'foo';
+		ob_start( function( $response ) {
+			return strtoupper( $response );
+		} );
+		echo 'bar';
+
 		AMP_Theme_Support::finish_output_buffering();
 		// get first layer buffer.
 		$output = ob_get_clean();
 
 		$this->assertContains( '<html amp', $output );
+		$this->assertContains( 'foo', $output );
+		$this->assertContains( 'BAR', $output );
 		$this->assertContains( '<amp-img src="test.png"', $output );
 		$this->assertNotContains( '<script data-test', $output );
 


### PR DESCRIPTION
Reverts #1066.

This correctly handles the where new output buffers are started during the execution of the page, for example via:

```php
add_action( 'wp_footer', function() {
	ob_start();
} );

add_action( 'wp_footer', function() {
	ob_start( function( $output ) {
		return str_replace( '</body>', 'HELLO WORLD</body>', $output );
	} );
} );
```