### PR TITLE
Ensure redirect is only done if there are unsanitized errors

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1654,7 +1654,7 @@ class AMP_Theme_Support {
 			if ( isset( $response_cache['body'] ) ) {
 
 				// Redirect to non-AMP version.
-				if ( ! amp_is_canonical() ) {
+				if ( ! amp_is_canonical() && $blocking_error_count > 0 ) {
 					if ( AMP_Validation_Manager::has_cap() ) {
 						$ampless_url = add_query_arg( AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR, $blocking_error_count, $ampless_url );
 					}


### PR DESCRIPTION
In testing, I was seeing something unexpected on a paired install. When accessing `?amp` I was getting redirected to `?amp_validation_errors=0`. It's clear why.

Follow-up on #1207 

