### PR TITLE
Eliminate amp-wp-enforced-sizes style from theme support stylesheet

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -1,9 +1,3 @@
-.amp-wp-enforced-sizes {
-	/** Our sizes fallback is 100vw, and we have a padding on the container; the max-width here prevents the element from overflowing. **/
-	max-width: 100%;
-	margin: 0 auto;
-}
-
 .amp-wp-unknown-size img {
 	/** Worst case scenario when we can't figure out dimensions for an image. **/
 	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/


### PR DESCRIPTION
This style rule causes problems on AMP Native sites (where `amp` theme support is present). An image element may have margins and width associated with it which the `amp-wp-enforced-sizes` style rule clobbers unexpectedly.

For example, in non-AMP given:

> ![image](https://user-images.githubusercontent.com/134745/40165484-f65a8124-5970-11e8-8f25-77d5a6c42f28.png)

With CSS properties:

```css
.logo {
    display: block;
    margin: 2rem 0 0;
    width: 300px;
    max-width: 100%;
    margin-bottom: 2rem;
}
```

This gets rendered in AMP as:

> ![image](https://user-images.githubusercontent.com/134745/40165493-ff4b289c-5970-11e8-9146-ed9005571995.png)

Since the following override:

```css
.amp-wp-enforced-sizes {
    max-width: 100%;
    margin: 0 auto;
}
```

I don't think this is relevant in an `amp` theme support context. I believe it was only relevant to AMP legacy post templates and can be removed now.