### PR TITLE
Opt-in to CORS mode for external font stylesheet links

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -590,6 +590,18 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $href !== $normalized_url ) {
 				$element->setAttribute( 'href', $normalized_url );
 			}
+
+			/*
+			 * Opt-in to CORS Mode for the stylesheet. This ensures that a service worker caching the external
+			 * stylesheet will not inflate the storage quota.
+			 *
+			 * See:
+			 * - https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
+			 * - https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses
+			 */
+			if ( ! $element->hasAttribute( 'crossorigin' ) ) {
+				$element->setAttribute( 'crossorigin', 'anonymous' );
+			}
 			return;
 		}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1186,9 +1186,34 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				preg_replace( '#^(http:)?(?=//)#', 'https:', $url ),
 				$link->getAttribute( 'href' )
 			);
+			$this->assertEquals( 'anonymous', $link->getAttribute( 'crossorigin' ) );
 		} else {
 			$this->assertEmpty( $link );
 		}
+	}
+
+	/**
+	 * Test addition of crossorigin attribute to external stylesheet links.
+	 *
+	 * @covers AMP_Style_Sanitizer::process_link_element()
+	 */
+	public function test_cors_enabled_stylesheet_url() {
+
+		// Test supplying crossorigin attribute.
+		$document  = AMP_DOM_Utils::get_dom( '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"></head></html>' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
+		$sanitizer->sanitize();
+		$link = $document->getElementsByTagName( 'link' )->item( 0 );
+		$this->assertInstanceOf( 'DOMElement', $link );
+		$this->assertEquals( 'anonymous', $link->getAttribute( 'crossorigin' ) );
+
+		// Test that existing crossorigin attribute is not overridden.
+		$document  = AMP_DOM_Utils::get_dom( '<html><head><link rel="stylesheet" crossorigin="use-credentials" href="https://fonts.googleapis.com/css?family=Tangerine"></head></html>' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
+		$sanitizer->sanitize();
+		$link = $document->getElementsByTagName( 'link' )->item( 0 );
+		$this->assertInstanceOf( 'DOMElement', $link );
+		$this->assertEquals( 'use-credentials', $link->getAttribute( 'crossorigin' ) );
 	}
 
 	/**


### PR DESCRIPTION
This ensures that a service worker caching an external stylesheet will not inflate the storage quota.

See:

* https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
* https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses

I've also suggested this in the doc for [Optimizing your hosted AMP pages
](https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#).