### PR TITLE
Output alt attribute in legacy templating  gravatar image

### DIFF
--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -2,7 +2,7 @@
 <?php if ( $post_author ) : ?>
 	<div class="amp-wp-meta amp-wp-byline">
 		<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
-			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array( 'size' => 24 ) ) ); ?>" width="24" height="24" layout="fixed"></amp-img>
+			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array( 'size' => 24 ) ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
 		<?php endif; ?>
 		<span class="amp-wp-author author vcard"><?php echo esc_html( $post_author->display_name ); ?></span>
 	</div>


### PR DESCRIPTION
**Request For Review**

Hi @westonruter,
This adds the display name that you [suggested](https://wordpress.org/support/topic/author-image-use-something-other-than-gravatar/#post-10334297) to the Gravatar's `alt` attribute:

<img width="1121" alt="avatar-alt-attribute" src="https://user-images.githubusercontent.com/4063887/40639508-daf0efbc-62d6-11e8-9083-865ea6a50f48.png">

For reference, here's the support topic that prompted this:
https://wordpress.org/support/topic/author-image-use-something-other-than-gravatar/#post-10334297