### PR TITLE
Improve handling of validation errors in response cache and admin display

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1058,7 +1058,7 @@ class AMP_Theme_Support {
 				'allow_dirty_styles'      => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
 				'allow_dirty_scripts'     => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
 				'enable_response_caching' => (
-					( ! defined( 'WP_DEBUG' ) || true !== WP_DEBUG )
+					! ( defined( 'WP_DEBUG' ) && WP_DEBUG )
 					&&
 					! AMP_Validation_Manager::should_validate_response()
 				),
@@ -1080,8 +1080,20 @@ class AMP_Theme_Support {
 
 			$response_cache = wp_cache_get( $response_cache_key, self::RESPONSE_CACHE_GROUP );
 
-			if ( ! empty( $response_cache ) ) {
-				return $response_cache;
+			// Make sure that all of the validation errors should be sanitized in the same way; if not, then the cached body should be discarded.
+			if ( isset( $response_cache['validation_results'] ) ) {
+				foreach ( $response_cache['validation_results'] as $validation_result ) {
+					$should_sanitize = AMP_Validation_Manager::is_validation_error_sanitized( $validation_result['error'] );
+					if ( $should_sanitize !== $validation_result['sanitized'] ) {
+						unset( $response_cache['body'] );
+						break;
+					}
+				}
+			}
+
+			// Short-circuit response with cached body.
+			if ( isset( $response_cache['body'] ) ) {
+				return $response_cache['body'];
 			}
 		}
 
@@ -1102,14 +1114,13 @@ class AMP_Theme_Support {
 				1
 			);
 		}
-		$dom = AMP_DOM_Utils::get_dom( $response );
 
-		$xpath = new DOMXPath( $dom );
-
+		$dom  = AMP_DOM_Utils::get_dom( $response );
 		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
 
+		// Make sure scripts from the body get moved to the head.
 		if ( isset( $head ) ) {
-			// Make sure scripts from the body get moved to the head.
+			$xpath = new DOMXPath( $dom );
 			foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
 				$head->appendChild( $script );
 			}
@@ -1208,7 +1219,17 @@ class AMP_Theme_Support {
 
 		// Cache response if enabled.
 		if ( true === $args['enable_response_caching'] ) {
-			wp_cache_set( $response_cache_key, $response, self::RESPONSE_CACHE_GROUP, MONTH_IN_SECONDS );
+			$response_cache = array(
+				'body'               => $response,
+				'validation_results' => array_map(
+					function( $result ) {
+						unset( $result['error']['sources'] );
+						return $result;
+					},
+					AMP_Validation_Manager::$validation_results
+				),
+			);
+			wp_cache_set( $response_cache_key, $response_cache, self::RESPONSE_CACHE_GROUP, MONTH_IN_SECONDS );
 		}
 
 		return $response;

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -198,20 +198,12 @@ class AMP_Invalid_URL_Post_Type {
 				continue;
 			}
 			$term = get_term_by( 'slug', $stored_validation_error['term_slug'], AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
-			if ( ! $term ) {
-				continue;
-			}
-			if ( $args['ignore_accepted'] && AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS === $term->term_group ) {
+			if ( $term && $args['ignore_accepted'] && AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS === $term->term_group ) {
 				continue;
 			}
 			$errors[] = array(
 				'term' => $term,
-				'data' => array_merge(
-					json_decode( $term->description, true ),
-					array(
-						'sources' => $stored_validation_error['sources'],
-					)
-				),
+				'data' => $stored_validation_error['data'],
 			);
 		}
 		return $errors;
@@ -318,15 +310,6 @@ class AMP_Invalid_URL_Post_Type {
 
 		$terms = array();
 		foreach ( $validation_errors as $data ) {
-			/*
-			 * Exclude sources from data since not available unless sources are being obtained,
-			 * and thus not able to be matched when hashed.
-			 */
-			$sources = null;
-			if ( isset( $data['sources'] ) ) {
-				$sources = $data['sources'];
-			}
-
 			$term_data = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( $data );
 			$term_slug = $term_data['slug'];
 			if ( ! isset( $terms[ $term_slug ] ) ) {
@@ -352,7 +335,7 @@ class AMP_Invalid_URL_Post_Type {
 				$terms[ $term_slug ] = $term;
 			}
 
-			$stored_validation_errors[] = compact( 'term_slug', 'sources' );
+			$stored_validation_errors[] = compact( 'term_slug', 'data' );
 		}
 
 		$post_content = wp_json_encode( $stored_validation_errors );

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -281,7 +281,7 @@ class AMP_Validation_Error_Taxonomy {
 			}
 
 			if ( ! empty( $validation_error['sources'] ) ) {
-				$source = array_pop( $validation_error['sources'] );
+				$source = array_shift( $validation_error['sources'] );
 
 				if ( isset( $source['type'], $source['name'] ) ) {
 					$invalid_sources[ $source['type'] ][] = $source['name'];

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -398,14 +398,10 @@ class AMP_Validation_Manager {
 		 *
 		 * @since 1.0
 		 *
-		 * @param bool  $sanitized Whether sanitized.
-		 * @param array $context   {
-		 *     Context data for validation error sanitization.
-		 *
-		 *     @type array $error Validation error being sanitized.
-		 * }
+		 * @param bool|null $sanitized Whether sanitized, or null if no default predetermined.
+		 * @param array     $error     Validation error being sanitized.
 		 */
-		$sanitized = apply_filters( 'amp_validation_error_sanitized', $sanitized, compact( 'error' ) );
+		$sanitized = apply_filters( 'amp_validation_error_sanitized', $sanitized, $error );
 
 		return $sanitized;
 	}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1009,7 +1009,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		ob_start();
 		?>
 		<!DOCTYPE html>
-		<html amp <?php language_attributes(); ?>>
+		<html amp>
 			<head>
 				<?php wp_head(); ?>
 				<script data-head>document.write('Illegal');</script>
@@ -1077,43 +1077,53 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$removed_nodes
 		);
 
-		$call_response = function() use ( $original_html ) {
-			return AMP_Theme_Support::prepare_response( $original_html, array(
-				'enable_response_caching' => true,
+		$prepare_response_args = array(
+			'enable_response_caching' => true,
+		);
+
+		$call_prepare_response = function() use ( $original_html, &$prepare_response_args ) {
+			AMP_Response_Headers::$headers_sent         = array();
+			AMP_Validation_Manager::$validation_results = array();
+			return AMP_Theme_Support::prepare_response( $original_html, $prepare_response_args );
+		};
+
+		$get_server_timing_header_count = function() {
+			return count( array_filter(
+				AMP_Response_Headers::$headers_sent,
+				function( $header ) {
+					return 'Server-Timing' === $header['name'];
+				}
 			) );
 		};
 
 		// Test that first response isn't cached.
-		$first_response = $call_response();
-		$this->assertGreaterThan( 0, count( array_filter(
-			AMP_Response_Headers::$headers_sent,
-			function( $header ) {
-				return 'Server-Timing' === $header['name'];
-			}
-		) ) );
+		$first_response = $call_prepare_response();
+		$this->assertGreaterThan( 0, $get_server_timing_header_count() );
+		$this->assertContains( '<html amp>', $first_response ); // Note: AMP because sanitized validation errors.
 
 		// Test that response cache is return upon second call.
-		AMP_Response_Headers::$headers_sent = array();
-		$this->assertEquals( $first_response, $call_response() );
-		$this->assertSame( 0, count( array_filter(
-			AMP_Response_Headers::$headers_sent,
-			function( $header ) {
-				return 'Server-Timing' === $header['name'];
-			}
-		) ) );
+		$this->assertEquals( $first_response, $call_prepare_response() );
+		$this->assertSame( 0, $get_server_timing_header_count() );
 
 		// Test new cache upon argument change.
-		AMP_Response_Headers::$headers_sent = array();
-		AMP_Theme_Support::prepare_response( $original_html, array(
-			'enable_response_caching' => true,
-			'test_reset_by_arg'       => true,
-		) );
-		$this->assertGreaterThan( 0, count( array_filter(
-			AMP_Response_Headers::$headers_sent,
-			function( $header ) {
-				return 'Server-Timing' === $header['name'];
-			}
-		) ) );
+		$prepare_response_args['test_reset_by_arg'] = true;
+		$call_prepare_response();
+		$this->assertGreaterThan( 0, $get_server_timing_header_count() );
+
+		// Test response is cached.
+		$call_prepare_response();
+		$this->assertSame( 0, $get_server_timing_header_count() );
+
+		// Test that response is no longer cached due to a change whether validation errors are sanitized.
+		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
+		add_filter( 'amp_validation_error_sanitized', '__return_false' );
+		$prepared_html = $call_prepare_response();
+		$this->assertGreaterThan( 0, $get_server_timing_header_count() );
+		$this->assertContains( '<html>', $prepared_html ); // Note: no AMP because unsanitized validation error.
+
+		// And test response is cached.
+		$call_prepare_response();
+		$this->assertSame( 0, $get_server_timing_header_count() );
 	}
 
 	/**


### PR DESCRIPTION
* Ensure response cache is varied by validation error sanitization status. If the response had been cached when all validation errors had marked as rejected (not-sanitized), then when one or more of those validation errors have their status changed to accepted (sanitized) then needs to make sure that the response cache will be updated. Otherwise, a validation error's status could change but no change would be reflected on the frontend.
* Improve searchability of validation errors in invalid AMP URL posts by storing full text of validation error in the `post_content`, instead of just storing the `sources`. Note that this means the validation error data is duplicated in the `amp_validation_error` term `description` as well as in the `post_content` of the `amp_invalid_url` post type. This is not concerning because the size is small, the data will not be updated once written, and denormalization improves performance for searching.
* Improve the “incompatible sources” summary so it shows more than just “core: wp-includes”.
* Account for `amp_validation_error_sanitized filter` when displaying validation errors in admin. (And let second filter argument be flatter as just a `$error` array, instead of `$context` containing `$error`.) Prevent offering to change validation error status when filter is forcing a certain status. For example, if I want to make sure that `invalid_attribute` validation errors are always sanitized, I could add this:

```php
add_filter( 'amp_validation_error_sanitized', function( $sanitized, $error ) {
	if ( $error['code'] === 'invalid_attribute' ) {
		$sanitized = true;
	}
	return $sanitized;
}, 10, 2 );
```

In the UI now, when looking at an invalid AMP URL post, this is indicated:

![image](https://user-images.githubusercontent.com/134745/40823629-e0ce31fa-6525-11e8-8b96-a76d5f698d21.png)

Likewise, in the list of validation errors, the checkboxes for doing bulk actions on such sanitization-forced errors are removed, as are the row actions:

![image](https://user-images.githubusercontent.com/134745/40823727-4b44c12a-6526-11e8-8e77-8353ac6fa62c.png)
