### PR TITLE
Force videopress to use html5 player for AMP

### DIFF
--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -554,7 +554,6 @@ class AMP_Validation_Utils {
 
 		// If no results from URL are available, validate post content outside frontend context.
 		if ( empty( $validation_errors ) && post_type_supports( $post->post_type, 'editor' ) ) {
-			do_action( 'pre_amp_render_post', $post->ID );
 			self::process_markup( $post->post_content );
 			$validation_errors = array_merge(
 				$validation_errors,

--- a/includes/utils/class-amp-validation-utils.php
+++ b/includes/utils/class-amp-validation-utils.php
@@ -554,6 +554,7 @@ class AMP_Validation_Utils {
 
 		// If no results from URL are available, validate post content outside frontend context.
 		if ( empty( $validation_errors ) && post_type_supports( $post->post_type, 'editor' ) ) {
+			do_action( 'pre_amp_render_post', $post->ID );
 			self::process_markup( $post->post_content );
 			$validation_errors = array_merge(
 				$validation_errors,

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -14,6 +14,7 @@ function amp_jetpack_mods() {
 	}
 	amp_jetpack_disable_sharing();
 	amp_jetpack_disable_related_posts();
+	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 }
 
 function amp_jetpack_disable_sharing() {
@@ -68,4 +69,20 @@ function jetpack_amp_build_stats_pixel_url() {
 	$data['ref'] = 'DOCUMENT_REFERRER'; // amp placeholder
 	$data = array_map( 'rawurlencode' , $data );
 	return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
+}
+
+/**
+ * Force videopress to use html5 player that would generate <video /> tag
+ * that will be later converted to <amp-video />
+ *
+ * @param array $options videopress shortcode options.
+ * @return array videopress shortcode options with `freedom` set to true
+ */
+function amp_videopress_enable_freedom_mode( $options ) {
+	$options['freedom'] = true;
+	return $options;
+}
+
+if ( isset( $_GET[ AMP_Validation_Utils::VALIDATE_QUERY_VAR ] ) ) {
+	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 }

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -83,6 +83,6 @@ function amp_videopress_enable_freedom_mode( $options ) {
 	return $options;
 }
 
-if ( isset( $_GET[ AMP_Validation_Utils::VALIDATE_QUERY_VAR ] ) ) {
+if ( isset( $_GET[ AMP_Validation_Utils::VALIDATE_QUERY_VAR ] ) ) { // WPCS: CSRF ok.
 	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 }

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -1,14 +1,22 @@
 <?php
+/**
+ * Jetpack bits.
+ *
+ * @todo Move this into Jetpack. See https://github.com/Automattic/amp-wp/issues/1021
+ * @package AMP
+ */
 
-// Jetpack bits.
-
-add_action( 'pre_amp_render_post', 'amp_jetpack_mods' );
+add_action( 'template_redirect', 'amp_jetpack_mods', 9 );
 
 /**
  * Disable Jetpack features that are not compatible with AMP.
  *
- **/
+ * @since 0.2
+ */
 function amp_jetpack_mods() {
+	if ( ! is_amp_endpoint() ) {
+		return;
+	}
 	if ( Jetpack::is_module_active( 'stats' ) ) {
 		add_action( 'amp_post_template_footer', 'jetpack_amp_add_stats_pixel' );
 	}
@@ -17,6 +25,11 @@ function amp_jetpack_mods() {
 	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 }
 
+/**
+ * Disable Jetpack sharing.
+ *
+ * @since 0.3
+ */
 function amp_jetpack_disable_sharing() {
 	add_filter( 'sharing_show', '__return_false', 100 );
 }
@@ -26,7 +39,8 @@ function amp_jetpack_disable_sharing() {
  *
  * That placeholder is useless since we can't ouput, and don't want to output Related Posts in AMP.
  *
- **/
+ * @since 0.2
+ */
 function amp_jetpack_disable_related_posts() {
 	if ( class_exists( 'Jetpack_RelatedPosts' ) ) {
 		$jprp = Jetpack_RelatedPosts::init();
@@ -34,7 +48,12 @@ function amp_jetpack_disable_related_posts() {
 	}
 }
 
-function jetpack_amp_add_stats_pixel( $amp_template ) {
+/**
+ * Add Jetpack stats pixel.
+ *
+ * @since 0.3.2
+ */
+function jetpack_amp_add_stats_pixel() {
 	if ( ! has_action( 'wp_footer', 'stats_footer' ) ) {
 		return;
 	}
@@ -48,26 +67,28 @@ function jetpack_amp_add_stats_pixel( $amp_template ) {
  *
  * Looks something like:
  *     https://pixel.wp.com/g.gif?v=ext&j=1%3A3.9.1&blog=1234&post=5678&tz=-4&srv=example.com&host=example.com&ref=&rand=0.4107963021218808
+ *
+ * @since 0.3.2
  */
 function jetpack_amp_build_stats_pixel_url() {
 	global $wp_the_query;
-	if ( function_exists( 'stats_build_view_data' ) ) { // added in https://github.com/Automattic/jetpack/pull/3445
+	if ( function_exists( 'stats_build_view_data' ) ) { // Added in <https://github.com/Automattic/jetpack/pull/3445>.
 		$data = stats_build_view_data();
 	} else {
-		$blog = Jetpack_Options::get_option( 'id' );
-		$tz = get_option( 'gmt_offset' );
-		$v = 'ext';
+		$blog     = Jetpack_Options::get_option( 'id' );
+		$tz       = get_option( 'gmt_offset' );
+		$v        = 'ext';
 		$blog_url = AMP_WP_Utils::parse_url( site_url() );
-		$srv = $blog_url['host'];
-		$j = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
-		$post = $wp_the_query->get_queried_object_id();
-		$data = compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
+		$srv      = $blog_url['host'];
+		$j        = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
+		$post     = $wp_the_query->get_queried_object_id();
+		$data     = compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
 	}
 
-	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? rawurlencode( $_SERVER['HTTP_HOST'] ) : ''; // input var ok
-	$data['rand'] = 'RANDOM'; // amp placeholder
-	$data['ref'] = 'DOCUMENT_REFERRER'; // amp placeholder
-	$data = array_map( 'rawurlencode' , $data );
+	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? rawurlencode( $_SERVER['HTTP_HOST'] ) : ''; // input var ok.
+	$data['rand'] = 'RANDOM'; // amp placeholder.
+	$data['ref']  = 'DOCUMENT_REFERRER'; // amp placeholder.
+	$data         = array_map( 'rawurlencode', $data );
 	return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
 }
 
@@ -75,14 +96,12 @@ function jetpack_amp_build_stats_pixel_url() {
  * Force videopress to use html5 player that would generate <video /> tag
  * that will be later converted to <amp-video />
  *
+ * @since 0.7.1
+ *
  * @param array $options videopress shortcode options.
  * @return array videopress shortcode options with `freedom` set to true
  */
 function amp_videopress_enable_freedom_mode( $options ) {
 	$options['freedom'] = true;
 	return $options;
-}
-
-if ( isset( $_GET[ AMP_Validation_Utils::VALIDATE_QUERY_VAR ] ) ) { // WPCS: CSRF ok.
-	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 }

--- a/jetpack-helper.php
+++ b/jetpack-helper.php
@@ -78,16 +78,16 @@ function jetpack_amp_build_stats_pixel_url() {
 		$blog     = Jetpack_Options::get_option( 'id' );
 		$tz       = get_option( 'gmt_offset' );
 		$v        = 'ext';
-		$blog_url = AMP_WP_Utils::parse_url( site_url() );
+		$blog_url = wp_parse_url( site_url() );
 		$srv      = $blog_url['host'];
 		$j        = sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION );
 		$post     = $wp_the_query->get_queried_object_id();
 		$data     = compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
 	}
 
-	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? rawurlencode( $_SERVER['HTTP_HOST'] ) : ''; // input var ok.
-	$data['rand'] = 'RANDOM'; // amp placeholder.
-	$data['ref']  = 'DOCUMENT_REFERRER'; // amp placeholder.
+	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var ok.
+	$data['rand'] = 'RANDOM'; // AMP placeholder.
+	$data['ref']  = 'DOCUMENT_REFERRER'; // AMP placeholder.
 	$data         = array_map( 'rawurlencode', $data );
 	return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
 }

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -235,3 +235,16 @@ function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions ) {
 
 	return $dimensions;
 }
+
+/**
+ * Force videopress to use html5 player that would generate <video /> tag
+ * that will be later converted to <amp-video />
+ *
+ * @param array $options videopress shortcode options.
+ * @return array videopress shortcode options with `freedom` set to true
+ */
+function amp_videopress_enable_freedom_mode( $options ) {
+	$options['freedom'] = true;
+	return $options;
+}
+add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -19,6 +19,7 @@ add_filter( 'amp_options_menu_is_enabled', '__return_false', 9999 );
 function jetpack_amp_disable_the_content_filters() {
 	add_filter( 'post_flair_disable', '__return_true', 99 );
 	add_filter( 'videopress_show_2015_player', '__return_true' );
+	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 	add_filter( 'protected_embeds_use_form_post', '__return_false' );
 
 	remove_filter( 'the_title', 'widont' );
@@ -247,4 +248,3 @@ function amp_videopress_enable_freedom_mode( $options ) {
 	$options['freedom'] = true;
 	return $options;
 }
-add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -19,7 +19,6 @@ add_filter( 'amp_options_menu_is_enabled', '__return_false', 9999 );
 function jetpack_amp_disable_the_content_filters() {
 	add_filter( 'post_flair_disable', '__return_true', 99 );
 	add_filter( 'videopress_show_2015_player', '__return_true' );
-	add_filter( 'videopress_shortcode_options', 'amp_videopress_enable_freedom_mode' );
 	add_filter( 'protected_embeds_use_form_post', '__return_false' );
 
 	remove_filter( 'the_title', 'widont' );
@@ -235,16 +234,4 @@ function wpcom_amp_extract_image_dimensions_from_getimagesize( $dimensions ) {
 	}
 
 	return $dimensions;
-}
-
-/**
- * Force videopress to use html5 player that would generate <video /> tag
- * that will be later converted to <amp-video />
- *
- * @param array $options videopress shortcode options.
- * @return array videopress shortcode options with `freedom` set to true
- */
-function amp_videopress_enable_freedom_mode( $options ) {
-	$options['freedom'] = true;
-	return $options;
 }


### PR DESCRIPTION
Videopress embed uses an `iframe` and a `script` tag,
`script` tag is not allowed in AMP, so it's stripped and a warning is generated.

![screen shot 2018-05-07 at 10 19 17](https://user-images.githubusercontent.com/326402/39692969-24b520ac-51eb-11e8-8f42-592f84b1cc42.png)


This PR tries to force html5 player, so the player would be actually a `<video />` tag
that would be converted to `<amp-video />`.


