### PR TITLE
Ensure only remaining AMP scripts are printed when preparing response

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1128,9 +1128,17 @@ class AMP_Theme_Support {
 			}
 		}
 
-		// Print all scripts, some of which may have already been printed and inject into head.
+		/*
+		 * Print additional AMP component scripts which have been discovered by the sanitizers, and inject into the head.
+		 * Before printing the AMP scripts, make sure that no plugins will be manipulating the output to be invalid AMP
+		 * since at this point the sanitizers have completed and won't check what is output here.
+		 */
 		ob_start();
-		remove_all_filters( 'print_scripts_array' ); // Make sure only the script handles we pass in will in fact get printed.
+		$possible_hooks = array( 'wp_print_scripts', 'print_scripts_array', 'script_loader_src', 'clean_url', 'script_loader_tag', 'attribute_escape' );
+		foreach ( $possible_hooks as $possible_hook ) {
+			remove_all_filters( $possible_hook ); // An action and a filter are the same thing.
+		}
+		add_filter( 'script_loader_tag', 'amp_filter_script_loader_tag', PHP_INT_MAX, 2 ); // Make sure this one required filter is present.
 		wp_scripts()->do_items( array_keys( $amp_scripts ) );
 		$script_tags = ob_get_clean();
 		if ( ! empty( $script_tags ) ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1130,7 +1130,8 @@ class AMP_Theme_Support {
 
 		// Print all scripts, some of which may have already been printed and inject into head.
 		ob_start();
-		wp_print_scripts( array_keys( $amp_scripts ) );
+		remove_all_filters( 'print_scripts_array' ); // Make sure only the script handles we pass in will in fact get printed.
+		wp_scripts()->do_items( array_keys( $amp_scripts ) );
 		$script_tags = ob_get_clean();
 		if ( ! empty( $script_tags ) ) {
 			$response = preg_replace(

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -976,6 +976,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_action( 'wp_enqueue_scripts', function() {
 			wp_enqueue_script( 'amp-list' );
 		} );
+		add_action( 'wp_print_scripts', function() {
+			echo '<!-- wp_print_scripts -->';
+		} );
+		add_filter( 'script_loader_tag', function( $tag, $handle ) {
+			return preg_replace( '/(?<=<script)/', " handle='$handle' ", $tag );
+		}, 10, 2 );
 		add_action( 'wp_footer', function() {
 			wp_print_scripts( 'amp-mathml' );
 			?>
@@ -1016,6 +1022,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			},
 		) );
 
+		$this->assertNotContains( 'handle=', $sanitized_html );
+		$this->assertEquals( 2, substr_count( $sanitized_html, '<!-- wp_print_scripts -->' ) );
 		$this->assertContains( '<meta charset="' . get_bloginfo( 'charset' ) . '">', $sanitized_html );
 		$this->assertContains( '<meta name="viewport" content="width=device-width,minimum-scale=1">', $sanitized_html );
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
@@ -1036,7 +1044,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-ad-latest.js\' async custom-element="amp-ad"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		$this->assertContains( '<button>no-onclick</button>', $sanitized_html );
-		$this->assertCount( 3, $removed_nodes );
+		$this->assertCount( 4, $removed_nodes );
 		$this->assertInstanceOf( 'DOMElement', $removed_nodes['script'] );
 		$this->assertInstanceOf( 'DOMAttr', $removed_nodes['onclick'] );
 	}


### PR DESCRIPTION
This fixes a bug exposed when testing the plugin with W3 Total Cache. That plugin prints out a script at the `wp_print_scripts` action which is triggered when calling `wp_print_scripts()`. We can avoid this duplication of script printing by directly calling `wp_scripts()->do_items()` instead of `wp_print_scripts()` which is essentially a wrapper for the former. The being printed here are the AMP component scripts that were discovered during the sanitization process. As such these scripts are run _after_ sanitization has been completed, thus it is important that only the remaining AMP scripts be output here. The changes here ensure this.