### PR TITLE
Ensure before/after is amended to filtered comment_reply_link

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -793,7 +793,7 @@ class AMP_Theme_Support {
 
 		// Continue to show default link to wp-login when user is not logged-in.
 		if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
-			return $link;
+			return $args['before'] . $link . $args['after'];
 		}
 
 		$state_id  = self::get_comment_form_state_id( get_the_ID() );
@@ -814,7 +814,7 @@ class AMP_Theme_Support {
 			esc_attr( sprintf( $args['reply_to_text'], $comment->comment_author ) ),
 			$args['reply_text']
 		);
-		return $link;
+		return $args['before'] . $link . $args['after'];
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -772,18 +772,23 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		global $post;
 		$post          = $this->factory()->post->create_and_get(); // WPCS: global override ok.
 		$comment       = $this->factory()->comment->create_and_get();
-		$link          = get_comment_link( $comment );
+		$link          = sprintf( '<a href="%s">', get_comment_link( $comment ) );
 		$respond_id    = '5234';
 		$reply_text    = 'Reply';
 		$reply_to_text = 'Reply to';
-		$args          = compact( 'respond_id', 'reply_text', 'reply_to_text' );
+		$before        = '<div class="reply">';
+		$after         = '</div>';
+		$args          = compact( 'respond_id', 'reply_text', 'reply_to_text', 'before', 'after' );
 		$comment       = $this->factory()->comment->create_and_get();
+
 		update_option( 'comment_registration', true );
 		$filtered_link = AMP_Theme_Support::filter_comment_reply_link( $link, $args, $comment );
-		$this->assertEquals( $link, $filtered_link );
+		$this->assertEquals( $before . $link . $after, $filtered_link );
 		update_option( 'comment_registration', false );
 
 		$filtered_link = AMP_Theme_Support::filter_comment_reply_link( $link, $args, $comment );
+		$this->assertStringStartsWith( $before, $filtered_link );
+		$this->assertStringEndsWith( $after, $filtered_link );
 		$this->assertContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $filtered_link );
 		$this->assertContains( $comment->comment_author, $filtered_link );
 		$this->assertContains( $comment->comment_ID, $filtered_link );


### PR DESCRIPTION
The [`\get_comment_reply_link()`](https://developer.wordpress.org/reference/functions/get_comment_reply_link/) function returns with:

```php
return apply_filters( 'comment_reply_link', $args['before'] . $link . $args['after'], $args, $comment, $post );
```

Currently when we re-construct the `$link` we're not adding the before/after args in `AMP_Theme_Support::filter_comment_reply_link()` when returning:

https://github.com/Automattic/amp-wp/blob/2328f71ea256640d6bb2c6122e11e5aab6afa499/includes/class-amp-theme-support.php#L774-L781

So we need to ensure that the before/after text is added.