### PR TITLE
Fix handling of amp-bind attributes to ensure that “>” can appear inside attribute values

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -207,7 +207,7 @@ class AMP_DOM_Utils {
 		$amp_bind_attr_prefix = self::get_amp_bind_placeholder_prefix();
 
 		// Pattern for HTML attribute accounting for binding attr name, boolean attribute, single/double-quoted attribute value, and unquoted attribute values.
-		$attr_regex = '#^\s+(?P<name>\[?[a-zA-Z0-9_\-]+\]?)(?P<value>=(?:"[^"]*"|\'[^\']*\'|[^\'"\s]+))?#';
+		$attr_regex = '#^\s+(?P<name>\[?[a-zA-Z0-9_\-]+\]?)(?P<value>=(?:"[^"]*+"|\'[^\']*+\'|[^\'"\s]+))?#';
 
 		/**
 		 * Replace callback.
@@ -243,15 +243,15 @@ class AMP_DOM_Utils {
 		// Match all start tags that contain a binding attribute.
 		$pattern   = join( '', array(
 			'#<',
-			'(?P<name>[a-zA-Z0-9_\-]+)',          // Tag name.
-			'(?P<attrs>\s',
-			'(?:[^>"\'\[\]]+|"[^"]*"|\'[^\']*\')*', // Non-binding attributes tokens.
-			'\[[a-zA-Z0-9_\-]+\]\s*=',              // One binding attribute key.
-			'(?:[^>"\']+|"[^"]*"|\'[^\']*\')*',     // Any attribute tokens, including binding ones.
+			'(?P<name>[a-zA-Z0-9_\-]+)',               // Tag name.
+			'(?P<attrs>\s',                            // Attributes.
+			'(?:[^>"\'\[\]]+|"[^"]*+"|\'[^\']*+\')*+', // Non-binding attributes tokens.
+			'\[[a-zA-Z0-9_\-]+\]',                     // One binding attribute key.
+			'(?:[^>"\']+|"[^"]*+"|\'[^\']*+\')*+',     // Any attribute tokens, including binding ones.
 			')>#s',
 		) );
 		$converted = preg_replace_callback(
-			$pattern, // @todo This pattern easily results in a PREG_BACKTRACK_LIMIT_ERROR.
+			$pattern,
 			$replace_callback,
 			$html
 		);

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -240,14 +240,18 @@ class AMP_DOM_Utils {
 			return '<' . $tag_matches['name'] . $new_attrs . '>';
 		};
 
-		/*
-		 * Match all start tags that probably contain a binding attribute.
-		 * @todo Warning: The following pattern is brittle since it truncates HTML tags that have attributes that contain ">" or "=>".
-		 * For example, if there exists: `<body class="foo" [class]="bodyClasses.concat( isBar ? 'bar' : '' ).filter( className => '' != className )">`
-		 * Then this results in the following being output as the first child fo the body: `'' != className )">`
-		 */
+		// Match all start tags that contain a binding attribute.
+		$pattern   = join( '', array(
+			'#<',
+			'(?P<name>[a-zA-Z0-9_\-]+)',          // Tag name.
+			'(?P<attrs>\s',
+			'(?:[^>"\'\[\]]+|"[^"]*"|\'[^\']*\')*', // Non-binding attributes tokens.
+			'\[[a-zA-Z0-9_\-]+\]\s*=',              // One binding attribute key.
+			'(?:[^>"\']+|"[^"]*"|\'[^\']*\')*',     // Any attribute tokens, including binding ones.
+			')>#s',
+		) );
 		$converted = preg_replace_callback(
-			'#<(?P<name>[a-zA-Z0-9_\-]+)(?P<attrs>\s[^>]+\]=[^>]+)>#',
+			$pattern, // @todo This pattern easily results in a PREG_BACKTRACK_LIMIT_ERROR.
 			$replace_callback,
 			$html
 		);

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -110,12 +110,12 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		// Test malformed.
 		$malformed_html = array(
 			'<amp-img width="123" [text]="..."</amp-img>',
-			'<amp-img width="123" [text] data-test="asd"></amp-img>',
+			'<amp-img width="123" [text="..."]></amp-img>',
 			'<amp-img width="123" [text]="..." *bad*></amp-img>',
 		);
 		foreach ( $malformed_html as $html ) {
 			$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $html );
-			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_prefix(), $converted );
+			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_prefix(), $converted, "Source: $html" );
 		}
 	}
 
@@ -242,6 +242,8 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 			array( 10 ),
 			array( 100 ),
 			array( 1000 ),
+			array( 10000 ),
+			array( 100000 ),
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -709,9 +709,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-bind' ),
 			),
 
+			'amp_bind_with_greater_than_symbol'                         => array(
+				'<div class="home page-template-default page page-id-7 logged-in wp-custom-logo group-blog" [class]="minnow.bodyClasses.concat( minnow.navMenuExpanded ? \'sidebar-open\' : \'\' ).filter( className => \'\' != className )">hello</div>',
+				'<div class="home page-template-default page page-id-7 logged-in wp-custom-logo group-blog" [class]="minnow.bodyClasses.concat( minnow.navMenuExpanded ? \'sidebar-open\' : \'\' ).filter( className =&gt; \'\' != className )">hello</div>',
+				array( 'amp-bind' ),
+			),
+
 			'amp_bad_bind_attr'                                         => array(
-				'<a [unrecognized] [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
-				'<a [href]="/">test</a><p [text]="\'Hello \' + name">Hello World</p>',
+				'<a [href]=\'/\' [hidden]>test</a><p [text]="\'Hello \' + name" [unrecognized] title="Foo"><button [disabled]="" [type]=\'\'>Hello World</button></p>',
+				'<a [href]="/" [hidden]>test</a><p [text]="\'Hello \' + name" title="Foo"><button [disabled]="" [type]="">Hello World</button></p>',
 				array( 'amp-bind' ),
 			),
 


### PR DESCRIPTION
Spurred on by @surma's post: [My most useful RegExp trick](https://dassur.ma/things/regexp-quote/).

The key part to getting this to work on large data sets was something new to me in regex: [Possessive Quantifiers](https://www.regular-expressions.info/possessive.html). This prevents backtracking and avoids `PREG_BACKTRACK_LIMIT_ERROR` from happening. 

So now WordPress-served responses can successfully include:

```php
<body class="bar" [class]="bodyClasses.concat( isBar ? 'bar' : '' ).filter( className => '' != className )">
```

Whereas previously this would fail and cause `'' != className )">` to be the first text content of the `body` element. With this PR it is no longer is it required to use `&gt;` in the attribute as a workaround.

There was no perceived change in performance between the old and new regex patterns.

Again, the reason for all of this regex replacing is because PHP's DOMDocument (via libxml) does not like the bracketed amp-bind attribute syntax. So we have to convert them prior to parsing and restore them after serializing.