### PR TITLE
Add filter for changing the amphtml url

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -230,7 +230,7 @@ function amp_add_amphtml_link() {
 	}
 
 	if ( $amp_url ) {
-		printf( '<link rel="amphtml" href="%s">', esc_url( $amp_url ) );
+		printf( '<link rel="amphtml" href="%s">', esc_url( apply_filters( 'amp_amphtml_url', $amp_url ) ) );
 	}
 }
 


### PR DESCRIPTION
It would be nice to have a filter where we can change the `amphtml` URL rendered for formatting purposes.

Ref: #80636-z