### PR TITLE
Soft-deprecate AMP_Base_Sanitizer::get_body_node()

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -159,11 +159,10 @@ abstract class AMP_Base_Sanitizer {
 	 * Get HTML body as DOMElement from DOMDocument received by the constructor.
 	 *
 	 * @deprecated Just reference $root_element instead.
-	 * @return DOMElement The body or html element.
+	 * @return DOMElement The body element.
 	 */
 	protected function get_body_node() {
-		_deprecated_function( __METHOD__, 'AMP_Base_Sanitizer::$root_element', '0.7' );
-		return $this->root_element;
+		return $this->dom->getElementsByTagName( 'body' )->item( 0 );
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,11 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 ## Changelog ##
 
 ### 0.7.1 (Unreleased) ###
-- Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132).
-- Supply the extracted dimensions to images determined to need them; fixes regression from 0.6 this is key for Gutenberg compat. See [#1117](https://github.com/Automattic/amp-wp/pull/1117).
-- Ensure before/after is amended to filtered comment_reply_link. See [#1118](https://github.com/Automattic/amp-wp/pull/1118).
+- Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132). Props westonruter.
+- Supply the extracted dimensions to images determined to need them; fixes regression from 0.6 this is key for Gutenberg compat. See [#1117](https://github.com/Automattic/amp-wp/pull/1117). Props westonruter.
+- Ensure before/after is amended to filtered comment_reply_link. See [#1118](https://github.com/Automattic/amp-wp/pull/1118). Props westonruter.
 - Force VideoPress to use html5 player for AMP. See [#1125](https://github.com/Automattic/amp-wp/pull/1125). Props yurynix.
+- Soft-deprecate `AMP_Base_Sanitizer::get_body_node()` instead of hard-deprecating it (with triggered notice). See [#1141](https://github.com/Automattic/amp-wp/pull/1141). Props westonruter.
 
 See [0.7.1 milestone](https://github.com/Automattic/amp-wp/milestone/8?closed=1).
 

--- a/readme.txt
+++ b/readme.txt
@@ -45,10 +45,11 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 == Changelog ==
 
 = 0.7.1 (Unreleased) =
-- Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132).
-- Supply the extracted dimensions to images determined to need them; fixes regression from 0.6 this is key for Gutenberg compat. See [#1117](https://github.com/Automattic/amp-wp/pull/1117).
-- Ensure before/after is amended to filtered comment_reply_link. See [#1118](https://github.com/Automattic/amp-wp/pull/1118).
+- Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132). Props westonruter.
+- Supply the extracted dimensions to images determined to need them; fixes regression from 0.6 this is key for Gutenberg compat. See [#1117](https://github.com/Automattic/amp-wp/pull/1117). Props westonruter.
+- Ensure before/after is amended to filtered comment_reply_link. See [#1118](https://github.com/Automattic/amp-wp/pull/1118). Props westonruter.
 - Force VideoPress to use html5 player for AMP. See [#1125](https://github.com/Automattic/amp-wp/pull/1125). Props yurynix.
+- Soft-deprecate `AMP_Base_Sanitizer::get_body_node()` instead of hard-deprecating it (with triggered notice). See [#1141](https://github.com/Automattic/amp-wp/pull/1141). Props westonruter.
 
 See [0.7.1 milestone](https://github.com/Automattic/amp-wp/milestone/8?closed=1).
 


### PR DESCRIPTION
There's no need to hard-deprecate this method with a warning. And it may be useful still to have this method to get the `body` when the `html` element is not desired.

See https://wordpress.org/support/topic/amp_base_sanitizerget_body/