### PR TITLE
Add caching of redirect to non-AMP URL when validation errors present

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1441,21 +1441,6 @@ class AMP_Validation_Manager {
 	}
 
 	/**
-	 * Determine if there are any validation errors which have not been ignored.
-	 *
-	 * @return int Count of errors that block AMP.
-	 */
-	public static function count_blocking_validation_errors() {
-		$count = 0;
-		foreach ( self::$validation_results as $result ) {
-			if ( false === $result['sanitized'] ) {
-				$count++;
-			}
-		}
-		return $count;
-	}
-
-	/**
 	 * Finalize validation.
 	 *
 	 * @see AMP_Validation_Manager::add_admin_bar_menu_items()


### PR DESCRIPTION
When an AMP response in paired mode has unsanitized validation errors, the behavior is to redirect to the non-AMP version. I realized that the response cache was not applying in this case when it could be. This PR explores what that can look like.