### PR TITLE
Fix parsing CSS selectors which contain commas

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/PHP-CSS-Parser.git",
-                "reference": "b2965f032e739e48c2cee4288bd755b54a21ebed"
+                "reference": "16998f94e27a89eabae9457226b7458694419c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/b2965f032e739e48c2cee4288bd755b54a21ebed",
-                "reference": "b2965f032e739e48c2cee4288bd755b54a21ebed",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/16998f94e27a89eabae9457226b7458694419c28",
+                "reference": "16998f94e27a89eabae9457226b7458694419c28",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
             "support": {
                 "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
             },
-            "time": "2018-07-25 04:58:40"
+            "time": "2018-07-25 17:48:13"
         }
     ],
     "packages-dev": [

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -699,7 +699,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$parsed      = null;
 		$cache_key   = null;
-		$cache_group = 'amp-parsed-stylesheet-v9';
+		$cache_group = 'amp-parsed-stylesheet-v10'; // This should be bumped whenever the PHP-CSS-Parser is updated.
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
@@ -1823,11 +1823,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			$edited_selectors = array( $selector );
 			foreach ( $this->selector_mappings as $html_selector => $amp_selectors ) { // Note: The $selector_mappings array contains ~6 items.
-				$html_pattern = '/(?<=^|[^a-z0-9_-])' . preg_quote( $html_selector ) . '(?=$|[^a-z0-9_-])/i';
+				$html_pattern = '/(?<=^|[^a-z0-9_-])' . preg_quote( $html_selector, '/' ) . '(?=$|[^a-z0-9_-])/i';
 				foreach ( $edited_selectors as &$edited_selector ) { // Note: The $edited_selectors array contains only item in the normal case.
 					$original_selector = $edited_selector;
 					$amp_selector      = array_shift( $amp_selectors );
-					$amp_tag_pattern   = '/(?<=^|[^a-z0-9_-])' . preg_quote( $amp_selector ) . '(?=$|[^a-z0-9_-])/i';
+					$amp_tag_pattern   = '/(?<=^|[^a-z0-9_-])' . preg_quote( $amp_selector, '/' ) . '(?=$|[^a-z0-9_-])/i';
 					preg_match( $amp_tag_pattern, $edited_selector, $matches );
 					if ( ! empty( $matches ) && $amp_selector === $matches[0] ) {
 						continue;

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -189,6 +189,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c8aa9e9{width:50px;width:60px;background-color:red}',
 				),
 			),
+
+			'multi_selector_in_not_pseudo_class'         => array(
+				'<style>.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul { color:red; }</style><div class="widget"></div>',
+				'<div class="widget"></div>',
+				array(
+					'.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul{color:red}',
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
I found an issue where a CSS selectors would fail to parse correctly when they contain commas. For example:

```css
.widget:not(.widget_text, .jetpack_widget_social_icons) ul {
    list-style: none;
    margin: 0;
    padding: 0;
}
```

There should only be one selector here: `.widget:not(.widget_text, .jetpack_widget_social_icons) ul`. Instead, the parser incorrectly extracts two:

* `.widget:not(.widget_text`
* `.jetpack_widget_social_icons) ul`

The fix is to add placeholders for expressions contained in parentheses or brackets prior to splitting, and then replace the placeholders with their original values on the split selectors.

This PR updates the PHP-CSS-Parser to the state of the library with this upstream PR merged: https://github.com/sabberworm/PHP-CSS-Parser/pull/138

This PR also fixes a PHPCS complaint regarding `preg_quote()` not having an explicit `$delimiter` set.