### PR TITLE
Adding id as a valid attribute for amp-iframe

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1657,9 +1657,7 @@ class AMP_Allowed_Tags_Generated {
 						'value' => '',
 					),
 					'sandbox' => array(),
-					'scrolling' => array(
-						'value_regex' => 'auto|yes|no',
-					),
+
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1657,7 +1657,9 @@ class AMP_Allowed_Tags_Generated {
 						'value' => '',
 					),
 					'sandbox' => array(),
-
+					'scrolling' => array(
+						'value_regex' => 'auto|yes|no',
+					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -153,6 +153,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					}
 					break;
 
+				case 'scrolling':
+					break;
+
 				default:
 					$out[ $name ] = $value;
 					break;

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -153,9 +153,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					}
 					break;
 
-				case 'scrolling':
-					break;
-
 				default:
 					$out[ $name ] = $value;
 					break;

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -121,6 +121,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type string $sandbox <iframe> `sandbox` attribute - Pass along if found; default to value of self::SANDBOX_DEFAULTS
 	 *      @type string $class <iframe> `class` attribute - Pass along if found
 	 *      @type string $sizes <iframe> `sizes` attribute - Pass along if found
+	 *      @type string $id <iframe> `id` attribute - Pass along if found
 	 *      @type int $frameborder <iframe> `frameborder` attribute - Filter to '0' or '1'; default to '0'
 	 *      @type bool $allowfullscreen <iframe> `allowfullscreen` attribute - Convert 'false' to empty string ''
 	 *      @type bool $allowtransparency <iframe> `allowtransparency` attribute - Convert 'false' to empty string ''
@@ -135,6 +136,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				case 'sandbox':
 				case 'class':
 				case 'sizes':
+				case 'id':
 					$out[ $name ] = $value;
 					break;
 

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -107,6 +107,10 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
 		$sanitizer->sanitize();
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+		$whitelist_sanitizer->sanitize();
+
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
 		$this->assertEquals( $expected, $content );

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -58,6 +58,11 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com/iframe" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
+			'iframe_with_id_attribute'                  => array(
+				'<iframe src="https://example.com/iframe" id="myIframe"></iframe>',
+				'<amp-iframe src="https://example.com/iframe" id="myIframe" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+			),
+
 			'iframe_with_protocol_relative_url' => array(
 				'<iframe src="//example.com/video/132886713"></iframe>',
 				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -50,7 +50,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 			'iframe_with_blacklisted_attribute' => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto"></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'iframe_with_sizes_attribute_is_overridden' => array(


### PR DESCRIPTION
The id attribute of any iframe is being removed in the amp-iframe-sanitizer. I believed it's save to pass it as it's done with the classes, size, etc.