### PR TITLE
Prefer the Custom Logo as the publisher icon

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -584,16 +584,8 @@ function amp_get_schemaorg_metadata() {
 	$custom_logo_id  = get_theme_mod( 'custom_logo' );
 
 	if ( has_custom_logo() && $custom_logo_id ) {
-		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
-		$is_proper_size  = (
-			isset( $custom_logo_img[0], $custom_logo_img[1], $custom_logo_img[2] )
-			&&
-			$custom_logo_img[1] <= $max_logo_width
-			&&
-			$custom_logo_img[2] <= $max_logo_height
-		);
-
-		if ( $is_proper_size ) {
+		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, array( $max_logo_width, $max_logo_height ), false );
+		if ( $custom_logo_img ) {
 			$schema_img_url = $custom_logo_img[0];
 			$schema_img     = array(
 				'width'  => $custom_logo_img[1],
@@ -604,12 +596,10 @@ function amp_get_schemaorg_metadata() {
 
 	if ( ! isset( $schema_img_url ) ) {
 		$schema_img_url = get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE );
-		if ( $schema_img_url ) {
-			$schema_img = array(
-				'width'  => AMP_Post_Template::SITE_ICON_SIZE,
-				'height' => AMP_Post_Template::SITE_ICON_SIZE,
-			);
-		}
+		$schema_img     = array(
+			'width'  => AMP_Post_Template::SITE_ICON_SIZE,
+			'height' => AMP_Post_Template::SITE_ICON_SIZE,
+		);
 	}
 
 	/**
@@ -625,7 +615,7 @@ function amp_get_schemaorg_metadata() {
 	 */
 	$schema_img_url = apply_filters( 'amp_site_icon_url', $schema_img_url );
 
-	if ( isset( $schema_img_url, $schema_img ) ) {
+	if ( $schema_img_url ) {
 		$metadata['publisher']['logo'] = array_merge(
 			array(
 				'@type' => 'ImageObject',

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -595,7 +595,7 @@ function amp_get_schemaorg_metadata() {
 
 		if ( $is_proper_size ) {
 			$schema_img_url = $custom_logo_img[0];
-			$schema_img = array(
+			$schema_img     = array(
 				'width'  => $custom_logo_img[1],
 				'height' => $custom_logo_img[2],
 			);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -579,24 +579,39 @@ function amp_get_schemaorg_metadata() {
 		),
 	);
 
+	/*
+	 * "The logo should be a rectangle, not a square. The logo should fit in a 60x600px rectangle.,
+	 * and either be exactly 60px high (preferred), or exactly 600px wide. For example, 450x45px
+	 * would not be acceptable, even though it fits in the 600x60px rectangle."
+	 * See <https://developers.google.com/search/docs/data-types/article#logo-guidelines>.
+	 */
 	$max_logo_width  = 600;
 	$max_logo_height = 60;
 	$custom_logo_id  = get_theme_mod( 'custom_logo' );
+	$schema_img      = array();
 
 	if ( has_custom_logo() && $custom_logo_id ) {
 		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, array( $max_logo_width, $max_logo_height ), false );
 		if ( $custom_logo_img ) {
-			$schema_img_url = $custom_logo_img[0];
-			$schema_img     = array(
+			// @todo Warning: The width/height returned may not actually be physically the $max_logo_width and $max_logo_height for the image returned.
+			$schema_img = array(
+				'url'    => $custom_logo_img[0],
 				'width'  => $custom_logo_img[1],
 				'height' => $custom_logo_img[2],
 			);
 		}
 	}
 
-	if ( ! isset( $schema_img_url ) ) {
-		$schema_img_url = get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE );
-		$schema_img     = array(
+	// Try Site Icon, though it is not ideal because "The logo should be a rectangle, not a square." per <https://developers.google.com/search/docs/data-types/article#logo-guidelines>.
+	if ( empty( $schema_img['url'] ) ) {
+		/*
+		 * Note that AMP_Post_Template::SITE_ICON_SIZE is used and not $max_logo_height because 32px is the largest
+		 * size that is defined in \WP_Site_Icon::$site_icon_sizes which is less than 60px. It may be a good idea
+		 * to add a site_icon_image_sizes filter which appends 60 to the list of sizes, but this will only help
+		 * when adding a new site icon and it would be irrelevant when a custom logo is present, per above.
+		 */
+		$schema_img = array(
+			'url'    => get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE ),
 			'width'  => AMP_Post_Template::SITE_ICON_SIZE,
 			'height' => AMP_Post_Template::SITE_ICON_SIZE,
 		);
@@ -609,17 +624,19 @@ function amp_get_schemaorg_metadata() {
 	 * But the Custom Logo is now the preferred publisher logo, if it exists and its dimensions aren't too big.
 	 *
 	 * @since 0.3
-	 * @todo Why is the size set to 32px?
 	 *
 	 * @param string $schema_img_url URL of the publisher logo, either the Custom Logo or the Site Icon.
 	 */
-	$schema_img_url = apply_filters( 'amp_site_icon_url', $schema_img_url );
+	$filtered_schema_img_url = apply_filters( 'amp_site_icon_url', $schema_img['url'] );
+	if ( $filtered_schema_img_url !== $schema_img['url'] ) {
+		$schema_img['url'] = $filtered_schema_img_url;
+		unset( $schema_img['width'], $schema_img['height'] ); // Clear width/height since now unknown, and not required.
+	}
 
-	if ( $schema_img_url ) {
+	if ( ! empty( $schema_img['url'] ) ) {
 		$metadata['publisher']['logo'] = array_merge(
 			array(
 				'@type' => 'ImageObject',
-				'url'   => $schema_img_url,
 			),
 			$schema_img
 		);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -582,6 +582,7 @@ function amp_get_schemaorg_metadata() {
 	$max_logo_width  = 600;
 	$max_logo_height = 60;
 	$custom_logo_id  = get_theme_mod( 'custom_logo' );
+
 	if ( has_custom_logo() && $custom_logo_id ) {
 		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
 		$is_proper_size  = (
@@ -593,40 +594,42 @@ function amp_get_schemaorg_metadata() {
 		);
 
 		if ( $is_proper_size ) {
+			$schema_img_url = $custom_logo_img[0];
 			$schema_img = array(
-				'url'    => $custom_logo_img[0],
 				'width'  => $custom_logo_img[1],
 				'height' => $custom_logo_img[2],
 			);
 		}
 	}
 
-	if ( ! isset( $schema_img ) ) {
-
-		/**
-		 * Filters the site icon used in AMP responses.
-		 *
-		 * In general the `get_site_icon_url` filter should be used instead.
-		 *
-		 * @since 0.3
-		 * @todo Why is the size set to 32px?
-		 *
-		 * @param string $site_icon_url
-		 */
-		$site_icon_img_url = apply_filters( 'amp_site_icon_url', get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE ) );
-		if ( $site_icon_img_url ) {
+	if ( ! isset( $schema_img_url ) ) {
+		$schema_img_url = get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE );
+		if ( $schema_img_url ) {
 			$schema_img = array(
-				'url'    => $site_icon_img_url,
 				'width'  => AMP_Post_Template::SITE_ICON_SIZE,
 				'height' => AMP_Post_Template::SITE_ICON_SIZE,
 			);
 		}
 	}
 
-	if ( isset( $schema_img ) ) {
+	/**
+	 * Filters the publisher logo URL in the schema.org data.
+	 *
+	 * Previously, this only filtered the Site Icon, as that was the only possible schema.org publisher logo.
+	 * But the Custom Logo is now the preferred publisher logo, if it exists and its dimensions aren't too big.
+	 *
+	 * @since 0.3
+	 * @todo Why is the size set to 32px?
+	 *
+	 * @param string $schema_img_url URL of the publisher logo, either the Custom Logo or the Site Icon.
+	 */
+	$schema_img_url = apply_filters( 'amp_site_icon_url', $schema_img_url );
+
+	if ( isset( $schema_img_url, $schema_img ) ) {
 		$metadata['publisher']['logo'] = array_merge(
 			array(
 				'@type' => 'ImageObject',
+				'url'   => $schema_img_url,
 			),
 			$schema_img
 		);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -579,10 +579,10 @@ function amp_get_schemaorg_metadata() {
 		),
 	);
 
-	$custom_logo_id  = get_theme_mod( 'custom_logo' );
 	$max_logo_width  = 600;
 	$max_logo_height = 60;
-	if ( $custom_logo_id && 'attachment' === get_post_type( $custom_logo_id ) ) {
+	$custom_logo_id  = get_theme_mod( 'custom_logo' );
+	if ( has_custom_logo() && $custom_logo_id ) {
 		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
 		$is_proper_size  = (
 			isset( $custom_logo_img[0], $custom_logo_img[1], $custom_logo_img[2] )

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -579,10 +579,20 @@ function amp_get_schemaorg_metadata() {
 		),
 	);
 
-	$custom_logo_id = get_theme_mod( 'custom_logo' );
+	$custom_logo_id  = get_theme_mod( 'custom_logo' );
+	$max_logo_width  = 600;
+	$max_logo_height = 60;
 	if ( $custom_logo_id && 'attachment' === get_post_type( $custom_logo_id ) ) {
 		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
-		if ( isset( $custom_logo_img[0], $custom_logo_img[1], $custom_logo_img[2] ) ) {
+		$is_proper_size  = (
+			isset( $custom_logo_img[0], $custom_logo_img[1], $custom_logo_img[2] )
+			&&
+			$custom_logo_img[1] <= $max_logo_width
+			&&
+			$custom_logo_img[2] <= $max_logo_height
+		);
+
+		if ( $is_proper_size ) {
 			$schema_img = array(
 				'url'    => $custom_logo_img[0],
 				'width'  => $custom_logo_img[1],

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -579,23 +579,46 @@ function amp_get_schemaorg_metadata() {
 		),
 	);
 
-	/**
-	 * Filters the site icon used in AMP responses.
-	 *
-	 * In general the `get_site_icon_url` filter should be used instead.
-	 *
-	 * @since 0.3
-	 * @todo Why is the size set to 32px?
-	 *
-	 * @param string $site_icon_url
-	 */
-	$site_icon_url = apply_filters( 'amp_site_icon_url', get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE ) );
-	if ( $site_icon_url ) {
-		$metadata['publisher']['logo'] = array(
-			'@type'  => 'ImageObject',
-			'url'    => $site_icon_url,
-			'height' => AMP_Post_Template::SITE_ICON_SIZE,
-			'width'  => AMP_Post_Template::SITE_ICON_SIZE,
+	$custom_logo_id = get_theme_mod( 'custom_logo' );
+	if ( $custom_logo_id && 'attachment' === get_post_type( $custom_logo_id ) ) {
+		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
+		if ( isset( $custom_logo_img[0], $custom_logo_img[1], $custom_logo_img[2] ) ) {
+			$schema_img = array(
+				'url'    => $custom_logo_img[0],
+				'width'  => $custom_logo_img[1],
+				'height' => $custom_logo_img[2],
+			);
+		}
+	}
+
+	if ( ! isset( $schema_img ) ) {
+
+		/**
+		 * Filters the site icon used in AMP responses.
+		 *
+		 * In general the `get_site_icon_url` filter should be used instead.
+		 *
+		 * @since 0.3
+		 * @todo Why is the size set to 32px?
+		 *
+		 * @param string $site_icon_url
+		 */
+		$site_icon_img_url = apply_filters( 'amp_site_icon_url', get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE ) );
+		if ( $site_icon_img_url ) {
+			$schema_img = array(
+				'url'    => $site_icon_img_url,
+				'width'  => AMP_Post_Template::SITE_ICON_SIZE,
+				'height' => AMP_Post_Template::SITE_ICON_SIZE,
+			);
+		}
+	}
+
+	if ( isset( $schema_img ) ) {
+		$metadata['publisher']['logo'] = array_merge(
+			array(
+				'@type' => 'ImageObject',
+			),
+			$schema_img
 		);
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 ## Changelog ##
 
 ### 1.0 (unreleased) ###
-- ...
+- Prefer the Custom Logo as the schema.org publisher icon, over the Site Icon. See [#1144](https://github.com/Automattic/amp-wp/pull/1144). Props kienstra, westonruter.
 
 ### 0.7.1 (Unreleased) ###
 - Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132). Props westonruter.

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 == Changelog ==
 
 = 1.0 (unreleased) =
-- ...
+- Prefer the Custom Logo as the schema.org publisher icon, over the Site Icon. See [#1144](https://github.com/Automattic/amp-wp/pull/1144). Props kienstra, westonruter.
 
 = 0.7.1 (Unreleased) =
 - Limit showing AMP validation warnings to when `amp` theme support is present. See [#1132](https://github.com/Automattic/amp-wp/pull/1132). Props westonruter.

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -463,7 +463,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			'url'    => $expected_site_icon_img[0],
 			'width'  => 32,
 		);
-		$metadata = amp_get_schemaorg_metadata();
+		$metadata                  = amp_get_schemaorg_metadata();
 		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
 		update_option( 'site_icon', null );
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -474,8 +474,14 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
 		update_option( 'site_icon', null );
 
-		// Test the custom logo with too much height, expecting the publisher logo to fall back to the site icon.
-		$custom_logo_excessive_height = 150;
+		/**
+		 * Test the publisher logo when the Custom Logo naturally has too much height, a common scenario.
+		 *
+		 * It's expected that the URL is the same,
+		 * but the height should be 60, the maximum height for the schema.org publisher logo.
+		 * And the width should be proportional to the new height.
+		 */
+		$custom_logo_excessive_height = 250;
 		update_post_meta(
 			$custom_logo_id,
 			'_wp_attachment_metadata',
@@ -486,8 +492,17 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		);
 		set_theme_mod( 'custom_logo', $custom_logo_id );
 		update_option( 'site_icon', $site_icon_id );
-		$metadata = amp_get_schemaorg_metadata();
-		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
+		$metadata   = amp_get_schemaorg_metadata();
+		$max_height = 60;
+		$this->assertEquals(
+			array(
+				'@type'  => $logo_type,
+				'height' => $max_height,
+				'url'    => $expected_logo_img[0],
+				'width'  => $custom_logo_width * $max_height / $custom_logo_excessive_height, // Proportional to downsized height.
+			),
+			$metadata['publisher']['logo']
+		);
 		set_theme_mod( 'custom_logo', null );
 		update_option( 'site_icon', null );
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -457,16 +457,31 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$expected_site_icon_img = wp_get_attachment_image_src( $site_icon_id, 'full', false );
 
 		update_option( 'site_icon', $site_icon_id );
-		$metadata = amp_get_schemaorg_metadata();
-		$this->assertEquals(
-			array(
-				'@type'  => $logo_type,
-				'height' => 32,
-				'url'    => $expected_site_icon_img[0],
-				'width'  => 32,
-			),
-			$metadata['publisher']['logo']
+		$expected_schema_site_icon = array(
+			'@type'  => $logo_type,
+			'height' => 32,
+			'url'    => $expected_site_icon_img[0],
+			'width'  => 32,
 		);
+		$metadata = amp_get_schemaorg_metadata();
+		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
+		update_option( 'site_icon', null );
+
+		// Test the custom logo icon with too much height, expecting the publisher logo to fall back to the site icon.
+		$custom_logo_excessive_height = 150;
+		update_post_meta(
+			$custom_logo_id,
+			'_wp_attachment_metadata',
+			array(
+				'width'  => $custom_logo_width,
+				'height' => $custom_logo_excessive_height,
+			)
+		);
+		set_theme_mod( 'custom_logo', $custom_logo_id );
+		update_option( 'site_icon', $site_icon_id );
+		$metadata = amp_get_schemaorg_metadata();
+		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
+		set_theme_mod( 'custom_logo', null );
 		update_option( 'site_icon', null );
 
 		// Test page.

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -579,7 +579,6 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( 'George', $metadata['author']['name'] );
 	}
 
-
 	/**
 	 * Get a mock publisher logo URL, to test that the filter works as expected.
 	 *


### PR DESCRIPTION
**Pull Request**

This uses Weston's [suggested snippet](https://github.com/Automattic/amp-wp/issues/975#issue-300126934) in #975. 

If the [Custom Logo](https://developer.wordpress.org/themes/functionality/custom-logo/) exists, this uses it as the publisher icon for schema.org. As Weston mentioned,
this is more likely to follow the AMP [logo guidelines](https://developers.google.com/search/docs/data-types/article#logo-guidelines).

If it doesn't exist, or it exceeds the maximum dimensions, this uses the same logic as before. It simply gets the Site Icon.

Closes #975.