### PR TITLE
Convert video src to HTTPS

### DIFF
--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -162,7 +162,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * "Filter" HTML attributes for <amp-audio> elements.
 	 *
 	 * @since 0.2
-	 * @since 1.0 Force HTTPS for src and poster attributes.
+	 * @since 1.0 Force HTTPS for the src attribute.
 	 *
 	 * @param string[] $attributes {
 	 *      Attributes.
@@ -184,7 +184,6 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
-				case 'poster':
 				case 'src':
 					$out[ $name ] = $this->maybe_enforce_https_src( $value, true );
 					break;
@@ -194,6 +193,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					$out[ $name ] = $this->sanitize_dimension( $value, $name );
 					break;
 
+				case 'poster':
 				case 'class':
 				case 'sizes':
 					$out[ $name ] = $value;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -56,7 +56,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+		for ( $i = $num_nodes - 1; $i >= 0; $i -- ) {
 			$node           = $nodes->item( $i );
 			$amp_data       = $this->get_data_amp_attributes( $node );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
@@ -96,9 +96,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					continue;
 				}
 
-				if ( $old_child_attributes['src'] !== $new_child_attributes['src'] ) {
-					$new_child_node->setAttribute( 'src', $new_child_attributes['src'] );
-				}
+				$this->update_src( $new_child_node, $new_child_attributes['src'], $old_child_attributes['src'] );
 
 				/**
 				 * Only append source tags with a valid src attribute
@@ -128,6 +126,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * Filter video dimensions, try to get width and height from original file if missing.
 	 *
 	 * @param array $new_attributes Attributes.
+	 *
 	 * @return array Modified attributes.
 	 */
 	protected function filter_video_dimensions( $new_attributes ) {
@@ -155,6 +154,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 		}
+
 		return $new_attributes;
 	}
 
@@ -165,17 +165,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0 Force HTTPS for the src attribute.
 	 *
 	 * @param string[] $attributes {
-	 *      Attributes.
+	 *                             Attributes.
 	 *
-	 *      @type string $src Video URL - Empty if HTTPS required per $this->args['require_https_src']
-	 *      @type int $width <video> attribute - Set to numeric value if px or %
-	 *      @type int $height <video> attribute - Set to numeric value if px or %
-	 *      @type string $poster <video> attribute - Pass along if found
-	 *      @type string $class <video> attribute - Pass along if found
-	 *      @type bool $controls <video> attribute - Convert 'false' to empty string ''
-	 *      @type bool $loop <video> attribute - Convert 'false' to empty string ''
-	 *      @type bool $muted <video> attribute - Convert 'false' to empty string ''
-	 *      @type bool $autoplay <video> attribute - Convert 'false' to empty string ''
+	 * @type string    $src        Video URL - Empty if HTTPS required per $this->args['require_https_src']
+	 * @type int       $width      <video> attribute - Set to numeric value if px or %
+	 * @type int       $height     <video> attribute - Set to numeric value if px or %
+	 * @type string    $poster     <video> attribute - Pass along if found
+	 * @type string    $class      <video> attribute - Pass along if found
+	 * @type bool      $controls   <video> attribute - Convert 'false' to empty string ''
+	 * @type bool      $loop       <video> attribute - Convert 'false' to empty string ''
+	 * @type bool      $muted      <video> attribute - Convert 'false' to empty string ''
+	 * @type bool      $autoplay   <video> attribute - Convert 'false' to empty string ''
 	 * }
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */
@@ -222,5 +222,19 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Update the node's src attribute if it is different from the old src attribute.
+	 *
+	 * @param DOMNode $node    The given DOMNode.
+	 * @param string  $new_src The new src attribute.
+	 * @param string  $old_src The old src attribute.
+	 */
+	protected function update_src( &$node, $new_src, $old_src ) {
+		if ( $old_src === $new_src ) {
+			return;
+		}
+		$node->setAttribute( 'src', $new_src );
 	}
 }

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -47,6 +47,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize the <video> elements from the HTML contained in this instance's DOMDocument.
 	 *
 	 * @since 0.2
+	 * @since 1.0 Set the filtered child node's src attribute.
 	 */
 	public function sanitize() {
 		$nodes     = $this->dom->getElementsByTagName( self::$tag );
@@ -95,11 +96,14 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					continue;
 				}
 
+				if ( $old_child_attributes['src'] !== $new_child_attributes['src'] ) {
+					$new_child_node->setAttribute( 'src', $new_child_attributes['src'] );
+				}
+
 				/**
 				 * Only append source tags with a valid src attribute
 				 */
 				$new_node->appendChild( $new_child_node );
-
 			}
 
 			/*
@@ -158,6 +162,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * "Filter" HTML attributes for <amp-audio> elements.
 	 *
 	 * @since 0.2
+	 * @since 1.0 Force src HTTPS.
 	 *
 	 * @param string[] $attributes {
 	 *      Attributes.
@@ -180,7 +185,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
-					$out[ $name ] = $this->maybe_enforce_https_src( $value );
+					$out[ $name ] = $this->maybe_enforce_https_src( $value, true );
 					break;
 
 				case 'width':

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -162,7 +162,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * "Filter" HTML attributes for <amp-audio> elements.
 	 *
 	 * @since 0.2
-	 * @since 1.0 Force src HTTPS.
+	 * @since 1.0 Force HTTPS for src and poster attributes.
 	 *
 	 * @param string[] $attributes {
 	 *      Attributes.
@@ -184,6 +184,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
+				case 'poster':
 				case 'src':
 					$out[ $name ] = $this->maybe_enforce_https_src( $value, true );
 					break;
@@ -193,7 +194,6 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					$out[ $name ] = $this->sanitize_dimension( $value, $name );
 					break;
 
-				case 'poster':
 				case 'class':
 				case 'sizes':
 					$out[ $name ] = $value;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -56,7 +56,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		for ( $i = $num_nodes - 1; $i >= 0; $i -- ) {
+		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node           = $nodes->item( $i );
 			$amp_data       = $this->get_data_amp_attributes( $node );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
@@ -165,17 +165,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0 Force HTTPS for the src attribute.
 	 *
 	 * @param string[] $attributes {
-	 *                             Attributes.
+	 *      Attributes.
 	 *
-	 * @type string    $src        Video URL - Empty if HTTPS required per $this->args['require_https_src']
-	 * @type int       $width      <video> attribute - Set to numeric value if px or %
-	 * @type int       $height     <video> attribute - Set to numeric value if px or %
-	 * @type string    $poster     <video> attribute - Pass along if found
-	 * @type string    $class      <video> attribute - Pass along if found
-	 * @type bool      $controls   <video> attribute - Convert 'false' to empty string ''
-	 * @type bool      $loop       <video> attribute - Convert 'false' to empty string ''
-	 * @type bool      $muted      <video> attribute - Convert 'false' to empty string ''
-	 * @type bool      $autoplay   <video> attribute - Convert 'false' to empty string ''
+	 *      @type string    $src        Video URL - Empty if HTTPS required per $this->args['require_https_src']
+	 *      @type int       $width      <video> attribute - Set to numeric value if px or %
+	 *      @type int       $height     <video> attribute - Set to numeric value if px or %
+	 *      @type string    $poster     <video> attribute - Pass along if found
+	 *      @type string    $class      <video> attribute - Pass along if found
+	 *      @type bool      $controls   <video> attribute - Convert 'false' to empty string ''
+	 *      @type bool      $loop       <video> attribute - Convert 'false' to empty string ''
+	 *      @type bool      $muted      <video> attribute - Convert 'false' to empty string ''
+	 *      @type bool      $autoplay   <video> attribute - Convert 'false' to empty string ''
 	 * }
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -98,7 +98,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	<source src="http://example.com/video.mp4" type="video/mp4">
 	<source src="http://example.com/video.ogv" type="video/ogg">
 </video>',
-				'<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"></amp-video>',
+				'<amp-video width="480" height="300" poster="http://example.com/video-image.gif" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"></amp-video>',
 			),
 		);
 	}

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -94,7 +94,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'http_video_with_children' => array(
-				'<video width="480" height="300" poster="https://example.com/video-image.gif">
+				'<video width="480" height="300" poster="http://example.com/video-image.gif">
 	<source src="http://example.com/video.mp4" type="video/mp4">
 	<source src="http://example.com/video.ogv" type="video/ogg">
 </video>',

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -90,7 +90,15 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'https_not_required' => array(
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="http://example.com/video.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"></amp-video>',
+			),
+
+			'http_video_with_children' => array(
+				'<video width="480" height="300" poster="https://example.com/video-image.gif">
+	<source src="http://example.com/video.mp4" type="video/mp4">
+	<source src="http://example.com/video.ogv" type="video/ogg">
+</video>',
+				'<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"></amp-video>',
 			),
 		);
 	}


### PR DESCRIPTION
This PR automatically handles the conversion of the `src` ~~and `poster`~~ attribute~s~ from HTTP to HTTPS to generate valid AMP for the `<amp-video>` and its subsequent child nodes. 

Work is focused within the `AMP_Video_Sanitizer`:

- Forces by passing `true` to `$this-maybe_enforce_https_src( $value, true )` for ~~both~~ the `src` ~~and `poster`~~ attribute~s~.
- Updates the child node(s) `src` attribute when it changes through the filtering.

Closes #976.

## For Example

As noted in #976, when using a shortcode like this (which has a `poster` attribute added):

```
[video width="740" height="428" mp4="http://ads-up.fr/app/uploads/2016/06/BingAdsEditor-Mac-Multicomptes.mp4" loop="true" poster="http://www.pngmart.com/files/3/YouTube-Transparent-PNG.png"][/video]
```

this PR automatically converts the `http` to `https` for the valid AMP render:

```
<amp-video class="wp-video-shortcode i-amphtml-element i-amphtml-layout-responsive i-amphtml-layout-size-defined i-amphtml-video-interface i-amphtml-layout" width="740" height="428" poster="http://www.pngmart.com/files/3/YouTube-Transparent-PNG.png" loop="" autoplay="" controls="" layout="responsive">
  <i-amphtml-sizer style="display: block; padding-top: 57.9048%;"></i-amphtml-sizer>
  <video playsinline="" webkit-playsinline="" poster="https://www.pngmart.com/files/3/YouTube-Transparent-PNG.png" class="i-amphtml-fill-content i-amphtml-replaced-content" loop="" controls="">
    <source type="video/mp4" src="https://ads-up.fr/app/uploads/2016/06/BingAdsEditor-Mac-Multicomptes.mp4?_=1">
  </video>
</amp-video>
```

![amp-issue-976-force-https](https://user-images.githubusercontent.com/7284611/42958602-98f21b0c-8b4b-11e8-914f-8040dd06cba3.png)




