### PR TITLE
Add support for extracting (pixel) dimensions from SVG images

### DIFF
--- a/includes/lib/fasterimage/FasterImage.php
+++ b/includes/lib/fasterimage/FasterImage.php
@@ -35,6 +35,8 @@ class FasterImage
      */
     public function batch(array $urls)
     {
+    	echo __METHOD__ . ':' . __LINE__ . PHP_EOL;
+    	print_r($urls);
 
         $multi   = curl_multi_init();
         $results = array();
@@ -72,9 +74,12 @@ class FasterImage
             $error = curl_error($$count);
 
             if ( $error ) {
-                $results[$uri]['failure_reason'] = $error;
+                $results[$uri]['failure_reason'] = sprintf( '%s (error code: %s)', $error, curl_errno( $$count ) );
             }
         }
+
+	    echo __METHOD__ . ':' . __LINE__ . PHP_EOL;
+	    print_r($results);
 
         return $results;
     }
@@ -97,6 +102,7 @@ class FasterImage
      */
     protected function handle($url, & $result)
     {
+	    echo __METHOD__ . ':' . __LINE__ . PHP_EOL;
         $stream           = new Stream();
         $parser           = new ImageParser($stream);
         $result['rounds'] = 0;
@@ -128,6 +134,7 @@ class FasterImage
         curl_setopt($ch, CURLOPT_ENCODING, "");
 
         curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $str) use (& $result, & $parser, & $stream, $url) {
+	        echo __METHOD__ . ':' . __LINE__ . PHP_EOL;
 
             $result['rounds']++;
             $result['bytes'] += strlen($str);
@@ -135,6 +142,7 @@ class FasterImage
             $stream->write($str);
 
             try {
+            	echo "TRY: " . __METHOD__ . ':' . __LINE__ . PHP_EOL;
                 // store the type in the result array by looking at the bits
                 $result['type'] = $parser->parseType();
 
@@ -143,8 +151,10 @@ class FasterImage
                  * for the size.
                  */
                 $result['size'] = $parser->parseSize() ?: 'failed';
+                print_r($result);
             }
             catch (StreamBufferTooSmallException $e) {
+            	echo "StreamBufferTooSmallException\n";
                 /*
                  * If this exception is thrown, we don't have enough of the stream buffered
                  * so in order to tell curl to keep streaming we need to return the number
@@ -159,6 +169,7 @@ class FasterImage
                 return strlen($str);
             }
             catch (InvalidImageException $e) {
+	            echo "InvalidImageException\n";
 
                 /*
                  * This means we've determined that we're lost and don't know

--- a/includes/lib/fasterimage/ImageParser.php
+++ b/includes/lib/fasterimage/ImageParser.php
@@ -137,9 +137,6 @@ class ImageParser
                 default:
                     $this->stream->resetPointer();
                     $markup = $this->stream->read( 1024 );
-	                echo( __METHOD__ . ':' . $markup . "\n" );
-	                echo( ( false !== strpos( $markup, '<svg' ) ? 'YES SVG' : 'NOPE' ) . "\n" );
-
                     if ( false !== strpos( $markup, '<svg' ) ) {
                         $this->type = 'svg';
                     } else {
@@ -365,7 +362,6 @@ class ImageParser
     {
         $this->stream->resetPointer();
         $markup = $this->stream->read( 1024 );
-	    echo( __METHOD__ . ':' . $markup . "\n" );
         if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
             return null;
         }

--- a/includes/lib/fasterimage/ImageParser.php
+++ b/includes/lib/fasterimage/ImageParser.php
@@ -136,7 +136,11 @@ class ImageParser
                     return $this->type = 'tiff';
                 default:
                     $this->stream->resetPointer();
-                    if ( false !== strpos( $this->stream->read( 1024 ), '<svg' ) ) {
+                    $markup = $this->stream->read( 1024 );
+	                echo( __METHOD__ . ':' . $markup . "\n" );
+	                echo( ( false !== strpos( $markup, '<svg' ) ? 'YES SVG' : 'NOPE' ) . "\n" );
+
+                    if ( false !== strpos( $markup, '<svg' ) ) {
                         $this->type = 'svg';
                     } else {
                         return false;
@@ -359,7 +363,9 @@ class ImageParser
      */
     protected function parseSizeForSvg()
     {
+        $this->stream->resetPointer();
         $markup = $this->stream->read( 1024 );
+	    echo( __METHOD__ . ':' . $markup . "\n" );
         if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
             return null;
         }
@@ -374,6 +380,12 @@ class ImageParser
         }
         if ( $width && $height ) {
             return [ $width, $height ];
+        }
+        if ( preg_match( '/\sviewBox=([\'"])[^\1]*(?:,|\s)+(?P<width>\d+(?:\.\d+)?)(?:px)?(?:,|\s)+(?P<height>\d+(?:\.\d+)?)(?:px)?\s*\1/', $svg_start_tag, $matches ) ) {
+            return [
+                floatval( $matches['width'] ),
+                floatval( $matches['height'] )
+            ];
         }
         return null;
     }

--- a/includes/lib/fasterimage/ImageParser.php
+++ b/includes/lib/fasterimage/ImageParser.php
@@ -57,6 +57,8 @@ class ImageParser
                 return $this->parseSizeForPSD();
             case 'webp':
                 return $this->parseSizeForWebp();
+            case 'svg':
+                return $this->parseSizeForSvg();
         }
 
         return null;
@@ -133,7 +135,12 @@ class ImageParser
                 case "MM":
                     return $this->type = 'tiff';
                 default:
-                    return false;
+                    $this->stream->resetPointer();
+                    if ( false !== strpos( $this->stream->read( 1024 ), '<svg' ) ) {
+                        $this->type = 'svg';
+                    } else {
+                        return false;
+                    }
             }
         }
 
@@ -343,6 +350,32 @@ class ImageParser
                 return null;
         }
 
+    }
+
+    /**
+     * Parse size for SVG.
+     *
+     * @return array|null Size or null.
+     */
+    protected function parseSizeForSvg()
+    {
+        $markup = $this->stream->read( 1024 );
+        if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
+            return null;
+        }
+        $svg_start_tag = $matches[0];
+        $width = null;
+        $height = null;
+        if ( preg_match( '/\swidth=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
+            $width = floatval( $matches[2] );
+        }
+        if ( preg_match( '/\sheight=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
+            $height = floatval( $matches[2] );
+        }
+        if ( $width && $height ) {
+            return [ $width, $height ];
+        }
+        return null;
     }
 
     /**

--- a/includes/lib/fastimage/class-fastimage.php
+++ b/includes/lib/fastimage/class-fastimage.php
@@ -71,10 +71,8 @@ class FastImage
                     return $this->type = 'png';
                 default:
                     $this->strpos = 0;
-	                $markup = $this->getChars( 1024 );
-	                $this->strpos = 0;
-	                echo( __METHOD__ . ':' . $markup . "\n" );
-	                echo( ( false !== strpos( $markup, '<svg' ) ? 'YES SVG' : 'NOPE' ) . "\n" );
+                    $markup = $this->getChars( 1024 );
+                    $this->strpos = 0;
                     if ( false !== strpos( $markup, '<svg' ) ) {
                         $this->type = 'svg';
                     } else {
@@ -174,36 +172,27 @@ class FastImage
     {
         $this->strpos = 0;
         $markup = $this->getChars( 1024 );
-        echo( __METHOD__ . ':' . $markup . "\n" );
         if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
             return null;
         }
-        echo( __METHOD__ . ':' . __LINE__ );
         $svg_start_tag = $matches[0];
         $width = null;
         $height = null;
-	    echo( __METHOD__ . ':' . __LINE__ );
         if ( preg_match( '/\swidth=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
             $width = floatval( $matches[2] );
         }
-	    echo( __METHOD__ . ':' . __LINE__ );
         if ( preg_match( '/\sheight=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
             $height = floatval( $matches[2] );
         }
-	    echo( __METHOD__ . ':' . __LINE__ );
         if ( $width && $height ) {
-	        echo( __METHOD__ . ':' . __LINE__ );
             return array( $width, $height );
         }
-	    echo( __METHOD__ . ':' . __LINE__ );
         if ( preg_match( '/\sviewBox=([\'"])[^\1]*(?:,|\s)+(?P<width>\d+(?:\.\d+)?)(?:px)?(?:,|\s)+(?P<height>\d+(?:\.\d+)?)(?:px)?\s*\1/', $svg_start_tag, $matches ) ) {
-	        echo( __METHOD__ . ':' . __LINE__ );
             return array(
                 floatval( $matches['width'] ),
                 floatval( $matches['height'] )
             );
         }
-	    echo( __METHOD__ . ':' . __LINE__ );
         return null;
     }
 

--- a/includes/lib/fastimage/class-fastimage.php
+++ b/includes/lib/fastimage/class-fastimage.php
@@ -71,7 +71,11 @@ class FastImage
                     return $this->type = 'png';
                 default:
                     $this->strpos = 0;
-                    if ( false !== strpos( $this->getChars( 1024 ), '<svg' ) ) {
+	                $markup = $this->getChars( 1024 );
+	                $this->strpos = 0;
+	                echo( __METHOD__ . ':' . $markup . "\n" );
+	                echo( ( false !== strpos( $markup, '<svg' ) ? 'YES SVG' : 'NOPE' ) . "\n" );
+                    if ( false !== strpos( $markup, '<svg' ) ) {
                         $this->type = 'svg';
                     } else {
                         return false;
@@ -170,21 +174,36 @@ class FastImage
     {
         $this->strpos = 0;
         $markup = $this->getChars( 1024 );
+        echo( __METHOD__ . ':' . $markup . "\n" );
         if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
             return null;
         }
+        echo( __METHOD__ . ':' . __LINE__ );
         $svg_start_tag = $matches[0];
         $width = null;
         $height = null;
+	    echo( __METHOD__ . ':' . __LINE__ );
         if ( preg_match( '/\swidth=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
             $width = floatval( $matches[2] );
         }
+	    echo( __METHOD__ . ':' . __LINE__ );
         if ( preg_match( '/\sheight=([\'"])(\d+(\.\d+)?)(px)?\1/', $svg_start_tag, $matches ) ) {
             $height = floatval( $matches[2] );
         }
+	    echo( __METHOD__ . ':' . __LINE__ );
         if ( $width && $height ) {
+	        echo( __METHOD__ . ':' . __LINE__ );
             return array( $width, $height );
         }
+	    echo( __METHOD__ . ':' . __LINE__ );
+        if ( preg_match( '/\sviewBox=([\'"])[^\1]*(?:,|\s)+(?P<width>\d+(?:\.\d+)?)(?:px)?(?:,|\s)+(?P<height>\d+(?:\.\d+)?)(?:px)?\s*\1/', $svg_start_tag, $matches ) ) {
+	        echo( __METHOD__ . ':' . __LINE__ );
+            return array(
+                floatval( $matches['width'] ),
+                floatval( $matches['height'] )
+            );
+        }
+	    echo( __METHOD__ . ':' . __LINE__ );
         return null;
     }
 

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -172,7 +172,6 @@ class AMP_Image_Dimension_Extractor {
 	 * @param array $images Array to populate with results of image/dimension inspection.
 	 */
 	private static function fetch_images_via_fast_image( $urls_to_fetch, &$images ) {
-		echo __METHOD__ . PHP_EOL; // WPCS: XSS OK.
 
 		$image = new FastImage();
 		$urls  = array_keys( $urls_to_fetch );
@@ -196,7 +195,6 @@ class AMP_Image_Dimension_Extractor {
 	 * @param array $images Array to populate with results of image/dimension inspection.
 	 */
 	private static function fetch_images_via_faster_image( $urls_to_fetch, &$images ) {
-		echo __METHOD__ . PHP_EOL; // WPCS: XSS OK.
 		$urls = array_keys( $urls_to_fetch );
 
 		if ( ! function_exists( 'amp_get_fasterimage_client' ) ) {

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -172,6 +172,7 @@ class AMP_Image_Dimension_Extractor {
 	 * @param array $images Array to populate with results of image/dimension inspection.
 	 */
 	private static function fetch_images_via_fast_image( $urls_to_fetch, &$images ) {
+		echo __METHOD__ . PHP_EOL; // WPCS: XSS OK.
 
 		$image = new FastImage();
 		$urls  = array_keys( $urls_to_fetch );
@@ -195,6 +196,7 @@ class AMP_Image_Dimension_Extractor {
 	 * @param array $images Array to populate with results of image/dimension inspection.
 	 */
 	private static function fetch_images_via_faster_image( $urls_to_fetch, &$images ) {
+		echo __METHOD__ . PHP_EOL; // WPCS: XSS OK.
 		$urls = array_keys( $urls_to_fetch );
 
 		if ( ! function_exists( 'amp_get_fasterimage_client' ) ) {

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -10,8 +10,8 @@ define( 'AMP_IMG_DIMENSION_TEST_INVALID_FILE', dirname( __FILE__ ) . '/assets/no
 // Not ideal to use remote URLs (since the remote service can change); mocking would be better.
 define( 'IMG_350', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/350x150.png' );
 define( 'IMG_1024', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/1024x768.png' );
-define( 'IMG_SVG', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/316f589ce7f0c809a8ff101745f7ba5ea94505fb/amp.svg' );
-define( 'IMG_SVG_VIEWPORT', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/316f589ce7f0c809a8ff101745f7ba5ea94505fb/google.svg' );
+define( 'IMG_SVG', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/fd58ec3fc426645885f6a3afa58ad64fbc70ea89/amp.svg' );
+define( 'IMG_SVG_VIEWPORT', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/fd58ec3fc426645885f6a3afa58ad64fbc70ea89/google.svg' );
 
 /**
  * Tests for AMP_Image_Dimension_Extractor.
@@ -184,11 +184,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			),
 		);
 
-		// Temp start.
-		$sources  = wp_array_slice_assoc( $sources, array( IMG_SVG ) );
-		$expected = wp_array_slice_assoc( $expected, array( IMG_SVG ) );
-
-		// Temp end.
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
 		echo "\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n";

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -5,12 +5,12 @@
  * @package AMP
  */
 
-define( 'AMP_IMG_DIMENSION_TEST_VALID_FILE', dirname( __FILE__ ) . '/assets/wordpress-logo.png' );
 define( 'AMP_IMG_DIMENSION_TEST_INVALID_FILE', dirname( __FILE__ ) . '/assets/not-exists.png' );
 
 // Not ideal to use remote URLs (since the remote service can change); mocking would be better.
 define( 'IMG_350', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/350x150.png' );
 define( 'IMG_1024', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/1024x768.png' );
+define( 'IMG_SVG', 'https://www.ampproject.org/static/img/logo-blue.svg' );
 
 /**
  * Tests for AMP_Image_Dimension_Extractor.
@@ -159,6 +159,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 		$sources  = array(
 			IMG_350  => false,
 			IMG_1024 => false,
+			IMG_SVG  => false,
 		);
 		$expected = array(
 			IMG_350  => array(
@@ -168,6 +169,10 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_1024 => array(
 				'width'  => 1024,
 				'height' => 768,
+			),
+			IMG_SVG  => array(
+				'width'  => 175,
+				'height' => 60,
 			),
 		);
 
@@ -183,6 +188,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 		$sources  = array(
 			IMG_350  => false,
 			IMG_1024 => false,
+			IMG_SVG  => false,
 		);
 		$expected = array(
 			IMG_350  => array(
@@ -192,6 +198,10 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_1024 => array(
 				'width'  => 1024,
 				'height' => 768,
+			),
+			IMG_SVG  => array(
+				'width'  => 175,
+				'height' => 60,
 			),
 		);
 
@@ -240,6 +250,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_350                             => false,
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
 			IMG_1024                            => false,
+			IMG_SVG                             => false,
 		);
 		$expected = array(
 			IMG_350                             => array(
@@ -250,6 +261,10 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_1024                            => array(
 				'width'  => 1024,
 				'height' => 768,
+			),
+			IMG_SVG                             => array(
+				'width'  => 175,
+				'height' => 60,
 			),
 		);
 
@@ -266,6 +281,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_350                             => false,
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
 			IMG_1024                            => false,
+			IMG_SVG                             => false,
 		);
 		$expected = array(
 			IMG_350                             => array(
@@ -277,6 +293,10 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 				'width'  => 1024,
 				'height' => 768,
 			),
+			IMG_SVG                             => array(
+				'width'  => 175,
+				'height' => 60,
+			),
 		);
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources, 'synchronous' );
@@ -287,11 +307,11 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	/**
 	 * Test get_default_user_agent()
 	 *
-	 * @covers get_default_user_agent()
+	 * @covers \AMP_Image_Dimension_Extractor::get_default_user_agent()
 	 */
 	public function test__amp_wp_user_agent() {
 		$expected   = 'amp-wp, v' . AMP__VERSION . ', ';
-		$user_agent = AMP_Image_Dimension_Extractor::get_default_user_agent( '' );
+		$user_agent = AMP_Image_Dimension_Extractor::get_default_user_agent();
 		$user_agent = substr( $user_agent, 0, strlen( $expected ) );
 
 		$this->assertEquals( $expected, $user_agent );

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -10,7 +10,8 @@ define( 'AMP_IMG_DIMENSION_TEST_INVALID_FILE', dirname( __FILE__ ) . '/assets/no
 // Not ideal to use remote URLs (since the remote service can change); mocking would be better.
 define( 'IMG_350', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/350x150.png' );
 define( 'IMG_1024', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/1024x768.png' );
-define( 'IMG_SVG', 'https://www.ampproject.org/static/img/logo-blue.svg' );
+define( 'IMG_SVG', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/316f589ce7f0c809a8ff101745f7ba5ea94505fb/amp.svg' );
+define( 'IMG_SVG_VIEWPORT', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/316f589ce7f0c809a8ff101745f7ba5ea94505fb/google.svg' );
 
 /**
  * Tests for AMP_Image_Dimension_Extractor.
@@ -156,28 +157,41 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * Test multiple valid image files.
 	 */
 	public function test__multiple_valid_image_files() {
+		echo "\n>>>>>>>>>>>>>>>>>>>>>> " . __METHOD__ . ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n";
+
 		$sources  = array(
-			IMG_350  => false,
-			IMG_1024 => false,
-			IMG_SVG  => false,
+			IMG_350          => false,
+			IMG_1024         => false,
+			IMG_SVG          => false,
+			IMG_SVG_VIEWPORT => false,
 		);
 		$expected = array(
-			IMG_350  => array(
+			IMG_350          => array(
 				'width'  => 350,
 				'height' => 150,
 			),
-			IMG_1024 => array(
+			IMG_1024         => array(
 				'width'  => 1024,
 				'height' => 768,
 			),
-			IMG_SVG  => array(
+			IMG_SVG          => array(
 				'width'  => 175,
 				'height' => 60,
 			),
+			IMG_SVG_VIEWPORT => array(
+				'width'  => 251,
+				'height' => 80,
+			),
 		);
 
+		// Temp start.
+		$sources  = wp_array_slice_assoc( $sources, array( IMG_SVG ) );
+		$expected = wp_array_slice_assoc( $expected, array( IMG_SVG ) );
+
+		// Temp end.
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
+		echo "\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n";
 		$this->assertEquals( $expected, $dimensions );
 	}
 
@@ -186,22 +200,27 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 */
 	public function test__multiple_valid_image_files_synchronous() {
 		$sources  = array(
-			IMG_350  => false,
-			IMG_1024 => false,
-			IMG_SVG  => false,
+			IMG_350          => false,
+			IMG_1024         => false,
+			IMG_SVG          => false,
+			IMG_SVG_VIEWPORT => false,
 		);
 		$expected = array(
-			IMG_350  => array(
+			IMG_350          => array(
 				'width'  => 350,
 				'height' => 150,
 			),
-			IMG_1024 => array(
+			IMG_1024         => array(
 				'width'  => 1024,
 				'height' => 768,
 			),
-			IMG_SVG  => array(
+			IMG_SVG          => array(
 				'width'  => 175,
 				'height' => 60,
+			),
+			IMG_SVG_VIEWPORT => array(
+				'width'  => 251,
+				'height' => 80,
 			),
 		);
 
@@ -250,7 +269,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_350                             => false,
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
 			IMG_1024                            => false,
-			IMG_SVG                             => false,
 		);
 		$expected = array(
 			IMG_350                             => array(
@@ -261,10 +279,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_1024                            => array(
 				'width'  => 1024,
 				'height' => 768,
-			),
-			IMG_SVG                             => array(
-				'width'  => 175,
-				'height' => 60,
 			),
 		);
 
@@ -281,7 +295,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_350                             => false,
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
 			IMG_1024                            => false,
-			IMG_SVG                             => false,
 		);
 		$expected = array(
 			IMG_350                             => array(
@@ -292,10 +305,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 			IMG_1024                            => array(
 				'width'  => 1024,
 				'height' => 768,
-			),
-			IMG_SVG                             => array(
-				'width'  => 175,
-				'height' => 60,
 			),
 		);
 

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -10,7 +10,7 @@ define( 'AMP_IMG_DIMENSION_TEST_INVALID_FILE', dirname( __FILE__ ) . '/assets/no
 // Not ideal to use remote URLs (since the remote service can change); mocking would be better.
 define( 'IMG_350', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/350x150.png' );
 define( 'IMG_1024', 'http://i0.wp.com/amptest.files.wordpress.com/2017/03/1024x768.png' );
-define( 'IMG_SVG', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/fd58ec3fc426645885f6a3afa58ad64fbc70ea89/amp.svg' );
+define( 'IMG_SVG', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/fd58ec3fc426645885f6a3afa58ad64fbc70ea89/amp.svg' ); // @todo For some reason, FasterImage times out on this if the XML PI is absent.
 define( 'IMG_SVG_VIEWPORT', 'https://gist.githubusercontent.com/westonruter/90fbaaced3851bf6ef762996c8c4375d/raw/fd58ec3fc426645885f6a3afa58ad64fbc70ea89/google.svg' );
 
 /**
@@ -157,8 +157,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * Test multiple valid image files.
 	 */
 	public function test__multiple_valid_image_files() {
-		echo "\n>>>>>>>>>>>>>>>>>>>>>> " . __METHOD__ . ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n";
-
 		$sources  = array(
 			IMG_350          => false,
 			IMG_1024         => false,
@@ -186,7 +184,6 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
-		echo "\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n";
 		$this->assertEquals( $expected, $dimensions );
 	}
 


### PR DESCRIPTION
When there are `img` tags that reference SVG images and the `img` does not include the `width` or `height` in HTML, we need to obtain the dimensions of the underlying SVG image in its own `width` and `height` attributes in a similar way to how we extract dimensions from raster image formats like PNG and JPEG.

- [x] Extract width/height from `viewBox` if `width` or `height` attributes aren't pixel values.