### PR TITLE
Use $mode_mutable to only disable Template Mode <input> elements in some cases.

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -154,7 +154,7 @@ class AMP_Options_Menu {
 			<?php endif; ?>
 			<dl>
 				<dt>
-					<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="disabled" <?php checked( $theme_support, 'disabled' ); ?> <?php disabled( ! $theme_support_mutable ); ?>>
+					<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="disabled" <?php checked( $theme_support, 'disabled' ); ?> <?php disabled( ! $mode_mutable ); ?>>
 					<label for="theme_support_disabled">
 						<strong><?php esc_html_e( 'Classic', 'amp' ); ?></strong>
 					</label>
@@ -164,7 +164,7 @@ class AMP_Options_Menu {
 				</dd>
 				<?php if ( $mode_mutable || 'paired' === $support_args['mode'] ) : ?>
 					<dt>
-						<input type="radio" id="theme_support_paired" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, 'paired' ); ?> <?php disabled( ! $theme_support_mutable ); ?>>
+						<input type="radio" id="theme_support_paired" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, 'paired' ); ?> <?php disabled( ! $mode_mutable ); ?>>
 						<label for="theme_support_paired">
 							<strong><?php esc_html_e( 'Paired', 'amp' ); ?></strong>
 						</label>
@@ -175,7 +175,7 @@ class AMP_Options_Menu {
 				<?php endif; ?>
 				<?php if ( $mode_mutable || 'native' === $support_args['mode'] ) : ?>
 					<dt>
-						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?> <?php disabled( ! $theme_support_mutable ); ?>>
+						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?> <?php disabled( ! $mode_mutable ); ?>>
 						<label for="theme_support_native">
 							<strong><?php esc_html_e( 'Native', 'amp' ); ?></strong>
 						</label>


### PR DESCRIPTION
**Request For Review**

Hi @westonruter,
Could you please review this PR for #1245? It might not be the correct solution. 

But it worked locally to avoid disabling the `<input>` elements for the Template Modes.

If I understand this right, it looks like the `<input>` elements for "Classic," "Paired," and "Native" should only be disabled (or hidden) if the theme passes a `'mode'` argument, like:
```php
add_theme_support( 'amp', array(
	'mode' => 'native',
) );
```
Then, it would look like:
<img width="1273" alt="theme-support-mode" src="https://user-images.githubusercontent.com/4063887/42242901-29140f66-7ed5-11e8-96a3-4aca3a0e5198.png">


Still, I might not have understood the intent.