### PR TITLE
Add workaround to preserve CSS calc() functions

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -713,6 +713,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$open_parens++;
 				} elseif ( ')' === $css[ $final_offset ] ) {
 					$open_parens--;
+				} elseif ( ';' === $css[ $final_offset ] || '}' === $css[ $final_offset ] ) {
+					break; // Stop looking since clearly came to the end of the property. Unbalanced parentheses.
 				}
 
 				// Found the end of the calc() function, so replace it with a placeholder function.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -150,6 +150,16 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $parse_css_duration = 0.0;
 
 	/**
+	 * Placeholders for calc() values that are temporarily removed from CSS since they cause parse errors.
+	 *
+	 * @since 1.0
+	 * @see AMP_Style_Sanitizer::add_calc_placeholders()
+	 *
+	 * @var array
+	 */
+	private $calc_placeholders = array();
+
+	/**
 	 * AMP_Base_Sanitizer constructor.
 	 *
 	 * @since 0.7
@@ -521,7 +531,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$cache_key = md5( $stylesheet . serialize( $cache_impacting_options ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		$cache_group = 'amp-parsed-stylesheet-v1';
+		$cache_group = 'amp-parsed-stylesheet-v2';
 		if ( wp_using_ext_object_cache() ) {
 			$parsed = wp_cache_get( $cache_key, $cache_group );
 		} else {
@@ -578,6 +588,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			),
 			$options
 		);
+
+		// Find calc() functions and replace with placeholders since PHP-CSS-Parser can't handle them.
+		$stylesheet_string = $this->add_calc_placeholders( $stylesheet_string );
 
 		$stylesheet        = array();
 		$validation_errors = array();
@@ -645,6 +658,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						$selectors_parsed[ $selector ] = $classes;
 					}
 
+					// Restore calc() functions that were replaced with placeholders.
+					if ( ! empty( $this->calc_placeholders ) ) {
+						$declaration = str_replace(
+							array_keys( $this->calc_placeholders ),
+							array_values( $this->calc_placeholders ),
+							$declaration
+						);
+					}
+
 					$stylesheet[] = array(
 						$selectors_parsed,
 						$declaration,
@@ -653,6 +675,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$stylesheet[] = $split_stylesheet[ $i ];
 				}
 			}
+
+			// Reset calc placeholders.
+			$this->calc_placeholders = array();
 		} catch ( Exception $exception ) {
 			$validation_errors[] = array(
 				'code'    => 'css_parse_error',
@@ -663,6 +688,54 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$this->parse_css_duration += ( microtime( true ) - $start_time );
 
 		return compact( 'stylesheet', 'validation_errors' );
+	}
+
+	/**
+	 * Add placeholders for calc() functions which the PHP-CSS-Parser doesn't handle them properly yet.
+	 *
+	 * @since 1.0
+	 * @link https://github.com/sabberworm/PHP-CSS-Parser/issues/79
+	 *
+	 * @param string $css CSS.
+	 * @return string CSS with calc() functions replaced with placeholders.
+	 */
+	private function add_calc_placeholders( $css ) {
+		$offset = 0;
+		while ( preg_match( '/(?:-\w+-)?\bcalc\(/', $css, $matches, PREG_OFFSET_CAPTURE, $offset ) ) {
+			$match_string = $matches[0][0];
+			$match_offset = $matches[0][1];
+			$css_length   = strlen( $css );
+			$open_parens  = 1;
+			$start_offset = $match_offset + strlen( $match_string );
+			$final_offset = $start_offset;
+			for ( ; $final_offset < $css_length; $final_offset++ ) {
+				if ( '(' === $css[ $final_offset ] ) {
+					$open_parens++;
+				} elseif ( ')' === $css[ $final_offset ] ) {
+					$open_parens--;
+				}
+
+				// Found the end of the calc() function, so replace it with a placeholder function.
+				if ( 0 === $open_parens ) {
+					$matched_calc = substr( $css, $match_offset, $final_offset - $match_offset + 1 );
+					$placeholder  = sprintf( '-wp-calc-placeholder(%d)', count( $this->calc_placeholders ) );
+
+					// Store the placeholder function so the original calc() can be put in its place.
+					$this->calc_placeholders[ $placeholder ] = $matched_calc;
+
+					// Update the CSS to replace the matched calc() with the placeholder function.
+					$css = substr( $css, 0, $match_offset ) . $placeholder . substr( $css, $final_offset + 1 );
+
+					// Update offset based on difference of length of placeholder vs original matched calc().
+					$final_offset += strlen( $placeholder ) - strlen( $matched_calc );
+					break;
+				}
+			}
+
+			// Start matching at the next byte after the match.
+			$offset = $final_offset + 1;
+		}
+		return $css;
 	}
 
 	/**

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -292,6 +292,21 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'styles_with_calc_functions' => array(
+				implode( '', array(
+					'<html amp><head>',
+					'<style amp-custom>body { color: red; width: -webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) ); outline: solid 1px blue; }</style>',
+					'<style amp-custom>.alignwide{ max-width: calc(50% + 22.5rem); border: solid 1px red; }</style>',
+					'<style amp-custom>.alignwide{ height: calc(10% + ( 1px ); color: red; }</style>', // Test unbalanced parentheses.
+					'</head><body><div class="alignwide"></div></body></html>',
+				) ),
+				array(
+					'body{color:red;width:-webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) );outline:solid 1px blue;}',
+					'.alignwide{max-width:calc(50% + 22.5rem);border:solid 1px red;}',
+					'.alignwide{color:red;}',
+				),
+				array(),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -297,13 +297,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'<html amp><head>',
 					'<style amp-custom>body { color: red; width: -webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) ); outline: solid 1px blue; }</style>',
 					'<style amp-custom>.alignwide{ max-width: calc(50% + 22.5rem); border: solid 1px red; }</style>',
-					'<style amp-custom>.alignwide{ height: calc(10% + ( 1px ); color: red; }</style>', // Test unbalanced parentheses.
+					'<style amp-custom>.alignwide{ height: calc(10% + ( 1px ); color: red; content: ")";}</style>', // Test unbalanced parentheses.
 					'</head><body><div class="alignwide"></div></body></html>',
 				) ),
 				array(
 					'body{color:red;width:-webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) );outline:solid 1px blue;}',
 					'.alignwide{max-width:calc(50% + 22.5rem);border:solid 1px red;}',
-					'.alignwide{color:red;}',
+					'.alignwide{color:red;content:")";}',
 				),
 				array(),
 			),


### PR DESCRIPTION
It turns out that CSS `calc()` functions aren't parsed properly by the CSS parser. There is an old issue open to support them: https://github.com/sabberworm/PHP-CSS-Parser/issues/79. In the mean time, this makes sure that these functions are preserved by replacing them with placeholders prior to parsing, and then returning the original functions after parsing.