### PR TITLE
Tree-shake CSS selectors for HTML elements that target non-active languages

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -324,6 +324,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'unamerican_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
+				'<html amp><head><meta charset="utf-8"><style>html[lang=en-US] {color:red} html[lang="en-US"] {color:white} html[lang^=en] {color:blue} html[lang="en-CA"] {color:red}  html[lang^=ar] { color:green; } html[lang="es-MX"] { color:green; }</style></head><body><span>Test</span></body></html>',
+				array(
+					'html[lang=en-US]{color:red}html[lang="en-US"]{color:white}html[lang^=en]{color:blue}',
+				),
+				array(),
+			),
 		);
 	}
 
@@ -336,6 +343,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array  $expected_errors      Expected error codes.
 	 */
 	public function test_link_and_style_elements( $source, $expected_stylesheets, $expected_errors = array() ) {
+		add_filter( 'locale', function() {
+			return 'en_US';
+		} );
 		$dom = AMP_DOM_Utils::get_dom( $source );
 
 		$error_codes = array();


### PR DESCRIPTION
In Twenty Seventeen there is about 5KB+ of rules with selectors to add styles that are specific to various languages:

https://github.com/WordPress/wordpress-develop/blob/a830dbcab3147e67b3076d3d15c89975df675fbb/src/wp-content/themes/twentyseventeen/style.css#L582-L913

Based on the site's locale, we should only include the rules that are relevant. In other words, this is attribute-based tree-shaking for the root element. It doesn't really make sense for all of these to be always served in the CSS. Note that amp-bind'ed `[lang]` is not allowed, so there is not the concern that they will become relevant later: the language won't be changed at runtime.

The changes in this PR reduce the resulting CSS size from 33,129 bytes down to 27,741 bytes on an example page in English, a 16% reduction.