### PR TITLE
Redirect to post list table in case of admin bar validate request failure

### DIFF
--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -895,6 +895,13 @@ class AMP_Invalid_URL_Post_Type {
 
 			if ( $post ) {
 				$redirect = get_edit_post_link( $post->ID, 'raw' );
+			} else {
+				$redirect = admin_url(
+					add_query_arg(
+						array( 'post_type' => self::POST_TYPE_SLUG ),
+						'edit.php'
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
Fixes issue when clicking the Validate URL link in the admin bar:

![image](https://user-images.githubusercontent.com/134745/41945020-cfec1e94-795f-11e8-94e3-99b93780f7cf.png)

Whereby if there is an HTTP request error the plugin currently redirects back to the page with query vars added to it (and no other indication of an error):

> `/?amp_validate_error=http_request_failed&amp_urls_tested=0`

When instead it should redirect to the post list table:

![image](https://user-images.githubusercontent.com/134745/41945003-bc965bd4-795f-11e8-9244-def404875fdd.png)
