### PR TITLE
Restore admin bar on AMP pages and improve AMP menu items

### DIFF
--- a/assets/css/admin-bar.css
+++ b/assets/css/admin-bar.css
@@ -1,0 +1,1058 @@
+/*
+This is forked from core's admin-bar.css from WP 4.9.6
+- Rules for IE<9 have been removed.
+- References to .hover have been replaced with :focus-within (which is not supported in IE11).
+- A universal selector properties have been removed which interferes with AMP shadow elements.
+*/
+
+
+#wpadminbar * {
+	height: auto;
+	width: auto;
+	margin: 0;
+	padding: 0;
+	/* Removed because interferes with amp-img>img: position: static; */
+	text-shadow: none;
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 13px;
+	font-weight: 400;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	line-height: 32px;
+	border-radius: 0;
+	box-sizing: content-box;
+	transition: none;
+	-webkit-font-smoothing: subpixel-antialiased; /* Prevent Safari from switching to standard antialiasing on hover */
+	-moz-osx-font-smoothing: auto; /* Prevent Firefox from inheriting from themes that use other values */
+}
+
+.rtl #wpadminbar * {
+	font-family: Tahoma, sans-serif;
+}
+
+html:lang(he-il) .rtl #wpadminbar *  {
+	font-family: Arial, sans-serif;
+}
+
+#wpadminbar .ab-empty-item {
+	cursor: default;
+}
+
+#wpadminbar .ab-empty-item,
+#wpadminbar a.ab-item,
+#wpadminbar > #wp-toolbar span.ab-label,
+#wpadminbar > #wp-toolbar span.noticon {
+	color: #eee;
+}
+
+#wpadminbar #wp-admin-bar-site-name a.ab-item,
+#wpadminbar #wp-admin-bar-my-sites a.ab-item {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#wpadminbar ul li:before,
+#wpadminbar ul li:after {
+	content: normal;
+}
+
+#wpadminbar a,
+#wpadminbar a:hover,
+#wpadminbar a img,
+#wpadminbar a img:hover {
+	outline: none;
+	border: none;
+	text-decoration: none;
+	background: none;
+}
+
+#wpadminbar a:focus,
+#wpadminbar a:active,
+#wpadminbar input[type="text"],
+#wpadminbar input[type="password"],
+#wpadminbar input[type="number"],
+#wpadminbar input[type="search"],
+#wpadminbar input[type="email"],
+#wpadminbar input[type="url"],
+#wpadminbar select,
+#wpadminbar textarea,
+#wpadminbar div {
+	box-shadow: none;
+	outline: none;
+}
+
+#wpadminbar {
+	direction: ltr;
+	color: #ccc;
+	font-size: 13px;
+	font-weight: 400;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	line-height: 32px;
+	height: 32px;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	min-width: 600px; /* match the min-width of the body in wp-admin.css */
+	z-index: 99999;
+	background: #23282d;
+}
+
+#wpadminbar .ab-sub-wrapper,
+#wpadminbar ul,
+#wpadminbar ul li {
+	background: none;
+	clear: none;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	position: relative;
+	text-indent: 0;
+	z-index: 99999;
+}
+
+#wpadminbar ul#wp-admin-bar-root-default>li {
+	margin-right: 0;
+}
+
+#wpadminbar .quicklinks ul {
+	text-align: left;
+}
+
+#wpadminbar li {
+	float: left;
+}
+
+#wpadminbar .ab-empty-item {
+	outline: none;
+}
+
+#wpadminbar .quicklinks .ab-top-secondary > li {
+	float: right;
+}
+
+#wpadminbar .quicklinks a,
+#wpadminbar .quicklinks .ab-empty-item,
+#wpadminbar .shortlink-input {
+	height: 32px;
+	display: block;
+	padding: 0 10px;
+	margin: 0;
+}
+
+#wpadminbar .quicklinks > ul > li > a {
+	padding: 0 8px 0 7px;
+}
+
+#wpadminbar .menupop .ab-sub-wrapper,
+#wpadminbar .shortlink-input {
+	margin: 0;
+	padding: 0;
+	box-shadow: 0 3px 5px rgba(0,0,0,0.2);
+	background: #32373c;
+	display: none;
+	position: absolute;
+	float: none;
+}
+
+#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
+	min-width: 100%;
+}
+
+#wpadminbar .ab-top-secondary .menupop .ab-sub-wrapper {
+	right: 0;
+	left: auto;
+}
+
+#wpadminbar .ab-submenu {
+	padding: 6px 0;
+}
+
+#wpadminbar .selected .shortlink-input {
+	display: block;
+}
+
+#wpadminbar .quicklinks .menupop ul li {
+	float: none;
+}
+
+#wpadminbar .quicklinks .menupop ul li a strong {
+	font-weight: 600;
+}
+
+#wpadminbar .quicklinks .menupop ul li .ab-item,
+#wpadminbar .quicklinks .menupop ul li a strong,
+#wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item,
+#wpadminbar .shortlink-input {
+	line-height: 26px;
+	height: 26px;
+	white-space: nowrap;
+	min-width: 140px;
+}
+
+#wpadminbar .shortlink-input {
+	width: 200px;
+}
+
+#wpadminbar.nojs li:hover > .ab-sub-wrapper,
+#wpadminbar li:focus-within > .ab-sub-wrapper {
+	display: block;
+}
+
+#wpadminbar .menupop li:hover > .ab-sub-wrapper,
+#wpadminbar .menupop li:focus-within > .ab-sub-wrapper {
+	margin-left: 100%;
+	margin-top: -32px;
+}
+
+#wpadminbar .ab-top-secondary .menupop li:hover > .ab-sub-wrapper,
+#wpadminbar .ab-top-secondary .menupop li:focus-within > .ab-sub-wrapper {
+	margin-left: 0;
+	left: inherit;
+	right: 100%;
+}
+
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
+#wpadminbar .ab-top-menu > li:focus-within > .ab-item {
+	background: #32373c;
+	color: #00b9eb;
+}
+#wpadminbar .ab-top-menu > li:focus-within > .ab-item {
+	background: #32373c;
+	color: #00b9eb;
+}
+
+#wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
+#wpadminbar > #wp-toolbar li:focus-within span.ab-label,
+#wpadminbar:not(.mobile) > #wp-toolbar a:focus span.ab-label {
+	color: #00b9eb;
+}
+
+#wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
+#wpadminbar .ab-icon,
+#wpadminbar .ab-item:before {
+	position: relative;
+	float: left;
+	font: normal 20px/1 dashicons;
+	speak: none;
+	padding: 4px 0;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	background-image: none !important;
+	margin-right: 6px;
+}
+
+#wpadminbar .ab-icon:before,
+#wpadminbar .ab-item:before,
+#wpadminbar #adminbarsearch:before {
+	color: #a0a5aa;
+	color: rgba(240,245,250,0.6);
+}
+
+#wpadminbar .ab-icon:before,
+#wpadminbar .ab-item:before,
+#wpadminbar #adminbarsearch:before {
+	position: relative;
+	transition: all .1s ease-in-out;
+}
+
+#wpadminbar .ab-label {
+	display: inline-block;
+	height: 32px;
+}
+
+#wpadminbar .ab-submenu .ab-item {
+	color: #b4b9be;
+	color: rgba(240,245,250,0.7);
+}
+
+#wpadminbar .quicklinks .menupop ul li a,
+#wpadminbar .quicklinks .menupop ul li a strong,
+#wpadminbar .quicklinks .menupop:focus-within ul li a,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a {
+	color: #b4b9be;
+	color: rgba(240,245,250,0.7);
+}
+
+#wpadminbar .quicklinks .menupop ul li a:hover,
+#wpadminbar .quicklinks .menupop ul li a:focus,
+#wpadminbar .quicklinks .menupop ul li a:hover strong,
+#wpadminbar .quicklinks .menupop ul li a:focus strong,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop:focus-within > a,
+#wpadminbar .quicklinks .menupop:focus-within ul li a:hover,
+#wpadminbar .quicklinks .menupop:focus-within ul li a:focus,
+#wpadminbar .quicklinks .menupop:focus-within ul li div[tabindex]:hover,
+#wpadminbar .quicklinks .menupop:focus-within ul li div[tabindex]:focus,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:hover,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:focus,
+#wpadminbar li:hover .ab-icon:before,
+#wpadminbar li:hover .ab-item:before,
+#wpadminbar li a:focus .ab-icon:before,
+#wpadminbar li .ab-item:focus:before,
+#wpadminbar li .ab-item:focus .ab-icon:before,
+#wpadminbar li:focus-within .ab-icon:before,
+#wpadminbar li:focus-within .ab-item:before,
+#wpadminbar li:hover #adminbarsearch:before,
+#wpadminbar li #adminbarsearch.adminbar-focused:before {
+	color: #00b9eb;
+}
+
+#wpadminbar.mobile .quicklinks .ab-icon:before,
+#wpadminbar.mobile .quicklinks .ab-item:before {
+	color: #b4b9be;
+}
+
+#wpadminbar .menupop .menupop > .ab-item:before,
+#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
+	position: absolute;
+	font: normal 17px/1 dashicons;
+	speak: none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#wpadminbar .menupop .menupop > .ab-item {
+	display: block;
+	padding-right: 2em;
+}
+
+#wpadminbar .menupop .menupop > .ab-item:before {
+	top: 1px;
+	right: 4px;
+	content: "\f139";
+	color: inherit;
+}
+
+#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item {
+	padding-left: 2em;
+	padding-right: 1em;
+}
+
+#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
+	top: 1px;
+	left: 6px;
+	content: "\f141";
+}
+
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary {
+	display: block;
+	position: relative;
+	right: auto;
+	margin: 0;
+	box-shadow: none;
+}
+
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary,
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu {
+	background: #464b50;
+}
+
+#wpadminbar .quicklinks .menupop .ab-sub-secondary > li > a:hover,
+#wpadminbar .quicklinks .menupop .ab-sub-secondary > li .ab-item:focus a {
+	color: #00b9eb;
+}
+
+#wpadminbar .quicklinks a span#ab-updates {
+	background: #eee;
+	color: #32373c;
+	display: inline;
+	padding: 2px 5px;
+	font-size: 10px;
+	font-weight: 600;
+	border-radius: 10px;
+}
+
+#wpadminbar .quicklinks a:hover span#ab-updates  {
+	background: #fff;
+	color: #000;
+}
+
+#wpadminbar .ab-top-secondary {
+	float: right;
+}
+
+#wpadminbar ul li:last-child,
+#wpadminbar ul li:last-child .ab-item {
+	box-shadow: none;
+}
+
+/**
+ * My Account
+ */
+#wp-admin-bar-my-account > ul {
+	min-width: 198px;
+}
+
+#wp-admin-bar-my-account > .ab-item:before {
+	content: "\f110";
+	top: 2px;
+	float: right;
+	margin-left: 6px;
+	margin-right: 0;
+}
+
+#wp-admin-bar-my-account.with-avatar > .ab-item:before {
+	display: none;
+	content: none;
+}
+
+#wp-admin-bar-my-account.with-avatar > ul {
+	min-width: 270px;
+}
+
+#wpadminbar #wp-admin-bar-user-actions > li {
+	margin-left: 16px;
+	margin-right: 16px;
+}
+
+#wpadminbar #wp-admin-bar-user-actions.ab-submenu {
+	padding: 6px 0 12px;
+}
+
+#wpadminbar #wp-admin-bar-my-account.with-avatar #wp-admin-bar-user-actions > li {
+	margin-left: 88px;
+}
+
+#wpadminbar #wp-admin-bar-user-info {
+	margin-top: 6px;
+	margin-bottom: 15px;
+	height: auto;
+	background: none;
+}
+
+#wp-admin-bar-user-info .avatar {
+	/* TODO: The amp-img>img does not get loaded since the container is initially hidden, and :hover does not trigger a re-calc. Resizing the window does, however. */
+	position: absolute;
+	left: -72px;
+	top: 4px;
+	width: 64px;
+	height: 64px;
+}
+
+#wpadminbar #wp-admin-bar-user-info a {
+	background: none;
+	height: auto;
+}
+
+#wpadminbar #wp-admin-bar-user-info span {
+	background: none;
+	padding: 0;
+	height: 18px;
+}
+
+#wpadminbar #wp-admin-bar-user-info .display-name,
+#wpadminbar #wp-admin-bar-user-info .username {
+	display: block;
+}
+
+#wpadminbar #wp-admin-bar-user-info .username {
+	color: #a0a5aa;
+	font-size: 11px;
+}
+
+#wpadminbar #wp-admin-bar-my-account.with-avatar > .ab-empty-item img,
+#wpadminbar #wp-admin-bar-my-account.with-avatar > a img {
+	width: 16px; /* Was auto. */
+	height: 16px;
+	padding: 0;
+	border: 1px solid #82878c;
+	background: #eee;
+	line-height: 24px;
+	vertical-align: middle;
+	margin: -4px 0 0 6px;
+	float: none;
+	display: inline-block; /* Was inline. */
+}
+
+/**
+ * WP Logo
+ */
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
+	width: 15px;
+	height: 20px;
+	margin-right: 0;
+	padding: 6px 0 5px;
+}
+
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
+	padding: 0 7px;
+}
+
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
+	content: "\f120";
+	top: 2px;
+}
+
+/*
+ * My Sites & Site Title
+ */
+#wpadminbar .quicklinks li .blavatar {
+	float: left;
+	font: normal 16px/1 dashicons !important;
+	speak: none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #eee;
+}
+
+#wpadminbar .quicklinks li a:hover .blavatar,
+#wpadminbar .quicklinks li a:focus .blavatar,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop:focus-within > a .blavatar {
+	color: #00b9eb;
+}
+
+#wpadminbar .quicklinks li .blavatar:before {
+	content: "\f120";
+	height: 16px;
+	width: 16px;
+	display: inline-block;
+	margin: 6px 8px 0 -2px;
+}
+
+#wpadminbar #wp-admin-bar-appearance {
+	margin-top: -12px;
+}
+
+#wpadminbar #wp-admin-bar-my-sites > .ab-item:before,
+#wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f541";
+	top: 2px;
+}
+
+#wpadminbar #wp-admin-bar-customize > .ab-item:before {
+	content: "\f540";
+	top: 2px;
+}
+
+
+#wpadminbar #wp-admin-bar-edit > .ab-item:before {
+	content: "\f464";
+	top: 2px;
+}
+
+#wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f226";
+}
+
+.wp-admin #wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f102";
+}
+
+
+
+/**
+ * Comments
+ */
+#wpadminbar #wp-admin-bar-comments .ab-icon {
+	margin-right: 6px;
+}
+
+#wpadminbar #wp-admin-bar-comments .ab-icon:before {
+	content: "\f101";
+	top: 3px;
+}
+
+#wpadminbar #wp-admin-bar-comments .count-0 {
+	opacity: .5;
+}
+
+/**
+ * New Content
+ */
+#wpadminbar #wp-admin-bar-new-content .ab-icon:before {
+	content: "\f132";
+	top: 4px;
+}
+
+/**
+ * Updates
+ */
+#wpadminbar #wp-admin-bar-updates .ab-icon:before {
+	content: "\f463";
+	top: 2px;
+}
+
+/**
+ * Search
+ */
+#wpadminbar #wp-admin-bar-search .ab-item {
+	padding: 0;
+	background: transparent;
+}
+
+#wpadminbar #adminbarsearch {
+	position: relative;
+	height: 32px;
+	padding: 0 2px;
+	z-index: 1;
+}
+
+#wpadminbar #adminbarsearch:before {
+	position: absolute;
+	top: 6px;
+	left: 5px;
+	z-index: 20;
+	font: normal 20px/1 dashicons !important;
+	content: "\f179";
+	speak: none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+/* The admin bar search field needs to reset many styles that might be inherited from the active Theme CSS. See ticket #40313. */
+#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input {
+	display: inline-block;
+	float: none;
+	position: relative;
+	z-index: 30;
+	font-size: 13px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	line-height: 24px;
+	text-indent: 0;
+	height: 24px;
+	width: 24px;
+	max-width: none;
+	padding: 0 3px 0 24px;
+	margin: 0;
+	color: #ccc;
+	background-color: rgba( 255, 255, 255, 0 );
+	border: none;
+	outline: none;
+	cursor: pointer;
+	box-shadow: none;
+	box-sizing: border-box;
+	transition-duration: 400ms;
+	transition-property: width, background;
+	transition-timing-function: ease;
+}
+
+#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus {
+	z-index: 10;
+	color: #000;
+	width: 200px;
+	background-color: rgba( 255, 255, 255, 0.9 );
+	cursor: text;
+	border: 0;
+}
+
+/* Removed IE hacks. */
+
+#wpadminbar #adminbarsearch .adminbar-button {
+	display: none;
+}
+
+/**
+ * Customize support classes
+ */
+.no-customize-support .hide-if-no-customize,
+.customize-support .hide-if-customize,
+.no-customize-support #wpadminbar .hide-if-no-customize,
+.no-customize-support.wp-core-ui .hide-if-no-customize,
+.no-customize-support .wp-core-ui .hide-if-no-customize,
+.customize-support #wpadminbar .hide-if-customize,
+.customize-support.wp-core-ui .hide-if-customize,
+.customize-support .wp-core-ui .hide-if-customize {
+	display: none;
+}
+
+/* Skip link */
+#wpadminbar .screen-reader-text,
+#wpadminbar .screen-reader-text span {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	-webkit-clip-path: inset(50%);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}
+
+#wpadminbar .screen-reader-shortcut {
+	position: absolute;
+	top: -1000em;
+}
+
+#wpadminbar .screen-reader-shortcut:focus {
+	left: 6px;
+	top: 7px;
+	height: auto;
+	width: auto;
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	padding: 15px 23px 14px;
+	background: #f1f1f1;
+	color: #0073aa;
+	z-index: 100000;
+	line-height: normal;
+	text-decoration: none;
+	box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+}
+
+/**
+ * Removed IE 6-targeted rules
+ */
+
+/* Removed No @font-face support */
+
+@media screen and ( max-width: 782px ) {
+	/* Toolbar Touchification*/
+	html #wpadminbar {
+		height: 46px;
+		min-width: 300px;
+	}
+
+	#wpadminbar * {
+		font-size: 14px;
+		font-weight: 400;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		line-height: 32px;
+	}
+
+	#wpadminbar .quicklinks > ul > li > a,
+	#wpadminbar .quicklinks .ab-empty-item {
+		padding: 0;
+		height: 46px;
+		line-height: 46px;
+		width: auto;
+	}
+
+	#wpadminbar .ab-icon {
+		font: 40px/1 dashicons !important;
+		margin: 0;
+		padding: 0;
+		width: 52px;
+		height: 46px;
+		text-align: center;
+	}
+
+	#wpadminbar .ab-icon:before {
+		text-align: center;
+	}
+
+	#wpadminbar .ab-submenu {
+		padding: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-site-name a.ab-item,
+	#wpadminbar #wp-admin-bar-my-sites a.ab-item,
+	#wpadminbar #wp-admin-bar-my-account a.ab-item {
+		text-overflow: clip;
+	}
+
+	#wpadminbar .ab-label {
+		display: none;
+	}
+
+	#wpadminbar .menupop li:hover > .ab-sub-wrapper,
+	#wpadminbar .menupop li:focus-within > .ab-sub-wrapper {
+		margin-top: -46px;
+	}
+
+	#wpadminbar .ab-top-menu .menupop .ab-sub-wrapper .menupop > .ab-item {
+		padding-right: 30px;
+	}
+
+	#wpadminbar .menupop .menupop > .ab-item:before {
+		top: 10px;
+		right: 6px;
+	}
+
+	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper .ab-item {
+		font-size: 16px;
+		padding: 8px 16px;
+	}
+
+	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper a:empty {
+		display: none;
+	}
+
+	/* WP logo */
+	#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
+		padding: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
+		padding: 0;
+		width: 52px;
+		height: 46px;
+		text-align: center;
+		vertical-align: top;
+	}
+
+	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
+		font: 28px/1 dashicons !important;
+		top: -3px;
+	}
+
+	#wpadminbar .ab-icon,
+	#wpadminbar .ab-item:before {
+		padding: 0;
+	}
+
+	/* My Sites and "Site Title" menu */
+	#wpadminbar #wp-admin-bar-my-sites > .ab-item,
+	#wpadminbar #wp-admin-bar-site-name > .ab-item,
+	#wpadminbar #wp-admin-bar-customize > .ab-item,
+	#wpadminbar #wp-admin-bar-edit > .ab-item,
+	#wpadminbar #wp-admin-bar-my-account > .ab-item {
+		text-indent: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		width: 52px;
+		padding: 0;
+		color: #a0a5aa; /* @todo not needed? this text is hidden */
+		position: relative;
+	}
+
+	#wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
+	#wpadminbar .ab-icon,
+	#wpadminbar .ab-item:before {
+		padding: 0;
+		margin-right: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-edit > .ab-item:before,
+	#wpadminbar #wp-admin-bar-my-sites > .ab-item:before,
+	#wpadminbar #wp-admin-bar-site-name > .ab-item:before,
+	#wpadminbar #wp-admin-bar-customize > .ab-item:before,
+	#wpadminbar #wp-admin-bar-my-account > .ab-item:before {
+		display: block;
+		text-indent: 0;
+		font: normal 32px/1 dashicons;
+		speak: none;
+		top: 7px;
+		width: 52px;
+		text-align: center;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+	}
+
+	#wpadminbar #wp-admin-bar-appearance {
+		margin-top: 0;
+	}
+
+	#wpadminbar .quicklinks li .blavatar:before {
+		display: none;
+	}
+
+	/* Search */
+	#wpadminbar #wp-admin-bar-search {
+		display: none;
+	}
+
+	/* New Content */
+	#wpadminbar #wp-admin-bar-new-content .ab-icon:before {
+		top: 0;
+		line-height: 53px;
+		height: 46px !important;
+		text-align: center;
+		width: 52px;
+		display: block;
+	}
+
+	/* Updates */
+	#wpadminbar #wp-admin-bar-updates {
+		text-align: center;
+	}
+
+	#wpadminbar #wp-admin-bar-updates .ab-icon:before {
+		top: 3px;
+	}
+
+	/* Comments */
+	#wpadminbar #wp-admin-bar-comments .ab-icon {
+		margin: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-comments .ab-icon:before {
+		display: block;
+		font-size: 34px;
+		height: 46px;
+		line-height: 47px;
+		top: 0;
+	}
+
+	/* My Account */
+	#wpadminbar #wp-admin-bar-my-account > a {
+		position: relative;
+		white-space: nowrap;
+		text-indent: 150%; /* More than 100% indention is needed since this element has padding */
+		width: 28px;
+		padding: 0 10px;
+		overflow: hidden; /* Prevent link text from forcing horizontal scrolling on mobile */
+	}
+
+	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+		position: absolute;
+		top: 13px;
+		right: 10px;
+		width: 26px;
+		height: 26px;
+	}
+
+	#wpadminbar #wp-admin-bar-user-actions.ab-submenu {
+		padding: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-user-actions.ab-submenu img.avatar {
+		display: none;
+	}
+
+	#wpadminbar #wp-admin-bar-my-account.with-avatar #wp-admin-bar-user-actions > li {
+		margin: 0;
+	}
+
+	#wpadminbar #wp-admin-bar-user-info .display-name {
+		height: auto;
+		font-size: 16px;
+		line-height: 24px;
+		color: #eee;
+	}
+
+	#wpadminbar #wp-admin-bar-user-info a {
+		padding-top: 4px;
+	}
+
+	#wpadminbar #wp-admin-bar-user-info .username {
+		line-height: 0.8 !important;
+		margin-bottom: -2px;
+	}
+
+	/* Show only default top level items */
+	#wp-toolbar > ul > li {
+		display: none;
+	}
+
+	#wpadminbar li#wp-admin-bar-menu-toggle,
+	#wpadminbar li#wp-admin-bar-wp-logo,
+	#wpadminbar li#wp-admin-bar-my-sites,
+	#wpadminbar li#wp-admin-bar-updates,
+	#wpadminbar li#wp-admin-bar-site-name,
+	#wpadminbar li#wp-admin-bar-customize,
+	#wpadminbar li#wp-admin-bar-new-content,
+	#wpadminbar li#wp-admin-bar-edit,
+	#wpadminbar li#wp-admin-bar-comments,
+	#wpadminbar li#wp-admin-bar-my-account {
+		display: block;
+	}
+
+	/* Allow dropdown list items to appear normally */
+	#wpadminbar li:hover ul li,
+	#wpadminbar li:focus-within ul li,
+	#wpadminbar li:hover ul li:hover ul li {
+		display: list-item;
+	}
+
+	/* Override default min-width so dropdown lists aren't stretched
+		to 100% viewport width at responsive sizes. */
+	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
+		min-width: -webkit-fit-content;
+		min-width: -moz-fit-content;
+		min-width: fit-content;
+	}
+
+	#wpadminbar ul#wp-admin-bar-root-default > li {
+		margin-right: 0;
+	}
+
+	/* Experimental fix for touch toolbar dropdown positioning */
+	#wpadminbar .ab-top-menu,
+	#wpadminbar .ab-top-secondary,
+	#wpadminbar #wp-admin-bar-wp-logo,
+	#wpadminbar #wp-admin-bar-my-sites,
+	#wpadminbar #wp-admin-bar-site-name,
+	#wpadminbar #wp-admin-bar-updates,
+	#wpadminbar #wp-admin-bar-comments,
+	#wpadminbar #wp-admin-bar-new-content,
+	#wpadminbar #wp-admin-bar-edit,
+	#wpadminbar #wp-admin-bar-my-account {
+		position: static;
+	}
+
+	#wpadminbar #wp-admin-bar-my-account {
+		float: right;
+	}
+
+	.network-admin #wpadminbar ul#wp-admin-bar-top-secondary > li#wp-admin-bar-my-account {
+		margin-right: 0;
+	}
+
+	/* Realign arrows on taller responsive submenus */
+
+	#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
+		top: 10px;
+		left: 0;
+	}
+}
+
+/* Smartphone */
+@media screen and (max-width: 600px) {
+	/* Removed: #wpadminbar { position: absolute; } */
+
+	#wp-responsive-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 400;
+	}
+
+	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
+		width: 100%;
+		left: 0;
+	}
+
+	#wpadminbar .menupop .menupop > .ab-item:before {
+		display: none;
+	}
+
+	#wpadminbar #wp-admin-bar-wp-logo.menupop .ab-sub-wrapper {
+		margin-left: 0;
+	}
+
+	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper {
+		margin: 0;
+		width: 100%;
+		top: auto;
+		left: auto;
+		position: relative;
+	}
+
+	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper .ab-item {
+		font-size: 16px;
+		padding: 6px 15px 19px 30px;
+	}
+
+	#wpadminbar li:hover ul li ul li {
+		display: list-item;
+	}
+
+	#wpadminbar li#wp-admin-bar-wp-logo,
+	#wpadminbar li#wp-admin-bar-updates {
+		display: none;
+	}
+
+	/* Make submenus full-width at this size */
+
+	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper {
+		position: static;
+		box-shadow: none;
+	}
+}
+
+/* Very narrow screens */
+@media screen and (max-width: 400px) {
+	#wpadminbar li#wp-admin-bar-comments {
+		display: none;
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/PHP-CSS-Parser.git",
-                "reference": "ccad0dcd0a234a49528e330f22f2332676b3bd95"
+                "reference": "30a931eed6d8c014751bc11602648f959771a627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/ccad0dcd0a234a49528e330f22f2332676b3bd95",
-                "reference": "ccad0dcd0a234a49528e330f22f2332676b3bd95",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/30a931eed6d8c014751bc11602648f959771a627",
+                "reference": "30a931eed6d8c014751bc11602648f959771a627",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
             "support": {
                 "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
             },
-            "time": "2018-05-30 06:47:52"
+            "time": "2018-06-19 23:34:25"
         }
     ],
     "packages-dev": [
@@ -124,16 +124,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-06-06T23:58:19+00:00"
         },
         {
             "name": "wimg/php-compatibility",

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -352,23 +352,11 @@ class AMP_Theme_Support {
 		 * Disable admin bar because admin-bar.css (28K) and Dashicons (48K) alone
 		 * combine to surpass the 50K limit imposed for the amp-custom style.
 		 */
-		add_action( 'admin_bar_init', function() {
-			wp_dequeue_script( 'admin-bar' );
-			wp_styles()->registered['admin-bar']->src = amp_get_asset_url( 'css/admin-bar.css' );
-			wp_styles()->registered['admin-bar']->ver = AMP__VERSION;
-			add_filter( 'body_class', function( $body_classes ) {
-				return array_merge(
-					array_diff(
-						$body_classes,
-						array( 'no-customize-support' )
-					),
-					array( 'customize-support' )
-				);
-			} );
-			add_action( 'admin_bar_menu', function() {
-				remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' );
-			}, 41 );
-		} );
+		if ( AMP_Options_Manager::get_option( 'disable_admin_bar' ) ) {
+			add_filter( 'show_admin_bar', '__return_false', 100 );
+		} else {
+			add_action( 'admin_bar_init', array( __CLASS__, 'init_admin_bar' ) );
+		}
 
 		/*
 		 * Start output buffering at very low priority for sake of plugins and themes that use template_redirect
@@ -933,6 +921,37 @@ class AMP_Theme_Support {
 	}
 
 	/**
+	 * Configure the admin bar for AMP.
+	 *
+	 * @since 1.0
+	 */
+	public static function init_admin_bar() {
+
+		// Replace admin-bar.css in core with forked version which makes use of :focus-within among other change for AMP-compat.
+		wp_styles()->registered['admin-bar']->src = amp_get_asset_url( 'css/admin-bar.css' );
+		wp_styles()->registered['admin-bar']->ver = AMP__VERSION;
+
+		// Remove script which is almost entirely made obsolete by :focus-inside in the forked admin-bar.css.
+		wp_dequeue_script( 'admin-bar' );
+
+		// Remove customize support script since not valid AMP.
+		add_action( 'admin_bar_menu', function() {
+			remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' );
+		}, 41 );
+
+		// Emulate customize support script in PHP, to assume Customizer.
+		add_filter( 'body_class', function( $body_classes ) {
+			return array_merge(
+				array_diff(
+					$body_classes,
+					array( 'no-customize-support' )
+				),
+				array( 'customize-support' )
+			);
+		} );
+	}
+
+	/**
 	 * Print AMP boilerplate and custom styles.
 	 */
 	public static function print_amp_styles() {
@@ -1269,11 +1288,9 @@ class AMP_Theme_Support {
 			trigger_error( esc_html( sprintf( __( 'The database has the %s encoding when it needs to be utf-8 to work with AMP.', 'amp' ), get_bloginfo( 'charset' ) ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		}
 
-		if ( AMP_Validation_Manager::should_validate_response() ) {
-			AMP_Validation_Manager::finalize_validation( $dom, array(
-				'remove_source_comments' => ! isset( $_GET['amp_preserve_source_comments'] ), // WPCS: CSRF.
-			) );
-		}
+		AMP_Validation_Manager::finalize_validation( $dom, array(
+			'remove_source_comments' => ! isset( $_GET['amp_preserve_source_comments'] ), // WPCS: CSRF.
+		) );
 
 		$response  = "<!DOCTYPE html>\n";
 		$response .= AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -352,7 +352,23 @@ class AMP_Theme_Support {
 		 * Disable admin bar because admin-bar.css (28K) and Dashicons (48K) alone
 		 * combine to surpass the 50K limit imposed for the amp-custom style.
 		 */
-		add_filter( 'show_admin_bar', '__return_false', 100 );
+		add_action( 'admin_bar_init', function() {
+			wp_dequeue_script( 'admin-bar' );
+			wp_styles()->registered['admin-bar']->src = amp_get_asset_url( 'css/admin-bar.css' );
+			wp_styles()->registered['admin-bar']->ver = AMP__VERSION;
+			add_filter( 'body_class', function( $body_classes ) {
+				return array_merge(
+					array_diff(
+						$body_classes,
+						array( 'no-customize-support' )
+					),
+					array( 'customize-support' )
+				);
+			} );
+			add_action( 'admin_bar_menu', function() {
+				remove_action( 'wp_before_admin_bar_render', 'wp_customize_support_script' );
+			}, 41 );
+		} );
 
 		/*
 		 * Start output buffering at very low priority for sake of plugins and themes that use template_redirect

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -28,6 +28,7 @@ class AMP_Options_Manager {
 		'analytics'            => array(),
 		'force_sanitization'   => false,
 		'accept_tree_shaking'  => false,
+		'disable_admin_bar'    => false,
 	);
 
 	/**
@@ -117,6 +118,7 @@ class AMP_Options_Manager {
 
 		$options['force_sanitization']  = ! empty( $new_options['force_sanitization'] );
 		$options['accept_tree_shaking'] = ! empty( $new_options['accept_tree_shaking'] );
+		$options['disable_admin_bar']   = ! empty( $new_options['disable_admin_bar'] );
 
 		// Validate post type support.
 		if ( isset( $new_options['supported_post_types'] ) ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -257,6 +257,16 @@ class AMP_Options_Menu {
 					jQuery( '.amp-tree-shaking' ).toggleClass( 'hidden', this.checked && 'native' !== jQuery( 'input[type=radio][name="amp-options[theme_support]"]:checked' ).val() );
 				} ).trigger( 'change' );
 			</script>
+
+			<p>
+				<label for="disable_admin_bar">
+					<input id="disable_admin_bar" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[disable_admin_bar]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'disable_admin_bar' ) ); ?>>
+					<?php esc_html_e( 'Disable admin bar on AMP pages.', 'amp' ); ?>
+				</label>
+			</p>
+			<p class="description">
+				<?php esc_html_e( 'An additional stylesheet is required to properly render the admin bar. If the additional stylesheet causes the total CSS to surpass 50KB then the admin bar should be disabled to prevent a validation error or an unstyled admin bar in AMP responses.', 'amp' ); ?>
+			</p>
 		</fieldset>
 		<?php
 	}

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -600,14 +600,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		$navigation_top->parentNode->insertBefore( $navigation_top_fixed, $navigation_top->nextSibling );
 
-		$position_observer = AMP_DOM_Utils::create_node( $this->dom, 'amp-position-observer', array(
+		$attributes = array(
 			'layout'              => 'nodisplay',
 			'intersection-ratios' => 1,
 			'on'                  => implode( ';', array(
 				'exit:navigationTopShow.start',
 				'enter:navigationTopHide.start',
 			) ),
-		) );
+		);
+		if ( is_admin_bar_showing() ) {
+			$attributes['viewport-margins'] = '32px 0';
+		}
+		$position_observer = AMP_DOM_Utils::create_node( $this->dom, 'amp-position-observer', $attributes );
 		$navigation_top->appendChild( $position_observer );
 
 		$animations = array(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -542,6 +542,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$stylesheet   = trim( $element->textContent );
 		$cdata_spec   = $is_keyframes ? $this->style_keyframes_cdata_spec : $this->style_custom_cdata_spec;
 
+		// Honor the style's media attribute.
+		$media = $element->getAttribute( 'media' );
+		if ( $media && 'all' !== $media ) {
+			$stylesheet = sprintf( '@media %s { %s }', $media, $stylesheet );
+		}
+
 		$stylesheet = $this->process_stylesheet( $stylesheet, array(
 			'allowed_at_rules'   => $cdata_spec['css_spec']['allowed_at_rules'],
 			'property_whitelist' => $cdata_spec['css_spec']['allowed_declarations'],

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -699,7 +699,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$parsed      = null;
 		$cache_key   = null;
-		$cache_group = 'amp-parsed-stylesheet-v8';
+		$cache_group = 'amp-parsed-stylesheet-v9';
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
@@ -1616,7 +1616,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$ruleset->getSelectors()
 		) );
 		$important_ruleset->setRules( $importants );
-		$css_list->append( $important_ruleset ); // @todo It would be preferable if the important ruleset were inserted adjacent to the original rule.
+
+		$i = array_search( $ruleset, $css_list->getContents(), true );
+		if ( false !== $i ) {
+			$css_list->splice( $i + 1, 0, array( $important_ruleset ) );
+		} else {
+			$css_list->append( $important_ruleset );
+		}
 
 		return $results;
 	}

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1355,11 +1355,9 @@ class AMP_Invalid_URL_Post_Type {
 			return;
 		}
 
-		// Remember URL is stored in post_title. Adding query var prevents redirection to non-AMP page.
-		$view_url = add_query_arg( AMP_Validation_Manager::VALIDATE_QUERY_VAR, '', $url );
 		?>
 		<h2 class="amp-invalid-url">
-			<a href="<?php echo esc_url( $view_url ); ?>"><?php echo esc_html( $url ); ?></a>
+			<a href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $url ); ?></a>
 		</h2>
 		<?php
 	}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -317,6 +317,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'selectors_with_ie_hacks_removed' => array(
+				'<html amp><head><meta charset="utf-8"><style>* html span { color:red; background: blue !important; } span { text-decoration:underline; } *+html span { border: solid green; }</style></head><body><span>Test</span></body></html>',
+				array(
+					'span{text-decoration:underline}',
+				),
+				array(),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -310,6 +310,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'style_with_media_element' => array(
+				'<html amp><head><meta charset="utf-8"><style media="print">.print { display:none; }</style></head><body><button class="print" on="tap:AMP.print()"></button></body></html>',
+				array(
+					'@media print{.print{display:none}}',
+				),
+				array(),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -102,7 +102,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<style>div > span { font-weight:bold !important; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				array(
-					'div > span{font-style:italic}@media screen and ( max-width: 640px ){div > span{font-style:normal}:root:not(#_):not(#_) div > span{font-weight:normal}}:root:not(#_):not(#_) div > span{font-weight:bold}',
+					'div > span{font-style:italic}:root:not(#_):not(#_) div > span{font-weight:bold}@media screen and ( max-width: 640px ){div > span{font-style:normal}:root:not(#_):not(#_) div > span{font-weight:normal}}',
 				),
 			),
 

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -97,6 +97,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'analytics'            => array(),
 				'force_sanitization'   => false,
 				'accept_tree_shaking'  => false,
+				'disable_admin_bar'    => false,
 			),
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -376,7 +376,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 1000, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'dequeue_customize_preview_scripts' ) ) );
 		$this->assertEquals( 10, has_filter( 'customize_partial_render', array( self::TESTED_CLASS, 'filter_customize_partial_render' ) ) );
 		$this->assertEquals( 10, has_action( 'wp_footer', 'amp_print_analytics' ) );
-		$this->assertEquals( 100, has_filter( 'show_admin_bar', '__return_false' ) );
+		$this->assertEquals( 10, has_action( 'admin_bar_init', array( self::TESTED_CLASS, 'init_admin_bar' ) ) );
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.PHP.NewConstants.php_int_minFound
 		$this->assertEquals( $priority, has_action( 'template_redirect', array( self::TESTED_CLASS, 'start_output_buffering' ) ) );
 
@@ -387,6 +387,15 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 100, has_action( 'comment_form', array( self::TESTED_CLASS, 'amend_comment_form' ) ) );
 		$this->assertFalse( has_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'get_header_image_tag', array( self::TESTED_CLASS, 'amend_header_image_with_video_header' ) ) );
+	}
+
+	/**
+	 * Test add_hooks() when admin bar is turned off.
+	 */
+	public function test_add_hooks_no_admin_bar() {
+		AMP_Options_Manager::update_option( 'disable_admin_bar', true );
+		AMP_Theme_Support::add_hooks();
+		$this->assertEquals( 100, has_filter( 'show_admin_bar', '__return_false' ) );
 	}
 
 	/**


### PR DESCRIPTION
* Show admin bar on AMP pages by default. Use a forked version of `admin-bar.css` from core to utilize `:focus-within` instead of relying on jQuery to toggle `hover` classes.
* Add setting for turning off admin bar in AMP responses, since the admin bar may cause the total CSS to exceed 50KB, in particular Twenty Fifteen.
* Improve AMP admin bar menu item:
  * Add link between AMP and non-AMP versions when on non-native.
  * Show actual validation errors when viewing admin bar in AMP.
  * Show warning emoji when there are sanitized unaccepted validation errors.
* Add missing recognition for `media` attribute on `style` elements.
* Fix handling of `!important` transformations by inserting higher-specificity rules adjacent to their original rule instead of appending to the very end of the stylesheet.
* Automatically tree-shake obsolete IE6/IE7 CSS selector hacks.

New admin setting:

![image](https://user-images.githubusercontent.com/134745/41630622-c07b4320-73e4-11e8-83a3-fc21453992ba.png)

Link to AMP version from non-AMP page in paired mode:

![image](https://user-images.githubusercontent.com/134745/41630638-df344334-73e4-11e8-9c1a-5aa026f6471c.png)

Admin bar item that appears after having been redirected from AMP to non-AMP version due to non-sanitized validation errors:

![image](https://user-images.githubusercontent.com/134745/41630680-130783c4-73e5-11e8-96da-ff52715cc8d7.png)

Admin bar item that appears on AMP page when there is an unaccepted validation error that has been forcibly sanitized:

![image](https://user-images.githubusercontent.com/134745/41630727-5c11f23e-73e5-11e8-9339-68f59a4d3f9c.png)

Admin bar item in native mode when there are unaccepted validation errors:

![image](https://user-images.githubusercontent.com/134745/41630706-36774b64-73e5-11e8-9138-41bf9cdc9235.png)


Fixes #1205 