### PR TITLE
Update PHP-CSS-Parser to use new calc() support

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/PHP-CSS-Parser.git",
-                "reference": "30a931eed6d8c014751bc11602648f959771a627"
+                "reference": "b2965f032e739e48c2cee4288bd755b54a21ebed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/30a931eed6d8c014751bc11602648f959771a627",
-                "reference": "30a931eed6d8c014751bc11602648f959771a627",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/b2965f032e739e48c2cee4288bd755b54a21ebed",
+                "reference": "b2965f032e739e48c2cee4288bd755b54a21ebed",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
             "support": {
                 "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
             },
-            "time": "2018-06-19 23:34:25"
+            "time": "2018-07-25 04:58:40"
         }
     ],
     "packages-dev": [
@@ -175,30 +175,31 @@
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "8.1.0",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -208,7 +209,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -223,7 +224,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-27T21:58:38+00:00"
+            "time": "2018-07-17T13:42:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -476,7 +476,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		// Add recognition of amp_validation_error_status query var (which will only apply in admin since post type is not publicly_queryable).
 		add_filter( 'query_vars', function( $query_vars ) {
-			$query_vars[] = self::VALIDATION_ERROR_STATUS_QUERY_VAR;
+			$query_vars[] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR;
 			return $query_vars;
 		} );
 
@@ -500,8 +500,8 @@ class AMP_Validation_Error_Taxonomy {
 		// Add bulk actions.
 		add_filter( 'bulk_actions-edit-' . self::TAXONOMY_SLUG, function( $bulk_actions ) {
 			unset( $bulk_actions['delete'] );
-			$bulk_actions[ self::VALIDATION_ERROR_ACCEPT_ACTION ] = __( 'Accept', 'amp' );
-			$bulk_actions[ self::VALIDATION_ERROR_REJECT_ACTION ] = __( 'Reject', 'amp' );
+			$bulk_actions[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION ] = __( 'Accept', 'amp' );
+			$bulk_actions[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION ] = __( 'Reject', 'amp' );
 			return $bulk_actions;
 		} );
 
@@ -525,7 +525,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		// Hide empty term addition form.
 		add_action( 'admin_enqueue_scripts', function() {
-			if ( self::TAXONOMY_SLUG === get_current_screen()->taxonomy ) {
+			if ( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG === get_current_screen()->taxonomy ) {
 				wp_add_inline_style( 'common', '
 					#col-left { display: none; }
 					#col-right { float:none; width: auto; }
@@ -540,7 +540,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		// Make sure parent menu item is expanded when visiting the taxonomy term page.
 		add_filter( 'parent_file', function( $parent_file ) {
-			if ( get_current_screen()->taxonomy === self::TAXONOMY_SLUG ) {
+			if ( get_current_screen()->taxonomy === AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ) {
 				$parent_file = AMP_Options_Manager::OPTION_NAME;
 			}
 			return $parent_file;
@@ -548,7 +548,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		// Replace the primary column to be error instead of the removed name column..
 		add_filter( 'list_table_primary_column', function( $primary_column ) {
-			if ( get_current_screen() && self::TAXONOMY_SLUG === get_current_screen()->taxonomy ) {
+			if ( get_current_screen() && AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG === get_current_screen()->taxonomy ) {
 				$primary_column = 'error';
 			}
 			return $primary_column;
@@ -569,7 +569,7 @@ class AMP_Validation_Error_Taxonomy {
 		}
 		add_filter( 'terms_clauses', function( $clauses, $taxonomies ) use ( $group ) {
 			global $wpdb;
-			if ( self::TAXONOMY_SLUG === $taxonomies[0] && self::$should_filter_terms_clauses_for_error_validation_status ) {
+			if ( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG === $taxonomies[0] && AMP_Validation_Error_Taxonomy::$should_filter_terms_clauses_for_error_validation_status ) {
 				$clauses['where'] .= $wpdb->prepare( ' AND t.term_group = %d', $group );
 			}
 			return $clauses;

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -386,7 +386,7 @@ class AMP_Validation_Manager {
 					if ( urlParser.href !== location.href ) {
 						history.replaceState( {}, '', urlParser.href );
 					}
-				})( <?php echo wp_json_encode( self::VALIDATION_ERRORS_QUERY_VAR ); ?> );
+				})( <?php echo wp_json_encode( AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR ); ?> );
 				</script>
 				<?php
 			} );

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -117,10 +117,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'illegal_at_rule_in_style_attribute' => array(
-				'<span style="color:brown; @media screen { color:green }">Parse error.</span>',
-				'<span>Parse error.</span>',
+				'<span style="color:brown; @media screen { color:green }">invalid @-rule omitted.</span>',
+				'<span class="amp-wp-481af57">invalid @-rule omitted.</span>',
+				array(
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-481af57{color:brown}',
+				),
 				array(),
-				array( 'css_parse_error' ),
 			),
 
 			'illegal_at_rules_removed' => array(
@@ -147,6 +149,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					':root:not(#_) #child{color:red}:root:not(#_):not(#_) #parent #child{color:pink}:root:not(#_) .foo{color:blue}:root:not(#_):not(#_) #me .foo{color:green}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-ab79d9e{color:purple}',
+				),
+			),
+
+			'grid_lines'                                  => array(
+				'<style>.wrapper {display: grid;grid-template-columns: [main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end];grid-template-rows: [main-start] 100px [content-start] 100px [content-end] 100px [main-end];}</style><div class="wrapper"></div>',
+				'<div class="wrapper"></div>',
+				array(
+					'.wrapper{display:grid;grid-template-columns:[main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end];grid-template-rows:[main-start] 100px [content-start] 100px [content-end] 100px [main-end]}',
 				),
 			),
 
@@ -298,14 +308,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'styles_with_calc_functions' => array(
 				implode( '', array(
 					'<html amp><head>',
-					'<style amp-custom>body { color: red; width: -webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) ); outline: solid 1px blue; }</style>',
-					'<style amp-custom>.alignwide{ max-width: calc(50% + 22.5rem); border: solid 1px red; }</style>',
+					'<style amp-custom>body { color: red; width: calc( 1px + calc( 2vh / 3 ) - 2px * 5 ); outline: solid 1px blue; }</style>',
+					'<style amp-custom>.alignwide{ max-width: -webkit-calc(50% + 22.5rem); border: solid 1px red; }</style>',
 					'<style amp-custom>.alignwide{ height: calc(10% + ( 1px ); color: red; content: ")"}</style>', // Test unbalanced parentheses.
 					'</head><body><div class="alignwide"></div></body></html>',
 				) ),
 				array(
-					'body{color:red;width:-webkit-calc( 1px + 2vh * 3pt - ( 4em / 5 ) );outline:solid 1px blue}',
-					'.alignwide{max-width:calc(50% + 22.5rem);border:solid 1px red}',
+					'body{color:red;width:calc(1px + calc(2vh / 3) - 2px * 5);outline:solid 1px blue}',
+					'.alignwide{max-width:-webkit-calc(50% + 22.5rem);border:solid 1px red}',
 					'.alignwide{color:red;content:")"}',
 				),
 				array(),


### PR DESCRIPTION
* Update PHP-CSS-Parser to [8.2.0](https://github.com/sabberworm/PHP-CSS-Parser/blob/master/CHANGELOG.md#820-2018-07-13) which includes built-in support for `calc()`, support for parsing grid-lines, better error recovery, and improved performance.
* Remove obsolete `calc()` workaround code.

Fixes #1240.