### PR TITLE
Pass '/' as an argument to home_url(), preventing possible 404

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -113,7 +113,7 @@ class AMP_Post_Template {
 
 			'document_title'        => function_exists( 'wp_get_document_title' ) ? wp_get_document_title() : wp_title( '', false ), // Back-compat with 4.3.
 			'canonical_url'         => get_permalink( $this->ID ),
-			'home_url'              => home_url(),
+			'home_url'              => home_url( '/' ),
 			'blog_name'             => get_bloginfo( 'name' ),
 
 			'html_tag_attributes'   => array(),


### PR DESCRIPTION
**Request For Code Review**

Could you please review this pull request for #1158?

As you saw, there's a [support topic](https://wordpress.org/support/topic/need-to-add-slash-to-end-of-url/#post-10293713) where the link wrapping the home logo in legacy templating lead to a 404 page.

And according to the [documentation](https://codex.wordpress.org/Function_Reference/home_url#Default_Usage
) for `home_url()`, passing the `'/'` argument is the default usage.

Closes #1158