### PR TITLE
[WIP] Fix wide image to contain in content

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -229,7 +229,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Make final modifications to DOMNode
 	 *
-	 * @param DOMNode $node The DOMNode to adjust and replace.
+	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 */
 	private function adjust_and_replace_node( $node ) {
 
@@ -269,7 +269,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function maybe_add_lightbox_attributes( $attributes, $node ) {
 		$parent_node = $node->parentNode;
-		if ( 'figure' !== $parent_node->tagName ) {
+		if ( ! ( $parent_node instanceof DOMElement ) || 'figure' !== $parent_node->tagName ) {
 			return $attributes;
 		}
 
@@ -347,11 +347,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 * @see https://github.com/Automattic/amp-wp/issues/1086
 	 *
-	 * @param DOMNode $node The DOMNode to adjust and replace.
+	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 */
 	protected function add_auto_width_to_figure( $node ) {
 		$figure = $node->parentNode;
-		if ( ! $figure instanceof DOMElement || 'figure' !== $figure->tagName ) {
+		if ( ! ( $figure instanceof DOMElement ) || 'figure' !== $figure->tagName ) {
 			return;
 		}
 
@@ -366,10 +366,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
+		$new_style = 'width: auto;';
 		if ( $figure->hasAttribute( 'style' ) ) {
-			$figure->setAttribute( 'style', 'width: auto;' . $figure->getAttribute( 'style' ) );
+			$figure->setAttribute( 'style', $new_style . $figure->getAttribute( 'style' ) );
 		} else {
-			$figure->setAttribute( 'style', 'width: auto' );
+			$figure->setAttribute( 'style', $new_style );
 		}
 	}
 }

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -257,6 +257,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$new_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
 		$new_node = $this->handle_centering( $new_node );
 		$node->parentNode->replaceChild( $new_node, $node );
+		$this->add_auto_width_to_figure( $new_node );
 	}
 
 	/**
@@ -338,5 +339,37 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$figure->appendChild( $node );
 
 		return $figure;
+	}
+
+	/**
+	 * Add an inline style to set the `<figure>` element's width to `auto` instead of `fit-content`.
+	 *
+	 * @since 1.0
+	 * @see https://github.com/Automattic/amp-wp/issues/1086
+	 *
+	 * @param DOMNode $node The DOMNode to adjust and replace.
+	 */
+	protected function add_auto_width_to_figure( $node ) {
+		$figure = $node->parentNode;
+		if ( ! $figure instanceof DOMElement || 'figure' !== $figure->tagName ) {
+			return;
+		}
+
+		$class = $figure->getAttribute( 'class' );
+		// Target only the <figure> with a 'wp-block-image' class attribute.
+		if ( false === strpos( $class, 'wp-block-image' ) ) {
+			return;
+		}
+
+		// Target only <figure> without a 'is-resized' class attribute.
+		if ( false !== strpos( $class, 'is-resized' ) ) {
+			return;
+		}
+
+		if ( $figure->hasAttribute( 'style' ) ) {
+			$figure->setAttribute( 'style', 'width: auto;' . $figure->getAttribute( 'style' ) );
+		} else {
+			$figure->setAttribute( 'style', 'width: auto' );
+		}
 	}
 }

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -183,6 +183,31 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure data-amp-lightbox="true"><img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
 				'<figure data-amp-lightbox="true"><amp-img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
+
+			'wide_image'                               => array(
+				'<figure class="wp-block-image"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			),
+
+			'wide_image_center_aligned'                => array(
+				'<figure class="wp-block-image aligncenter"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image aligncenter" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			),
+
+			'wide_image_left_aligned'                  => array(
+				'<figure class="wp-block-image alignleft"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image alignleft" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			),
+
+			'wide_image_right_aligned'                 => array(
+				'<figure class="wp-block-image alignright"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image alignright" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			),
+
+			'wide_image_is_resized'                    => array(
+				'<figure class="wp-block-image is-resized"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image is-resized"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			),
 		);
 	}
 

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -186,22 +186,22 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'wide_image'                               => array(
 				'<figure class="wp-block-image"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
 			),
 
 			'wide_image_center_aligned'                => array(
 				'<figure class="wp-block-image aligncenter"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image aligncenter" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image aligncenter" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
 			),
 
-			'wide_image_left_aligned'                  => array(
-				'<figure class="wp-block-image alignleft"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignleft" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+			'wide_image_left_aligned_custom_style'     => array(
+				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image alignleft" style="width: auto;border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
 			),
 
 			'wide_image_right_aligned'                 => array(
 				'<figure class="wp-block-image alignright"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignright" style="width: auto"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image alignright" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
 			),
 
 			'wide_image_is_resized'                    => array(


### PR DESCRIPTION
This PR solves the problem of wide images overflowing the content width.  It adds an inline style of `width: auto` to the `<figure>` element when it has the class attribute `'wp-block-image'` but not `is-resized`. 

Why?  

Gutenberg adds the class attributes and sets the CSS rule to:

```css
.wp-block-image {
    width: -webkit-fit-content;
    width: -moz-fit-content;
    width: fit-content;
}
```

The width value of `fit-content` is causing wider images to overflow.  See the details in issue #1086 more information as well as screenshots.  You can view the example posts here: [Gutenberg post](https://paired-ampconfdemo.pantheonsite.io/2018/07/24/wide-image-alignments-with-gutenberg-image-blocks/?amp) and [Classic Editor post](https://paired-ampconfdemo.pantheonsite.io/2018/07/24/wide-image-alignments-with-classic-editor/?amp).

By adding the inline CSS rule, wider images rescale and fit within the content.

It's worth noting that the issue does not occur with the Classic Editor.

Closes #1086.