### PR TITLE
Add information about stylesheets included and excluded in style[amp-custom]

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1397,6 +1397,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 							__( 'Too much CSS output (by %d bytes).', 'amp' ),
 							( $final_size + $sheet_size ) - $stylesheet_set['cdata_spec']['max_bytes']
 						),
+						'node'    => $pending_stylesheet['node'],
 					);
 					if ( isset( $pending_stylesheet['sources'] ) ) {
 						$validation_error['sources'] = $pending_stylesheet['sources'];


### PR DESCRIPTION
The following will be included, for example, to list out the stylesheets that are concatenated into `style[amp-custom]` and also to indicate which stylesheets were excluded for being too large.

```html
<!--
The style[amp-custom] element is populated with:
- link#ampconf-css[rel=stylesheet][id=ampconf-css][href=https://src.wordpress-develop.test/wp-content/themes/ampconf/assets/dist/css/main.css?ver=4.9.6-alpha-42959-src][type=text/css][media=all] (15053 bytes)
- link#jetpack-widget-social-icons-styles-css[rel=stylesheet][id=jetpack-widget-social-icons-styles-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/widgets/social-icons/social-icons.css?ver=20170506][type=text/css][media=all] (207 bytes)
Total size: 15260 bytes

The following stylesheets are too large to be include in style[amp-custom]:
- link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.0-alpha][type=text/css][media=all] (77107 bytes)
-->
```

This will be very helpful for debugging and it will improve transparency.