### PR TITLE
Fix sending sanitizer class name in amp_sanitize Server-Timing headers

### DIFF
--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -101,7 +101,7 @@ class AMP_Content_Sanitizer {
 		}
 
 		// Sanitize.
-		foreach ( $sanitizers as $sanitizer ) {
+		foreach ( $sanitizers as $sanitizer_class => $sanitizer ) {
 			$sanitize_class_start = microtime( true );
 
 			$sanitizer->sanitize();


### PR DESCRIPTION
I found in https://github.com/Automattic/amp-wp/issues/990#issuecomment-407616272 that the `Server-Timing` headers are incorrect for the sanitizers, with erroneously repeating `AMP_Tag_And_Attribute_Sanitizer` for each sanitizer:

```
Server-Timing: amp_output_buffer;desc="AMP Output Buffer";dur=325.990915
Server-Timing: amp_dom_parse;desc="AMP DOM Parse";dur=4.322052
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.546932
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=6.416798
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.148058
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.276089
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.092030
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.113010
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.106812
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.201941
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.336885
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.022888
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.175953
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.034809
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=0.024796
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=38.730860
Server-Timing: amp_sanitize;desc="AMP_Tag_And_Attribute_Sanitizer";dur=81.669092
Server-Timing: amp_dom_serialize;desc="AMP DOM Serialize";dur=7.952929
```

This is due to a bug I introduced in 7a218aa0bae195988dfbe7a9d00f37cc0fcb3e49 for #1175.