### PR TITLE
Add support for allowing a site subset to be native AMP

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -296,7 +296,6 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *         'template_dir' => 'my-amp-templates',
  *     ) );
  *
- * @todo Why do we even need this function?
  * @see \AMP_Theme_Support::is_paired_available()
  *
  * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
@@ -319,18 +318,9 @@ function amp_is_canonical() {
 		if ( ! empty( $args['template_dir'] ) ) {
 			return false;
 		}
-//
-//		// Otherwise, the available_callback dictates whether AMP is available.
-//		if ( isset( $args['available_callback'] ) && is_callable( $args['available_callback'] ) ) {
-//			return call_user_func( $args['available_callback'] );
-//		}
 	}
 	return true;
 }
-//
-//function amp_is_available() {
-//
-//}
 
 /**
  * Load classes.

--- a/amp.php
+++ b/amp.php
@@ -295,15 +295,6 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *          ),
  *      ) );
  *
- * Or if you want to prevent AMP from being used on the front page and on any Other template that is unrecognized:
- *
- *      add_theme_support( 'amp', array(
- *          'templates_supported' => array(
- *              'is_front_page' => false,
- *              'unrecognized' => false,
- *          ),
- *      ) );
- *
  * Or if you want to force AMP to be used on all templates:
  *
  *      add_theme_support( 'amp', array(

--- a/amp.php
+++ b/amp.php
@@ -301,6 +301,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *          'templates_supported' => 'all',
  *      ) );
  *
+ * @see AMP_Theme_Support::read_theme_support()
  * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
  */
 function amp_is_canonical() {
@@ -311,9 +312,22 @@ function amp_is_canonical() {
 	$mode    = 'native';
 	$support = get_theme_support( 'amp' );
 	if ( is_array( $support ) ) {
-		$args = array_shift( $support );
+		$args    = array_shift( $support );
+		$support = AMP_Options_Manager::get_option( 'theme_support' );
+
+		// If support is optional, look at DB option if mode is not explicitly set in theme support.
+		if ( ! empty( $args['optional'] ) ) {
+			if ( 'disabled' === $support ) {
+				return false;
+			} elseif ( ! isset( $args['mode'] ) ) {
+				return 'native' === $support;
+			}
+		}
+
 		if ( isset( $args['mode'] ) ) {
 			$mode = $args['mode'];
+		} elseif ( 'disabled' !== $support ) {
+			$mode = $support; // Supplied via admin screen.
 		} elseif ( ! empty( $args['template_dir'] ) ) {
 			$mode = 'paired'; // If there is a template_dir, then paired mode is implied.
 		}

--- a/amp.php
+++ b/amp.php
@@ -301,6 +301,10 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
  */
 function amp_is_canonical() {
+	if ( ! current_theme_supports( 'amp' ) ) {
+		return false;
+	}
+
 	$support = get_theme_support( 'amp' );
 	if ( true === $support ) {
 		return true;
@@ -310,8 +314,8 @@ function amp_is_canonical() {
 		$args = array_shift( $support );
 
 		// If paired arg is supplied, then it is never canonical.
-		if ( ! empty( $args['paired'] ) ) {
-			return false;
+		if ( isset( $args['paired'] ) ) {
+			return ! $args['paired'];
 		}
 
 		// If there is a template_dir, then paired mode is implied.

--- a/amp.php
+++ b/amp.php
@@ -286,22 +286,29 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *          'mode' => 'native',
  *      ) );
  *
- * If you want to force AMP to always be served on a given template, use the amp_supportable_templates filter,
+ * If you want to force AMP to always be served on a given template, you can use the templates_supported arg,
  * for example to always serve the Category template in AMP:
  *
- *      add_filter( 'amp_supportable_templates', function( $templates ) {
- *          $templates['is_category']['supported'] = true;
- *          return $template;
- *      } );
+ *      add_theme_support( 'amp', array(
+ *          'templates_supported' => array(
+ *              'is_category' => true,
+ *          ),
+ *      ) );
  *
- * Or if you want to prevent AMP from ever being served on the homepage:
+ * Or if you want to prevent AMP from being used on the front page and on any Other template that is unrecognized:
  *
- *      add_filter( 'amp_supportable_templates', function( $templates ) {
- *          $templates['is_front_page']['supported'] = false;
- *          return $template;
- *      } );
+ *      add_theme_support( 'amp', array(
+ *          'templates_supported' => array(
+ *              'is_front_page' => false,
+ *              'unrecognized' => false,
+ *          ),
+ *      ) );
  *
- * @todo There needs to be a required flag which is the same as forcing all to be supported. This would be the same in the UI as the all_templates_supported flag. Might as well rename all_templates_supported to just required. If required is set to be false, or if any of the supported templates are immutable, then this option should not be available.
+ * Or if you want to force AMP to be used on all templates:
+ *
+ *      add_theme_support( 'amp', array(
+ *          'templates_supported' => 'all',
+ *      ) );
  *
  * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
  */

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -43,6 +43,22 @@ class AMP_Editor_Blocks {
 		if ( function_exists( 'gutenberg_init' ) ) {
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 			add_filter( 'wp_kses_allowed_html', array( $this, 'whitelist_block_atts_in_wp_kses_allowed_html' ), 10, 2 );
+
+			/*
+			 * Dirty AMP is required when a site is in native mode but not all templates are being served
+			 * as AMP. In particular, if a single post is using AMP-specific Gutenberg Blocks which make
+			 * use of AMP components, and the singular template is served as AMP but the blog page is not,
+			 * then the non-AMP blog page need to load the AMP runtime scripts so that the AMP components
+			 * in the posts displayed there will be rendered properly. This is only relevant on native AMP
+			 * sites because the AMP Gutenberg blocks are only made available in that mode; they are not
+			 * presented in the Gutenberg inserter in paired mode. In general, using AMP components in
+			 * non-AMP documents is still not officially supported, so it's occurrence is being minimized
+			 * as much as possible. For more, see <https://github.com/Automattic/amp-wp/issues/1192>.
+			 */
+			if ( amp_is_canonical() ) {
+				add_filter( 'the_content', array( $this, 'tally_content_requiring_amp_scripts' ) );
+				add_action( 'wp_print_footer_scripts', array( $this, 'print_dirty_amp_scripts' ) );
+			}
 		}
 	}
 
@@ -144,5 +160,33 @@ class AMP_Editor_Blocks {
 				'hasThemeSupport' => current_theme_supports( 'amp' ),
 			) ) )
 		);
+	}
+
+	/**
+	 * Tally the AMP component scripts that are needed in a dirty AMP document.
+	 *
+	 * @param string $content Content.
+	 * @return string Content (unmodified).
+	 */
+	public function tally_content_requiring_amp_scripts( $content ) {
+		if ( ! is_amp_endpoint() ) {
+			$pattern = sprintf( '/<(%s)\b.*?>/s', join( '|', $this->amp_blocks ) );
+			if ( preg_match_all( $pattern, $content, $matches ) ) {
+				$this->content_required_amp_scripts = array_merge(
+					$this->content_required_amp_scripts,
+					$matches[1]
+				);
+			}
+		}
+		return $content;
+	}
+
+	/**
+	 * Print AMP scripts required for AMP components used in a non-AMP document (dirty AMP).
+	 */
+	public function print_dirty_amp_scripts() {
+		if ( ! is_amp_endpoint() && ! empty( $this->content_required_amp_scripts ) ) {
+			wp_scripts()->do_items( $this->content_required_amp_scripts );
+		}
 	}
 }

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -170,8 +170,6 @@ class AMP_Post_Meta_Box {
 			is_post_type_viewable( $post->post_type )
 			&&
 			current_user_can( 'edit_post', $post->ID )
-			&&
-			! amp_is_canonical()
 		);
 
 		if ( true !== $verify ) {

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -203,7 +203,7 @@ class AMP_Post_Meta_Box {
 		);
 
 		// The preceding variables are used inside the following amp-status.php template.
-		include_once AMP__DIR__ . '/templates/admin/amp-status.php';
+		include AMP__DIR__ . '/templates/admin/amp-status.php';
 	}
 
 	/**

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -184,20 +184,17 @@ class AMP_Post_Meta_Box {
 			return;
 		}
 
-		$errors = AMP_Post_Type_Support::get_support_errors( $post );
-		$status = empty( $errors ) ? self::ENABLED_STATUS : self::DISABLED_STATUS;
-		$errors = array_diff( $errors, array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.
-
-		// Handle special case of the static front page or page for posts.
 		if ( current_theme_supports( 'amp' ) ) {
 			$availability = AMP_Theme_Support::get_template_availability( $post );
+			$status       = $availability['supported'] ? self::ENABLED_STATUS : self::DISABLED_STATUS;
+			$errors       = array_diff( $availability['errors'], array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.
 			if ( true === $availability['immutable'] ) {
 				$errors[] = 'status_immutable';
-				$status   = $availability['supported'] ? self::ENABLED_STATUS : self::DISABLED_STATUS;
-			} elseif ( ! $availability['supported'] && in_array( 'template_unsupported', $availability['errors'], true ) ) {
-				$errors[] = 'template_unsupported';
-				$status   = self::DISABLED_STATUS;
 			}
+		} else {
+			$errors = AMP_Post_Type_Support::get_support_errors( $post );
+			$status = empty( $errors ) ? self::ENABLED_STATUS : self::DISABLED_STATUS;
+			$errors = array_diff( $errors, array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.
 		}
 
 		$labels = array(

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -170,6 +170,7 @@ class AMP_Post_Meta_Box {
 			is_post_type_viewable( $post->post_type )
 			&&
 			current_user_can( 'edit_post', $post->ID )
+			// @todo What if a site does not have non-AMP pages? Formerly this was indicated via amp_is_canonical(). Now we need a flag for whether AMP is exclusive to a theme, in which case all templates and post types must render AMP. In other words, all_templates_supported.
 		);
 
 		if ( true !== $verify ) {

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -184,6 +184,11 @@ class AMP_Post_Meta_Box {
 			return;
 		}
 
+		/*
+		 * When theme support is present then theme templates can be served in AMP and we check first if the template is available.
+		 * Checking for template availability will include a check for get_support_errors. Otherwise, if theme support is not present
+		 * then we just check get_support_errors.
+		 */
 		if ( current_theme_supports( 'amp' ) ) {
 			$availability = AMP_Theme_Support::get_template_availability( $post );
 			$status       = $availability['supported'] ? self::ENABLED_STATUS : self::DISABLED_STATUS;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -123,6 +123,9 @@ function amp_get_permalink( $post_id ) {
 			||
 			// If the post type is hierarchical then the /amp/ endpoint isn't available.
 			is_post_type_hierarchical( get_post_type( $post_id ) )
+			||
+			// Attachment pages don't accept the /amp/ endpoint.
+			'attachment' === get_post_type( $post_id )
 		);
 		if ( $use_query_var ) {
 			$amp_url = add_query_arg( amp_get_slug(), '', $permalink );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -317,60 +317,23 @@ function is_amp_endpoint() {
 		return false;
 	}
 
-	// Otherwise, it is an AMP endpoint if AMP is available.
-	return amp_get_availability();
-}
-
-/**
- * Determine availability of AMP for the given query.
- *
- * @since 1.0
- * @global WP_Query $wp_the_query
- *
- * @param WP_Query|null $query Query. If null then the global query will be used.
- * @return bool Whether AMP is available.
- */
-function amp_get_availability( $query = null ) {
-	global $wp_the_query;
-	if ( ! $query ) {
-		$query = $wp_the_query;
-	}
-
-	if ( ! ( $query instanceof WP_Query ) ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'No WP_Query available.', 'amp' ), '1.0' );
-		return false;
-	}
-
-	$available = null;
-	if ( current_theme_supports( 'amp' ) ) {
-		$args = get_theme_support( 'amp' );
-		if ( isset( $args[0]['available_callback'] ) && is_callable( $args[0]['available_callback'] ) ) {
-			$callback = $args[0]['available_callback'];
-
-			// If the available_callback is a method on the query, then call the method on the query itself.
-			if ( is_string( $callback ) && 'is_' === substr( $callback, 0, 3 ) && method_exists( $query, $callback ) ) {
-				$available = call_user_func( array( $query, $callback ) );
-			} else {
-				$available = call_user_func( $callback );
-			}
-		}
-	}
-
-	// Availability has been is programmatically determined via the available_callback.
-	if ( is_bool( $available ) ) {
-		return $available;
-	}
-
-	if ( $query->is_singular() ) {
+	// Check if the queried object supports AMP.
+	if ( is_singular() ) {
 		/**
 		 * Post.
 		 *
 		 * @var WP_Post $queried_object
 		 */
-		$queried_object = $query->get_queried_object();
-		return post_supports_amp( $queried_object ); // @todo FAIL: This is calling get_support_errors(), and get_support_errors() is calling amp_get_availability().
+		$queried_object = get_queried_object();
+		if ( ! post_supports_amp( $queried_object ) ) {
+			return false;
+		}
+	}
+
+	if ( current_theme_supports( 'amp' ) ) {
+		return true === AMP_Theme_Support::get_template_availability();
 	} else {
-		return (bool) AMP_Options_Manager::get_option( 'non_singular_supported' ); // @todo Consider other kinds of queries.
+		return false; // Legacy templates only support posts via AMP_Post_Template.
 	}
 }
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -257,7 +257,10 @@ function post_supports_amp( $post ) {
 		case AMP_Post_Meta_Box::DISABLED_STATUS:
 			return false;
 
-		// Disabled by default for custom page templates, page on front and page for posts, unless 'amp' theme support is present.
+		/*
+		 * Disabled by default for custom page templates, page on front and page for posts, unless 'amp' theme
+		 * support is present (in which case AMP_Theme_Support::get_template_availability() determines availability).
+		 */
 		default:
 			$enabled = current_theme_supports( 'amp' ) || (
 				! (bool) get_page_template_slug( $post )

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -321,7 +321,8 @@ function is_amp_endpoint() {
 	}
 
 	if ( current_theme_supports( 'amp' ) ) {
-		return true === AMP_Theme_Support::get_template_availability();
+		$template_available = true === AMP_Theme_Support::get_template_availability();
+		return amp_is_canonical() ? $template_available : $has_amp_query_var;
 	} else {
 
 		// Check if the queried object supports AMP.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -320,22 +320,21 @@ function is_amp_endpoint() {
 		return false;
 	}
 
-	// Check if the queried object supports AMP.
-	if ( is_singular() ) {
-		/**
-		 * Post.
-		 *
-		 * @var WP_Post $queried_object
-		 */
-		$queried_object = get_queried_object();
-		if ( ! post_supports_amp( $queried_object ) ) {
-			return false;
-		}
-	}
-
 	if ( current_theme_supports( 'amp' ) ) {
 		return true === AMP_Theme_Support::get_template_availability();
 	} else {
+
+		// Check if the queried object supports AMP.
+		if ( is_singular() ) {
+			/**
+			 * Post.
+			 *
+			 * @var WP_Post $queried_object
+			 */
+			$queried_object = get_queried_object();
+			return post_supports_amp( $queried_object );
+		}
+
 		return false; // Legacy templates only support posts via AMP_Post_Template.
 	}
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -239,54 +239,10 @@ function amp_add_amphtml_link() {
  * @see   AMP_Post_Type_Support::get_support_errors()
  *
  * @param WP_Post $post Post.
- *
  * @return bool Whether the post supports AMP.
  */
 function post_supports_amp( $post ) {
-	$errors = AMP_Post_Type_Support::get_support_errors( $post );
-
-	// Return false if an error is found.
-	if ( ! empty( $errors ) ) {
-		return false;
-	}
-
-	switch ( get_post_meta( $post->ID, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
-		case AMP_Post_Meta_Box::ENABLED_STATUS:
-			return true;
-
-		case AMP_Post_Meta_Box::DISABLED_STATUS:
-			return false;
-
-		/*
-		 * Disabled by default for custom page templates, page on front and page for posts, unless 'amp' theme
-		 * support is present (in which case AMP_Theme_Support::get_template_availability() determines availability).
-		 */
-		default:
-			$enabled = current_theme_supports( 'amp' ) || (
-				! (bool) get_page_template_slug( $post )
-				&&
-				! (
-					'page' === $post->post_type
-					&&
-					'page' === get_option( 'show_on_front' )
-					&&
-					in_array( (int) $post->ID, array(
-						(int) get_option( 'page_on_front' ),
-						(int) get_option( 'page_for_posts' ),
-					), true )
-				)
-			);
-
-			/**
-			 * Filters whether default AMP status should be enabled or not.
-			 *
-			 * @since 0.6
-			 *
-			 * @param string  $status Status.
-			 * @param WP_Post $post   Post.
-			 */
-			return apply_filters( 'amp_post_status_default_enabled', $enabled, $post );
-	}
+	return 0 === count( AMP_Post_Type_Support::get_support_errors( $post ) );
 }
 
 /**
@@ -299,6 +255,7 @@ function post_supports_amp( $post ) {
  * @return bool Whether it is the AMP endpoint.
  */
 function is_amp_endpoint() {
+	global $wp_query;
 	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 		return false;
 	}
@@ -326,7 +283,7 @@ function is_amp_endpoint() {
 	} else {
 
 		// Check if the queried object supports AMP.
-		if ( is_singular() ) {
+		if ( is_singular() || ( $wp_query instanceof WP_Query && $wp_query->is_posts_page ) ) {
 			/**
 			 * Post.
 			 *

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -94,6 +94,23 @@ class AMP_Post_Type_Support {
 			$errors[] = 'skip-post';
 		}
 
+		$query = new WP_Query();
+
+		$query->queried_object    = $post;
+		$query->queried_object_id = $post->ID;
+		if ( 'page' === $post->post_type ) {
+			$query->set( 'post_id', $post->ID );
+		} else {
+			$query->set( 'p', $post->ID );
+		}
+		$query->parse_query();
+
+		$availability = amp_get_availability( $query );
+		if ( ! $availability ) {
+			$errors[] = '';
+		}
+
+
 		return $errors;
 	}
 }

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -94,23 +94,6 @@ class AMP_Post_Type_Support {
 			$errors[] = 'skip-post';
 		}
 
-		$query = new WP_Query();
-
-		$query->queried_object    = $post;
-		$query->queried_object_id = $post->ID;
-		if ( 'page' === $post->post_type ) {
-			$query->set( 'post_id', $post->ID );
-		} else {
-			$query->set( 'p', $post->ID );
-		}
-		$query->parse_query();
-
-		$availability = amp_get_availability( $query );
-		if ( ! $availability ) {
-			$errors[] = '';
-		}
-
-
 		return $errors;
 	}
 }

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -14,9 +14,11 @@ class AMP_Post_Type_Support {
 	/**
 	 * Get post types that plugin supports out of the box (which cannot be disabled).
 	 *
+	 * @deprecated
 	 * @return string[] Post types.
 	 */
 	public static function get_builtin_supported_post_types() {
+		_deprecated_function( __METHOD__, '1.0' );
 		return array_filter( array( 'post' ), 'post_type_exists' );
 	}
 
@@ -27,17 +29,12 @@ class AMP_Post_Type_Support {
 	 * @return string[] Post types eligible for AMP.
 	 */
 	public static function get_eligible_post_types() {
-		return array_merge(
-			self::get_builtin_supported_post_types(),
-			array( 'page', 'attachment' ),
-			array_values( get_post_types(
-				array(
-					'public'   => true,
-					'_builtin' => false,
-				),
-				'names'
-			) )
-		);
+		return array_values( get_post_types(
+			array(
+				'public' => true,
+			),
+			'names'
+		) );
 	}
 
 	/**
@@ -49,10 +46,11 @@ class AMP_Post_Type_Support {
 	 * @since 0.6
 	 */
 	public static function add_post_type_support() {
-		$post_types = array_merge(
-			self::get_builtin_supported_post_types(),
-			AMP_Options_Manager::get_option( 'supported_post_types', array() )
-		);
+		if ( current_theme_supports( 'amp' ) && AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
+			$post_types = self::get_eligible_post_types();
+		} else {
+			$post_types = AMP_Options_Manager::get_option( 'supported_post_types', array() );
+		}
 		foreach ( $post_types as $post_type ) {
 			add_post_type_support( $post_type, amp_get_slug() );
 		}
@@ -72,8 +70,7 @@ class AMP_Post_Type_Support {
 		}
 		$errors = array();
 
-		// Because `add_rewrite_endpoint` doesn't let us target specific post_types.
-		if ( isset( $post->post_type ) && ! post_type_supports( $post->post_type, amp_get_slug() ) ) {
+		if ( ! post_type_supports( $post->post_type, amp_get_slug() ) ) {
 			$errors[] = 'post-type-support';
 		}
 

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -29,7 +29,7 @@ class AMP_Post_Type_Support {
 	public static function get_eligible_post_types() {
 		return array_merge(
 			self::get_builtin_supported_post_types(),
-			array( 'page' ),
+			array( 'page', 'attachment' ),
 			array_values( get_post_types(
 				array(
 					'public'   => true,

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -91,6 +91,48 @@ class AMP_Post_Type_Support {
 			$errors[] = 'skip-post';
 		}
 
+		$status = get_post_meta( $post->ID, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true );
+		if ( $status ) {
+			if ( AMP_Post_Meta_Box::DISABLED_STATUS === $status ) {
+				$errors[] = 'post-status-disabled';
+			}
+		} else {
+			/*
+			 * Disabled by default for custom page templates, page on front and page for posts, unless 'amp' theme
+			 * support is present (in which case AMP_Theme_Support::get_template_availability() determines availability).
+			 */
+			$enabled = (
+				current_theme_supports( 'amp' )
+				||
+				(
+					! (bool) get_page_template_slug( $post )
+					&&
+					! (
+						'page' === $post->post_type
+						&&
+						'page' === get_option( 'show_on_front' )
+						&&
+						in_array( (int) $post->ID, array(
+							(int) get_option( 'page_on_front' ),
+							(int) get_option( 'page_for_posts' ),
+						), true )
+					)
+				)
+			);
+
+			/**
+			 * Filters whether default AMP status should be enabled or not.
+			 *
+			 * @since 0.6
+			 *
+			 * @param string  $status Status.
+			 * @param WP_Post $post   Post.
+			 */
+			$enabled = apply_filters( 'amp_post_status_default_enabled', $enabled, $post );
+			if ( ! $enabled ) {
+				$errors[] = 'post-status-disabled';
+			}
+		}
 		return $errors;
 	}
 }

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -374,19 +374,6 @@ class AMP_Theme_Support {
 
 		$matching_templates    = array();
 		$supportable_templates = self::get_supportable_templates();
-
-		/*
-		 * Singular template support is included here though it is not explicitly listed among the templates by default.
-		 * It is the post type support that is used to indicate whether a given singular post template should be served
-		 * via post_supports_amp() including the metabox toggle to enable/disable AMP, and the amp_skip_post filter.
-		 */
-		if ( ! isset( $supportable_templates['is_singular'] ) ) {
-			$supportable_templates['is_singular'] = array(
-				'callback'  => 'is_singular',
-				'supported' => true,
-			);
-		}
-
 		foreach ( $supportable_templates as $id => $supportable_template ) {
 			if ( empty( $supportable_template['callback'] ) ) {
 				$callback = $id;
@@ -468,14 +455,13 @@ class AMP_Theme_Support {
 	/**
 	 * Get the templates which can be supported.
 	 *
-	 * @todo The callback could have support for running in an admin context.
 	 * @return array Supportable templates.
 	 */
 	public static function get_supportable_templates() {
 		$templates = array(
 			'is_singular' => array(
-				'label' => __( 'Singular', 'amp' ),
-				// This needs to default to true.
+				'label'       => __( 'Singular', 'amp' ),
+				'description' => __( 'Required for the above content types.', 'amp' ),
 			),
 		);
 		if ( 'page' === get_option( 'show_on_front' ) ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -458,14 +458,10 @@ class AMP_Theme_Support {
 		}
 
 		$all_templates_supported_by_theme_support = false;
-		$theme_templates_supported                = array();
 		if ( isset( $theme_support_args['templates_supported'] ) ) {
 			$all_templates_supported_by_theme_support = 'all' === $theme_support_args['templates_supported'];
-			if ( is_array( $theme_support_args['templates_supported'] ) ) {
-				$theme_templates_supported = $theme_support_args['templates_supported'];
-			}
 		}
-		$all_templates_supported          = (
+		$all_templates_supported = (
 			$all_templates_supported_by_theme_support || AMP_Options_Manager::get_option( 'all_templates_supported' )
 		);
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -489,7 +489,7 @@ class AMP_Theme_Support {
 			if ( is_string( $callback ) && 'is_' === substr( $callback, 0, 3 ) && method_exists( $query, $callback ) ) {
 				$is_match = call_user_func( array( $query, $callback ) );
 			} elseif ( is_callable( $callback ) ) {
-				$is_match = call_user_func( $callback );
+				$is_match = call_user_func( $callback, $query );
 			} else {
 				/* translators: %s is the supportable template ID. */
 				_doing_it_wrong( __FUNCTION__, esc_html__( 'Supportable template "%s" does not have a callable callback.', 'amp' ), '1.0' );
@@ -535,6 +535,15 @@ class AMP_Theme_Support {
 			}
 		}
 
+		// The is_home() condition is the default so discard it if there are other matching templates.
+		if ( count( $matching_templates ) > 1 && isset( $matching_templates['is_home'] ) ) {
+			unset( $matching_templates['is_home'] );
+		}
+
+		/*
+		 * If there are more than one matching templates, then something is probably not right.
+		 * Template conditions need to be set up properly to prevent this from happening.
+		 */
 		if ( count( $matching_templates ) > 1 ) {
 			_doing_it_wrong( __FUNCTION__, esc_html__( 'Did not expect there to be more than one matching template. Did you filter amp_supportable_templates to not honor the template hierarchy?', 'amp' ), '1.0' );
 		}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -163,7 +163,6 @@ class AMP_Theme_Support {
 		$theme_support_args   = false;
 
 		// @todo Do we really need this optional flag? Yes. As it allows us to define the mode. Maybe it should be 'required' instead. Key for theme marketplaces? But if a theme is using the AMP features anyway, then it should have AMP as built-in and not be optional.
-
 		// If theme support is present in the theme, but it is marked as optional, then go ahead and remove it if theme support is not enabled in the admin.
 		if ( current_theme_supports( 'amp' ) ) {
 			$support            = get_theme_support( 'amp' );
@@ -478,7 +477,7 @@ class AMP_Theme_Support {
 
 		// If there aren't any matching templates left that are supported, then we consider it to not be available.
 		if ( ! $matching_template ) {
-			if ( AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
+			if ( AMP_Options_Manager::get_option( 'all_templates_supported' ) || AMP_Options_Manager::get_option( 'unrecognized_templates_supported' ) ) {
 				return array_merge(
 					$default_response,
 					array(
@@ -573,10 +572,6 @@ class AMP_Theme_Support {
 				'is_404'     => array(
 					'label' => __( 'Not Found (404)', 'amp' ),
 				),
-//				'other'    => array(
-//					'label'    => __( 'Other', 'amp' ),
-//					'callback' => '__return_true', // @todo This can be treated as the parent of all, as the default.
-//				),
 			)
 		);
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -468,9 +468,6 @@ class AMP_Theme_Support {
 		$all_templates_supported          = (
 			$all_templates_supported_by_theme_support || AMP_Options_Manager::get_option( 'all_templates_supported' )
 		);
-		$unrecognized_templates_supported = ( // @todo Get this from $supportable_templates.
-			isset( $theme_templates_supported['unrecognized'] ) ? true === $theme_templates_supported['unrecognized'] : AMP_Options_Manager::get_option( 'unrecognized_templates_supported' )
-		);
 
 		// Make sure global $wp_query is set in case of conditionals that unfortunately look at global scope.
 		$prev_query = $wp_query;
@@ -552,7 +549,7 @@ class AMP_Theme_Support {
 
 		// If there aren't any matching templates left that are supported, then we consider it to not be available.
 		if ( ! $matching_template ) {
-			if ( $all_templates_supported || $unrecognized_templates_supported ) {
+			if ( $all_templates_supported ) {
 				return array_merge(
 					$default_response,
 					array(

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -478,10 +478,19 @@ class AMP_Theme_Support {
 
 		// If there aren't any matching templates left that are supported, then we consider it to not be available.
 		if ( ! $matching_template ) {
-			return array_merge(
-				$default_response,
-				array( 'errors' => array( 'no_matching_template' ) )
-			);
+			if ( AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
+				return array_merge(
+					$default_response,
+					array(
+						'supported' => true,
+					)
+				);
+			} else {
+				return array_merge(
+					$default_response,
+					array( 'errors' => array( 'no_matching_template' ) )
+				);
+			}
 		}
 		$matching_template = array_merge( $default_response, $matching_template );
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -157,8 +157,10 @@ class AMP_Theme_Support {
 	 * Read theme support and apply options from admin for whether theme support is enabled and via what template is enabled.
 	 *
 	 * @see AMP_Post_Type_Support::add_post_type_support() For where post type support is added, since it is irrespective of theme support.
+	 *
+	 * @param bool $check_args Whether the theme support args should be checked.
 	 */
-	public static function read_theme_support() {
+	public static function read_theme_support( $check_args = WP_DEBUG ) {
 		self::$support_added_via_option = false;
 
 		self::$initial_theme_support_args = false;
@@ -170,7 +172,7 @@ class AMP_Theme_Support {
 				self::$initial_theme_support_args = array_shift( $support );
 
 				// Validate theme support usage.
-				if ( WP_DEBUG ) {
+				if ( $check_args ) {
 					$keys = array( 'template_dir', 'comments_live_list', 'mode', 'optional', 'templates_supported' );
 					if ( ! is_array( self::$initial_theme_support_args ) ) {
 						trigger_error( esc_html__( 'Expected AMP theme support arg to be array.', 'amp' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
@@ -199,8 +201,8 @@ class AMP_Theme_Support {
 			$theme_support_args = array();
 		}
 
-		// If theme support is not present, then allow it to be added via the admin.
-		if ( ! current_theme_supports( 'amp' ) ) {
+		// If theme support is not present (or it is optional), then allow it to be added via the admin.
+		if ( ! current_theme_supports( 'amp' ) || ! empty( $theme_support_args['optional'] ) ) {
 			if ( 'disabled' === $theme_support_option ) {
 				return;
 			}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -172,6 +172,7 @@ class AMP_Theme_Support {
 				// Validate theme support usage.
 				$keys = array( 'template_dir', 'comments_live_list', 'mode', 'optional', 'templates_supported', 'available_callback' );
 				if ( ! is_array( self::$initial_theme_support_args ) ) {
+					self::$initial_theme_support_args = array();
 					_doing_it_wrong( 'add_theme_support', esc_html__( 'Expected AMP theme support arg to be array.', 'amp' ), '1.0' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				} elseif ( count( array_diff( array_keys( self::$initial_theme_support_args ), $keys ) ) !== 0 ) {
 					_doing_it_wrong( 'add_theme_support', esc_html( sprintf(  // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -281,6 +281,7 @@ class AMP_Theme_Support {
 	 * Returns true when there is a template_dir defined in theme support, and if a defined available_callback
 	 * returns true.
 	 *
+	 * @see amp_is_canonical()
 	 * @return bool Whether available.
 	 */
 	public static function is_paired_available() {
@@ -296,6 +297,10 @@ class AMP_Theme_Support {
 		 */
 		$queried_object = get_queried_object();
 		if ( is_singular() && ! post_supports_amp( $queried_object ) ) {
+			return false;
+		}
+
+		if ( ! is_singular() && ! AMP_Options_Manager::get_option( 'non_singular_supported' ) ) {
 			return false;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -442,7 +442,7 @@ class AMP_Theme_Support {
 		);
 
 		if ( ! ( $query instanceof WP_Query ) ) {
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'No WP_Query available.', 'amp' ), '1.0' );
+			_doing_it_wrong( __METHOD__, esc_html__( 'No WP_Query available.', 'amp' ), '1.0' );
 			return array_merge(
 				$default_response,
 				array( 'errors' => array( 'no_query_available' ) )
@@ -503,6 +503,9 @@ class AMP_Theme_Support {
 
 		// Make sure children override their parents.
 		$matching_template_ids = array_keys( $matching_templates );
+		foreach ( array_diff( array_keys( $supportable_templates ), $matching_template_ids ) as $template_id ) {
+			unset( $supportable_templates[ $template_id ] );
+		}
 		foreach ( $matching_template_ids as $id ) {
 			$has_children = false;
 			foreach ( $supportable_templates as $other_id => $supportable_template ) {
@@ -538,7 +541,7 @@ class AMP_Theme_Support {
 		 * Template conditions need to be set up properly to prevent this from happening.
 		 */
 		if ( count( $matching_templates ) > 1 ) {
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'Did not expect there to be more than one matching template. Did you filter amp_supportable_templates to not honor the template hierarchy?', 'amp' ), '1.0' );
+			_doing_it_wrong( __METHOD__, esc_html__( 'Did not expect there to be more than one matching template. Did you filter amp_supportable_templates to not honor the template hierarchy?', 'amp' ), '1.0' );
 		}
 
 		$matching_template = array_shift( $matching_templates );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -309,10 +309,12 @@ class AMP_Theme_Support {
 				$new_url = add_query_arg( amp_get_slug(), '', amp_remove_endpoint( $old_url ) );
 				if ( $old_url !== $new_url ) {
 					wp_safe_redirect( $new_url, 302 );
+					// @codeCoverageIgnoreStart
 					if ( $exit ) {
 						exit;
 					}
 					return true;
+					// @codeCoverageIgnoreEnd
 				}
 			}
 		}
@@ -343,10 +345,12 @@ class AMP_Theme_Support {
 		 * occur or when a non-canonical AMP theme is used.
 		 */
 		wp_safe_redirect( $ampless_url, 302 );
+		// @codeCoverageIgnoreStart
 		if ( $exit ) {
 			exit;
 		}
 		return true;
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -392,17 +396,6 @@ class AMP_Theme_Support {
 		foreach ( self::$template_types as $template_type ) {
 			add_filter( "{$template_type}_template_hierarchy", array( __CLASS__, 'filter_amp_template_hierarchy' ) );
 		}
-	}
-
-	/**
-	 * Return whether support for all templates is required by the theme.
-	 *
-	 * @since 1.0
-	 * @return bool Whether theme requires all templates to support AMP.
-	 */
-	public static function is_template_support_required() {
-		$theme_support_args = self::get_theme_support_args( array( 'initial' => true ) );
-		return ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] );
 	}
 
 	/**
@@ -475,7 +468,7 @@ class AMP_Theme_Support {
 		$all_templates_supported          = (
 			$all_templates_supported_by_theme_support || AMP_Options_Manager::get_option( 'all_templates_supported' )
 		);
-		$unrecognized_templates_supported = (
+		$unrecognized_templates_supported = ( // @todo Get this from $supportable_templates.
 			isset( $theme_templates_supported['unrecognized'] ) ? true === $theme_templates_supported['unrecognized'] : AMP_Options_Manager::get_option( 'unrecognized_templates_supported' )
 		);
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -677,6 +677,7 @@ class AMP_Theme_Support {
 		foreach ( get_post_types( $post_type_args, 'objects' ) as $post_type ) {
 			$templates[ sprintf( 'is_post_type_archive[%s]', $post_type->name ) ] = array(
 				'label'    => $post_type->labels->archives,
+				'parent'   => 'is_archive',
 				'callback' => function ( WP_Query $query ) use ( $post_type ) {
 					return $query->is_post_type_archive( $post_type->name );
 				},

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -140,7 +140,7 @@ class AMP_Options_Manager {
 		if ( isset( $new_options['supported_templates'] ) ) {
 			$options['supported_templates'] = array_intersect(
 				$new_options['supported_templates'],
-				array_keys( AMP_Theme_Support::get_template_conditional_options() )
+				array_keys( AMP_Theme_Support::get_supportable_templates() )
 			);
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -124,7 +124,9 @@ class AMP_Options_Manager {
 		$options['disable_admin_bar']   = ! empty( $new_options['disable_admin_bar'] );
 
 		$theme_support_args = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
-		if ( ! AMP_Theme_Support::is_template_support_required() ) {
+
+		$is_template_support_required = ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] );
+		if ( ! $is_template_support_required ) {
 			$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
 			if ( ! isset( $theme_support_args['templates_supported']['unrecognized'] ) ) {
 				$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -120,10 +120,10 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $new_options['theme_support'];
 		}
 
-		$options['force_sanitization']     = ! empty( $new_options['force_sanitization'] );
-		$options['accept_tree_shaking']    = ! empty( $new_options['accept_tree_shaking'] );
-		$options['disable_admin_bar']      = ! empty( $new_options['disable_admin_bar'] );
-		$options['non_singular_supported'] = ! empty( $new_options['non_singular_supported'] );
+		$options['force_sanitization']      = ! empty( $new_options['force_sanitization'] );
+		$options['accept_tree_shaking']     = ! empty( $new_options['accept_tree_shaking'] );
+		$options['disable_admin_bar']       = ! empty( $new_options['disable_admin_bar'] );
+		$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
 
 		// Validate post type support.
 		if ( isset( $new_options['supported_post_types'] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -23,12 +23,13 @@ class AMP_Options_Manager {
 	 * @var array
 	 */
 	protected static $defaults = array(
-		'theme_support'        => 'disabled',
-		'supported_post_types' => array(),
-		'analytics'            => array(),
-		'force_sanitization'   => false,
-		'accept_tree_shaking'  => false,
-		'disable_admin_bar'    => false,
+		'theme_support'          => 'disabled',
+		'supported_post_types'   => array(),
+		'analytics'              => array(),
+		'force_sanitization'     => false,
+		'accept_tree_shaking'    => false,
+		'disable_admin_bar'      => false,
+		'non_singular_supported' => true,
 	);
 
 	/**
@@ -116,9 +117,10 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $new_options['theme_support'];
 		}
 
-		$options['force_sanitization']  = ! empty( $new_options['force_sanitization'] );
-		$options['accept_tree_shaking'] = ! empty( $new_options['accept_tree_shaking'] );
-		$options['disable_admin_bar']   = ! empty( $new_options['disable_admin_bar'] );
+		$options['force_sanitization']     = ! empty( $new_options['force_sanitization'] );
+		$options['accept_tree_shaking']    = ! empty( $new_options['accept_tree_shaking'] );
+		$options['disable_admin_bar']      = ! empty( $new_options['disable_admin_bar'] );
+		$options['non_singular_supported'] = ! empty( $new_options['non_singular_supported'] );
 
 		// Validate post type support.
 		if ( isset( $new_options['supported_post_types'] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -24,7 +24,7 @@ class AMP_Options_Manager {
 	 */
 	protected static $defaults = array(
 		'theme_support'           => 'disabled',
-		'supported_post_types'    => array(),
+		'supported_post_types'    => array( 'post' ),
 		'analytics'               => array(),
 		'force_sanitization'      => false,
 		'accept_tree_shaking'     => false,
@@ -126,8 +126,8 @@ class AMP_Options_Manager {
 		$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
 
 		// Validate post type support.
+		$options['supported_post_types'] = array();
 		if ( isset( $new_options['supported_post_types'] ) ) {
-			$options['supported_post_types'] = array();
 			foreach ( $new_options['supported_post_types'] as $post_type ) {
 				if ( ! post_type_exists( $post_type ) ) {
 					add_settings_error( self::OPTION_NAME, 'unknown_post_type', __( 'Unrecognized post type.', 'amp' ) );
@@ -192,11 +192,10 @@ class AMP_Options_Manager {
 	 * @see add_settings_error()
 	 */
 	public static function check_supported_post_type_update_errors() {
-		$builtin_support = AMP_Post_Type_Support::get_builtin_supported_post_types();
 		$supported_types = self::get_option( 'supported_post_types', array() );
 		foreach ( AMP_Post_Type_Support::get_eligible_post_types() as $name ) {
 			$post_type = get_post_type_object( $name );
-			if ( empty( $post_type ) || in_array( $post_type->name, $builtin_support, true ) ) {
+			if ( empty( $post_type ) ) {
 				continue;
 			}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -121,31 +121,37 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $new_options['theme_support'];
 		}
 
-		$options['force_sanitization']               = ! empty( $new_options['force_sanitization'] );
-		$options['accept_tree_shaking']              = ! empty( $new_options['accept_tree_shaking'] );
-		$options['disable_admin_bar']                = ! empty( $new_options['disable_admin_bar'] );
-		$options['all_templates_supported']          = ! empty( $new_options['all_templates_supported'] );
-		$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
+		$options['force_sanitization']  = ! empty( $new_options['force_sanitization'] );
+		$options['accept_tree_shaking'] = ! empty( $new_options['accept_tree_shaking'] );
+		$options['disable_admin_bar']   = ! empty( $new_options['disable_admin_bar'] );
 
-		// Validate post type support.
-		$options['supported_post_types'] = array();
-		if ( isset( $new_options['supported_post_types'] ) ) {
-			foreach ( $new_options['supported_post_types'] as $post_type ) {
-				if ( ! post_type_exists( $post_type ) ) {
-					add_settings_error( self::OPTION_NAME, 'unknown_post_type', __( 'Unrecognized post type.', 'amp' ) );
-				} else {
-					$options['supported_post_types'][] = $post_type;
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
+		if ( ! AMP_Theme_Support::is_template_support_required() ) {
+			$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
+			if ( ! isset( $theme_support_args['templates_supported']['unrecognized'] ) ) {
+				$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
+			}
+
+			// Validate post type support.
+			$options['supported_post_types'] = array();
+			if ( isset( $new_options['supported_post_types'] ) ) {
+				foreach ( $new_options['supported_post_types'] as $post_type ) {
+					if ( ! post_type_exists( $post_type ) ) {
+						add_settings_error( self::OPTION_NAME, 'unknown_post_type', __( 'Unrecognized post type.', 'amp' ) );
+					} else {
+						$options['supported_post_types'][] = $post_type;
+					}
 				}
 			}
-		}
 
-		// Validate supported templates.
-		$options['supported_templates'] = array();
-		if ( isset( $new_options['supported_templates'] ) ) {
-			$options['supported_templates'] = array_intersect(
-				$new_options['supported_templates'],
-				array_keys( AMP_Theme_Support::get_supportable_templates() )
-			);
+			// Validate supported templates.
+			$options['supported_templates'] = array();
+			if ( isset( $new_options['supported_templates'] ) ) {
+				$options['supported_templates'] = array_intersect(
+					$new_options['supported_templates'],
+					array_keys( AMP_Theme_Support::get_supportable_templates() )
+				);
+			}
 		}
 
 		// Validate analytics.

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -23,14 +23,15 @@ class AMP_Options_Manager {
 	 * @var array
 	 */
 	protected static $defaults = array(
-		'theme_support'           => 'disabled',
-		'supported_post_types'    => array( 'post' ),
-		'analytics'               => array(),
-		'force_sanitization'      => false,
-		'accept_tree_shaking'     => false,
-		'disable_admin_bar'       => false,
-		'all_templates_supported' => true,
-		'supported_templates'     => array(
+		'theme_support'                    => 'disabled',
+		'supported_post_types'             => array( 'post' ),
+		'analytics'                        => array(),
+		'force_sanitization'               => false,
+		'accept_tree_shaking'              => false,
+		'disable_admin_bar'                => false,
+		'all_templates_supported'          => true,
+		'unrecognized_templates_supported' => true,
+		'supported_templates'              => array(
 			'is_singular',
 		),
 	);
@@ -120,10 +121,11 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $new_options['theme_support'];
 		}
 
-		$options['force_sanitization']      = ! empty( $new_options['force_sanitization'] );
-		$options['accept_tree_shaking']     = ! empty( $new_options['accept_tree_shaking'] );
-		$options['disable_admin_bar']       = ! empty( $new_options['disable_admin_bar'] );
-		$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
+		$options['force_sanitization']               = ! empty( $new_options['force_sanitization'] );
+		$options['accept_tree_shaking']              = ! empty( $new_options['accept_tree_shaking'] );
+		$options['disable_admin_bar']                = ! empty( $new_options['disable_admin_bar'] );
+		$options['all_templates_supported']          = ! empty( $new_options['all_templates_supported'] );
+		$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
 
 		// Validate post type support.
 		$options['supported_post_types'] = array();

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -24,16 +24,14 @@ class AMP_Options_Manager {
 	 */
 	protected static $defaults = array(
 		'theme_support'                    => 'disabled',
-		'supported_post_types'             => array( 'post' ), // @todo Try updating from 0.7 to 1.0.
+		'supported_post_types'             => array( 'post' ),
 		'analytics'                        => array(),
 		'force_sanitization'               => false,
 		'accept_tree_shaking'              => false,
 		'disable_admin_bar'                => false,
 		'all_templates_supported'          => true,
-		'unrecognized_templates_supported' => true,
-		'supported_templates'              => array(
-			'is_singular', // @todo Why?
-		),
+		'unrecognized_templates_supported' => false,
+		'supported_templates'              => array( 'is_singular' ),
 	);
 
 	/**
@@ -132,7 +130,6 @@ class AMP_Options_Manager {
 				$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
 			}
 
-			// @todo Store associative array instead?
 			// Validate post type support.
 			$options['supported_post_types'] = array();
 			if ( isset( $new_options['supported_post_types'] ) ) {
@@ -145,7 +142,6 @@ class AMP_Options_Manager {
 				}
 			}
 
-			// @todo Store associative array instead.
 			// Validate supported templates.
 			$options['supported_templates'] = array();
 			if ( isset( $new_options['supported_templates'] ) ) {
@@ -200,6 +196,9 @@ class AMP_Options_Manager {
 				}
 			}
 		}
+
+		// Store the current version with the options so we know the format.
+		$options['version'] = AMP__VERSION;
 
 		return $options;
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -23,15 +23,14 @@ class AMP_Options_Manager {
 	 * @var array
 	 */
 	protected static $defaults = array(
-		'theme_support'                    => 'disabled',
-		'supported_post_types'             => array( 'post' ),
-		'analytics'                        => array(),
-		'force_sanitization'               => false,
-		'accept_tree_shaking'              => false,
-		'disable_admin_bar'                => false,
-		'all_templates_supported'          => true,
-		'unrecognized_templates_supported' => false,
-		'supported_templates'              => array( 'is_singular' ),
+		'theme_support'           => 'disabled',
+		'supported_post_types'    => array( 'post' ),
+		'analytics'               => array(),
+		'force_sanitization'      => false,
+		'accept_tree_shaking'     => false,
+		'disable_admin_bar'       => false,
+		'all_templates_supported' => true,
+		'supported_templates'     => array( 'is_singular' ),
 	);
 
 	/**
@@ -128,9 +127,6 @@ class AMP_Options_Manager {
 		$is_template_support_required = ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] );
 		if ( ! $is_template_support_required ) {
 			$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
-			if ( ! isset( $theme_support_args['templates_supported']['unrecognized'] ) ) {
-				$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
-			}
 
 			// Validate post type support.
 			$options['supported_post_types'] = array();

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -24,7 +24,7 @@ class AMP_Options_Manager {
 	 */
 	protected static $defaults = array(
 		'theme_support'                    => 'disabled',
-		'supported_post_types'             => array( 'post' ),
+		'supported_post_types'             => array( 'post' ), // @todo Try updating from 0.7 to 1.0.
 		'analytics'                        => array(),
 		'force_sanitization'               => false,
 		'accept_tree_shaking'              => false,
@@ -32,7 +32,7 @@ class AMP_Options_Manager {
 		'all_templates_supported'          => true,
 		'unrecognized_templates_supported' => true,
 		'supported_templates'              => array(
-			'is_singular',
+			'is_singular', // @todo Why?
 		),
 	);
 
@@ -132,6 +132,7 @@ class AMP_Options_Manager {
 				$options['unrecognized_templates_supported'] = ! empty( $new_options['unrecognized_templates_supported'] );
 			}
 
+			// @todo Store associative array instead?
 			// Validate post type support.
 			$options['supported_post_types'] = array();
 			if ( isset( $new_options['supported_post_types'] ) ) {
@@ -144,6 +145,7 @@ class AMP_Options_Manager {
 				}
 			}
 
+			// @todo Store associative array instead.
 			// Validate supported templates.
 			$options['supported_templates'] = array();
 			if ( isset( $new_options['supported_templates'] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -30,7 +30,9 @@ class AMP_Options_Manager {
 		'accept_tree_shaking'     => false,
 		'disable_admin_bar'       => false,
 		'all_templates_supported' => true,
-		'supported_templates'     => array(),
+		'supported_templates'     => array(
+			'is_singular',
+		),
 	);
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -23,13 +23,16 @@ class AMP_Options_Manager {
 	 * @var array
 	 */
 	protected static $defaults = array(
-		'theme_support'          => 'disabled',
-		'supported_post_types'   => array(),
-		'analytics'              => array(),
-		'force_sanitization'     => false,
-		'accept_tree_shaking'    => false,
-		'disable_admin_bar'      => false,
-		'non_singular_supported' => true,
+		'theme_support'           => 'disabled',
+		'supported_post_types'    => array(),
+		'analytics'               => array(),
+		'force_sanitization'      => false,
+		'accept_tree_shaking'     => false,
+		'disable_admin_bar'       => false,
+		'all_templates_supported' => false,
+		'supported_templates'     => array(
+			'single',
+		),
 	);
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -122,23 +122,23 @@ class AMP_Options_Manager {
 		$options['accept_tree_shaking'] = ! empty( $new_options['accept_tree_shaking'] );
 		$options['disable_admin_bar']   = ! empty( $new_options['disable_admin_bar'] );
 
+		// Validate post type support.
+		$options['supported_post_types'] = array();
+		if ( isset( $new_options['supported_post_types'] ) ) {
+			foreach ( $new_options['supported_post_types'] as $post_type ) {
+				if ( ! post_type_exists( $post_type ) ) {
+					add_settings_error( self::OPTION_NAME, 'unknown_post_type', __( 'Unrecognized post type.', 'amp' ) );
+				} else {
+					$options['supported_post_types'][] = $post_type;
+				}
+			}
+		}
+
 		$theme_support_args = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
 
 		$is_template_support_required = ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] );
-		if ( ! $is_template_support_required ) {
+		if ( ! $is_template_support_required && ! isset( $theme_support_args['available_callback'] ) ) {
 			$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
-
-			// Validate post type support.
-			$options['supported_post_types'] = array();
-			if ( isset( $new_options['supported_post_types'] ) ) {
-				foreach ( $new_options['supported_post_types'] as $post_type ) {
-					if ( ! post_type_exists( $post_type ) ) {
-						add_settings_error( self::OPTION_NAME, 'unknown_post_type', __( 'Unrecognized post type.', 'amp' ) );
-					} else {
-						$options['supported_post_types'][] = $post_type;
-					}
-				}
-			}
 
 			// Validate supported templates.
 			$options['supported_templates'] = array();

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -29,10 +29,8 @@ class AMP_Options_Manager {
 		'force_sanitization'      => false,
 		'accept_tree_shaking'     => false,
 		'disable_admin_bar'       => false,
-		'all_templates_supported' => false,
-		'supported_templates'     => array(
-			'single',
-		),
+		'all_templates_supported' => true,
+		'supported_templates'     => array(),
 	);
 
 	/**
@@ -135,6 +133,15 @@ class AMP_Options_Manager {
 					$options['supported_post_types'][] = $post_type;
 				}
 			}
+		}
+
+		// Validate supported templates.
+		$options['supported_templates'] = array();
+		if ( isset( $new_options['supported_templates'] ) ) {
+			$options['supported_templates'] = array_intersect(
+				$new_options['supported_templates'],
+				array_keys( AMP_Theme_Support::get_template_conditional_options() )
+			);
 		}
 
 		// Validate analytics.

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -322,7 +322,9 @@ class AMP_Options_Menu {
 				}
 			</style>
 			<h4 class="title"><?php esc_html_e( 'Non-Singular Templates', 'amp' ); ?></h4>
-			<?php self::list_template_conditional_options( AMP_Theme_Support::get_template_conditional_options() ); ?>
+			<?php
+			self::list_template_conditional_options( AMP_Theme_Support::get_template_conditional_options() );
+			?>
 			<script>
 				// Let clicks on parent items automatically cause the children checkboxes to have same checked state applied.
 				(function ( $ ) {
@@ -365,27 +367,35 @@ class AMP_Options_Menu {
 	}
 
 	/**
-	 * @param array $options Options.
-	 * @param bool $parent_checked
+	 * List template conditional options.
+	 *
+	 * @param array       $options Options.
+	 * @param string|null $parent  ID of the parent option.
 	 */
-	private function list_template_conditional_options( $options, $parent_checked = false ) {
+	private function list_template_conditional_options( $options, $parent = null ) {
 		$element_name = AMP_Options_Manager::OPTION_NAME . '[supported_templates][]';
 		?>
 		<ul>
 			<?php foreach ( $options as $id => $option ) : ?>
 				<?php
-				$has_children = ! empty( $option['children'] );
-				$element_id   = AMP_Options_Manager::OPTION_NAME . '-supported-templates-' . $id;
+				$element_id = AMP_Options_Manager::OPTION_NAME . '-supported-templates-' . $id;
+				if ( $parent ? empty( $option['parent'] ) || $parent !== $option['parent'] : ! empty( $option['parent'] ) ) {
+					continue;
+				}
 				?>
 				<li>
-					<input type="checkbox" id="<?php echo esc_attr( $element_id ); ?>" name="<?php echo esc_attr( $element_name ); ?>" value="<?php echo esc_attr( $id ); ?>">
+					<input
+						type="checkbox"
+						id="<?php echo esc_attr( $element_id ); ?>"
+						name="<?php echo esc_attr( $element_name ); ?>"
+						value="<?php echo esc_attr( $id ); ?>"
+						<?php checked( ! empty( $option['supported'] ) ); ?>
+					>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $option['label'] ); ?>
 					</label>
 
-					<?php if ( $has_children ) : ?>
-						<?php self::list_template_conditional_options( $option['children'] ); ?>
-					<?php endif; ?>
+					<?php self::list_template_conditional_options( $options, $id ); ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -258,6 +258,7 @@ class AMP_Options_Menu {
 			<script>
 				jQuery( 'input[type=radio][name="amp-options[theme_support]"]' ).change( function() {
 					jQuery( '.amp-force-sanitize' ).toggleClass( 'hidden', 'native' === this.value );
+					jQuery( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === this.value );
 					jQuery( '.amp-force-sanitize-canonical' ).toggleClass( 'hidden', 'native' !== this.value );
 					jQuery( '#force_sanitization' ).trigger( 'change' );
 				} ).filter( ':checked' ).trigger( 'change' );

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -330,6 +330,12 @@ class AMP_Options_Menu {
 			<?php
 			self::list_template_conditional_options( AMP_Theme_Support::get_supportable_templates() );
 			?>
+			<p>
+				<label for="unrecognized_templates_supported">
+					<input id="unrecognized_templates_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[unrecognized_templates_supported]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'unrecognized_templates_supported' ) ); ?>>
+					<?php esc_html_e( 'Other', 'amp' ); ?>
+				</label>
+			</p>
 			<script>
 				// Let clicks on parent items automatically cause the children checkboxes to have same checked state applied.
 				(function ( $ ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -292,7 +292,7 @@ class AMP_Options_Menu {
 				</label>
 			</p>
 			<p class="description">
-				<?php esc_html_e( 'Non-singular means templates like categories, date archives, author pages, and so on.', 'amp' ); ?>
+				<?php esc_html_e( 'This will allow all of the URLs on your site to be served as AMP by default.', 'amp' ); ?>
 			</p>
 		</fieldset>
 
@@ -302,7 +302,7 @@ class AMP_Options_Menu {
 			$element_name    = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
 			?>
 			<legend>
-				<h2 class="title"><?php esc_html_e( 'Single Templates', 'amp' ); ?></h2>
+				<h4 class="title"><?php esc_html_e( 'Singular', 'amp' ); ?></h4>
 			</legend>
 
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
@@ -333,19 +333,38 @@ class AMP_Options_Menu {
 
 		<?php
 		// This is inspired by Jetpack's Widget Conditions.
+		// @todo We need to construct a WP_Query for each? There will neeed to
 		$templates = array(
-			'page' => array(
-				'front' => array(),
-				'posts' => array(),
-				'date'  => array(),
-			),
-			'author' => array(
+			'author'   => array(
 				'' => __( 'All author pages', 'amp' ),
 			),
-			'category' => array(
-				'' => __( 'All category pages', 'amp' ),
-			)
+			'category' => array_merge(
+				array(
+					'' => __( 'All category pages', 'amp' ),
+				)
+			),
+			'tag'      => array_merge(
+				array(
+					'' => __( 'All tag pages', 'amp' ),
+				)
+			),
+			'date'     => array(
+				''      => __( 'All date archives', 'amp' ),
+				'day'   => __( 'Daily archives', 'amp' ),
+				'month' => __( 'Monthly archives', 'amp' ),
+				'year'  => __( 'Yearly archives', 'amp' ),
+			),
+			'page'     => array(
+				'front'   => __( 'Front page', 'amp' ),
+				'posts'   => __( 'Posts page', 'amp' ),
+				'archive' => __( 'Archive page', 'amp' ),
+				'404'     => __( '404 error page', 'amp' ),
+				'search'  => __( 'Search results', 'amp' ),
+			),
+			// @todo Post type archives.
+			// @todo Custom taxonomies.
 		);
+
 		?>
 
 		<fieldset class="non_singular_supported">

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -290,7 +290,7 @@ class AMP_Options_Menu {
 
 		?>
 		<fieldset id="all_templates_supported_fieldset">
-			<?php if ( AMP_Theme_Support::is_template_support_required() ) : ?>
+			<?php if ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] ) : ?>
 				<div class="notice notice-info notice-alt inline">
 					<p>
 						<?php esc_html_e( 'The current theme requires all templates to support AMP.', 'amp' ); ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -99,13 +99,13 @@ class AMP_Options_Menu {
 		);
 
 		add_settings_field(
-			'supported_queries',
-			__( 'Supported Queries', 'amp' ),
-			array( $this, 'render_supported_queries' ),
+			'supported_templates',
+			__( 'Supported Templates', 'amp' ),
+			array( $this, 'render_supported_templates' ),
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
 			array(
-				'class' => 'amp-post-type-support-field',
+				'class' => 'amp-template-support-field',
 			)
 		);
 
@@ -272,23 +272,23 @@ class AMP_Options_Menu {
 	}
 
 	/**
-	 * Post types support section renderer.
+	 * Supported templates section renderer.
 	 *
-	 * @since 0.6
+	 * @since 1.0
 	 */
-	public function render_supported_queries() {
+	public function render_supported_templates() {
 		?>
 		<script>
 			jQuery( 'input[type=radio][name="amp-options[theme_support]"]' ).change( function() {
-				jQuery( 'fieldset.non_singular_supported' ).toggleClass( 'hidden', 'disabled' === this.value );
+				jQuery( 'fieldset.non_singular_supported, fieldset.all_templates_supported' ).toggleClass( 'hidden', 'disabled' === this.value );
 			} ).filter( ':checked' ).trigger( 'change' );
 		</script>
 
-		<fieldset class="non_singular_supported">
+		<fieldset class="all_templates_supported">
 			<p>
-				<label for="non_singular_supported">
-					<input id="non_singular_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[non_singular_supported]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'non_singular_supported' ) ); ?>>
-					<?php esc_html_e( 'Serve non-singular templates as AMP.', 'amp' ); ?>
+				<label for="all_templates_supported">
+					<input id="all_templates_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[all_templates_supported]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'all_templates_supported' ) ); ?>>
+					<?php esc_html_e( 'Serve all templates as AMP regardless of what is being queried.', 'amp' ); ?>
 				</label>
 			</p>
 			<p class="description">
@@ -302,10 +302,9 @@ class AMP_Options_Menu {
 			$element_name    = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
 			?>
 			<legend>
-				<h2 class="title"><?php esc_html_e( 'Post Types', 'amp' ); ?></h2>
+				<h2 class="title"><?php esc_html_e( 'Single Templates', 'amp' ); ?></h2>
 			</legend>
 
-			<!-- TODO Checkbox to allow other queries -->
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
 				<?php
 				$element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}";
@@ -329,6 +328,35 @@ class AMP_Options_Menu {
 			<?php endforeach; ?>
 			<p class="description">
 				<?php esc_html_e( 'Select the content types that you would like to be made available in AMP.', 'amp' ); ?>
+			</p>
+		</fieldset>
+
+		<?php
+		// This is inspired by Jetpack's Widget Conditions.
+		$templates = array(
+			'page' => array(
+				'front' => array(),
+				'posts' => array(),
+				'date'  => array(),
+			),
+			'author' => array(
+				'' => __( 'All author pages', 'amp' ),
+			),
+			'category' => array(
+				'' => __( 'All category pages', 'amp' ),
+			)
+		);
+		?>
+
+		<fieldset class="non_singular_supported">
+			<p>
+				<label for="non_singular_supported">
+					<input id="non_singular_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[non_singular_supported]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'non_singular_supported' ) ); ?>>
+					<?php esc_html_e( 'Serve non-singular templates as AMP.', 'amp' ); ?>
+				</label>
+			</p>
+			<p class="description">
+				<?php esc_html_e( 'Non-singular means templates like categories, date archives, author pages, and so on.', 'amp' ); ?>
 			</p>
 		</fieldset>
 		<?php

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -134,6 +134,9 @@ class AMP_Options_Menu {
 			||
 			! empty( $support_args[0]['__added_via_option'] )
 		);
+
+		// @todo Consider $theme_support['paired'] and if set, and true, only show Paired option; otherwise, show Native option.
+		// @todo Change $theme_support_mutable to be if ! empty( $theme_support['optional'] ) or ! $theme_support['required']?
 		if ( ! $theme_support_mutable ) {
 			if ( amp_is_canonical() ) {
 				$theme_support = 'native';
@@ -277,6 +280,8 @@ class AMP_Options_Menu {
 	 * @since 1.0
 	 */
 	public function render_supported_templates() {
+
+		// @todo If AMP theme support is native and required, let all_templates_supported be true? Maybe template support could have an all_templates_supported flag?
 		?>
 		<fieldset id="all_templates_supported_fieldset">
 			<p>
@@ -299,17 +304,17 @@ class AMP_Options_Menu {
 			<ul>
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
 				<li>
-				<?php $element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}"; ?>
-				<input
-					type="checkbox"
-					id="<?php echo esc_attr( $element_id ); ?>"
-					name="<?php echo esc_attr( $element_name ); ?>"
-					value="<?php echo esc_attr( $post_type->name ); ?>"
-					<?php checked( true, post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
-					>
-				<label for="<?php echo esc_attr( $element_id ); ?>">
-					<?php echo esc_html( $post_type->label ); ?>
-				</label>
+					<?php $element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}"; ?>
+					<input
+						type="checkbox"
+						id="<?php echo esc_attr( $element_id ); ?>"
+						name="<?php echo esc_attr( $element_name ); ?>"
+						value="<?php echo esc_attr( $post_type->name ); ?>"
+						<?php checked( true, post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
+						>
+					<label for="<?php echo esc_attr( $element_id ); ?>">
+						<?php echo esc_html( $post_type->label ); ?>
+					</label>
 				</li>
 			<?php endforeach; ?>
 			</ul>
@@ -395,6 +400,12 @@ class AMP_Options_Menu {
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $option['label'] ); ?>
 					</label>
+
+					<?php if ( ! empty( $option['description'] ) ) : ?>
+						<span class="description">
+							&mdash; <?php echo esc_html( $option['description'] ); ?>
+						</span>
+					<?php endif; ?>
 
 					<?php self::list_template_conditional_options( $options, $id ); ?>
 				</li>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -344,16 +344,6 @@ class AMP_Options_Menu {
 			<?php
 			self::list_template_conditional_options( AMP_Theme_Support::get_supportable_templates() );
 			?>
-			<p>
-				<?php
-				$disabled = isset( $theme_support_args['templates_supported']['unrecognized'] );
-				$checked  = $disabled ? $theme_support_args['templates_supported']['unrecognized'] : AMP_Options_Manager::get_option( 'unrecognized_templates_supported' );
-				?>
-				<label for="unrecognized_templates_supported">
-					<input id="unrecognized_templates_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[unrecognized_templates_supported]' ); ?>" <?php checked( $checked ); ?> <?php disabled( $disabled ); ?>>
-					<?php esc_html_e( 'Other', 'amp' ); ?>
-				</label>
-			</p>
 			<script>
 				// Let clicks on parent items automatically cause the children checkboxes to have same checked state applied.
 				(function ( $ ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -299,7 +299,7 @@ class AMP_Options_Menu {
 			<?php $element_name = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]'; ?>
 			<h4 class="title"><?php esc_html_e( 'Content Types', 'amp' ); ?></h4>
 			<p>
-				<?php esc_html_e( 'The following content types will be available as AMP by default, but you can override this on an item-by-item basis:', 'amp' ); ?>
+				<?php esc_html_e( 'The following content types will be available as AMP:', 'amp' ); ?>
 			</p>
 			<ul>
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
@@ -310,7 +310,7 @@ class AMP_Options_Menu {
 						id="<?php echo esc_attr( $element_id ); ?>"
 						name="<?php echo esc_attr( $element_name ); ?>"
 						value="<?php echo esc_attr( $post_type->name ); ?>"
-						<?php checked( true, post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
+						<?php checked( post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
 						>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $post_type->label ); ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -293,6 +293,9 @@ class AMP_Options_Menu {
 		<fieldset id="singular_templates_fieldset">
 			<?php $element_name = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]'; ?>
 			<h4 class="title"><?php esc_html_e( 'Singular Templates', 'amp' ); ?></h4>
+			<p>
+				<?php esc_html_e( 'The following content types will be available as AMP by default, but you can override this on an item-by-item basis:', 'amp' ); ?>
+			</p>
 			<ul>
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
 				<li>
@@ -304,7 +307,6 @@ class AMP_Options_Menu {
 					value="<?php echo esc_attr( $post_type->name ); ?>"
 					<?php checked( true, post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
 					>
-				<!-- @todo Hidden to capture actual state? -->
 				<label for="<?php echo esc_attr( $element_id ); ?>">
 					<?php echo esc_html( $post_type->label ); ?>
 				</label>
@@ -321,9 +323,18 @@ class AMP_Options_Menu {
 			</style>
 			<h4 class="title"><?php esc_html_e( 'Non-Singular Templates', 'amp' ); ?></h4>
 			<?php self::list_template_conditional_options( AMP_Theme_Support::get_template_conditional_options() ); ?>
+			<script>
+				// Let clicks on parent items automatically cause the children checkboxes to have same checked state applied.
+				(function ( $ ) {
+					$( '#non_singular_templates_fieldset input[type=checkbox]' ).on( 'click', function() {
+						$( this ).siblings( 'ul' ).find( 'input[type=checkbox]' ).prop( 'checked', this.checked );
+					} );
+				})( jQuery );
+			</script>
 		</fieldset>
 
 		<script>
+			// Update the visibility of the fieldsets based on the selected template mode and then whether all templates are indicated to be supported.
 			(function ( $ ) {
 				var templateModeInputs, themeSupportDisabledInput, allTemplatesSupportedInput;
 				templateModeInputs = $( 'input[type=radio][name="amp-options[theme_support]"]' );
@@ -331,9 +342,18 @@ class AMP_Options_Menu {
 				allTemplatesSupportedInput = $( '#all_templates_supported' );
 
 				function updateFieldsetVisibility() {
-					$( '#all_templates_supported_fieldset' ).toggleClass( 'hidden', themeSupportDisabledInput.prop( 'checked' ) );
-					$( '#singular_templates_fieldset' ).toggleClass( 'hidden', allTemplatesSupportedInput.prop( 'checked' ) && ! themeSupportDisabledInput.prop( 'checked' ) );
-					$( '#non_singular_templates_fieldset' ).toggleClass( 'hidden', allTemplatesSupportedInput.prop( 'checked' ) || themeSupportDisabledInput.prop( 'checked' ) );
+					$( '#all_templates_supported_fieldset, #singular_templates_fieldset > .title' ).toggleClass(
+						'hidden',
+						themeSupportDisabledInput.prop( 'checked' )
+					);
+					$( '#singular_templates_fieldset' ).toggleClass(
+						'hidden',
+						allTemplatesSupportedInput.prop( 'checked' ) && ! themeSupportDisabledInput.prop( 'checked' )
+					);
+					$( '#non_singular_templates_fieldset' ).toggleClass(
+						'hidden',
+						allTemplatesSupportedInput.prop( 'checked' ) || themeSupportDisabledInput.prop( 'checked' )
+					);
 				}
 
 				templateModeInputs.on( 'change', updateFieldsetVisibility );

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -129,21 +129,15 @@ class AMP_Options_Menu {
 		$support_args  = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
 
 		$theme_support_mutable = (
-			empty( $support_args )
-			||
 			! empty( $support_args['optional'] )
 			||
 			AMP_Theme_Support::is_support_added_via_option()
 		);
 
-		$mode_mutable = ! ( is_array( $support_args ) && isset( $support_args['mode'] ) );
+		$mode_mutable = ! isset( $support_args['mode'] );
 
 		if ( ! $theme_support_mutable || ( ! $mode_mutable && 'disabled' !== $theme_support ) ) {
-			if ( amp_is_canonical() ) {
-				$theme_support = 'native';
-			} else {
-				$theme_support = 'paired';
-			}
+			$theme_support = isset( $support_args['mode'] ) ? $support_args['mode'] : 'native';
 		}
 
 		$should_have_theme_support = in_array( get_template(), array( 'twentyfifteen', 'twentysixteen', 'twentyseventeen' ), true );
@@ -168,7 +162,7 @@ class AMP_Options_Menu {
 				<dd>
 					<?php esc_html_e( 'Display AMP responses in classic (legacy) post templates in a basic design that does not match your theme\'s templates.', 'amp' ); ?>
 				</dd>
-				<?php if ( $mode_mutable || ! amp_is_canonical() ) : ?>
+				<?php if ( $mode_mutable || 'paired' === $support_args['mode'] ) : ?>
 					<dt>
 						<input type="radio" id="theme_support_paired" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, 'paired' ); ?> <?php disabled( ! $theme_support_mutable ); ?>>
 						<label for="theme_support_paired">
@@ -179,7 +173,7 @@ class AMP_Options_Menu {
 						<?php esc_html_e( 'Reuse active theme\'s templates to display AMP responses, but use separate URLs for AMP. The canonical URLs for your site will not have AMP. If there are AMP validation errors encountered in the AMP response and the validation errors are not accepted for sanitization, then the AMP version will redirect to the non-AMP version.', 'amp' ); ?>
 					</dd>
 				<?php endif; ?>
-				<?php if ( $mode_mutable || amp_is_canonical() ) : ?>
+				<?php if ( $mode_mutable || 'native' === $support_args['mode'] ) : ?>
 					<dt>
 						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?> <?php disabled( ! $theme_support_mutable ); ?>>
 						<label for="theme_support_native">

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -297,7 +297,7 @@ class AMP_Options_Menu {
 
 		<fieldset id="singular_templates_fieldset">
 			<?php $element_name = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]'; ?>
-			<h4 class="title"><?php esc_html_e( 'Singular Templates', 'amp' ); ?></h4>
+			<h4 class="title"><?php esc_html_e( 'Content Types', 'amp' ); ?></h4>
 			<p>
 				<?php esc_html_e( 'The following content types will be available as AMP by default, but you can override this on an item-by-item basis:', 'amp' ); ?>
 			</p>
@@ -326,7 +326,7 @@ class AMP_Options_Menu {
 					margin-left: 40px;
 				}
 			</style>
-			<h4 class="title"><?php esc_html_e( 'Non-Singular Templates', 'amp' ); ?></h4>
+			<h4 class="title"><?php esc_html_e( 'Templates', 'amp' ); ?></h4>
 			<?php
 			self::list_template_conditional_options( AMP_Theme_Support::get_supportable_templates() );
 			?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -323,7 +323,7 @@ class AMP_Options_Menu {
 			</style>
 			<h4 class="title"><?php esc_html_e( 'Non-Singular Templates', 'amp' ); ?></h4>
 			<?php
-			self::list_template_conditional_options( AMP_Theme_Support::get_template_conditional_options() );
+			self::list_template_conditional_options( AMP_Theme_Support::get_supportable_templates() );
 			?>
 			<script>
 				// Let clicks on parent items automatically cause the children checkboxes to have same checked state applied.
@@ -390,6 +390,7 @@ class AMP_Options_Menu {
 						name="<?php echo esc_attr( $element_name ); ?>"
 						value="<?php echo esc_attr( $id ); ?>"
 						<?php checked( ! empty( $option['supported'] ) ); ?>
+						<?php disabled( ! empty( $option['immutable'] ) ); ?>
 					>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $option['label'] ); ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -132,7 +132,7 @@ class AMP_Options_Menu {
 		$theme_support_mutable = (
 			empty( $support_args )
 			||
-			! empty( $support_args[0]['__added_via_option'] )
+			AMP_Theme_Support::is_support_added_via_option()
 		);
 
 		// @todo Consider $theme_support['paired'] and if set, and true, only show Paired option; otherwise, show Native option.
@@ -387,6 +387,12 @@ class AMP_Options_Menu {
 				if ( $parent ? empty( $option['parent'] ) || $parent !== $option['parent'] : ! empty( $option['parent'] ) ) {
 					continue;
 				}
+
+				// Skip showing an option if it doesn't have a label.
+				if ( empty( $option['label'] ) ) {
+					continue;
+				}
+
 				?>
 				<li>
 					<input
@@ -403,7 +409,7 @@ class AMP_Options_Menu {
 
 					<?php if ( ! empty( $option['description'] ) ) : ?>
 						<span class="description">
-							&mdash; <?php echo esc_html( $option['description'] ); ?>
+							&mdash; <?php echo wp_kses_post( $option['description'] ); ?>
 						</span>
 					<?php endif; ?>
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -99,9 +99,9 @@ class AMP_Options_Menu {
 		);
 
 		add_settings_field(
-			'supported_post_types',
-			__( 'Post Type Support', 'amp' ),
-			array( $this, 'render_post_types_support' ),
+			'supported_queries',
+			__( 'Supported Queries', 'amp' ),
+			array( $this, 'render_supported_queries' ),
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
 			array(
@@ -276,16 +276,36 @@ class AMP_Options_Menu {
 	 *
 	 * @since 0.6
 	 */
-	public function render_post_types_support() {
-		$builtin_support = AMP_Post_Type_Support::get_builtin_supported_post_types();
-		$element_name    = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
+	public function render_supported_queries() {
 		?>
 		<script>
 			jQuery( 'input[type=radio][name="amp-options[theme_support]"]' ).change( function() {
-				jQuery( '.amp-post-type-support-field' ).toggleClass( 'hidden', 'paired' !== this.value && 'disabled' !== this.value );
+				jQuery( 'fieldset.non_singular_supported' ).toggleClass( 'hidden', 'disabled' === this.value );
 			} ).filter( ':checked' ).trigger( 'change' );
 		</script>
+
+		<fieldset class="non_singular_supported">
+			<p>
+				<label for="non_singular_supported">
+					<input id="non_singular_supported" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[non_singular_supported]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'non_singular_supported' ) ); ?>>
+					<?php esc_html_e( 'Serve non-singular templates as AMP.', 'amp' ); ?>
+				</label>
+			</p>
+			<p class="description">
+				<?php esc_html_e( 'Non-singular means templates like categories, date archives, author pages, and so on.', 'amp' ); ?>
+			</p>
+		</fieldset>
+
 		<fieldset>
+			<?php
+			$builtin_support = AMP_Post_Type_Support::get_builtin_supported_post_types();
+			$element_name    = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
+			?>
+			<legend>
+				<h2 class="title"><?php esc_html_e( 'Post Types', 'amp' ); ?></h2>
+			</legend>
+
+			<!-- TODO Checkbox to allow other queries -->
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
 				<?php
 				$element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}";
@@ -299,7 +319,7 @@ class AMP_Options_Menu {
 					id="<?php echo esc_attr( $element_id ); ?>"
 					name="<?php echo esc_attr( $element_name ); ?>"
 					value="<?php echo esc_attr( $post_type->name ); ?>"
-					<?php checked( true, amp_is_canonical() || post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
+					<?php checked( true, post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
 					<?php disabled( $is_builtin ); ?>
 					>
 				<label for="<?php echo esc_attr( $element_id ); ?>">

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -419,14 +419,25 @@ class AMP_Options_Menu {
 
 				?>
 				<li>
-					<input
-						type="checkbox"
-						id="<?php echo esc_attr( $element_id ); ?>"
-						name="<?php echo esc_attr( $element_name ); ?>"
-						value="<?php echo esc_attr( $id ); ?>"
-						<?php checked( ! empty( $option['supported'] ) ); ?>
-						<?php disabled( ! empty( $option['immutable'] ) ); ?>
-					>
+					<?php if ( empty( $option['immutable'] ) ) : ?>
+						<input
+							type="checkbox"
+							id="<?php echo esc_attr( $element_id ); ?>"
+							name="<?php echo esc_attr( $element_name ); ?>"
+							value="<?php echo esc_attr( $id ); ?>"
+							<?php checked( ! empty( $option['user_supported'] ) ); ?>
+						>
+					<?php else : // Persist user selection even when checkbox disabled, when selection forced by theme/filter. ?>
+						<input
+							type="checkbox"
+							id="<?php echo esc_attr( $element_id ); ?>"
+							<?php checked( ! empty( $option['supported'] ) ); ?>
+							<?php disabled( true ); ?>
+						>
+						<?php if ( ! empty( $option['user_supported'] ) ) : ?>
+							<input type="hidden" name="<?php echo esc_attr( $element_name ); ?>" value="<?php echo esc_attr( $id ); ?>">
+						<?php endif; ?>
+					<?php endif; ?>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $option['label'] ); ?>
 					</label>

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -218,7 +218,13 @@ class AMP_Validation_Manager {
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar.
 	 */
 	public static function add_admin_bar_menu_items( $wp_admin_bar ) {
-		if ( is_admin() || ! self::has_cap() || is_wp_error( AMP_Theme_Support::get_template_availability() ) ) {
+		if ( is_admin() || ! self::has_cap() ) {
+			self::$amp_admin_bar_item_added = false;
+			return;
+		}
+
+		$availability = AMP_Theme_Support::get_template_availability();
+		if ( ! $availability['supported'] ) {
 			self::$amp_admin_bar_item_added = false;
 			return;
 		}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -218,7 +218,7 @@ class AMP_Validation_Manager {
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar.
 	 */
 	public static function add_admin_bar_menu_items( $wp_admin_bar ) {
-		if ( is_admin() || ! self::has_cap() || ! ( amp_is_canonical() || AMP_Theme_Support::is_paired_available() ) ) {
+		if ( is_admin() || ! self::has_cap() || is_wp_error( AMP_Theme_Support::get_template_availability() ) ) {
 			self::$amp_admin_bar_item_added = false;
 			return;
 		}

--- a/templates/admin/amp-status.php
+++ b/templates/admin/amp-status.php
@@ -56,7 +56,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 					if ( in_array( 'skip-post', $errors, true ) ) {
 						$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
 					}
-					if ( count( array_diff( $errors, array( 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post' ) ) ) > 0 ) {
+					if ( count( array_diff( $errors, array( 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template-unavailable' ) ) ) > 0 ) {
 						$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
 					}
 					echo implode( ' ', $error_messages ); // WPCS: xss ok.

--- a/templates/admin/amp-status.php
+++ b/templates/admin/amp-status.php
@@ -42,7 +42,14 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 				<p>
 					<?php
 					$error_messages = array();
-					if ( in_array( 'template-unavailable', $errors, true ) ) {
+					if ( in_array( 'status_immutable', $errors, true ) ) {
+						if ( self::ENABLED_STATUS === $status ) {
+							$error_messages[] = __( 'Your site does not allow AMP to be disabled.', 'amp' );
+						} else {
+							$error_messages[] = __( 'Your site does not allow AMP to be enabled.', 'amp' );
+						}
+					}
+					if ( in_array( 'template_unsupported', $errors, true ) ) {
 						/* translators: %s is URL to AMP settings screen */
 						$error_messages[] = wp_kses_post( sprintf( __( 'There are no <a href="%s">supported templates</a> to display this in AMP.', 'amp' ), esc_url( admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) ) ) );
 					}
@@ -56,7 +63,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 					if ( in_array( 'skip-post', $errors, true ) ) {
 						$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
 					}
-					if ( count( array_diff( $errors, array( 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template-unavailable' ) ) ) > 0 ) {
+					if ( count( array_diff( $errors, array( 'status_immutable', 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template_unsupported' ) ) ) > 0 ) {
 						$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
 					}
 					echo implode( ' ', $error_messages ); // WPCS: xss ok.

--- a/templates/admin/amp-status.php
+++ b/templates/admin/amp-status.php
@@ -41,22 +41,25 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 			<div class="inline notice notice-warning notice-alt">
 				<p>
 					<?php
-					$support_errors_codes = AMP_Post_Type_Support::get_support_errors( $post );
-					$support_errors       = array();
-					if ( in_array( 'password-protected', $support_errors_codes, true ) ) {
-						$support_errors[] = __( 'AMP cannot be enabled on password protected posts.', 'amp' );
-					}
-					if ( in_array( 'post-type-support', $support_errors_codes, true ) ) {
+					$error_messages = array();
+					if ( in_array( 'template-unavailable', $errors, true ) ) {
 						/* translators: %s is URL to AMP settings screen */
-						$support_errors[] = wp_kses_post( sprintf( __( 'AMP cannot be enabled because this <a href="%s">post type does not support it</a>.', 'amp' ), admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) ) );
+						$error_messages[] = wp_kses_post( sprintf( __( 'There are no <a href="%s">supported templates</a> to display this in AMP.', 'amp' ), esc_url( admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) ) ) );
 					}
-					if ( in_array( 'skip-post', $support_errors_codes, true ) ) {
-						$support_errors[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
+					if ( in_array( 'password-protected', $errors, true ) ) {
+						$error_messages[] = __( 'AMP cannot be enabled on password protected posts.', 'amp' );
 					}
-					if ( count( array_diff( $support_errors_codes, array( 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post' ) ) ) > 0 ) {
-						$support_errors[] = __( 'Unavailable for an unknown reason.', 'amp' );
+					if ( in_array( 'post-type-support', $errors, true ) ) {
+						/* translators: %s is URL to AMP settings screen */
+						$error_messages[] = wp_kses_post( sprintf( __( 'AMP cannot be enabled because this <a href="%s">post type does not support it</a>.', 'amp' ), esc_url( admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) ) ) );
 					}
-					echo implode( ' ', $support_errors ); // WPCS: xss ok.
+					if ( in_array( 'skip-post', $errors, true ) ) {
+						$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
+					}
+					if ( count( array_diff( $errors, array( 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post' ) ) ) > 0 ) {
+						$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
+					}
+					echo implode( ' ', $error_messages ); // WPCS: xss ok.
 					?>
 				</p>
 			</div>

--- a/templates/admin/amp-status.php
+++ b/templates/admin/amp-status.php
@@ -49,7 +49,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 							$error_messages[] = __( 'Your site does not allow AMP to be enabled.', 'amp' );
 						}
 					}
-					if ( in_array( 'template_unsupported', $errors, true ) ) {
+					if ( in_array( 'template_unsupported', $errors, true ) || in_array( 'no_matching_template', $errors, true ) ) {
 						/* translators: %s is URL to AMP settings screen */
 						$error_messages[] = wp_kses_post( sprintf( __( 'There are no <a href="%s">supported templates</a> to display this in AMP.', 'amp' ), esc_url( admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) ) ) );
 					}
@@ -63,7 +63,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 					if ( in_array( 'skip-post', $errors, true ) ) {
 						$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
 					}
-					if ( count( array_diff( $errors, array( 'status_immutable', 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template_unsupported' ) ) ) > 0 ) {
+					if ( count( array_diff( $errors, array( 'status_immutable', 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template_unsupported', 'no_matching_template' ) ) ) > 0 ) {
 						$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
 					}
 					echo implode( ' ', $error_messages ); // WPCS: xss ok.

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -316,6 +316,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \is_amp_endpoint()
 	 */
 	public function test_is_amp_endpoint() {
+		$this->go_to( get_permalink( $this->factory()->post->create() ) );
 		$this->assertFalse( is_amp_endpoint() );
 
 		// Legacy query var.

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -35,8 +35,8 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 	 * @covers \is_amp_endpoint()
 	 */
 	public function test__is_amp_endpoint() {
-		$user_id = $this->factory->user->create();
-		$post_id = $this->factory->post->create( array(
+		$user_id = $this->factory()->user->create();
+		$post_id = $this->factory()->post->create( array(
 			'post_author' => $user_id,
 		) );
 
@@ -58,6 +58,7 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->assertFalse( $after_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
 
 		add_theme_support( 'amp' );
+		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( is_amp_endpoint() );
 
 		// Make is_admin() true, as requests for an admin page aren't for AMP endpoints.

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -108,7 +108,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array $source_attributes   Source Attrs.
 	 * @param array $expected_attributes Expected Attrs.
 	 * @param array $args                Args.
-	 * @covers AMP_Base_Sanitizer::enforce_fixed_height()
+	 * @covers AMP_Base_Sanitizer::set_layout()
 	 */
 	public function test_set_layout( $source_attributes, $expected_attributes, $args = array() ) {
 		$sanitizer           = new AMP_Test_Stub_Sanitizer( new DOMDocument(), $args );
@@ -316,7 +316,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	/**
 	 * Tests set_attachment_layout_attributes.
 	 *
-	 * @covers AMP_Base_Sanitizer::set_attachment_layout_attributes()
+	 * @covers AMP_Base_Sanitizer::filter_attachment_layout_attributes()
 	 */
 	public function test_filter_attachment_layout_attributes() {
 		$sanitizer    = new AMP_Test_Stub_Sanitizer( new DOMDocument(), array() );

--- a/tests/test-class-amp-gfycat-embed-handler.php
+++ b/tests/test-class-amp-gfycat-embed-handler.php
@@ -19,6 +19,20 @@ class AMP_Gfycat_Embed_Test extends WP_UnitTestCase {
 		global $post;
 		parent::setUp();
 
+		// Mock the HTTP request.
+		add_filter( 'pre_http_request', function( $pre, $r, $url ) {
+			if ( false === strpos( $url, 'tautwhoppingcougar' ) ) {
+				return $pre;
+			}
+			return array(
+				'body'     => '{"version":"1.0","type":"video","provider_name":"https://gfycat.com","width":500,"height":281,"title":"Melanie Raccoon riding bike-side angle (reddit)","html":"<iframe src=\'https://gfycat.com/ifr/tautwhoppingcougar\' frameborder=\'0\' scrolling=\'no\' width=\'500\' height=\'281.25\'  allowfullscreen></iframe>"}',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}, 10, 3 );
+
 		/*
 		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
 		 * method would short-circuit when this is the case:

--- a/tests/test-class-amp-hulu-embed-handler.php
+++ b/tests/test-class-amp-hulu-embed-handler.php
@@ -19,6 +19,21 @@ class AMP_Hulu_Embed_Test extends WP_UnitTestCase {
 		global $post;
 		parent::setUp();
 
+		// Mock the HTTP request.
+		add_filter( 'pre_http_request', function( $pre, $r, $url ) {
+			unset( $r );
+			if ( false === strpos( $url, '771496' ) ) {
+				return $pre;
+			}
+			return array(
+				'body'     => '{"title":"Out of the Box / Run Down Race Car (Doc McStuffins)","author_name":"Disney Junior","type":"video","provider_name":"Hulu","air_date":"Fri Mar 23 00:00:00 UTC 2012","embed_url":"//www.hulu.com/embed.html?eid=_hHzwnAcj3RrXMJFDDvkuw","thumbnail_url":"http://ib.huluim.com/video/60528019?size=240x180&caller=h1o&img=i","width":500,"thumbnail_width":500,"provider_url":"//www.hulu.com/","thumbnail_height":375,"cache_age":3600,"version":"1.0","large_thumbnail_url":"http://ib.huluim.com/video/60528019?size=512x288&caller=h1o&img=i","height":289,"large_thumbnail_width":512,"html":"<iframe width=\\"500\\" height=\\"289\\" src=\\"//www.hulu.com/embed.html?eid=_hHzwnAcj3RrXMJFDDvkuw\\" frameborder=\\"0\\" scrolling=\\"no\\" webkitAllowFullScreen mozallowfullscreen allowfullscreen> </iframe>","duration":1446.25,"large_thumbnail_height":288}',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}, 10, 3 );
+
 		/*
 		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
 		 * method would short-circuit when this is the case:

--- a/tests/test-class-amp-imgur-embed-handler.php
+++ b/tests/test-class-amp-imgur-embed-handler.php
@@ -19,6 +19,21 @@ class AMP_Imgur_Embed_Test extends WP_UnitTestCase {
 		global $post;
 		parent::setUp();
 
+		// Mock the HTTP request.
+		add_filter( 'pre_http_request', function( $pre, $r, $url ) {
+			unset( $r );
+			if ( false === strpos( $url, 'f462IUj' ) ) {
+				return $pre;
+			}
+			return array(
+				'body'     => '{"version":"1.0","type":"rich","provider_name":"Imgur","provider_url":"https:\\/\\/imgur.com","width":500,"height":750,"html":"<blockquote class=\\"imgur-embed-pub\\" lang=\\"en\\" data-id=\\"f462IUj\\"><a href=\\"https:\\/\\/imgur.com\\/f462IUj\\">Getting that beach body ready<\\/a><\\/blockquote><script async src=\\"\\/\\/s.imgur.com\\/min\\/embed.js\\" charset=\\"utf-8\\"><\\/script>"}', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}, 10, 3 );
+
 		/*
 		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
 		 * method would short-circuit when this is the case:

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -114,7 +114,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();
-		$this->assertContains( 'no supported templates to display this in AMP.', strip_tags( $output ) );
+		$this->assertContains( 'no supported templates to display this in AMP.', wp_strip_all_tags( $output ) );
 		$this->assertNotContains( $checkbox_enabled, $output );
 
 		// User doesn't have the capability to display the metabox.

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -112,6 +112,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
+		AMP_Options_Manager::update_option( 'unrecognized_templates_supported', false );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -112,7 +112,6 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		AMP_Options_Manager::update_option( 'unrecognized_templates_supported', false );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -76,19 +76,19 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 * @see AMP_Settings::render_status()
 	 */
 	public function test_render_status() {
-		$post = $this->factory->post->create_and_get();
-		wp_set_current_user( $this->factory->user->create( array(
+		$post = $this->factory()->post->create_and_get();
+		wp_set_current_user( $this->factory()->user->create( array(
 			'role' => 'administrator',
 		) ) );
 		$amp_status_markup = '<div class="misc-pub-section misc-amp-status"';
 
-		// This is in AMP 'canonical mode,' so it shouldn't have the AMP status.
+		// This is in AMP 'native mode' so it shouldn't have the AMP status.
 		add_theme_support( 'amp' );
 		ob_start();
 		$this->instance->render_status( $post );
-		$this->assertNotContains( $amp_status_markup, ob_get_clean() );
+		$this->assertContains( $amp_status_markup, ob_get_clean() );
 
-		// This is not in AMP 'canonical mode'.
+		// This is not in AMP 'canonical mode', but rather classic mode.
 		remove_theme_support( 'amp' );
 		ob_start();
 		$this->instance->render_status( $post );
@@ -101,7 +101,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertEmpty( ob_get_clean() );
 
 		add_post_type_support( 'post', amp_get_slug() );
-		wp_set_current_user( $this->factory->user->create( array(
+		wp_set_current_user( $this->factory()->user->create( array(
 			'role' => 'subscriber',
 		) ) );
 

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -111,6 +111,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
+		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -92,18 +92,15 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$this->assertEquals(
 			array(
-				'theme_support'           => 'disabled',
-				'supported_post_types'    => array(
-					'post',
-				),
-				'analytics'               => array(),
-				'force_sanitization'      => false,
-				'accept_tree_shaking'     => false,
-				'disable_admin_bar'       => false,
-				'all_templates_supported' => true,
-				'supported_templates'     => array(
-					'is_singular',
-				),
+				'theme_support'                    => 'disabled',
+				'supported_post_types'             => array( 'post' ),
+				'analytics'                        => array(),
+				'force_sanitization'               => false,
+				'accept_tree_shaking'              => false,
+				'disable_admin_bar'                => false,
+				'all_templates_supported'          => true,
+				'unrecognized_templates_supported' => true,
+				'supported_templates'              => array( 'is_singular' ),
 			),
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -90,14 +90,18 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		AMP_Options_Manager::register_settings(); // Adds validate_options as filter.
 		delete_option( AMP_Options_Manager::OPTION_NAME );
-		$this->assertSame(
+		$this->assertEquals(
 			array(
-				'theme_support'        => 'disabled',
-				'supported_post_types' => array(),
-				'analytics'            => array(),
-				'force_sanitization'   => false,
-				'accept_tree_shaking'  => false,
-				'disable_admin_bar'    => false,
+				'theme_support'           => 'disabled',
+				'supported_post_types'    => array(),
+				'analytics'               => array(),
+				'force_sanitization'      => false,
+				'accept_tree_shaking'     => false,
+				'disable_admin_bar'       => false,
+				'all_templates_supported' => true,
+				'supported_templates'     => array(
+					'is_singular',
+				),
 			),
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -92,15 +92,14 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$this->assertEquals(
 			array(
-				'theme_support'                    => 'disabled',
-				'supported_post_types'             => array( 'post' ),
-				'analytics'                        => array(),
-				'force_sanitization'               => false,
-				'accept_tree_shaking'              => false,
-				'disable_admin_bar'                => false,
-				'all_templates_supported'          => true,
-				'unrecognized_templates_supported' => false,
-				'supported_templates'              => array( 'is_singular' ),
+				'theme_support'           => 'disabled',
+				'supported_post_types'    => array( 'post' ),
+				'analytics'               => array(),
+				'force_sanitization'      => false,
+				'accept_tree_shaking'     => false,
+				'disable_admin_bar'       => false,
+				'all_templates_supported' => true,
+				'supported_templates'     => array( 'is_singular' ),
 			),
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -93,7 +93,9 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'theme_support'           => 'disabled',
-				'supported_post_types'    => array(),
+				'supported_post_types'    => array(
+					'post',
+				),
 				'analytics'               => array(),
 				'force_sanitization'      => false,
 				'accept_tree_shaking'     => false,
@@ -210,6 +212,11 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 */
 	public function test_check_supported_post_type_update_errors() {
 		global $wp_settings_errors;
+		add_theme_support( 'amp' );
+		AMP_Options_Manager::update_option( 'all_templates_supported', false );
+		foreach ( get_post_types() as $post_type ) {
+			remove_post_type_support( $post_type, 'amp' );
+		}
 
 		register_post_type( 'foo', array(
 			'public' => true,

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -99,7 +99,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'accept_tree_shaking'              => false,
 				'disable_admin_bar'                => false,
 				'all_templates_supported'          => true,
-				'unrecognized_templates_supported' => true,
+				'unrecognized_templates_supported' => false,
 				'supported_templates'              => array( 'is_singular' ),
 			),
 			AMP_Options_Manager::get_options()

--- a/tests/test-class-amp-options-menu.php
+++ b/tests/test-class-amp-options-menu.php
@@ -77,7 +77,7 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 		// Test add_setting_field().
 		$this->assertArrayHasKey( 'amp-options', $wp_settings_fields );
 		$this->assertArrayHasKey( 'general', $wp_settings_fields['amp-options'] );
-		$this->assertArrayHasKey( 'supported_post_types', $wp_settings_fields['amp-options']['general'] );
+		$this->assertArrayHasKey( 'supported_templates', $wp_settings_fields['amp-options']['general'] );
 	}
 
 	/**

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -54,6 +54,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::add_post_type_support()
 	 */
 	public function test_add_post_type_support() {
+		remove_theme_support( 'amp' );
 		register_post_type( 'book', array(
 			'label'  => 'Book',
 			'public' => true,
@@ -62,7 +63,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 			'label'  => 'Poem',
 			'public' => true,
 		) );
-		AMP_Options_Manager::update_option( 'supported_post_types', array( 'poem' ) );
+		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post', 'poem' ) );
 
 		AMP_Post_Type_Support::add_post_type_support();
 		$this->assertTrue( post_type_supports( 'post', amp_get_slug() ) );
@@ -76,6 +77,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::get_support_errors()
 	 */
 	public function test_get_support_error() {
+		remove_theme_support( 'amp' );
 		register_post_type( 'book', array(
 			'label'  => 'Book',
 			'public' => true,

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -23,15 +23,6 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_builtin_supported_post_types.
-	 *
-	 * @covers AMP_Post_Type_Support::get_builtin_supported_post_types()
-	 */
-	public function test_get_builtin_supported_post_types() {
-		$this->assertEquals( array( 'post' ), AMP_Post_Type_Support::get_builtin_supported_post_types() );
-	}
-
-	/**
 	 * Test get_eligible_post_types.
 	 *
 	 * @covers AMP_Post_Type_Support::get_eligible_post_types()
@@ -46,10 +37,11 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 			'public' => false,
 		) );
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'post',
 				'page',
+				'attachment',
 				'book',
 			),
 			AMP_Post_Type_Support::get_eligible_post_types()

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -311,9 +311,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 		AMP_Theme_Support::add_amp_template_filters();
 		foreach ( $template_types as $template_type ) {
-			$this->assertEquals( 10, has_filter( "{$template_type}_template_hierarchy", array( self::TESTED_CLASS, 'filter_paired_template_hierarchy' ) ) );
+			$this->assertEquals( 10, has_filter( "{$template_type}_template_hierarchy", array( self::TESTED_CLASS, 'filter_amp_template_hierarchy' ) ) );
 		}
-		$this->assertEquals( 100, has_filter( 'template_include', array( self::TESTED_CLASS, 'filter_paired_template_include' ) ) );
 	}
 
 	/**
@@ -774,30 +773,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'single.php',
 		);
 		$filtered_templates = AMP_Theme_Support::filter_amp_template_hierarchy( $templates );
-		foreach ( $filtered_templates as $key => $filtered_template ) {
-			$this->assertEquals( $template_dir . '/' . $templates[ $key ], $filtered_template );
-		}
-	}
 
-	/**
-	 * Test filter_paired_template_include.
-	 *
-	 * @covers AMP_Theme_Support::filter_amp_template_include()
-	 */
-	public function test_filter_paired_template_include() {
-		$template_dir = 'amp-templates';
-		$template     = 'single.php';
-		add_theme_support( 'amp', array(
-			'template_dir' => $template_dir,
-		) );
-		$this->assertEquals( $template, AMP_Theme_Support::filter_amp_template_include( $template ) );
-		remove_theme_support( 'amp' );
-		try {
-			AMP_Theme_Support::filter_amp_template_include( $template );
-		} catch ( Exception $exception ) {
-			$e = $exception;
+		$expected_templates = array();
+		foreach ( $templates as $template ) {
+			$expected_templates[] = $template_dir . '/' . $template;
+			$expected_templates[] = $template;
 		}
-		$this->assertTrue( isset( $e ) );
+
+		$this->assertEquals( $expected_templates, $filtered_templates );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -92,7 +92,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		} catch ( Exception $exception ) {
 			$e = $exception;
 		}
-		$this->assertEquals( 'Expected AMP theme support to only have template_dir and/or available_callback.', $e->getMessage() );
+		$this->assertStringStartsWith( 'Expected AMP theme support to keys', $e->getMessage() );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -425,8 +425,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// @todo Test with query, post, or page.
 		// @todo Test without availability of WP_Query (no_query_available).
 		// @todo Test without theme support (no_theme_support).
-		// @todo Test unrecognized by theme support arg.
-		// @todo Test unrecognized.
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -298,7 +298,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	/**
 	 * Test register_paired_hooks.
 	 *
-	 * @covers AMP_Theme_Support::register_paired_hooks()
+	 * @covers AMP_Theme_Support::add_amp_template_filters()
 	 */
 	public function test_register_paired_hooks() {
 		$template_types = array(
@@ -309,7 +309,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'author',
 			'category',
 		);
-		AMP_Theme_Support::register_paired_hooks();
+		AMP_Theme_Support::add_amp_template_filters();
 		foreach ( $template_types as $template_type ) {
 			$this->assertEquals( 10, has_filter( "{$template_type}_template_hierarchy", array( self::TESTED_CLASS, 'filter_paired_template_hierarchy' ) ) );
 		}
@@ -761,7 +761,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	/**
 	 * Test filter_paired_template_hierarchy.
 	 *
-	 * @covers AMP_Theme_Support::filter_paired_template_hierarchy()
+	 * @covers AMP_Theme_Support::filter_amp_template_hierarchy()
 	 */
 	public function test_filter_paired_template_hierarchy() {
 		$template_dir = 'amp-templates';
@@ -773,7 +773,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'single-post.php',
 			'single.php',
 		);
-		$filtered_templates = AMP_Theme_Support::filter_paired_template_hierarchy( $templates );
+		$filtered_templates = AMP_Theme_Support::filter_amp_template_hierarchy( $templates );
 		foreach ( $filtered_templates as $key => $filtered_template ) {
 			$this->assertEquals( $template_dir . '/' . $templates[ $key ], $filtered_template );
 		}
@@ -782,7 +782,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	/**
 	 * Test filter_paired_template_include.
 	 *
-	 * @covers AMP_Theme_Support::filter_paired_template_include()
+	 * @covers AMP_Theme_Support::filter_amp_template_include()
 	 */
 	public function test_filter_paired_template_include() {
 		$template_dir = 'amp-templates';
@@ -790,10 +790,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support( 'amp', array(
 			'template_dir' => $template_dir,
 		) );
-		$this->assertEquals( $template, AMP_Theme_Support::filter_paired_template_include( $template ) );
+		$this->assertEquals( $template, AMP_Theme_Support::filter_amp_template_include( $template ) );
 		remove_theme_support( 'amp' );
 		try {
-			AMP_Theme_Support::filter_paired_template_include( $template );
+			AMP_Theme_Support::filter_amp_template_include( $template );
 		} catch ( Exception $exception ) {
 			$e = $exception;
 		}

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -264,11 +264,15 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
 		remove_filter( 'amp_skip_post', '__return_true' );
 
-		// Check that available_callback works.
+		// Check that mode=paired works.
 		add_theme_support( 'amp', array(
-			'template_dir'       => 'amp-templates',
-			'available_callback' => 'is_singular',
+			'mode' => 'paired',
 		) );
+		add_filter( 'amp_supportable_templates', function( $supportable_templates ) {
+			$supportable_templates['is_singular']['supported'] = true;
+			$supportable_templates['is_search']['supported']   = false;
+			return $supportable_templates;
+		} );
 		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
 		$this->assertTrue( is_singular() );
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
@@ -1067,6 +1071,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::finish_init();
 		$wp_widget_factory = new WP_Widget_Factory();
 		wp_widgets_init();
+
+		$this->assertTrue( is_amp_endpoint() );
 
 		add_action( 'wp_enqueue_scripts', function() {
 			wp_enqueue_script( 'amp-list' );

--- a/tests/test-class-amp-widget-archives.php
+++ b/tests/test-class-amp-widget-archives.php
@@ -33,6 +33,16 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
+	}
+
+	/**
 	 * Test construct().
 	 *
 	 * @see AMP_Widget_Archives::__construct().

--- a/tests/test-class-amp-widget-archives.php
+++ b/tests/test-class-amp-widget-archives.php
@@ -62,6 +62,7 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	 * @see AMP_Widget_Archives::widget().
 	 */
 	public function test_widget() {
+		$this->assertTrue( is_amp_endpoint() );
 		$arguments = array(
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',

--- a/tests/test-class-amp-widget-categories.php
+++ b/tests/test-class-amp-widget-categories.php
@@ -62,6 +62,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	 * @covers AMP_Widget_Categories::widget()
 	 */
 	public function test_widget() {
+		$this->assertTrue( is_amp_endpoint() );
 		$arguments = array(
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',

--- a/tests/test-class-amp-widget-categories.php
+++ b/tests/test-class-amp-widget-categories.php
@@ -15,7 +15,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	/**
 	 * Instance of the widget.
 	 *
-	 * @var object.
+	 * @var AMP_Widget_Categories
 	 */
 	public $widget;
 
@@ -26,10 +26,20 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		add_theme_support( 'amp ' );
+		add_theme_support( 'amp' );
 		wp_maybe_load_widgets();
 		AMP_Theme_Support::init();
 		$this->widget = new AMP_Widget_Categories();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
 	}
 
 	/**

--- a/tests/test-class-amp-widget-media-video.php
+++ b/tests/test-class-amp-widget-media-video.php
@@ -17,7 +17,7 @@ class Test_AMP_Widget_Media_Video extends WP_UnitTestCase {
 	/**
 	 * Instance of the widget.
 	 *
-	 * @var object.
+	 * @var AMP_Widget_Media_Video.
 	 */
 	public $widget;
 
@@ -34,6 +34,17 @@ class Test_AMP_Widget_Media_Video extends WP_UnitTestCase {
 		parent::setUp();
 		wp_maybe_load_widgets();
 		$this->widget = new $class();
+		add_theme_support( 'amp' );
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
 	}
 
 	/**
@@ -42,6 +53,7 @@ class Test_AMP_Widget_Media_Video extends WP_UnitTestCase {
 	 * @covers AMP_Widget_Media_Video::inject_video_max_width_style()
 	 */
 	public function test_inject_video_max_width_style() {
+		$this->assertTrue( is_amp_endpoint() );
 		$video           = '<video src="http://example.com" height="100" width="200"></video>';
 		$video_no_height = '<video src="http://example.com" width="200"></video>';
 		$this->assertEquals( $video, $this->widget->inject_video_max_width_style( $video ) );

--- a/tests/test-class-amp-widget-text.php
+++ b/tests/test-class-amp-widget-text.php
@@ -34,6 +34,17 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 		parent::setUp();
 		wp_maybe_load_widgets();
 		$this->widget = new $class();
+		add_theme_support( 'amp' );
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_theme_support( 'amp' );
 	}
 
 	/**
@@ -42,7 +53,7 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 	 * @covers AMP_Widget_Text::inject_video_max_width_style()
 	 */
 	public function test_inject_video_max_width_style() {
-		add_theme_support( 'amp' );
+		$this->assertTrue( is_amp_endpoint() );
 		$video            = '<video src="http://example.com" height="100" width="200"></video>';
 		$video_only_width = '<video src="http://example.com/this-video" width="500">';
 		$this->assertEquals( $video, $this->widget->inject_video_max_width_style( array( $video ) ) );


### PR DESCRIPTION
It's been a journey trying to figure out the best way to empower both end users and theme developers over which parts of their site are served as AMP, and whether AMP is served as canonical or is available in paired mode.

ℹ️  The commits in this PR will be squashed/rebased when merged, so please excuse the messy commit history in this branch.

When in native/paired template modes, the Post Types section of the admin screen is extended to also display a selection of the templates for which AMP can be served on the site:

![image](https://user-images.githubusercontent.com/134745/42108208-b4e2d6b6-7b8e-11e8-9f41-bbc1292967db.png)

The supportable templates are organized hierarchically according to the WordPress template hierarchy, so you enable the Category template for AMP but the general Archives template is disabled, then the Category template status will override the Archives template status.

The available templates can be amended via the `amp_supportable_templates` filter. This filter can also be used by a theme/plugin to force AMP to be enabled or disabled for a given template, such as here to forbid AMP from the Category templates (since maybe they have some required custom JS):

```php
add_filter( 'amp_supportable_templates', function( $templates ) {
	$templates['is_category']['supported'] = false;
	return $templates;
} );
```

Or to force AMP to be enabled for the author template:

```php
add_filter( 'amp_supportable_templates', function( $templates ) {
	$templates['is_author']['supported'] = false;
	return $templates;
} );
``` 

You can use this filter to add new templates as well. For example if you wanted to give the user control over the year archive template (take note of the `parent`):

```php
add_filter( 'amp_supportable_templates', function( $templates ) {
	$templates['is_year'] = array(
		'label'  => __( 'Year', 'example' ),
		'parent' => 'is_date',
	);
	return $templates;
} );
```

That then is presented as:

![image](https://user-images.githubusercontent.com/134745/42108645-fece289c-7b8f-11e8-83ce-4910119edf00.png)

Lastly, there is a checkbox to automatically serve all templates and post types as AMP:

![image](https://user-images.githubusercontent.com/134745/42108684-1928ccec-7b90-11e8-9585-460f5266c7eb.png)

The availability of this option may will be determined whether or not a theme/plugin is forcibly setting the supported status for a given template.

You may also force all templates to be served as AMP at the theme support level:

```php
add_theme_support( 'amp', array(
    'templates_supported' => 'all'
) );
```

Or force certain templates to be supported or unsupported:

```php
add_theme_support( 'amp', array(
    'templates_supported' => array(
        'is_category' => false,
        'is_author' => true,
    )
) );
```

# Changelog Summary

* The template hierarchy is now exposed in the admin screen allowing the user to specify which kinds of templates should be served as AMP.
* The `amp_supportable_templates` filter allows you to customize the template hierarchy, add recognition for new template types, and force certain templates to be supported or forbidden in AMP.
* There is a new `templates_supported` arg on the `amp` theme support which can take a value of 'all' to force AMP to be available on all templates, or else an array mapping template IDs (e.g. `is_search`) to whether they are supported.
* The “Post” post type can now be turned off instead of always being forcibly enabled. 
* When `amp` theme support is present, the static homepage and page for posts are both enabled by default, as are pages with custom templates assigned.
* The template mode is now explicitly indicated via a `mode` theme support arg, which can either be `native` or `paired`.
* The `template_dir` can now be used in native mode as well.
* You can now define `add_theme_support( 'amp', array( 'mode' => 'native', 'optional' => true ) )` where the `optional` flag allows you to bypass actually activating the support in code, but forcing the mode to be `native` if they do add support. This allows the user to define `comments_live_list` in the theme without forcing AMP support to be present.
* Loading AMP component scripts has been restored on a native-mode site where AMP content appears on a non-AMP page.
* The `post_supports_amp()` logic has been consolidated into `AMP_Post_Type_Support::get_support_errors()`.
* ❗️ Breaking change: The `available_callback` has been eliminated.
* The restriction that `is_amp_endpoint()` cannot be called prior to `parse_query` action has been restored.

# Todo

- [x] Determine how a theme can force AMP to be used on all templates. If `mode` is `native` and AMP components are being used in all templates, then the theme needs to force all responses to be AMP. This could be done by a theme setting `supported` to true for all the `amp_supportable_templates`, but it seems there should be an easier way.
- [x] Add an “other” option to determine if AMP gets served by default for any templates not explicitly called out. This would be used in particular for `template_redirect` templates that are not loaded normally.
- [x] Address todos.
- [x] Should there be a way for a theme to explicitly mark templates as requiring for AMP other than by using the filter? An `all_templates_supported` flag on the theme support as a shortcut for using the filter? There could be a `templates_supported` arg when defining theme support which can take either `'all'` or an array of the template conditions which then become immutable.
- [x] Restore facilitation of serving AMP components in non-AMP documents if mode is native.

Fixes #934.