### PR TITLE
WIP: Move any content output during shutdown to be injected before closing body tag

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1043,6 +1043,10 @@ class AMP_Theme_Support {
 				1
 			);
 		}
+
+		// Move anything after </html>, such as Query Monitor output added at shutdown, to be moved before </body>.
+		$response = preg_replace( '#(</body>.*</html>)(.+)#s', '$2$1', $response );
+
 		$dom = AMP_DOM_Utils::get_dom( $response );
 
 		$xpath = new DOMXPath( $dom );


### PR DESCRIPTION
Plugins like Query Monitor output content at `shutdown`. This means the output is added after the `</html>` closing tag. The AMP plugin currently only sanitizes and outputs the contents of the `html` element. In order to ensure that content after the closing HTML tag is sanitized _and_ incorporated (_“embodied”_) into the document, we should consider moving the trailing content to be injected before the `</body>` tag.

- [ ] Add tests.