### PR TITLE
Construct schema.org meta script by appending text node

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -981,8 +981,9 @@ class AMP_Theme_Support {
 			}
 		}
 		if ( ! $has_schema_org_metadata ) {
-			$script = $dom->createElement( 'script', wp_json_encode( amp_get_schemaorg_metadata() ) );
+			$script = $dom->createElement( 'script' );
 			$script->setAttribute( 'type', 'application/ld+json' );
+			$script->appendChild( $dom->createTextNode( wp_json_encode( amp_get_schemaorg_metadata() ) ) );
 			$head->appendChild( $script );
 		}
 		// Ensure rel=canonical link.


### PR DESCRIPTION
I found on an environment that the Schema.org meta was being output empty as:

```html
<script type="application/ld+json"></script>
```

When looking at the logs I saw an error:

> PHP Warning: DOMDocument::createElement(): unterminated entity reference d=mm&amp;r=g&quot;,&quot;width&quot;:200,&quot;height&quot;:200}} in …/amp/includes/class-amp-theme-support.php on line 984

When looking up the [docs](http://php.net/manual/en/domdocument.createelement.php) for `DOMDocument::createElement()` I found that while it does take a second parameter for the value, it apparently does not do escaping (❓ ):

> The value of the element. By default, an empty element will be created. The value can also be set later with `DOMElement::$nodeValue`.
>
> The value is used verbatim except that the `<` and `>` entity references will escaped. Note that & has to be manually escaped; otherwise it is regarded as starting an entity reference. Also " won't be escaped.

This is even noted in the [second example](http://php.net/manual/en/domdocument.createelement.php#example-6547). This was causing problems for a value like, specifically for the ampersands in the URL:

```json
{"@context":"http:\/\/schema.org","publisher":{"@type":"Organization","name":"WCEU 2018 AMP Demos"},"@type":"WebPage","mainEntityOfPage":"https:\/\/amp-demo.xwp.io\/","headline":"Home","datePublished":"2018-06-10T23:06:03+00:00","dateModified":"2018-06-10T23:06:03+00:00","author":{"@type":"Person","name":"Weston Ruter"},"image":{"@type":"ImageObject","url":"https:\/\/secure.gravatar.com\/avatar\/bb16e7904f2f335b6c9f524cc533d2d2?s=200&d=mm&r=g","width":200,"height":200}}
```

The issue is fixed if the text node is explicitly created and appended to the `script` element.