### PR TITLE
Prevent CSS tree shaking from removing selectors with classes mentioned in [class] amp-bind attributes

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -225,7 +225,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Find all [class] attributes and capture the contents of any single- or double-quoted strings.
 			foreach ( $this->xpath->query( '//*/@' . AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'class' ) as $bound_class_attribute ) {
-				if ( preg_match_all( '/([\'"])([^\1]+?)\1/', $bound_class_attribute->nodeValue, $matches ) ) {
+				if ( preg_match_all( '/([\'"])([^\1]*?)\1/', $bound_class_attribute->nodeValue, $matches ) ) {
 					$classes .= ' ' . implode( ' ', $matches[2] );
 				}
 			}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -211,7 +211,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Get list of all the class names used in the document.
+	 * Get list of all the class names used in the document, including those used in [class] attributes.
 	 *
 	 * @since 1.0
 	 * @return array Used class names.
@@ -222,6 +222,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $this->xpath->query( '//*/@class' ) as $class_attribute ) {
 				$classes .= ' ' . $class_attribute->nodeValue;
 			}
+
+			// Find all [class] attributes and capture the contents of any single- or double-quoted strings.
+			foreach ( $this->xpath->query( '//*/@' . AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'class' ) as $bound_class_attribute ) {
+				if ( preg_match_all( '/([\'"])([^\1]+?)\1/', $bound_class_attribute->nodeValue, $matches ) ) {
+					$classes .= ' ' . implode( ' ', $matches[2] );
+				}
+			}
+
 			$this->used_class_names = array_unique( array_filter( preg_split( '/\s+/', trim( $classes ) ) ) );
 		}
 		return $this->used_class_names;

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -240,8 +240,13 @@ class AMP_DOM_Utils {
 			return '<' . $tag_matches['name'] . $new_attrs . '>';
 		};
 
+		/*
+		 * Match all start tags that probably contain a binding attribute.
+		 * @todo Warning: The following pattern is brittle since it truncates HTML tags that have attributes that contain ">" or "=>".
+		 * For example, if there exists: `<body class="foo" [class]="bodyClasses.concat( isBar ? 'bar' : '' ).filter( className => '' != className )">`
+		 * Then this results in the following being output as the first child fo the body: `'' != className )">`
+		 */
 		$converted = preg_replace_callback(
-			// Match all start tags that probably contain a binding attribute.
 			'#<(?P<name>[a-zA-Z0-9_\-]+)(?P<attrs>\s[^>]+\]=[^>]+)>#',
 			$replace_callback,
 			$html

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -389,6 +389,58 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that auto-removal (tree shaking) does not remove rules for classes mentioned in class and [class] attributes.
+	 *
+	 * @covers AMP_Style_Sanitizer::get_used_class_names()
+	 * @covers AMP_Style_Sanitizer::finalize_stylesheet_set()
+	 */
+	public function test_class_amp_bind_preservation() {
+		ob_start();
+		?>
+		<html amp>
+			<head>
+				<meta charset="utf-8">
+				<style>.sidebar1 { display:none }</style>
+				<style>.sidebar1.expanded { display:block }</style>
+				<style>.sidebar2{ visibility:hidden }</style>
+				<style>.sidebar2.visible { display:block }</style>
+				<style>.nothing { visibility:hidden; }</style>
+				</style>
+			</head>
+			<body>
+				<amp-state id="mySidebar">
+					<script type="application/json">
+						{
+							"expanded": false
+						}
+					</script>
+				</amp-state>
+				<aside class="sidebar1" [class]="mySidebar.expanded ? 'expanded' : ''">...</aside>
+				<aside class="sidebar2" [class]='mySidebar.expanded ? "visible" : ""'>...</aside>
+			</body>
+		</html>
+		<?php
+		$dom = AMP_DOM_Utils::get_dom( ob_get_clean() );
+
+		$error_codes = array();
+		$sanitizer   = new AMP_Style_Sanitizer( $dom, array(
+			'use_document_element'      => true,
+			'remove_unused_rules'       => 'always',
+			'validation_error_callback' => function( $error ) use ( &$error_codes ) {
+				$error_codes[] = $error['code'];
+			},
+		) );
+		$sanitizer->sanitize();
+		$this->assertEquals( array(), $error_codes );
+		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
+		$this->assertEquals( '.sidebar1{display:none;}', $actual_stylesheets[0] );
+		$this->assertEquals( '.sidebar1.expanded{display:block;}', $actual_stylesheets[1] );
+		$this->assertEquals( '.sidebar2{visibility:hidden;}', $actual_stylesheets[2] );
+		$this->assertEquals( '.sidebar2.visible{display:block;}', $actual_stylesheets[3] );
+		$this->assertEmpty( $actual_stylesheets[4] );
+	}
+
+	/**
 	 * Test that auto-removal is performed when remove_unused_rules=sometimes (the default), and that excessive CSS will be removed entirely.
 	 *
 	 * @covers AMP_Style_Sanitizer::finalize_stylesheet_set()

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -415,7 +415,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						}
 					</script>
 				</amp-state>
-				<aside class="sidebar1" [class]="mySidebar.expanded ? 'expanded' : ''">...</aside>
+				<aside class="sidebar1" [class]="! mySidebar.expanded ? '' : 'expanded'">...</aside>
 				<aside class="sidebar2" [class]='mySidebar.expanded ? "visible" : ""'>...</aside>
 			</body>
 		</html>

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1024,7 +1024,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<meta charset="' . get_bloginfo( 'charset' ) . '">', $sanitized_html );
 		$this->assertContains( '<meta name="viewport" content="width=device-width,minimum-scale=1">', $sanitized_html );
 		$this->assertContains( '<style amp-boilerplate>', $sanitized_html );
-		$this->assertContains( '<style amp-custom>body{background:black;}', $sanitized_html );
+		$this->assertRegExp( '#<style amp-custom>.*?body{background:black;}.*?</style>#s', $sanitized_html );
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-list-latest.js" async custom-element="amp-list"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
@@ -1041,9 +1041,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-ad-latest.js\' async custom-element="amp-ad"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		$this->assertContains( '<button>no-onclick</button>', $sanitized_html );
-		$this->assertCount( 4, $removed_nodes );
+		$this->assertCount( 3, $removed_nodes );
 		$this->assertInstanceOf( 'DOMElement', $removed_nodes['script'] );
 		$this->assertInstanceOf( 'DOMAttr', $removed_nodes['onclick'] );
+		$this->assertInstanceOf( 'DOMAttr', $removed_nodes['handle'] );
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up on #1048, and in particular this https://github.com/Automattic/amp-wp/pull/1048#issuecomment-379117270 from @camelburrito:

> usually the [class names] associated with `amp-bind` can be searchable in the dom (string search), even that would be a little risky because there could be string concat etc happening

I suspect that dynamic class names (constructed via concatenation) would be less likely than static ones, since dynamic class names would depend on having a correspondingly dynamic stylesheet. This doesn't seem likely. 

With the changes in this PR, with the following markup:

```html
<amp-state id="mySidebar">
	<script type="application/json">
		{"expanded": false}
	</script>
</amp-state>
<aside class="sidebar" [class]="mySidebar.expanded ? 'expanded' : ''">...</aside>
```
And given the following CSS:

```css
.sidebar { display:none }
.sidebar.expanded { display:block }
```
The second style rule will no longer be removed when tree shaking is being performed.

This should greatly reduce the amount of times that someone has to manually inform style sanitizer of the `dynamic_element_selectors`, for example:

```php
add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
	if ( ! isset( $sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] ) ) {
		$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] = array();
	}
	$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] = array_merge(
		$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'],
		array(
			'amp-list',
			'amp-live-list',
			'[submit-error]',
			'[submit-success]',
			'.expanded', // <= Added.
			'.sidebar-open', // <= Added.
		)
	);
	return $sanitizers;
} );
```