### PR TITLE
Fix AMP toggle in Customizer preview

### DIFF
--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -124,30 +124,32 @@ class AMP_Template_Customizer {
 	 * @since 0.6
 	 */
 	public function add_customizer_scripts() {
-		wp_enqueue_script(
-			'amp-customize-controls',
-			amp_get_asset_url( 'js/amp-customize-controls.js' ),
-			array( 'jquery', 'customize-controls' ),
-			AMP__VERSION,
-			true
-		);
+		if ( ! amp_is_canonical() ) {
+			wp_enqueue_script(
+				'amp-customize-controls',
+				amp_get_asset_url( 'js/amp-customize-controls.js' ),
+				array( 'jquery', 'customize-controls' ),
+				AMP__VERSION,
+				true
+			);
 
-		wp_add_inline_script( 'amp-customize-controls', sprintf( 'ampCustomizeControls.boot( %s );',
-			wp_json_encode( array(
-				'queryVar' => amp_get_slug(),
-				'panelId'  => self::PANEL_ID,
-				'ampUrl'   => amp_admin_get_preview_permalink(),
-				'l10n'     => array(
-					'unavailableMessage'  => __( 'AMP is not available for the page currently being previewed.', 'amp' ),
-					'unavailableLinkText' => __( 'Navigate to an AMP compatible page', 'amp' ),
-				),
-			) )
-		) );
+			wp_add_inline_script( 'amp-customize-controls', sprintf( 'ampCustomizeControls.boot( %s );',
+				wp_json_encode( array(
+					'queryVar' => amp_get_slug(),
+					'panelId'  => self::PANEL_ID,
+					'ampUrl'   => amp_admin_get_preview_permalink(),
+					'l10n'     => array(
+						'unavailableMessage'  => __( 'AMP is not available for the page currently being previewed.', 'amp' ),
+						'unavailableLinkText' => __( 'Navigate to an AMP compatible page', 'amp' ),
+					),
+				) )
+			) );
 
-		wp_enqueue_style(
-			'amp-customizer',
-			amp_get_asset_url( 'css/amp-customizer.css' )
-		);
+			wp_enqueue_style(
+				'amp-customizer',
+				amp_get_asset_url( 'css/amp-customizer.css' )
+			);
+		}
 
 		/**
 		 * Fires when plugins should register settings for AMP.

--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -166,8 +166,10 @@ class AMP_Template_Customizer {
 	 * Enqueues scripts used in both the AMP and non-AMP Customizer preview.
 	 *
 	 * @since 0.6
+	 * @global WP_Query $wp_query
 	 */
 	public function enqueue_preview_scripts() {
+		global $wp_query;
 
 		// Bail if user can't customize anyway.
 		if ( ! current_user_can( 'customize' ) ) {
@@ -182,9 +184,24 @@ class AMP_Template_Customizer {
 			true
 		);
 
+		if ( current_theme_supports( 'amp' ) ) {
+			$availability = AMP_Theme_Support::get_template_availability();
+			$available    = $availability['supported'];
+		} elseif ( is_singular() || $wp_query->is_posts_page ) {
+			/**
+			 * Queried object.
+			 *
+			 * @var WP_Post $queried_object
+			 */
+			$queried_object = get_queried_object();
+			$available      = post_supports_amp( $queried_object );
+		} else {
+			$available = false;
+		}
+
 		wp_add_inline_script( 'amp-customize-preview', sprintf( 'ampCustomizePreview.boot( %s );',
 			wp_json_encode( array(
-				'available' => (bool) is_singular() && post_supports_amp( get_queried_object() ),
+				'available' => $available,
 				'enabled'   => is_amp_endpoint(),
 			) )
 		) );


### PR DESCRIPTION
Fixes two issues:

* Hides the AMP toggle when in native mode, since there is nothing to toggle between.
* Fixes the disabled state of the toggle when the currently previewed URL is on a template that does not support AMP.
* Allows toggle to be enabled for the on the `page_for_posts` in classic mode.

This is the toggle in question:

![image](https://user-images.githubusercontent.com/134745/42351897-f0330482-807c-11e8-8b65-c59cd728f9fb.png)

To test, try turning on Native mode and confirm the toggle is hidden. Next, switch to Paired mode and disable AMP on the homepage template (assuming you have static front page). When you open the Customizer, the toggle should be disabled.