### PR TITLE
Ensure all sanitizers run when building featured image

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -349,7 +349,7 @@ class AMP_Post_Template {
 
 		list( $sanitized_html, $featured_scripts, $featured_styles ) = AMP_Content_Sanitizer::sanitize(
 			$featured_html,
-			array( 'AMP_Img_Sanitizer' => array() ),
+			amp_get_content_sanitizers( $this->post ),
 			array(
 				'content_max_width' => $this->get( 'content_max_width' ),
 			)


### PR DESCRIPTION
This is a regression introduced by #882 in c62dad662229f71e3ec7c6407c3fd834eb37e159.

This ensures that the `amp-anim` script, for example, will be assured to be included. It also ensures that if a plugin adds other markup to a featured image via the `post_thumbnail_html` filter that it will be properly sanitized.

Fixes #1090.