### PR TITLE
Prevent shortcode with WP_Query from overriding post shown for editing on edit post screen

### DIFF
--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -547,6 +547,10 @@ class AMP_Validation_Utils {
 				self::$validation_errors
 			);
 			self::reset_validation_results();
+
+			// Make sure original post is restored after applying shortcodes which could change it.
+			$GLOBALS['post'] = $post; // WPCS: override ok.
+			setup_postdata( $post );
 		}
 
 		// Incorporate frontend validation status if there is a known URL for the post.

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -539,20 +539,6 @@ class AMP_Validation_Utils {
 		$validation_status_post = null;
 		$validation_errors      = array();
 
-		// Validate post content outside frontend context.
-		if ( post_type_supports( $post->post_type, 'editor' ) ) {
-			self::process_markup( $post->post_content );
-			$validation_errors = array_merge(
-				$validation_errors,
-				self::$validation_errors
-			);
-			self::reset_validation_results();
-
-			// Make sure original post is restored after applying shortcodes which could change it.
-			$GLOBALS['post'] = $post; // WPCS: override ok.
-			setup_postdata( $post );
-		}
-
 		// Incorporate frontend validation status if there is a known URL for the post.
 		if ( is_post_type_viewable( $post->post_type ) ) {
 			$url = amp_get_permalink( $post->ID );
@@ -564,6 +550,20 @@ class AMP_Validation_Utils {
 					$validation_errors = array_merge( $validation_errors, $data );
 				}
 			}
+		}
+
+		// If no results from URL are available, validate post content outside frontend context.
+		if ( empty( $validation_errors ) && post_type_supports( $post->post_type, 'editor' ) ) {
+			self::process_markup( $post->post_content );
+			$validation_errors = array_merge(
+				$validation_errors,
+				self::$validation_errors
+			);
+			self::reset_validation_results();
+
+			// Make sure original post is restored after applying shortcodes which could change it.
+			$GLOBALS['post'] = $post; // WPCS: override ok.
+			setup_postdata( $post );
 		}
 
 		if ( empty( $validation_errors ) ) {


### PR DESCRIPTION
Also prevent validation errors from being duplicated. If there is a validation errors pulled from the frontend, skip also obtaining (duplicate) validation errors from the content alone.

Fixes #1105.