### PR TITLE
Add script to create built tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ amp.zip
 **/*-compiled.js
 languages/*.pot
 languages/*.php
+built

--- a/bin/tag-built.sh
+++ b/bin/tag-built.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+tag=$(git describe --tags)
+if [[ -z "$tag" ]]; then
+    echo "Error: Unable to determine tag."
+    exit 1
+fi
+
+built_tag="$tag-built"
+if git rev-parse "$built_tag" >/dev/null 2>&1; then
+    echo "Error: Built tag already exists: $built_tag"
+    exit 2
+fi
+
+if ! git diff-files --quiet || ! git diff-index --quiet --cached HEAD --; then
+    echo "Error: Repo is in dirty state"
+    exit 3
+fi
+
+git checkout "$tag"
+npm run build
+mkdir built
+git clone . built/
+cd built
+git checkout $tag
+git rm -r $(git ls-files)
+rsync -avz ../build/ ./
+git add -A .
+git commit -m "Build $tag" --no-verify
+git tag "$built_tag"
+git push origin "$built_tag"
+cd ..
+git push origin "$built_tag"
+rm -rf built
+
+echo "Pushed tag $built_tag."
+echo "See https://github.com/Automattic/amp-wp/releases/tag/$built_tag"
+echo "For https://github.com/Automattic/amp-wp/releases/tag/$tag"

--- a/contributing.md
+++ b/contributing.md
@@ -114,8 +114,9 @@ Contributors who want to make a new release, follow these steps:
 6. Run `npm run deploy` to to commit the plugin to WordPress.org.
 7. Confirm the release is available on WordPress.org; try installing it on a WordPress install and confirm it works.
 8. Publish GitHub release.
-9. Merge release branch into `develop`.
-10. Merge release tag into `master`.
-11. Publish release blog post, including link to GitHub release.
-12. Close the GitHub milestone and project.
-13. Make announcements.
+9. Create built release tag: `git fetch --tags && git checkout $(git tag | tail -n1) && ./bin/tag-built.sh` (then add link from release)
+10. Merge release branch into `develop`.
+11. Merge release tag into `master`.
+12. Publish release blog post, including link to GitHub release.
+13. Close the GitHub milestone and project.
+14. Make announcements.


### PR DESCRIPTION
This script commits a build of a tagged release to the repo and tags it. This facilitates installation of the plugin as a Git submodule, from Composer, and so on. This doesn't create the built tags automatically, but it should address the need. Fixes #1167.

Examples of this script employed:

* https://github.com/Automattic/amp-wp/releases/tag/0.7.1-built
* https://github.com/Automattic/amp-wp/releases/tag/1.0-alpha1-built