### PR TITLE
Address an issue of stretched <amp-img> when using '.aligncenter'.

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -248,8 +248,8 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.7
 	 * @see https://github.com/Automattic/amp-wp/issues/1104
 	 *
-	 * @param DOMNode|DOMElement $node The <amp-img> node.
-	 * @return DOMNode|DOMElement $node The <amp-img> node, possibly wrapped in a <figure>.
+	 * @param DOMElement $node The <amp-img> node.
+	 * @return DOMElement $node The <amp-img> node, possibly wrapped in a <figure>.
 	 */
 	public function handle_centering( $node ) {
 		$align_class = 'aligncenter';
@@ -257,7 +257,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$width       = $node->getAttribute( 'width' );
 
 		// If this doesn't have a width attribute, centering it in the <figure> wrapper won't work.
-		if ( ( false === strpos( $classes, $align_class ) ) || empty( $width ) ) {
+		if ( empty( $width ) || ! in_array( $align_class, preg_split( '/\s+/', trim( $classes ) ), true ) ) {
 			return $node;
 		}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -219,6 +219,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$new_tag = 'amp-img';
 		}
 		$new_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
+		$new_node = $this->handle_centering( $new_node );
 		$node->parentNode->replaceChild( $new_node, $node );
 	}
 
@@ -235,5 +236,44 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$ext  = self::$anim_extension;
 		$path = AMP_WP_Utils::parse_url( $url, PHP_URL_PATH );
 		return substr( $path, -strlen( $ext ) ) === $ext;
+	}
+
+	/**
+	 * Handles an issue with the aligncenter class.
+	 *
+	 * If the <amp-img> has the class aligncenter, this strips the class and wraps it in a <figure> to center the image.
+	 * There was an issue where the aligncenter class overrode the "display: inline-block" rule of AMP's layout="intrinsic" attribute.
+	 * So this strips that class, and instead wraps the image in a <figure> to center it.
+	 *
+	 * @since 0.7
+	 * @see https://github.com/Automattic/amp-wp/issues/1104
+	 *
+	 * @param DOMNode|DOMElement $node The <amp-img> node.
+	 * @return DOMNode|DOMElement $node The <amp-img> node, possibly wrapped in a <figure>.
+	 */
+	public function handle_centering( $node ) {
+		$align_class = 'aligncenter';
+		$classes     = $node->getAttribute( 'class' );
+		$width       = $node->getAttribute( 'width' );
+
+		// If this doesn't have a width attribute, centering it in the <figure> wrapper won't work.
+		if ( ( false === strpos( $classes, $align_class ) ) || empty( $width ) ) {
+			return $node;
+		}
+
+		// Strip the class, and wrap the <amp-img> in a <figure>.
+		$classes = trim( str_replace( $align_class, '', $classes ) );
+		$node->setAttribute( 'class', $classes );
+		$figure = AMP_DOM_Utils::create_node(
+			$this->dom,
+			'figure',
+			array(
+				'class' => $align_class,
+				'style' => "max-width: {$width}px;",
+			)
+		);
+		$figure->appendChild( $node );
+
+		return $figure;
 	}
 }

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -138,6 +138,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<img class="alignleft" src="http://placehold.it/350x150" width="350" height="150" />',
 				'<amp-img class="alignleft amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"></amp-img>',
 			),
+
+			'image_with_caption'                       => array(
+				'<figure class="wp-caption aligncenter"><img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
+				'<figure class="wp-caption aligncenter"><amp-img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
+			),
 		);
 	}
 

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -128,6 +128,16 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 <img src="http://placehold.it/380x180" width="380" height="180" />',
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
+
+			'image_center_aligned'                     => array(
+				'<img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150" />',
+				'<figure class="aligncenter" style="max-width: 350px;"><amp-img class="amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"></amp-img></figure>',
+			),
+
+			'image_left_aligned'                       => array(
+				'<img class="alignleft" src="http://placehold.it/350x150" width="350" height="150" />',
+				'<amp-img class="alignleft amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"></amp-img>',
+			),
 		);
 	}
 
@@ -176,5 +186,58 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			$whitelist_sanitizer->get_scripts()
 		);
 		$this->assertEquals( $expected, $scripts );
+	}
+
+	/**
+	 * Test handle_centering
+	 *
+	 * @covers AMP_Img_Sanitizer::handle_centering()
+	 */
+	public function test_handle_centering() {
+		$dom                = new DOMDocument();
+		$align_center_class = 'aligncenter';
+		$align_left_class   = 'alignleft';
+		$sanitizer          = new AMP_Img_Sanitizer( $dom );
+		$width              = 300;
+
+		$amp_img = AMP_DOM_Utils::create_node(
+			$dom,
+			'amp-img',
+			array(
+				'class' => $align_left_class,
+				'width' => $width,
+			)
+		);
+
+		// There's no aligncenter class, so the node shouldn't change.
+		$this->assertEquals( $amp_img, $sanitizer->handle_centering( $amp_img ) );
+
+		$amp_img = AMP_DOM_Utils::create_node(
+			$dom,
+			'amp-img',
+			array(
+				'class' => $align_left_class,
+			)
+		);
+
+		// There's no width attribute, so the node shouldn't change.
+		$this->assertEquals( $amp_img, $sanitizer->handle_centering( $amp_img ) );
+
+		$centered_amp_img = AMP_DOM_Utils::create_node(
+			$dom,
+			'amp-img',
+			array(
+				'class' => $align_center_class,
+				'width' => $width,
+			)
+		);
+		$processed_tag    = $sanitizer->handle_centering( $centered_amp_img );
+		$child            = $processed_tag->firstChild;
+
+		$this->assertEquals( 'figure', $processed_tag->nodeName );
+		$this->assertEquals( $align_center_class, $processed_tag->getAttribute( 'class' ) );
+		$this->assertEquals( "max-width: {$width}px;", $processed_tag->getAttribute( 'style' ) );
+		$this->assertEquals( 'amp-img', $child->nodeName );
+		$this->assertFalse( strpos( $child->getAttribute( 'class' ), $align_center_class ) );
 	}
 }


### PR DESCRIPTION
**Request For Code Review**

Hi @mehigh and @westonruter,
Could you please review this pull request, which addresses the problem in #1104 of image stretching? Thanks to @delawski for the solution.

This doesn't address [this comment](https://github.com/Automattic/amp-wp/issues/1104#issuecomment-385586532) in that issue, where "legacy templating" centered images, unless they had an `alignleft` or `alignright` class.

**Background**
There was an issue where the `aligncenter` class overrode the `"display: inline-block"` rule of AMP's `layout=intrinsic attribute`. So this strips that class, and instead wraps the image in a `<figure>` to center it.

**Testing**
The fastest way to test this is to simply use legacy templating, with any theme. Add an image that's less wide than about `600px`, and center-align it.
