### PR TITLE
Simplify theme support args

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -278,12 +278,24 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *
  *      add_theme_support( 'amp' );
  *
- * This will serve templates in native AMP by default but the user would be able to change the template mode
- * from native to paired in the admin. To force only native to be available, such as when you are using AMP components
- * in your theme templates, do:
+ * This will serve templates in native AMP, allowing you to use AMP components in your theme templates.
+ * If you want to make available in paired mode, where templates are served in AMP or non-AMP documents, do:
  *
  *      add_theme_support( 'amp', array(
- *          'mode' => 'native',
+ *          'paired' => true,
+ *      ) );
+ *
+ * Paired mode is also implied if you define a template_dir:
+ *
+ *      add_theme_support( 'amp', array(
+ *          'template_dir' => 'amp',
+ *      ) );
+ *
+ * If you want to have AMP-specific templates in addition to serving native AMP, do:
+ *
+ *      add_theme_support( 'amp', array(
+ *          'paired'       => false,
+ *          'template_dir' => 'amp',
  *      ) );
  *
  * If you want to force AMP to always be served on a given template, you can use the templates_supported arg,
@@ -309,30 +321,13 @@ function amp_is_canonical() {
 		return false;
 	}
 
-	$mode    = 'native';
-	$support = get_theme_support( 'amp' );
-	if ( is_array( $support ) ) {
-		$args    = array_shift( $support );
-		$support = AMP_Options_Manager::get_option( 'theme_support' );
-
-		// If support is optional, look at DB option if mode is not explicitly set in theme support.
-		if ( ! empty( $args['optional'] ) ) {
-			if ( 'disabled' === $support ) {
-				return false;
-			} elseif ( ! isset( $args['mode'] ) ) {
-				return 'native' === $support;
-			}
-		}
-
-		if ( isset( $args['mode'] ) ) {
-			$mode = $args['mode'];
-		} elseif ( 'disabled' !== $support ) {
-			$mode = $support; // Supplied via admin screen.
-		} elseif ( ! empty( $args['template_dir'] ) ) {
-			$mode = 'paired'; // If there is a template_dir, then paired mode is implied.
-		}
+	$args = AMP_Theme_Support::get_theme_support_args();
+	if ( isset( $args['paired'] ) ) {
+		return empty( $args['paired'] );
 	}
-	return 'native' === $mode;
+
+	// If there is a template_dir, then paired mode is implied.
+	return empty( $args['template_dir'] );
 }
 
 /**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1612,6 +1612,8 @@ class AMP_Theme_Support {
 					! ( defined( 'WP_DEBUG' ) && WP_DEBUG )
 					&&
 					! AMP_Validation_Manager::should_validate_response()
+					&&
+					! is_customize_preview()
 				),
 				'user_can_validate'       => AMP_Validation_Manager::has_cap(),
 			),
@@ -1741,7 +1743,7 @@ class AMP_Theme_Support {
 		$dom_serialize_start = microtime( true );
 		self::ensure_required_markup( $dom );
 
-		if ( ! AMP_Validation_Manager::should_validate_response() && $blocking_error_count > 0 ) {
+		if ( ! AMP_Validation_Manager::should_validate_response() && $blocking_error_count > 0 && ! self::is_customize_preview_iframe() ) {
 
 			// Note the canonical check will not currently ever be met because dirty AMP is not yet supported; all validation errors will forcibly be sanitized.
 			if ( amp_is_canonical() ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -94,7 +94,7 @@ class AMP_Theme_Support {
 	 * Theme support options that were added via option.
 	 *
 	 * @since 1.0
-	 * @var false|array
+	 * @var bool
 	 */
 	protected static $support_added_via_option = false;
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -91,19 +91,6 @@ class AMP_Theme_Support {
 	protected static $is_output_buffering = false;
 
 	/**
-	 * Original theme support args prior to being read.
-	 *
-	 * This is needed to be able to properly populate the admin screen with AMP options defined by theme support
-	 * when the theme support is optional and disabled in the admin. For example, it allows for the original
-	 * template `mode` from the theme support to be displayed in the admin screen even though read_theme_support
-	 * may have removed the `optional` the theme support.
-	 *
-	 * @see AMP_Theme_Support::read_theme_support()
-	 * @var array
-	 */
-	protected static $initial_theme_support_args = array();
-
-	/**
 	 * Theme support options that were added via option.
 	 *
 	 * @since 1.0
@@ -144,107 +131,77 @@ class AMP_Theme_Support {
 	}
 
 	/**
-	 * Determine whether theme support was added via option.
+	 * Determine whether theme support was added via admin option.
 	 *
 	 * @since 1.0
-	 * @return bool Optional support added.
+	 * @see AMP_Theme_Support::read_theme_support()
+	 *
+	 * @return bool Support added via option.
 	 */
 	public static function is_support_added_via_option() {
-		return false !== self::$support_added_via_option;
+		return self::$support_added_via_option;
 	}
 
 	/**
-	 * Read theme support and apply options from admin for whether theme support is enabled and via what template is enabled.
+	 * Check theme support args or add theme support if option is set in the admin.
 	 *
+	 * The DB option is only considered if the theme does not already explicitly support AMP.
+	 *
+	 * @see AMP_Theme_Support::is_support_added_via_option()
 	 * @see AMP_Post_Type_Support::add_post_type_support() For where post type support is added, since it is irrespective of theme support.
 	 */
 	public static function read_theme_support() {
-		self::$support_added_via_option = false;
-
-		self::$initial_theme_support_args = false;
-		if ( current_theme_supports( 'amp' ) ) {
-			self::$initial_theme_support_args = array();
-
-			$support = get_theme_support( 'amp' );
-			if ( is_array( $support ) ) {
-				self::$initial_theme_support_args = array_shift( $support );
-
-				// Validate theme support usage.
-				$keys = array( 'template_dir', 'comments_live_list', 'mode', 'optional', 'templates_supported', 'available_callback' );
-				if ( ! is_array( self::$initial_theme_support_args ) ) {
-					self::$initial_theme_support_args = array();
-					_doing_it_wrong( 'add_theme_support', esc_html__( 'Expected AMP theme support arg to be array.', 'amp' ), '1.0' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-				} elseif ( count( array_diff( array_keys( self::$initial_theme_support_args ), $keys ) ) !== 0 ) {
-					_doing_it_wrong( 'add_theme_support', esc_html( sprintf(  // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-						/* translators: %1$s is expected keys and %2$s is actual keys */
-						__( 'Expected AMP theme support to keys (%1$s) but saw (%2$s)', 'amp' ),
-						join( ', ', $keys ),
-						join( ', ', array_keys( self::$initial_theme_support_args ) )
-					) ), '1.0' );
-				}
-
-				if ( isset( self::$initial_theme_support_args['available_callback'] ) ) {
-					_doing_it_wrong( 'add_theme_support', esc_html__( 'The available_callback is deprecated when adding amp theme support in favor of declaratively setting the supported_templates.', 'amp' ), '1.0' );
-				}
-			}
-		}
-
 		$theme_support_option = AMP_Options_Manager::get_option( 'theme_support' );
-		$theme_support_args   = self::$initial_theme_support_args;
+		if ( current_theme_supports( 'amp' ) ) {
+			$args = self::get_theme_support_args();
 
-		// If theme support is present in the theme, but it is marked as optional, then go ahead and remove it if theme support is not enabled in the admin.
-		if ( current_theme_supports( 'amp' ) && ! empty( $theme_support_args['optional'] ) && 'disabled' === $theme_support_option ) {
-			remove_theme_support( 'amp' );
-			return;
-		}
+			// Validate theme support usage.
+			$keys = array( 'template_dir', 'comments_live_list', 'paired', 'templates_supported', 'available_callback' );
 
-		if ( ! $theme_support_args ) {
-			$theme_support_args = array();
-		}
-
-		// If theme support is not present (or it is optional), then allow it to be added via the admin.
-		if ( ! current_theme_supports( 'amp' ) || ! empty( $theme_support_args['optional'] ) ) {
-			if ( 'disabled' === $theme_support_option ) {
-				return;
+			if ( count( array_diff( array_keys( $args ), $keys ) ) !== 0 ) {
+				_doing_it_wrong( 'add_theme_support', esc_html( sprintf(  // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+					/* translators: %1$s is expected keys and %2$s is actual keys */
+					__( 'Expected AMP theme support to keys (%1$s) but saw (%2$s)', 'amp' ),
+					join( ', ', $keys ),
+					join( ', ', array_keys( $args ) )
+				) ), '1.0' );
 			}
 
-			$option_args = array(
-				'mode' => $theme_support_option,
-			);
-			add_theme_support( 'amp', array_merge( $option_args, $theme_support_args ) );
-			self::$support_added_via_option = $option_args;
+			if ( isset( $args['available_callback'] ) ) {
+				_doing_it_wrong( 'add_theme_support', esc_html__( 'The available_callback is deprecated when adding amp theme support in favor of declaratively setting the supported_templates.', 'amp' ), '1.0' );
+			}
+			self::$support_added_via_option = false;
+		} elseif ( 'disabled' !== $theme_support_option ) {
+			add_theme_support( 'amp', array(
+				'paired' => ( 'paired' === $theme_support_option ),
+			) );
+			self::$support_added_via_option = true;
 		}
 	}
 
 	/**
 	 * Get the theme support args.
 	 *
+	 * This avoids having to repeatedly call `get_theme_support()`, check the args, shift an item off the array, and so on.
+	 *
 	 * @since 1.0
 	 *
-	 * @param array $options Options.
-	 * @return array|false Theme support args.
+	 * @return array|false Theme support args, or false if theme support is not present.
 	 */
-	public static function get_theme_support_args( $options = array() ) {
-		$options = array_merge(
-			array( 'initial' => false ),
-			$options
-		);
-
-		if ( $options['initial'] ) {
-			return self::$initial_theme_support_args;
-		}
-
+	public static function get_theme_support_args() {
 		if ( ! current_theme_supports( 'amp' ) ) {
 			return false;
 		}
-
-		$theme_support_args = get_theme_support( 'amp' );
-		if ( is_array( $theme_support_args ) ) {
-			$theme_support_args = array_shift( $theme_support_args );
-		} else {
-			$theme_support_args = array();
+		$support = get_theme_support( 'amp' );
+		if ( true === $support ) {
+			return array(
+				'paired' => false,
+			);
 		}
-		return $theme_support_args;
+		if ( ! isset( $support[0] ) || ! is_array( $support[0] ) ) {
+			return array();
+		}
+		return $support[0];
 	}
 
 	/**
@@ -738,8 +695,7 @@ class AMP_Theme_Support {
 		 */
 		$templates = apply_filters( 'amp_supportable_templates', $templates );
 
-		// Obtain the initial template supported state by theme support flag.
-		$theme_support_args        = self::get_theme_support_args( array( 'initial' => true ) );
+		$theme_support_args        = self::get_theme_support_args();
 		$theme_supported_templates = array();
 		if ( isset( $theme_support_args['templates_supported'] ) ) {
 			$theme_supported_templates = $theme_support_args['templates_supported'];

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -211,6 +211,12 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_init() {
 		if ( ! is_amp_endpoint() ) {
+
+			// Redirect to AMP-less variable if AMP is not available for this URL and yet the query var is present.
+			if ( isset( $_GET[ amp_get_slug() ] ) ) { // WPCS: csrf ok.
+				self::redirect_ampless_url();
+			}
+
 			amp_add_frontend_actions();
 			return;
 		}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -134,7 +134,7 @@ class AMP_Options_Manager {
 			}
 		}
 
-		$theme_support_args = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
 
 		$is_template_support_required = ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] );
 		if ( ! $is_template_support_required && ! isset( $theme_support_args['available_callback'] ) ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -125,67 +125,62 @@ class AMP_Options_Menu {
 	 * @since 1.0
 	 */
 	public function render_theme_support() {
-		$theme_support = AMP_Options_Manager::get_option( 'theme_support' );
-		$support_args  = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) );
-
-		$theme_support_mutable = (
-			! empty( $support_args['optional'] )
-			||
-			AMP_Theme_Support::is_support_added_via_option()
-		);
-
-		$mode_mutable = ! isset( $support_args['mode'] );
-
-		if ( ! $theme_support_mutable || ( ! $mode_mutable && 'disabled' !== $theme_support ) ) {
-			$theme_support = isset( $support_args['mode'] ) ? $support_args['mode'] : 'native';
-		}
-
-		$should_have_theme_support = in_array( get_template(), array( 'twentyfifteen', 'twentysixteen', 'twentyseventeen' ), true );
+		$theme_support      = AMP_Options_Manager::get_option( 'theme_support' );
+		$paired_description = __( 'Reuses active theme\'s templates to display AMP responses, but uses separate URLs for AMP. The canonical URLs for your site will not have AMP. If there are AMP validation errors encountered in the AMP response and the validation errors are not accepted for sanitization, then the AMP version will redirect to the non-AMP version.', 'amp' );
+		$native_description = __( 'Reuses active theme\'s templates to display AMP responses but does not use separate URLs for AMP. Your canonical URLs are AMP. AMP-specific blocks are available for inserting into content. Any AMP validation errors are automatically sanitized.', 'amp' );
+		$builtin_support    = in_array( get_template(), array( 'twentyfifteen', 'twentysixteen', 'twentyseventeen' ), true );
 		?>
-		<fieldset>
-			<?php if ( current_theme_supports( 'amp' ) && ! $theme_support_mutable ) : ?>
-				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
-				</div>
-			<?php elseif ( $should_have_theme_support ) : ?>
-				<div class="notice notice-success notice-alt inline">
-					<p><?php esc_html_e( 'Your active theme is known to work well in paired or native mode.', 'amp' ); ?></p>
-				</div>
-			<?php endif; ?>
-			<dl>
-				<dt>
-					<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="disabled" <?php checked( $theme_support, 'disabled' ); ?> <?php disabled( ! $mode_mutable ); ?>>
-					<label for="theme_support_disabled">
-						<strong><?php esc_html_e( 'Classic', 'amp' ); ?></strong>
-					</label>
-				</dt>
-				<dd>
-					<?php esc_html_e( 'Display AMP responses in classic (legacy) post templates in a basic design that does not match your theme\'s templates.', 'amp' ); ?>
-				</dd>
-				<?php if ( $mode_mutable || 'paired' === $support_args['mode'] ) : ?>
+		<?php if ( current_theme_supports( 'amp' ) && ! AMP_Theme_Support::is_support_added_via_option() ) : ?>
+			<div class="notice notice-info notice-alt inline">
+				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
+			</div>
+			<p>
+				<?php if ( amp_is_canonical() ) : ?>
+					<strong><?php esc_html_e( 'Native:', 'amp' ); ?></strong>
+					<?php echo esc_html( $native_description ); ?>
+				<?php else : ?>
+					<strong><?php esc_html_e( 'Paired:', 'amp' ); ?></strong>
+					<?php echo esc_html( $paired_description ); ?>
+				<?php endif; ?>
+			</p>
+		<?php else : ?>
+			<fieldset>
+				<?php if ( $builtin_support ) : ?>
+					<div class="notice notice-success notice-alt inline">
+						<p><?php esc_html_e( 'Your active theme is known to work well in paired or native mode.', 'amp' ); ?></p>
+					</div>
+				<?php endif; ?>
+				<dl>
 					<dt>
-						<input type="radio" id="theme_support_paired" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, 'paired' ); ?> <?php disabled( ! $mode_mutable ); ?>>
+						<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="disabled" <?php checked( $theme_support, 'disabled' ); ?>>
+						<label for="theme_support_disabled">
+							<strong><?php esc_html_e( 'Classic', 'amp' ); ?></strong>
+						</label>
+					</dt>
+					<dd>
+						<?php esc_html_e( 'Display AMP responses in classic (legacy) post templates in a basic design that does not match your theme\'s templates.', 'amp' ); ?>
+					</dd>
+					<dt>
+						<input type="radio" id="theme_support_paired" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, 'paired' ); ?>>
 						<label for="theme_support_paired">
 							<strong><?php esc_html_e( 'Paired', 'amp' ); ?></strong>
 						</label>
 					</dt>
 					<dd>
-						<?php esc_html_e( 'Reuse active theme\'s templates to display AMP responses, but use separate URLs for AMP. The canonical URLs for your site will not have AMP. If there are AMP validation errors encountered in the AMP response and the validation errors are not accepted for sanitization, then the AMP version will redirect to the non-AMP version.', 'amp' ); ?>
+						<?php echo esc_html( $paired_description ); ?>
 					</dd>
-				<?php endif; ?>
-				<?php if ( $mode_mutable || 'native' === $support_args['mode'] ) : ?>
 					<dt>
-						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?> <?php disabled( ! $mode_mutable ); ?>>
+						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?>>
 						<label for="theme_support_native">
 							<strong><?php esc_html_e( 'Native', 'amp' ); ?></strong>
 						</label>
 					</dt>
 					<dd>
-						<?php esc_html_e( 'Reuse active theme\'s templates to display AMP responses but do not use separate URLs for AMP. Your canonical URLs are AMP. Select this if you want to use AMP-specific blocks in your content. Any AMP validation errors will be automatically sanitized.', 'amp' ); ?>
+						<?php echo esc_html( $native_description ); ?>
 					</dd>
-				<?php endif; ?>
-			</dl>
-		</fieldset>
+				</dl>
+			</fieldset>
+		<?php endif; ?>
 		<?php
 	}
 
@@ -280,7 +275,7 @@ class AMP_Options_Menu {
 	 * @since 1.0
 	 */
 	public function render_supported_templates() {
-		$theme_support_args = AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) ); // Initial so we can get before removed if optional.
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
 		?>
 
 		<?php if ( ! isset( $theme_support_args['available_callback'] ) ) : ?>
@@ -360,24 +355,29 @@ class AMP_Options_Menu {
 			<script>
 				// Update the visibility of the fieldsets based on the selected template mode and then whether all templates are indicated to be supported.
 				(function ( $ ) {
-					var templateModeInputs, themeSupportDisabledInput, allTemplatesSupportedInput;
+					var templateModeInputs, themeSupportDisabledInput, allTemplatesSupportedInput, supportForced;
 					templateModeInputs = $( 'input[type=radio][name="amp-options[theme_support]"]' );
 					themeSupportDisabledInput = $( '#theme_support_disabled' );
 					allTemplatesSupportedInput = $( '#all_templates_supported' );
+					supportForced = <?php echo wp_json_encode( current_theme_supports( 'amp' ) && ! AMP_Theme_Support::is_support_added_via_option() ); ?>;
+
+					function isThemeSupportDisabled() {
+						return ! supportForced && themeSupportDisabledInput.prop( 'checked' );
+					}
 
 					function updateFieldsetVisibility() {
 						var allTemplatesSupported = 0 === allTemplatesSupportedInput.length || allTemplatesSupportedInput.prop( 'checked' );
 						$( '#all_templates_supported_fieldset, #supported_post_types_fieldset > .title' ).toggleClass(
 							'hidden',
-							themeSupportDisabledInput.prop( 'checked' )
+							isThemeSupportDisabled()
 						);
 						$( '#supported_post_types_fieldset' ).toggleClass(
 							'hidden',
-							allTemplatesSupported && ! themeSupportDisabledInput.prop( 'checked' )
+							allTemplatesSupported && ! isThemeSupportDisabled()
 						);
 						$( '#supported_templates_fieldset' ).toggleClass(
 							'hidden',
-							allTemplatesSupported || themeSupportDisabledInput.prop( 'checked' )
+							allTemplatesSupported || isThemeSupportDisabled()
 						);
 					}
 

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -30,13 +30,22 @@ class Test_AMP extends WP_UnitTestCase {
 		add_theme_support( 'amp' );
 		$this->assertTrue( amp_is_canonical() );
 
-		remove_theme_support( 'amp' );
 		add_theme_support( 'amp', array(
 			'template_dir' => 'amp-templates',
 		) );
 		$this->assertFalse( amp_is_canonical() );
 
-		remove_theme_support( 'amp' );
+		add_theme_support( 'amp', array(
+			'paired'       => false,
+			'template_dir' => 'amp-templates',
+		) );
+		$this->assertTrue( amp_is_canonical() );
+
+		add_theme_support( 'amp', array(
+			'paired' => true,
+		) );
+		$this->assertFalse( amp_is_canonical() );
+
 		add_theme_support( 'amp', array(
 			'custom_prop' => 'something',
 		) );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -90,8 +90,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
-		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
-		$this->assertTrue( current_theme_supports( 'amp' ) );
 	}
 
 	/**
@@ -120,7 +118,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_read_theme_support_and_support_args() {
 
 		// Test with option set, but some configs supplied via theme support.
-		AMP_Options_Manager::update_option( 'theme_support', 'native' );
+		AMP_Options_Manager::update_option( 'theme_support', 'native' ); // Will be ignored since theme support flag set.
 		$args = array(
 			'templates_supported' => 'all',
 			'paired'              => true,
@@ -130,6 +128,17 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
 		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
+		$this->assertTrue( current_theme_supports( 'amp' ) );
+
+		add_theme_support( 'amp' );
+		$this->assertTrue( current_theme_supports( 'amp' ) );
+		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
+		$this->assertEquals( array( 'paired' => false ), AMP_Theme_Support::get_theme_support_args() );
+
+		remove_theme_support( 'amp' );
+		AMP_Options_Manager::update_option( 'theme_support', 'native' ); // Will be ignored since theme support flag set.
+		AMP_Theme_Support::read_theme_support();
+		$this->assertTrue( AMP_Theme_Support::is_support_added_via_option() );
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 	}
 

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -75,19 +75,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_theme_support(amp) with invalid arg.
-	 *
-	 * @expectedIncorrectUsage add_theme_support
-	 * @covers \AMP_Theme_Support::read_theme_support()
-	 * @covers \AMP_Theme_Support::get_theme_support_args()
-	 */
-	public function test_read_theme_support_bad_arg_type() {
-		add_theme_support( 'amp', 'invalid_argument_type' );
-		AMP_Theme_Support::read_theme_support();
-		$this->assertTrue( current_theme_supports( 'amp' ) );
-	}
-
-	/**
 	 * Test add_theme_support(amp) with invalid args.
 	 *
 	 * @expectedIncorrectUsage add_theme_support
@@ -96,14 +83,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_read_theme_support_bad_args_array() {
 		$args = array(
-			'mode'              => 'native',
+			'paired'            => false,
 			'invalid_param_key' => array(),
 		);
 		add_theme_support( 'amp', $args );
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
-		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) ) );
+		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 	}
 
@@ -132,36 +119,17 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_read_theme_support_and_support_args() {
 
-		// Test behavior of optional flag, that AMP is not enabled if the DB option is not set.
-		$args = array(
-			'optional' => true,
-			'mode'     => 'native',
-		);
-		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
-		add_theme_support( 'amp', $args );
-		AMP_Theme_Support::read_theme_support();
-		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) ) );
-		$this->assertFalse( AMP_Theme_Support::get_theme_support_args() );
-		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
-		$this->assertFalse( current_theme_supports( 'amp' ) );
-
-		// Test again with option set, but some configs supplied via theme support.
+		// Test with option set, but some configs supplied via theme support.
 		AMP_Options_Manager::update_option( 'theme_support', 'native' );
 		$args = array(
-			'optional'            => true,
-			'templates_supported' => 'native',
+			'templates_supported' => 'all',
+			'paired'              => true,
+			'comments_live_list'  => true,
 		);
 		add_theme_support( 'amp', $args );
 		AMP_Theme_Support::read_theme_support();
-		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args( array( 'initial' => true ) ) );
-		$this->assertEquals(
-			array_merge(
-				$args,
-				array( 'mode' => 'native' )
-			),
-			AMP_Theme_Support::get_theme_support_args( array( 'initial' => false ) )
-		);
-		$this->assertTrue( AMP_Theme_Support::is_support_added_via_option() );
+		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
+		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 	}
 
@@ -173,7 +141,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_finish_init() {
 		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test' ) );
 		add_theme_support( 'amp', array(
-			'mode'         => 'paired',
+			'paired'       => true,
 			'template_dir' => 'amp',
 		) );
 
@@ -194,7 +162,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test canonical, so amphtml link is not added and init finalizes.
 		remove_action( 'wp_head', 'amp_add_amphtml_link' );
 		add_theme_support( 'amp', array(
-			'mode'         => 'native',
+			'paired'       => false,
 			'template_dir' => 'amp',
 		) );
 		$this->go_to( get_permalink( $post_id ) );
@@ -341,7 +309,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Check that mode=paired works.
 		add_theme_support( 'amp', array(
-			'mode' => 'paired',
+			'paired' => true,
 		) );
 		add_filter( 'amp_supportable_templates', function( $supportable_templates ) {
 			$supportable_templates['is_singular']['supported'] = true;
@@ -1640,7 +1608,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->go_to( home_url( '/?amp' ) );
 		add_theme_support( 'amp', array(
-			'mode' => 'paired',
+			'paired' => true,
 		) );
 		add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
 			$sanitizers['AMP_Theme_Support_Sanitizer_Counter'] = array();


### PR DESCRIPTION
* Eliminate `optional` flag when adding `amp` theme support. If theme support is present, then the admin screen will show it is enabled without a way to turn it off. If no `amp` theme support flag is present, then the radio buttons are presented to toggle the mode.
* Eliminate the ability to `add_theme_support('amp')` and then let the `native` and `paired` modes be toggled between. If `add_theme_support('amp')` is present, then AMP is made available in native mode.
* Instead of passing a `mode` theme support arg, switch to a simpler `paired` toggle. For example, `add_theme_support('amp', array('paired' => true))`. You can still use AMP-specific templates in native mode via `add_theme_support('amp', array('paired' => false, 'template_dir' => 'amp'))`, though this should be uncommon.
* Fix issue with paired templates not being accessible in Customizer preview.
* Prevent response caching in Customizer preview.
* Redirect to AMP-less variable if AMP is not available for this URL and yet the query var is present.

# Paired mode set by theme support

![image](https://user-images.githubusercontent.com/134745/42251525-ccd6d554-7eec-11e8-9c7f-209fc239b98b.png)

# Native mode set by theme support

![image](https://user-images.githubusercontent.com/134745/42251550-e37b7fd0-7eec-11e8-870e-82ae68c8ef00.png)

# Theme support not present

![image](https://user-images.githubusercontent.com/134745/42251655-73137436-7eed-11e8-8267-92f3455b041d.png)


Fixes #1238