### PR TITLE
Fix is_amp_endpoint() on `wp-login.php`, `wp-signup.php` and `wp-activate.php`

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -260,7 +260,9 @@ function post_supports_amp( $post ) {
  * @return bool Whether it is the AMP endpoint.
  */
 function is_amp_endpoint() {
-	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+	global $pagenow;
+
+	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) {
 		return false;
 	}
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -336,6 +336,13 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// Native theme support.
 		add_theme_support( 'amp' );
 		$this->assertTrue( is_amp_endpoint() );
+
+		// Special core pages.
+		$pages = array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' );
+		foreach ( $pages as $page ) {
+			$GLOBALS['pagenow'] = $page;
+			$this->assertFalse( is_amp_endpoint() );
+		}
 	}
 
 	/**

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -22,8 +22,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		remove_theme_support( 'amp' );
-		global $wp_scripts;
+		global $wp_scripts, $pagenow;
 		$wp_scripts = null;
+		$pagenow    = 'index.php'; // Since clean_up_global_scope() doesn't.
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
When calling `is_amp_endpoint()` from one of the special WordPress files `wp-login.php`, `wp-signup.php` and `wp-activate.php`, it currently triggers the notice that it was called too early - which makes sense because no query is run on these pages, however it should instead bail before and simply return false. This is in line how it currently works in the admin or for REST requests.

The plugin itself calls `is_amp_endpoint()` from `wp-login.php` (from the `AMP_Editor_Blocks` class), so that currently causes a permanent notice to display.