### PR TITLE
Keep the Template Mode of Classic if selected, and the theme doesn't override it

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -136,7 +136,7 @@ class AMP_Options_Menu {
 
 		$mode_mutable = ! isset( $support_args['mode'] );
 
-		if ( ! $theme_support_mutable || ( ! $mode_mutable && 'disabled' !== $theme_support ) ) {
+		if ( ( ! $theme_support_mutable && 'disabled' !== $theme_support ) || ! $mode_mutable ) {
 			$theme_support = isset( $support_args['mode'] ) ? $support_args['mode'] : 'native';
 		}
 


### PR DESCRIPTION
**Request For Review**

Hi @westonruter,
Could you please review this, which addresses the issue in [#1246 (comment)](https://github.com/Automattic/amp-wp/pull/1246#issuecomment-402288725)? There are steps to reproduce there.

This might not be the right solution. But this allows displaying the Template Mode of "Classic." 

It also seems to still have the right behavior if a theme adds a `'mode'` argument, like:

```php
add_theme_support( 'amp', array(
	'comments_live_list' => true,
	'mode'               => 'native',
) );
```

In that example, it forces Native mode, even if Classic (disabled) is actually saved as the option. This is the same behavior as before this commit.

<img width="927" alt="theme-native-forced" src="https://user-images.githubusercontent.com/4063887/42251297-2a5d1c2e-7efc-11e8-8eef-286217076e6c.png">

Still, I might have overlooked other use-cases, or the intent of that line of code.
