### PR TITLE
Fix displaying AMP validation error at block level in the Gutenberg editor

### DIFF
--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -382,7 +382,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 
 			return wp.data.withSelect( function( select, ownProps ) {
 				return _.extend( {}, ownProps, {
-					ampBlockValidationErrors: select( module.storeName ).getBlockValidationErrors( ownProps.id )
+					ampBlockValidationErrors: select( module.storeName ).getBlockValidationErrors( ownProps.clientId )
 				} );
 			} )( AmpNoticeBlockEdit );
 		}

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -318,7 +318,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			currentPost = editorSelect.getCurrentPost();
 			validationErrors = _.map(
 				_.filter( currentPost[ module.data.ampValidityRestField ].results, function( result ) {
-					return ! result.sanitized;
+					return result.term_status !== 1; // If not accepted by the user.
 				} ),
 				function( result ) {
 					return result.error;

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -149,6 +149,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 
 			if ( ! module.isAMPEnabled() ) {
 				if ( ! module.lastStates.noticesAreReset ) {
+					module.lastStates.validationErrors = [];
 					module.lastStates.noticesAreReset = true;
 					module.resetWarningNotice();
 					module.resetBlockNotices();

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -42,7 +42,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			wp.i18n.setLocaleData( module.data.i18n, 'amp' );
 
 			wp.hooks.addFilter(
-				'blocks.BlockEdit',
+				'editor.BlockEdit',
 				'amp/add-notice',
 				module.conditionallyAddNotice
 			);

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -205,7 +205,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				}
 			} catch ( e ) {
 				// Clear out block validation errors in case the block sand errors cannot be aligned.
-				module.resetBLockNotices();
+				module.resetBlockNotices();
 
 				noticeMessage += ' ' + wp.i18n._n(
 					'It may not be due to content here.',

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -105,8 +105,13 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				return;
 			}
 
+            // Wait for the current post to be set up.
+            currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
+            if ( ! currentPost.hasOwnProperty( 'id' ) ) {
+                return;
+            }
+
 			hasActuallyUnacceptedError = false;
-			currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
 			ampValidity = currentPost[ module.data.ampValidityRestField ] || {};
 			validationErrors = _.map(
 				_.filter( ampValidity.results, function( result ) {

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -167,12 +167,6 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			// Remove any existing notice.
 			module.resetWarningNotice();
 
-			// If there are no validation errors then just make sure the validation notices are cleared from the blocks.
-			if ( ! validationErrors.length ) {
-				module.resetBlockNotices();
-				return;
-			}
-
 			noticeMessage = wp.i18n.sprintf(
 				wp.i18n._n(
 					'There is %s issue from AMP validation.',

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -30,15 +30,15 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 */
 		storeName: 'amp/blockValidation',
 
-        /**
+		/**
 		 * Holds the last states which are used for comparisons.
 		 *
 		 * @param {Object}
-         */
-        lastStates: {
-            validationErrors: [],
-            blockOrder: []
-        },
+		 */
+		lastStates: {
+			validationErrors: [],
+			blockOrder: []
+		},
 
 		/**
 		 * Boot module.
@@ -55,7 +55,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				'editor.BlockEdit',
 				'amp/add-notice',
 				module.conditionallyAddNotice,
-				99
+				99 // eslint-disable-line
 			);
 
 			module.store = module.registerStore();
@@ -100,28 +100,28 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			} );
 		},
 
-        /**
+		/**
 		 * Checks if the validate errors state change handler should wait before processing.
 		 *
-         * @returns {boolean}
-         */
-        waitToHandleStateChange: function waitToHandleStateChange() {
-            var currentPost;
+		 * @return {boolean} Whether should wait.
+		 */
+		waitToHandleStateChange: function waitToHandleStateChange() {
+			var currentPost;
 
-            // @todo Gutenberg currently is not persisting isDirty state if changes are made during save request. Block order mismatch.
-            // We can only align block validation errors with blocks in editor when in saved state, since only here will the blocks be aligned with the validation errors.
-            if ( wp.data.select( 'core/editor' ).isEditedPostDirty() || wp.data.select( 'core/editor' ).isCleanNewPost() ) {
-                return true;
-            }
+			// @todo Gutenberg currently is not persisting isDirty state if changes are made during save request. Block order mismatch.
+			// We can only align block validation errors with blocks in editor when in saved state, since only here will the blocks be aligned with the validation errors.
+			if ( wp.data.select( 'core/editor' ).isEditedPostDirty() || wp.data.select( 'core/editor' ).isCleanNewPost() ) {
+				return true;
+			}
 
-            // Wait for the current post to be set up.
-            currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
-            if ( ! currentPost.hasOwnProperty( 'id' ) ) {
-                return true;
-            }
+			// Wait for the current post to be set up.
+			currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
+			if ( ! currentPost.hasOwnProperty( 'id' ) ) {
+				return true;
+			}
 
-            return false;
-        },
+			return false;
+		},
 
 		/**
 		 * Handle state change regarding validation errors.
@@ -133,12 +133,12 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		handleValidationErrorsStateChange: function handleValidationErrorsStateChange() {
 			var currentPost, validationErrors, blockValidationErrors, noticeElement, noticeMessage, blockErrorCount, ampValidity, hasActuallyUnacceptedError;
 
-            if ( module.waitToHandleStateChange() ) {
-                return;
-            }
+			if ( module.waitToHandleStateChange() ) {
+				return;
+			}
 
 			hasActuallyUnacceptedError = false;
-            currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
+			currentPost = wp.data.select( 'core/editor' ).getCurrentPost();
 			ampValidity = currentPost[ module.data.ampValidityRestField ] || {};
 			validationErrors = _.map(
 				_.filter( ampValidity.results, function( result ) {
@@ -152,11 +152,11 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				}
 			);
 
-            // Short-circuit if there was no change to the validation errors.
-            if ( ! module.didValidationErrorsChange( validationErrors ) ) {
-                return;
-            }
-            module.lastStates.validationErrors = validationErrors;
+			// Short-circuit if there was no change to the validation errors.
+			if ( ! module.didValidationErrorsChange( validationErrors ) ) {
+				return;
+			}
+			module.lastStates.validationErrors = validationErrors;
 
 			// Remove any existing notice.
 			if ( module.validationWarningNoticeId ) {
@@ -237,40 +237,40 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			module.validationWarningNoticeId = wp.data.dispatch( 'core/editor' ).createWarningNotice( noticeElement, { spokenMessage: noticeMessage } ).notice.id;
 		},
 
-        /**
+		/**
 		 * Checks if the validation errors have changed.
 		 *
-         * @param {Object[]} validationErrors A list of validation errors.
-         * @returns {boolean|*} Returns true when the validation errors change.
-         */
-        didValidationErrorsChange: function didValidationErrorsChange( validationErrors ) {
-            if ( module.areBlocksOutOfSync() ) {
-                module.lastStates.validationErrors = [];
+		 * @param {Object[]} validationErrors A list of validation errors.
+		 * @return {boolean|*} Returns true when the validation errors change.
+		 */
+		didValidationErrorsChange: function didValidationErrorsChange( validationErrors ) {
+			if ( module.areBlocksOutOfSync() ) {
+				module.lastStates.validationErrors = [];
 			}
 
-            return (
-                module.lastStates.validationErrors.length !== validationErrors.length
-                ||
-                ( validationErrors && ! _.isEqual( module.lastStates.validationErrors, validationErrors ) )
-            );
-        },
+			return (
+				module.lastStates.validationErrors.length !== validationErrors.length
+				||
+				( validationErrors && ! _.isEqual( module.lastStates.validationErrors, validationErrors ) )
+			);
+		},
 
-        /**
-         * Checks if the block order is out of sync.
-         *
-         * Block uids change on page load and can get out of sync during normal editing and saving processes.  This method gives a check to determine if an "out of sync" condition occurred.
-         *
-         * @returns {boolean}
-         */
-        areBlocksOutOfSync: function areBlocksOutOfSync() {
-            var blockOrder = wp.data.select( 'core/editor' ).getBlockOrder();
-            if ( module.lastStates.blockOrder.length !== blockOrder.length || ! _.isEqual( module.lastStates.blockOrder, blockOrder ) ) {
-                module.lastStates.blockOrder = blockOrder;
-                return true;
-            }
+		/**
+		 * Checks if the block order is out of sync.
+		 *
+		 * Block uids change on page load and can get out of sync during normal editing and saving processes.  This method gives a check to determine if an "out of sync" condition occurred.
+		 *
+		 * @return {boolean} Whether out of sync.
+		 */
+		areBlocksOutOfSync: function areBlocksOutOfSync() {
+			var blockOrder = wp.data.select( 'core/editor' ).getBlockOrder();
+			if ( module.lastStates.blockOrder.length !== blockOrder.length || ! _.isEqual( module.lastStates.blockOrder, blockOrder ) ) {
+				module.lastStates.blockOrder = blockOrder;
+				return true;
+			}
 
-            return false;
-        },
+			return false;
+		},
 
 		/**
 		 * Get flattened block order.

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -30,6 +30,10 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 */
 		storeName: 'amp/blockValidation',
 
+        lastStates: {
+            validationErrors: []
+        },
+
 		/**
 		 * Boot module.
 		 *
@@ -142,11 +146,11 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				}
 			);
 
-			// Short-circuit if there was no change to the validation errors.
-			if ( ! validationErrors || _.isEqual( module.lastValidationErrors, validationErrors ) ) {
-				return;
-			}
-			module.lastValidationErrors = validationErrors;
+            // Short-circuit if there was no change to the validation errors.
+            if ( ! module.didValidationErrorsChange( validationErrors ) ) {
+                return;
+            }
+            module.lastStates.validationErrors = validationErrors;
 
 			// Remove any existing notice.
 			if ( module.validationWarningNoticeId ) {
@@ -226,6 +230,20 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 
 			module.validationWarningNoticeId = wp.data.dispatch( 'core/editor' ).createWarningNotice( noticeElement, { spokenMessage: noticeMessage } ).notice.id;
 		},
+
+        /**
+		 * Checks if the validation errors have changed.
+		 *
+         * @param {Object[]} validationErrors A list of validation errors.
+         * @returns {boolean|*} Returns true when the validation errors change.
+         */
+        didValidationErrorsChange: function didValidationErrorsChange( validationErrors ) {
+            return (
+                module.lastStates.validationErrors.length !== validationErrors.length
+                ||
+                ( validationErrors && ! _.isEqual( module.lastStates.validationErrors, validationErrors ) )
+            );
+        },
 
 		/**
 		 * Get flattened block order.

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -102,6 +102,19 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		},
 
 		/**
+		 * Checks if AMP is enabled for this post.
+		 *
+		 * @return {boolean} Returns true when the AMP toggle is on; else, false is returned.
+		 */
+		isAMPEnabled: function isAMPEnabled() {
+			var meta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+			if ( meta && meta.amp_status && window.wpAmpEditor.possibleStati.includes( meta.amp_status ) ) {
+				return 'enabled' === meta.amp_status;
+			}
+			return false;
+		},
+
+		/**
 		 * Checks if the validate errors state change handler should wait before processing.
 		 *
 		 * @return {boolean} Whether should wait.
@@ -133,6 +146,15 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 */
 		handleValidationErrorsStateChange: function handleValidationErrorsStateChange() {
 			var currentPost, validationErrors, blockValidationErrors, noticeElement, noticeMessage, blockErrorCount, ampValidity, hasActuallyUnacceptedError;
+
+			if ( ! module.isAMPEnabled() ) {
+				if ( ! module.lastStates.noticesAreReset ) {
+					module.lastStates.noticesAreReset = true;
+					module.resetWarningNotice();
+					module.resetBlockNotices();
+				}
+				return;
+			}
 
 			if ( module.waitToHandleStateChange() ) {
 				return;

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -30,8 +30,14 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 */
 		storeName: 'amp/blockValidation',
 
+        /**
+		 * Holds the last states which are used for comparisons.
+		 *
+		 * @param {Object}
+         */
         lastStates: {
-            validationErrors: []
+            validationErrors: [],
+            blockOrder: []
         },
 
 		/**
@@ -238,11 +244,32 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
          * @returns {boolean|*} Returns true when the validation errors change.
          */
         didValidationErrorsChange: function didValidationErrorsChange( validationErrors ) {
+            if ( module.areBlocksOutOfSync() ) {
+                module.lastStates.validationErrors = [];
+			}
+
             return (
                 module.lastStates.validationErrors.length !== validationErrors.length
                 ||
                 ( validationErrors && ! _.isEqual( module.lastStates.validationErrors, validationErrors ) )
             );
+        },
+
+        /**
+         * Checks if the block order is out of sync.
+         *
+         * Block uids change on page load and can get out of sync during normal editing and saving processes.  This method gives a check to determine if an "out of sync" condition occurred.
+         *
+         * @returns {boolean}
+         */
+        areBlocksOutOfSync: function areBlocksOutOfSync() {
+            var blockOrder = wp.data.select( 'core/editor' ).getBlockOrder();
+            if ( module.lastStates.blockOrder.length !== blockOrder.length || ! _.isEqual( module.lastStates.blockOrder, blockOrder ) ) {
+                module.lastStates.blockOrder = blockOrder;
+                return true;
+            }
+
+            return false;
         },
 
 		/**

--- a/assets/src/amp-block-editor-toggle.js
+++ b/assets/src/amp-block-editor-toggle.js
@@ -26,14 +26,14 @@ function AMPToggle( { enabledStatus, onAmpChange } ) {
 	return (
 		<Fragment>
 			<PluginPostStatusInfo>
-				{ ! errorMessages.length && __( 'Enable AMP', 'amp' ) }
+				{ ! errorMessages.length && <label htmlFor='amp-enabled'>{ __( 'Enable AMP', 'amp' ) }</label> }
 				{
 					! errorMessages.length &&
 					(
 						<FormToggle
 							checked={ 'enabled' === enabledStatus }
 							onChange={ () => onAmpChange( enabledStatus ) }
-							id={ 'amp-enabled' }
+							id='amp-enabled'
 						/>
 					)
 				}
@@ -41,7 +41,7 @@ function AMPToggle( { enabledStatus, onAmpChange } ) {
 					!! errorMessages.length &&
 					(
 						<Notice
-							status={ 'warning' }
+							status='warning'
 							isDismissible={ false }
 						>
 							{


### PR DESCRIPTION
This PR fixes the problems noted in #1292:

- [x] Changes the filter hook name to `editor.BlockEdit`.  This filter was changed in [Gutenberg 3.3](https://github.com/WordPress/gutenberg/blob/41fd116ca1f73a9b5c962c66ea0c4aae338ea35e/docs/reference/deprecated.md#330) as noted here:

>blocks.BlockEdit filter removed. Please use editor.BlockEdit instead.

- [x] Changes the block `uid` to `ownProps.clientId`.  The `id` property was changed in [Gutenberg 3.5.0](https://github.com/WordPress/gutenberg/blob/41fd116ca1f73a9b5c962c66ea0c4aae338ea35e/docs/reference/deprecated.md#350) to `.clientId` as noted here:

>All references to a block's `uid` have been replaced with equivalent props and selectors for `clientId`.

These two changes result in displaying the AMP validation error at the affected block upon saving or updating:

![amp-issue-block-level-notification](https://user-images.githubusercontent.com/7284611/43414259-e503d99a-93f7-11e8-9ab7-24a58d14b47b.png)

- [x] Handling when blocks get out of sync.

- [x] Handling notices when duplicating blocks.

- [x] Reset warning notice after removing all affected blocks.

- [x] Display block-level notices in native mode or when `force_sanitization` is enabled.

- [x] Display block-level notices on first loading the post into the editor.
When first opening a post in the editor, the validation notices are displayed.  They update when saving.

- [x] Remove and disable notice handling when the AMP toggle is off.
When the post's AMP toggle is off, the top and block level notices are removed.  It then bails out.  When the toggle is turned to on, the notices reappear after saving.

Closes #1292.