### PR TITLE
Issue #1157: Display schema.org image data for 'attachment' post type

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -524,6 +524,8 @@ function amp_get_post_image_metadata( $post = null ) {
 
 	if ( has_post_thumbnail( $post->ID ) ) {
 		$post_image_id = get_post_thumbnail_id( $post->ID );
+	} elseif ( 'attachment' === $post->post_type ) {
+		$post_image_id = $post->ID;
 	} else {
 		$attached_image_ids = get_posts(
 			array(

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -524,7 +524,7 @@ function amp_get_post_image_metadata( $post = null ) {
 
 	if ( has_post_thumbnail( $post->ID ) ) {
 		$post_image_id = get_post_thumbnail_id( $post->ID );
-	} elseif ( 'attachment' === $post->post_type ) {
+	} elseif ( ( 'attachment' === $post->post_type ) && wp_attachment_is( 'image', $post ) ) {
 		$post_image_id = $post->ID;
 	} else {
 		$attached_image_ids = get_posts(

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -416,7 +416,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			)
 		);
 		$this->go_to( get_permalink( $attachment_id ) );
-		$this->assertNull( amp_get_post_image_metadata( $attachment_id ) );
+		$this->assertFalse( amp_get_post_image_metadata( $attachment_id ) );
 	}
 
 	/**

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -374,10 +374,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertStringEndsWith( 'test-image.jpg', $metadata['url'] );
 
 		// Test an 'attachment' post type.
-		$attachment_src    = 'example/attachment.jpeg';
-		$attachment_height = 45;
-		$attachment_width  = 600;
-		$attachment_id     = $this->factory()->attachment->create_object(
+		$attachment_src          = 'example/attachment.jpeg';
+		$attachment_height       = 45;
+		$attachment_width        = 600;
+		$attachment_id           = $this->factory()->attachment->create_object(
 			$attachment_src,
 			0,
 			array(


### PR DESCRIPTION
On 'attachment' pages in Native AMP, there's no schema.org data for the image. 

This adds a conditional to check for the post type of 'attachment.' 

It's possible that the attachment is a video, like a `.mov` file. In that case, it won't return an image.

As reported in this support topic: https://wordpress.org/support/topic/structured-data-error-for-attachment-pages-media/

Closes #1157.