### PR TITLE
Supply the extracted dimensions to images determined to need them

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -247,7 +247,7 @@ abstract class AMP_Base_Sanitizer {
 	 */
 	public function add_or_append_attribute( &$attributes, $key, $value, $separator = ' ' ) {
 		if ( isset( $attributes[ $key ] ) ) {
-			$attributes[ $key ] .= $separator . $value;
+			$attributes[ $key ] = trim( $attributes[ $key ] . $separator . $value );
 		} else {
 			$attributes[ $key ] = $value;
 		}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -157,30 +157,48 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! $node instanceof DOMElement ) {
 					continue;
 				}
-				$height = $dimensions && isset( $dimensions['height'] ) ? $dimensions['height'] : self::FALLBACK_HEIGHT;
-				$width  = $dimensions && isset( $dimensions['width'] ) ? $dimensions['width'] : self::FALLBACK_WIDTH;
-				$class  = $node->getAttribute( 'class' );
+				$class = $node->getAttribute( 'class' );
 				if ( ! $class ) {
 					$class = '';
 				}
-				if (
-					! is_numeric( $node->getAttribute( 'width' ) ) &&
-					! is_numeric( $node->getAttribute( 'height' ) )
-				) {
-					$node->setAttribute( 'width', $width );
-					$node->setAttribute( 'height', $height );
-					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size' ) );
-				} elseif (
-					! is_numeric( $node->getAttribute( 'height' ) )
-				) {
-					$node->setAttribute( 'height', $height );
-					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size amp-wp-unknown-height' ) );
-				} elseif (
-					! is_numeric( $node->getAttribute( 'width' ) )
-				) {
-					$node->setAttribute( 'width', $width );
-					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size amp-wp-unknown-width' ) );
+				if ( ! $dimensions ) {
+					$class .= ' amp-wp-unknown-size';
 				}
+
+				$width  = isset( $this->args['content_max_width'] ) ? $this->args['content_max_width'] : self::FALLBACK_WIDTH;
+				$height = self::FALLBACK_HEIGHT;
+				if ( isset( $dimensions['width'] ) ) {
+					$width = $dimensions['width'];
+				}
+				if ( isset( $dimensions['height'] ) ) {
+					$height = $dimensions['height'];
+				}
+
+				if ( ! is_numeric( $node->getAttribute( 'width' ) ) ) {
+
+					// Let width have the right aspect ratio based on the height attribute.
+					if ( is_numeric( $node->getAttribute( 'height' ) ) && isset( $dimensions['height'] ) && isset( $dimensions['width'] ) ) {
+						$width = ( floatval( $node->getAttribute( 'height' ) ) * $dimensions['width'] ) / $dimensions['height'];
+					}
+
+					$node->setAttribute( 'width', $width );
+					if ( ! isset( $dimensions['width'] ) ) {
+						$class .= ' amp-wp-unknown-width';
+					}
+				}
+				if ( ! is_numeric( $node->getAttribute( 'height' ) ) ) {
+
+					// Let height have the right aspect ratio based on the width attribute.
+					if ( is_numeric( $node->getAttribute( 'width' ) ) && isset( $dimensions['width'] ) && isset( $dimensions['height'] ) ) {
+						$height = ( floatval( $node->getAttribute( 'width' ) ) * $dimensions['height'] ) / $dimensions['width'];
+					}
+
+					$node->setAttribute( 'height', $height );
+					if ( ! isset( $dimensions['height'] ) ) {
+						$class .= ' amp-wp-unknown-height';
+					}
+				}
+				$node->setAttribute( 'class', trim( $class ) );
 			}
 		}
 	}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -157,30 +157,29 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! $node instanceof DOMElement ) {
 					continue;
 				}
+				$height = $dimensions && isset( $dimensions['height'] ) ? $dimensions['height'] : self::FALLBACK_HEIGHT;
+				$width  = $dimensions && isset( $dimensions['width'] ) ? $dimensions['width'] : self::FALLBACK_WIDTH;
+				$class  = $node->getAttribute( 'class' );
+				if ( ! $class ) {
+					$class = '';
+				}
 				if (
 					! is_numeric( $node->getAttribute( 'width' ) ) &&
 					! is_numeric( $node->getAttribute( 'height' ) )
 				) {
-					$height = self::FALLBACK_HEIGHT;
-					$width  = self::FALLBACK_WIDTH;
 					$node->setAttribute( 'width', $width );
 					$node->setAttribute( 'height', $height );
-					$class = $node->hasAttribute( 'class' ) ? $node->getAttribute( 'class' ) . ' amp-wp-unknown-size' : 'amp-wp-unknown-size';
-					$node->setAttribute( 'class', $class );
+					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size' ) );
 				} elseif (
 					! is_numeric( $node->getAttribute( 'height' ) )
 				) {
-					$height = self::FALLBACK_HEIGHT;
 					$node->setAttribute( 'height', $height );
-					$class = $node->hasAttribute( 'class' ) ? $node->getAttribute( 'class' ) . ' amp-wp-unknown-size amp-wp-unknown-height' : 'amp-wp-unknown-size amp-wp-unknown-height';
-					$node->setAttribute( 'class', $class );
+					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size amp-wp-unknown-height' ) );
 				} elseif (
 					! is_numeric( $node->getAttribute( 'width' ) )
 				) {
-					$width = self::FALLBACK_WIDTH;
 					$node->setAttribute( 'width', $width );
-					$class = $node->hasAttribute( 'class' ) ? $node->getAttribute( 'class' ) . ' amp-wp-unknown-size amp-wp-unknown-width' : 'amp-wp-unknown-size amp-wp-unknown-width';
-					$node->setAttribute( 'class', $class );
+					$node->setAttribute( 'class', trim( $class . ' amp-wp-unknown-size amp-wp-unknown-width' ) );
 				}
 			}
 		}

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -1,15 +1,40 @@
 <?php
+/**
+ * Tests AMP_Style_Sanitizer.
+ *
+ * @package AMP
+ */
 
+/**
+ * Class AMP_Img_Sanitizer_Test
+ *
+ * @covers AMP_Style_Sanitizer
+ */
 class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
-	public static function force_remove_extraction_callbacks() {
-		remove_all_filters( 'amp_extract_image_dimensions_batch' );
-	}
 
+	/**
+	 * Set up.
+	 */
 	public function setUp() {
 		parent::setUp();
-		add_action( 'amp_extract_image_dimensions_batch_callbacks_registered', array( __CLASS__, 'force_remove_extraction_callbacks' ) );
+		add_filter( 'amp_extract_image_dimensions_batch', function( $urls ) {
+			$dimensions = array();
+			foreach ( array_keys( $urls ) as $url ) {
+				if ( preg_match( '#/(?P<width>\d+)x(?P<height>\d+)$#', $url, $matches ) ) {
+					$dimensions[ $url ] = array_map( 'intval', wp_array_slice_assoc( $matches, array( 'width', 'height' ) ) );
+				} else {
+					$dimensions[ $url ] = false;
+				}
+			}
+			return $dimensions;
+		} );
 	}
 
+	/**
+	 * Data for test_converter.
+	 *
+	 * @return array
+	 */
 	public function get_data() {
 		return array(
 			'no_images'                                => array(
@@ -38,18 +63,23 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'image_with_empty_width_and_height'        => array(
-				'<p><img src="http://placehold.it/300x300" width="" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="600" height="400" class="amp-wp-unknown-size amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><img src="http://placehold.it/200x300" width="" height="" /></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+			),
+
+			'image_with_undefined_width_and_height'    => array(
+				'<p><img src="http://placehold.it/200x300" /></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
 			),
 
 			'image_with_empty_width'                   => array(
-				'<p><img src="http://placehold.it/300x300" width="" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="600" height="300" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><img src="http://placehold.it/500x1000" width="" height="300" /></p>',
+				'<p><amp-img src="http://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
 			),
 
 			'image_with_empty_height'                  => array(
-				'<p><img src="http://placehold.it/300x300" width="300" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="300" height="400" class="amp-wp-unknown-size amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><img src="http://placehold.it/500x1000" width="300" height="" /></p>',
+				'<p><amp-img src="http://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
 			),
 
 			'image_with_zero_width'                    => array(
@@ -92,14 +122,14 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 
-			'image_with_no_dimensions_is_forced_dimensions' => array(
+			'image_with_no_dimensions_is_forced'       => array(
 				'<img src="http://placehold.it/350x150" />',
-				'<amp-img src="http://placehold.it/350x150" width="600" height="400" class="amp-wp-unknown-size amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 
-			'image_with_sizes_attribute_is_overridden' => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150"  />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+			'image_with_bad_src_url_get_fallback_dims' => array(
+				'<img src="http://example.com/404.png" />',
+				'<amp-img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 
 			'gif_image_conversion'                     => array(
@@ -147,21 +177,28 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test converter.
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 * @dataProvider get_data
 	 */
 	public function test_converter( $source, $expected ) {
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
 	}
 
+	/**
+	 * Test that amp-anim does not get included for a PNG.
+	 */
 	public function test_no_gif_no_image_scripts() {
-		$source = '<img src="http://placehold.it/350x150.png" width="350" height="150" alt="Placeholder!" />';
+		$source   = '<img src="http://placehold.it/350x150.png" width="350" height="150" alt="Placeholder!" />';
 		$expected = array();
 
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
@@ -175,11 +212,14 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $scripts );
 	}
 
+	/**
+	 * Test that amp-anim does get included for a GIF.
+	 */
 	public function test_no_gif_image_scripts() {
-		$source = '<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
+		$source   = '<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
 		$expected = array( 'amp-anim' => true );
 
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$sanitizer->sanitize();
 


### PR DESCRIPTION
There was a regression introduced in #979 whereby the dimensions determined are no longer actually supplied to the images that need them. Instead, the fallback image sizes are always used.

This issue is most plainly visible in Gutenberg where image blocks do not get output with `width` or `height`.

Additionally, this PR ensures that when a `width` or `height` are missing that the missing dimension gets its counterpart supplied based on the ratio of the underlying extracted image dimensions. So given an image that is 1944⨉1191 and `post_content` that contains:

```php
<img src="https://example.com/img.jpg">

<img src="https://example.com/img.jpg" width="50">

<img src="https://example.com/img.jpg" height="50">
```

✅ This gets converted to:

```html
<p><amp-img src="https://example.com/img.jpg" width="1944" height="1191" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>

<p><amp-img src="https://example.com/img.jpg" width="50" height="30.632716049383" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>

<p><amp-img src="https://example.com/img.jpg" height="50" width="81.612090680101" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>
```

![image](https://user-images.githubusercontent.com/134745/39659039-7e1f5a22-4fd4-11e8-9d00-6aff5694c497.png)

❌ As opposed to:

```html
<p><amp-img src="https://example.com/img.jpg" width="600" height="400" class="amp-wp-unknown-size amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>

<p><amp-img src="https://example.com/img.jpg" width="50" height="400" class="amp-wp-unknown-size amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>

<p><amp-img src="https://example.com/img.jpg" height="50" width="600" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>
```

![image](https://user-images.githubusercontent.com/134745/39659040-8a7b6da6-4fd4-11e8-8401-aae9cdf97af9.png)

Additionally, the `amp-wp-unknown-*` classes will only be provided if the dimensions are actually unknown (and fallbacks are used).

This PR also restores use of `content_max_width` if defined instead of `FALLBACK_WIDTH`.