### PR TITLE
Correct amp-audio styling on Twenty Sixteen and Twenty Seventeen

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -19,7 +19,7 @@ amp-fit-text h6 {
  * It set display:none for audio elements.
  * This selector is the same, though it uses amp-audio instead of audio.
  */
-amp-audio:not([controls]) {
+body amp-audio:not([controls]) {
 	display: inline-block;
 	height: auto;
 }

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -17,7 +17,7 @@ amp-fit-text h6 {
 /**
  * Override a style rule in Twenty Sixteen and Twenty Seventeen.
  * It set display:none for audio elements.
- * This selector is the same, though it uses amp-audio instead of audio.
+ * This selector is the same, though it adds body and uses amp-audio instead of audio.
  */
 body amp-audio:not([controls]) {
 	display: inline-block;

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -14,3 +14,12 @@ amp-fit-text h6 {
 	font-size: inherit;
 }
 
+/**
+ * Override a style rule in Twenty Sixteen and Twenty Seventeen.
+ * It set display:none for audio elements.
+ * This selector is the same, though it uses amp-audio instead of audio.
+ */
+amp-audio:not([controls]) {
+	display: inline-block;
+	height: auto;
+}


### PR DESCRIPTION
**Request For Review**

Hi @westonruter,
Could you please review this?

Like we talked about, [there's a style rule](https://github.com/WordPress/wordpress-develop/blob/d3014a47b48f0a66375a43b14edc3cdac63c7c52/src/wp-content/themes/twentysixteen/style.css#L94) in Twenty Sixteen and Twenty Seventeen that hides the Audio widget in AMP Paired Mode:


```css
audio:not([controls]) {
	display: none;
	height: 0;
}
```

https://validation-ampconfdemo.pantheonsite.io/2018/06/?amp
<img width="1429" alt="audio-widget" src="https://user-images.githubusercontent.com/4063887/41185028-00348574-6b4a-11e8-90b8-2476807bdbf7.png">

This PR overrides that rule. It worked locally with both themes.



