### PR TITLE
Fix adding images to AMP carousel gallery

### DIFF
--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -97,20 +97,24 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			$images = null;
+			$images = array();
 
 			// If it's not AMP lightbox, look for links first.
 			if ( ! $is_amp_lightbox ) {
-				$images = $node->getElementsByTagName( 'a' );
+				foreach ( $node->getElementsByTagName( 'a' ) as $element ) {
+					$images[] = $element;
+				}
 			}
 
 			// If not linking to anything then look for <amp-img>.
-			if ( ! $images || 0 === $images->length ) {
-				$images = $node->getElementsByTagName( 'amp-img' );
+			if ( empty( $images ) ) {
+				foreach ( $node->getElementsByTagName( 'amp-img' ) as $element ) {
+					$images[] = $element;
+				}
 			}
 
 			// Skip if no images found.
-			if ( ! $images || 0 === $images->length ) {
+			if ( empty( $images ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes issue which occurs when manipulating DOM elements that are part of a live list.

Amends #1121.

See https://github.com/Automattic/amp-wp/pull/1121/files/201654fa66c1c0dec3f7336c3dd2bf382d39e73e#r191989786