### PR TITLE
Add preload links & resource hints, and optimize order of elements in head

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1539,7 +1539,7 @@ class AMP_Theme_Support {
 		 * "Next, preload the AMP runtime v0.js <script> tag with <link as=script href=https://cdn.ampproject.org/v0.js rel=preload>.
 		 * The AMP runtime should start downloading as soon as possible because the AMP boilerplate hides the document via body { visibility:hidden }
 		 * until the AMP runtime has loaded. Preloading the AMP runtime tells the browser to download the script with a higher priority."
-		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos Optimize the AMP Runtime loading}
+		 * {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos Optimize the AMP Runtime loading}
 		 */
 		$prioritized_preloads = array();
 		if ( ! isset( $links['preload'] ) ) {
@@ -1580,7 +1580,7 @@ class AMP_Theme_Support {
 		 * "Specify the <script> tags for render-delaying extensions (e.g., amp-experiment, amp-dynamic-css-classes, and amp-story)."
 		 * "Specify the <script> tags for remaining extensions (e.g., amp-bind, ...). These extensions are not render-delaying and therefore
 		 * should not be preloaded because they might take away important bandwidth for the initial render."
-		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
+		 * {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
 		 */
 		if ( isset( $amp_scripts['amp-runtime'] ) ) {
 			$ordered_scripts['amp-runtime'] = $amp_scripts['amp-runtime'];
@@ -1600,7 +1600,7 @@ class AMP_Theme_Support {
 
 		/*
 		 * "Specify the <link> tag for your favicon."
-		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
+		 * {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
 		 */
 		if ( isset( $links['icon'] ) ) {
 			foreach ( $links['icon'] as $link ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -754,16 +754,15 @@ class AMP_Theme_Support {
 		} );
 
 		/*
-		 * "AMP HTML documents MUST contain the AMP boilerplate code (head > style[amp-boilerplate] and noscript > style[amp-boilerplate]) in their head tag."
-		 * https://www.ampproject.org/docs/fundamentals/spec#required-markup
+		 * "AMP HTML documents MUST contain the AMP boilerplate code (head > style[amp-boilerplate] and noscript > style[amp-boilerplate])
+		 * in their head tag." {@link https://www.ampproject.org/docs/fundamentals/spec#required-markup AMP Required markup}
 		 *
 		 * After "Specify the <link> tag for your favicon.", then
 		 * "Specify any custom styles by using the <style amp-custom> tag."
 		 *
 		 * Note that the boilerplate is added at the very end because:
-		 * "Finally, specify the AMP boilerplate code. By putting the boilerplate code last, it prevents custom styles
-		 * from accidentally overriding the boilerplate css rules."
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit
+		 * "Finally, specify the AMP boilerplate code. By putting the boilerplate code last, it prevents custom styles from accidentally
+		 * overriding the boilerplate css rules." {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
 		 *
 		 * Other required markup is added in the ensure_required_markup method, including meta charset, meta viewport, and rel=canonical link.
 		 */
@@ -1366,11 +1365,11 @@ class AMP_Theme_Support {
 	}
 
 	/**
-	 * Ensure markup required by AMP, and ensure the elements are in the optimal loading order.
+	 * Ensure the markup exists as required by AMP and elements are in the optimal loading order.
 	 *
-	 * Ensure meta[charset], meta[name=viewport], and link[rel=canonical]; a the whitelist sanitizer
-	 * may have removed an illegal meta[http-equiv] or meta[name=viewport]. Core only outputs a
-	 * canonical URL by default if a singular post. Add preload links.
+	 * Ensure meta[charset], meta[name=viewport], and link[rel=canonical] exist, as the whitelist sanitizer
+	 * may have removed an illegal meta[http-equiv] or meta[name=viewport]. For a singular post, core only outputs a
+	 * canonical URL by default. Adds the preload links.
 	 *
 	 * @since 0.7
 	 * @link https://www.ampproject.org/docs/reference/spec#required-markup
@@ -1396,7 +1395,7 @@ class AMP_Theme_Support {
 			$dom->documentElement->insertBefore( $head, $dom->documentElement->firstChild );
 		}
 
-		// Ensure there is a Schema.org script.
+		// Ensure there is a schema.org script.
 		$schema_org_meta_script = null;
 		foreach ( $head->getElementsByTagName( 'script' ) as $script ) {
 			if ( 'application/ld+json' === $script->getAttribute( 'type' ) && false !== strpos( $script->nodeValue, 'schema.org' ) ) {
@@ -1437,13 +1436,13 @@ class AMP_Theme_Support {
 		 *
 		 * "The first tag should be the meta charset tag, followed by any remaining meta tags."
 		 *
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
+		 * {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos Optimize the AMP Runtime loading}
 		 */
 		$meta_charset  = null;
 		$meta_viewport = null;
 		$meta_elements = array();
 		foreach ( $head->getElementsByTagName( 'meta' ) as $meta ) {
-			if ( $meta->hasAttribute( 'charset' ) ) { // There will not be a meta[http-equiv] because sanitizer would have removed.
+			if ( $meta->hasAttribute( 'charset' ) ) { // There will not be a meta[http-equiv] because the sanitizer removed it.
 				$meta_charset = $meta;
 			} elseif ( 'viewport' === $meta->getAttribute( 'name' ) ) {
 				$meta_viewport = $meta;
@@ -1485,7 +1484,7 @@ class AMP_Theme_Support {
 			$previous_node = $title;
 		}
 
-		// See <https://github.com/ampproject/amphtml/blob/2fd30ca984bceac05905bd5b17f9e0010629d719/src/render-delaying-services.js#L39-L43>.
+		// @see https://github.com/ampproject/amphtml/blob/2fd30ca984bceac05905bd5b17f9e0010629d719/src/render-delaying-services.js#L39-L43 AMPHTML Render Delaying Services SERVICES definition.
 		$render_delaying_extensions = array(
 			'amp-experiment',
 			'amp-dynamic-css-classes',
@@ -1535,11 +1534,12 @@ class AMP_Theme_Support {
 			$amp_scripts[ $missing_script_handle ] = AMP_DOM_Utils::create_node( $dom, 'script', $attrs );
 		}
 
-		/*
-		 * "Next, preload the AMP runtime v0.js <script> tag with  <link as=script href=https://cdn.ampproject.org/v0.js rel=preload>.
+		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		 *
+		 * "Next, preload the AMP runtime v0.js <script> tag with <link as=script href=https://cdn.ampproject.org/v0.js rel=preload>.
 		 * The AMP runtime should start downloading as soon as possible because the AMP boilerplate hides the document via body { visibility:hidden }
 		 * until the AMP runtime has loaded. Preloading the AMP runtime tells the browser to download the script with a higher priority."
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
+		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos Optimize the AMP Runtime loading}
 		 */
 		$prioritized_preloads = array();
 		if ( ! isset( $links['preload'] ) ) {
@@ -1579,8 +1579,8 @@ class AMP_Theme_Support {
 		/*
 		 * "Specify the <script> tags for render-delaying extensions (e.g., amp-experiment, amp-dynamic-css-classes, and amp-story)."
 		 * "Specify the <script> tags for remaining extensions (e.g., amp-bind, ...). These extensions are not render-delaying and therefore
-		 *  should not be preloaded because they might take away important bandwidth for the initial render."
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#
+		 * should not be preloaded because they might take away important bandwidth for the initial render."
+		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
 		 */
 		if ( isset( $amp_scripts['amp-runtime'] ) ) {
 			$ordered_scripts['amp-runtime'] = $amp_scripts['amp-runtime'];
@@ -1600,7 +1600,7 @@ class AMP_Theme_Support {
 
 		/*
 		 * "Specify the <link> tag for your favicon."
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit
+		 * {@see https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit AMP Hosting Guide}
 		 */
 		if ( isset( $links['icon'] ) ) {
 			foreach ( $links['icon'] as $link ) {
@@ -1876,7 +1876,7 @@ class AMP_Theme_Support {
 
 		$dom_serialize_start = microtime( true );
 
-		// Gather the all component scripts that are used in the document, and render any not already printed.
+		// Gather all component scripts that are used in the document and then render any not already printed.
 		$amp_scripts = $assets['scripts'];
 		foreach ( self::$embed_handlers as $embed_handler ) {
 			$amp_scripts = array_merge(
@@ -1886,7 +1886,7 @@ class AMP_Theme_Support {
 		}
 		foreach ( $amp_scripts as $handle => $src ) {
 			/*
-			 * Make sure the src is up to date. This allows for embed handlers to override the
+			 * Make sure the src is up-to-date. This allows for embed handlers to override the
 			 * default extension version by defining a different URL.
 			 */
 			if ( is_string( $src ) && wp_script_is( $handle, 'registered' ) ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -754,17 +754,27 @@ class AMP_Theme_Support {
 		} );
 
 		/*
-		 * Add additional markup required by AMP <https://www.ampproject.org/docs/reference/spec#required-markup>.
-		 * Note that the meta[name=viewport] is not added here because a theme may want to define one with additional
-		 * properties than included in the default configuration. If a theme doesn't include one, then the meta viewport
-		 * will be added when output buffering is finished. Note that meta charset _is_ output here because the output
-		 * buffer will need it to parse the document properly, and it must be exactly as is to be valid AMP. Nevertheless,
-		 * in this case too we should defer to the theme as well to output the meta charset because it is possible the
-		 * install is not on utf-8 and we may need to do a encoding conversion.
+		 * "AMP HTML documents MUST contain the AMP boilerplate code (head > style[amp-boilerplate] and noscript > style[amp-boilerplate]) in their head tag."
+		 * https://www.ampproject.org/docs/fundamentals/spec#required-markup
+		 *
+		 * After "Specify the <link> tag for your favicon.", then
+		 * "Specify any custom styles by using the <style amp-custom> tag."
+		 *
+		 * Note that the boilerplate is added at the very end because:
+		 * "Finally, specify the AMP boilerplate code. By putting the boilerplate code last, it prevents custom styles
+		 * from accidentally overriding the boilerplate css rules."
+		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit
+		 *
+		 * Other required markup is added in the ensure_required_markup method, including meta charset, meta viewport, and rel=canonical link.
 		 */
-		add_action( 'wp_print_styles', array( __CLASS__, 'print_amp_styles' ), 0 ); // Print boilerplate before theme and plugin stylesheets.
-		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
+		add_action( 'wp_head', function() {
+			echo '<style amp-custom></style>';
+		}, 0 );
+		add_action( 'wp_head', function() {
+			echo amp_get_boilerplate_code(); // WPCS: xss ok.
+		}, PHP_INT_MAX );
 
+		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'dequeue_customize_preview_scripts' ), 1000 );
 		add_filter( 'customize_partial_render', array( __CLASS__, 'filter_customize_partial_render' ) );
@@ -1356,25 +1366,19 @@ class AMP_Theme_Support {
 	}
 
 	/**
-	 * Print AMP boilerplate and custom styles.
-	 */
-	public static function print_amp_styles() {
-		echo amp_get_boilerplate_code() . "\n"; // WPCS: XSS OK.
-		echo "<style amp-custom></style>\n"; // This will by populated by AMP_Style_Sanitizer.
-	}
-
-	/**
-	 * Ensure markup required by AMP <https://www.ampproject.org/docs/reference/spec#required-markup>.
+	 * Ensure markup required by AMP, and ensure the elements are in the optimal loading order.
 	 *
 	 * Ensure meta[charset], meta[name=viewport], and link[rel=canonical]; a the whitelist sanitizer
 	 * may have removed an illegal meta[http-equiv] or meta[name=viewport]. Core only outputs a
-	 * canonical URL by default if a singular post.
+	 * canonical URL by default if a singular post. Add preload links.
 	 *
 	 * @since 0.7
+	 * @link https://www.ampproject.org/docs/reference/spec#required-markup
+	 * @link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
 	 * @todo All of this might be better placed inside of a sanitizer.
 	 *
 	 * @param DOMDocument $dom            Document.
-	 * @param string[]    $script_handles AMP script handles.
+	 * @param string[]    $script_handles AMP script handles for components identified during output buffering.
 	 */
 	public static function ensure_required_markup( DOMDocument $dom, $script_handles = array() ) {
 		/**
@@ -1384,57 +1388,36 @@ class AMP_Theme_Support {
 		 * @var DOMElement $script
 		 * @var DOMElement $link
 		 */
+
+		// Make sure the HEAD element is in the doc.
 		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
 		if ( ! $head ) {
 			$head = $dom->createElement( 'head' );
 			$dom->documentElement->insertBefore( $head, $dom->documentElement->firstChild );
 		}
-		$meta_charset  = null;
-		$meta_viewport = null;
-		foreach ( $head->getElementsByTagName( 'meta' ) as $meta ) {
-			if ( $meta->hasAttribute( 'charset' ) && 'utf-8' === strtolower( $meta->getAttribute( 'charset' ) ) ) { // @todo Also look for meta[http-equiv="Content-Type"]?
-				$meta_charset = $meta;
-			} elseif ( 'viewport' === $meta->getAttribute( 'name' ) ) {
-				$meta_viewport = $meta;
-			}
-		}
-		if ( ! $meta_charset ) {
-			// Warning: This probably means the character encoding needs to be converted.
-			$meta_charset = AMP_DOM_Utils::create_node( $dom, 'meta', array(
-				'charset' => 'utf-8',
-			) );
-			$head->insertBefore( $meta_charset, $head->firstChild );
-		}
-		if ( ! $meta_viewport ) {
-			$meta_viewport = AMP_DOM_Utils::create_node( $dom, 'meta', array(
-				'name'    => 'viewport',
-				'content' => 'width=device-width,minimum-scale=1',
-			) );
-			$head->insertBefore( $meta_viewport, $meta_charset->nextSibling );
-		}
-		// Prevent schema.org duplicates.
-		$has_schema_org_metadata = false;
+
+		// Ensure there is a Schema.org script.
+		$schema_org_meta_script = null;
 		foreach ( $head->getElementsByTagName( 'script' ) as $script ) {
 			if ( 'application/ld+json' === $script->getAttribute( 'type' ) && false !== strpos( $script->nodeValue, 'schema.org' ) ) {
-				$has_schema_org_metadata = true;
+				$schema_org_meta_script = $script;
 				break;
 			}
 		}
-		if ( ! $has_schema_org_metadata ) {
+		if ( ! $schema_org_meta_script ) {
 			$script = $dom->createElement( 'script' );
 			$script->setAttribute( 'type', 'application/ld+json' );
 			$script->appendChild( $dom->createTextNode( wp_json_encode( amp_get_schemaorg_metadata() ) ) );
 			$head->appendChild( $script );
 		}
 
+		// Ensure rel=canonical link.
 		$links         = array();
 		$link_elements = $head->getElementsByTagName( 'link' );
-
-		// Ensure rel=canonical link.
 		$rel_canonical = null;
 		foreach ( $link_elements as $link ) {
 			if ( $link->hasAttribute( 'rel' ) ) {
-				$links[ $link->getAttribute( 'rel' ) ][ $link->getAttribute( 'href' ) ] = $link;
+				$links[ $link->getAttribute( 'rel' ) ][] = $link;
 			}
 		}
 		if ( empty( $links['canonical'] ) ) {
@@ -1445,26 +1428,152 @@ class AMP_Theme_Support {
 			$head->appendChild( $rel_canonical );
 		}
 
+		/*
+		 * Ensure meta charset and meta viewport are present.
+		 *
+		 * "AMP is already quite restrictive about which markup is allowed in the <head> section. However,
+		 * there are a few basic optimizations that you can apply. The key is to structure the <head> section
+		 * in a way so that all render-blocking scripts and custom fonts load as fast as possible."
+		 *
+		 * "The first tag should be the meta charset tag, followed by any remaining meta tags."
+		 *
+		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
+		 */
+		$meta_charset  = null;
+		$meta_viewport = null;
+		$meta_elements = array();
+		foreach ( $head->getElementsByTagName( 'meta' ) as $meta ) {
+			if ( $meta->hasAttribute( 'charset' ) ) { // There will not be a meta[http-equiv] because sanitizer would have removed.
+				$meta_charset = $meta;
+			} elseif ( 'viewport' === $meta->getAttribute( 'name' ) ) {
+				$meta_viewport = $meta;
+			} else {
+				$meta_elements[] = $meta;
+			}
+		}
+		if ( ! $meta_charset ) {
+			// Warning: This probably means the character encoding needs to be converted.
+			$meta_charset = AMP_DOM_Utils::create_node( $dom, 'meta', array(
+				'charset' => 'utf-8',
+			) );
+		} else {
+			$head->removeChild( $meta_charset ); // So we can move it.
+		}
+		$head->insertBefore( $meta_charset, $head->firstChild );
+
+		if ( ! $meta_viewport ) {
+			$meta_viewport = AMP_DOM_Utils::create_node( $dom, 'meta', array(
+				'name'    => 'viewport',
+				'content' => 'width=device-width,minimum-scale=1',
+			) );
+		} else {
+			$head->removeChild( $meta_viewport ); // So we can move it.
+		}
+		$head->insertBefore( $meta_viewport, $meta_charset->nextSibling );
+
+		$previous_node = $meta_viewport;
+		foreach ( $meta_elements as $meta_element ) {
+			$meta_element->parentNode->removeChild( $meta_element );
+			$head->insertBefore( $meta_element, $previous_node->nextSibling );
+			$previous_node = $meta_element;
+		}
+
+		$title = $head->getElementsByTagName( 'title' )->item( 0 );
+		if ( $title ) {
+			$title->parentNode->removeChild( $title ); // So we can move it.
+			$head->insertBefore( $title, $previous_node->nextSibling );
+			$previous_node = $title;
+		}
+
+		// See <https://github.com/ampproject/amphtml/blob/2fd30ca984bceac05905bd5b17f9e0010629d719/src/render-delaying-services.js#L39-L43>.
+		$render_delaying_extensions = array(
+			'amp-experiment',
+			'amp-dynamic-css-classes',
+			'amp-story',
+		);
+
+		// Obtain the existing AMP scripts.
+		$amp_scripts     = array();
+		$ordered_scripts = array();
+		$head_scripts    = array();
+		$runtime_src     = wp_scripts()->registered['amp-runtime']->src;
+		foreach ( $head->getElementsByTagName( 'script' ) as $script ) { // Note that prepare_response() already moved body scripts to head.
+			$head_scripts[] = $script;
+		}
+		foreach ( $head_scripts as $script ) {
+			$src = $script->getAttribute( 'src' );
+			if ( ! $src || 'https://cdn.ampproject.org/' !== substr( $src, 0, 27 ) ) {
+				continue;
+			}
+			if ( $runtime_src === $src ) {
+				$amp_scripts['amp-runtime'] = $script;
+			} elseif ( $script->hasAttribute( 'custom-element' ) ) {
+				$amp_scripts[ $script->getAttribute( 'custom-element' ) ] = $script;
+			} elseif ( $script->hasAttribute( 'custom-template' ) ) {
+				$amp_scripts[ $script->getAttribute( 'custom-template' ) ] = $script;
+			} else {
+				continue;
+			}
+			$script->parentNode->removeChild( $script ); // So we can move it.
+		}
+
+		// Create scripts for any components discovered from output buffering.
+		foreach ( array_diff( $script_handles, array_keys( $amp_scripts ) ) as $missing_script_handle ) {
+			if ( ! wp_script_is( $missing_script_handle, 'registered' ) ) {
+				continue;
+			}
+			$attrs = array(
+				'src'   => wp_scripts()->registered[ $missing_script_handle ]->src,
+				'async' => '',
+			);
+			if ( 'amp-mustache' === $missing_script_handle ) {
+				$attrs['custom-template'] = $missing_script_handle;
+			} else {
+				$attrs['custom-element'] = $missing_script_handle;
+			}
+
+			$amp_scripts[ $missing_script_handle ] = AMP_DOM_Utils::create_node( $dom, 'script', $attrs );
+		}
+
+		/*
+		 * "Next, preload the AMP runtime v0.js <script> tag with  <link as=script href=https://cdn.ampproject.org/v0.js rel=preload>.
+		 * The AMP runtime should start downloading as soon as possible because the AMP boilerplate hides the document via body { visibility:hidden }
+		 * until the AMP runtime has loaded. Preloading the AMP runtime tells the browser to download the script with a higher priority."
+		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
+		 */
 		$prioritized_preloads = array();
 		if ( ! isset( $links['preload'] ) ) {
 			$links['preload'] = array();
 		}
 
-		/*
-		 * "AMP is already quite restrictive about which markup is allowed in the <head> section. However,
-		 * there are a few basic optimizations that you can apply. The key is to structure the <head> section
-		 * in a way so that all render-blocking scripts and custom fonts load as fast as possible."
-		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos
-		 */
-		$runtime_src = wp_scripts()->registered['amp-runtime']->src;
-		if ( isset( $links['preload'][ $runtime_src ] ) ) {
-			$prioritized_preloads[ $runtime_src ] = $links['preload'][ $runtime_src ];
-		} else {
-			$prioritized_preloads[ $runtime_src ] = AMP_DOM_Utils::create_node( $dom, 'link', array(
+		$prioritized_preloads[] = AMP_DOM_Utils::create_node( $dom, 'link', array(
+			'rel'  => 'preload',
+			'as'   => 'script',
+			'href' => $runtime_src,
+		) );
+
+		$amp_script_handles = array_keys( $amp_scripts );
+		foreach ( array_intersect( $render_delaying_extensions, $amp_script_handles ) as $script_handle ) {
+			if ( ! in_array( $script_handle, $render_delaying_extensions, true ) ) {
+				continue;
+			}
+			$prioritized_preloads[] = AMP_DOM_Utils::create_node( $dom, 'link', array(
 				'rel'  => 'preload',
 				'as'   => 'script',
-				'href' => $runtime_src,
+				'href' => $amp_scripts[ $script_handle ]->getAttribute( 'src' ),
 			) );
+		}
+		$links['preload'] = array_merge( $prioritized_preloads, $links['preload'] );
+
+		$link_relations = array( 'preconnect', 'dns-prefetch', 'preload', 'prerender', 'prefetch' );
+		foreach ( $link_relations as $rel ) {
+			if ( ! isset( $links[ $rel ] ) ) {
+				continue;
+			}
+			foreach ( $links[ $rel ] as $link ) {
+				$head->insertBefore( $link, $previous_node->nextSibling );
+				$previous_node = $link;
+			}
 		}
 
 		/*
@@ -1473,38 +1582,36 @@ class AMP_Theme_Support {
 		 *  should not be preloaded because they might take away important bandwidth for the initial render."
 		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#
 		 */
-		$render_delaying_extensions    = array( 'amp-experiment', 'amp-dynamic-css-classes', 'amp-story' ); // See <https://github.com/ampproject/amphtml/blob/2fd30ca984bceac05905bd5b17f9e0010629d719/src/render-delaying-services.js#L39-L43>.
-		$priority_order_script_handles = array_unique( array_merge(
-			array_intersect( $render_delaying_extensions, $script_handles ),
-			$script_handles
-		) );
-		foreach ( $priority_order_script_handles as $script_handle ) {
-			if ( ! wp_script_is( $script_handle, 'registered' ) ) {
-				continue;
-			}
-			$src = wp_scripts()->registered[ $script_handle ]->src;
-			if ( isset( $links['preload'][ $src ] ) ) {
-				$prioritized_preloads[ $src ] = $links['preload'][ $src ];
-			} else {
-				$prioritized_preloads[ $src ] = AMP_DOM_Utils::create_node( $dom, 'link', array(
-					'rel'  => 'preload',
-					'as'   => 'script',
-					'href' => $src,
-				) );
+		if ( isset( $amp_scripts['amp-runtime'] ) ) {
+			$ordered_scripts['amp-runtime'] = $amp_scripts['amp-runtime'];
+		}
+		foreach ( $render_delaying_extensions as $extension ) {
+			if ( isset( $amp_scripts[ $extension ] ) ) {
+				$ordered_scripts[ $extension ] = $amp_scripts[ $extension ];
+				unset( $amp_scripts[ $extension ] );
 			}
 		}
-		$links['preload'] = array_merge( $prioritized_preloads, $links['preload'] );
 
-		// Make sure resource hints and preload links are put at the top of the head.
-		$resource_hint_rels = array( 'preconnect', 'dns-prefetch', 'preload', 'prerender', 'prefetch' );
-		foreach ( $resource_hint_rels as $rel ) {
-			if ( ! isset( $links[ $rel ] ) ) {
-				continue;
-			}
-			foreach ( array_reverse( $links[ $rel ] ) as $link ) {
-				$head->insertBefore( $link, $meta_viewport->nextSibling );
+		$ordered_scripts = array_merge( $ordered_scripts, $amp_scripts );
+		foreach ( $ordered_scripts as $ordered_script ) {
+			$head->insertBefore( $ordered_script, $previous_node->nextSibling );
+			$previous_node = $ordered_script;
+		}
+
+		/*
+		 * "Specify the <link> tag for your favicon."
+		 * https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit
+		 */
+		if ( isset( $links['icon'] ) ) {
+			foreach ( $links['icon'] as $link ) {
+				$link->parentNode->removeChild( $link ); // So we can move it.
+				$head->insertBefore( $link, $previous_node->nextSibling );
+				$previous_node = $link;
 			}
 		}
+
+		// Note the style[amp-custom] and style[amp-boilerplate] are output in the add_hooks() method.
+		unset( $previous_node );
 	}
 
 	/**
@@ -1743,7 +1850,7 @@ class AMP_Theme_Support {
 		if ( isset( $head ) ) {
 			$xpath = new DOMXPath( $dom );
 			foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
-				$head->appendChild( $script );
+				$head->appendChild( $script->parentNode->removeChild( $script ) );
 			}
 		}
 
@@ -1777,7 +1884,15 @@ class AMP_Theme_Support {
 				$embed_handler->get_scripts()
 			);
 		}
-		$script_tags = amp_render_scripts( $amp_scripts );
+		foreach ( $amp_scripts as $handle => $src ) {
+			/*
+			 * Make sure the src is up to date. This allows for embed handlers to override the
+			 * default extension version by defining a different URL.
+			 */
+			if ( is_string( $src ) && wp_script_is( $handle, 'registered' ) ) {
+				wp_scripts()->registered[ $handle ]->src = $src;
+			}
+		}
 
 		self::ensure_required_markup( $dom, array_keys( $amp_scripts ) );
 
@@ -1827,16 +1942,6 @@ class AMP_Theme_Support {
 
 		$response  = "<!DOCTYPE html>\n";
 		$response .= AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
-
-		// Inject additional AMP component scripts which have been discovered by the sanitizers into the head.
-		if ( ! empty( $script_tags ) ) {
-			$response = preg_replace(
-				'#(?=</head>)#',
-				$script_tags,
-				$response,
-				1
-			);
-		}
 
 		AMP_Response_Headers::send_server_timing( 'amp_dom_serialize', -$dom_serialize_start, 'AMP DOM Serialize' );
 

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -148,19 +148,12 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'multiple_same_image'                      => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" />
-<img src="http://placehold.it/350x150" width="350" height="150" />
-<img src="http://placehold.it/350x150" width="350" height="150" />
-<img src="http://placehold.it/350x150" width="350" height="150" />
-				',
+				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" />',
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 
 			'multiple_different_images'                => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" />
-<img src="http://placehold.it/360x160" width="360" height="160" />
-<img src="http://placehold.it/370x170" width="370" height="170" />
-<img src="http://placehold.it/380x180" width="380" height="180" />',
+				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/360x160" width="360" height="160" /><img src="http://placehold.it/370x170" width="370" height="170" /><img src="http://placehold.it/380x180" width="380" height="180" />',
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 

--- a/tests/test-amp-script-sanitizer.php
+++ b/tests/test-amp-script-sanitizer.php
@@ -93,7 +93,7 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 
 		$content = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
 
-		$this->assertContains( '<!-- Google Tag Manager --><!-- End Google Tag Manager -->', $content );
+		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
 		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
 		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
 		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><div placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe><!--/noscript-->', $content );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -74,18 +74,26 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'multiple_same_video' => array(
-				'<video src="https://example.com/video.mp4" width="480" height="300"></video>
-<video src="https://example.com/video.mp4" width="480" height="300"></video>
-<video src="https://example.com/video.mp4" width="480" height="300"></video>
-<video src="https://example.com/video.mp4" width="480" height="300"></video>',
+				implode( '', array(
+					'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
+					'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
+					'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
+					'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
+				) ),
 				'<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video>',
 			),
 
 			'multiple_different_videos' => array(
-				'<video src="https://example.com/video1.mp4" width="480" height="300"></video>
-<video src="https://example.com/video2.ogv" width="300" height="480"></video>
-<video src="https://example.com/video3.webm" height="100" width="200"></video>',
-				'<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"></amp-video><amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"></amp-video>',
+				implode( '', array(
+					'<video src="https://example.com/video1.mp4" width="480" height="300"></video>',
+					'<video src="https://example.com/video2.ogv" width="300" height="480"></video>',
+					'<video src="https://example.com/video3.webm" height="100" width="200"></video>',
+				) ),
+				implode( '', array(
+					'<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"></amp-video>',
+					'<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"></amp-video>',
+					'<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"></amp-video>',
+				) ),
 			),
 
 			'https_not_required' => array(


### PR DESCRIPTION
In lieu of WordPress not yet supporting preload links (see [#42438](https://core.trac.wordpress.org/ticket/42438)) and not always supporting resource hints (see [#44668](https://core.trac.wordpress.org/ticket/44668)), we can use the fact that we have a `DOMDocument` to supply them when missing.

This seeks to implement much of the drafted [AMP hosting guide](https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit).

* Add `preload` links for AMP runtime and render-blocking extension scripts.
* Ensure `preconnect` resource link is added for Google Fonts.
* Optimize order of elements in head, including putting `style[amp-custom]` before external external stylesheets and place boilerplate after `style[amp-custom]`.

In my testing, the changes in this PR improve the Lighthouse Performance score on my dev environment for Twenty Sixteen by 2 points: 78 to 80. 

![image](https://user-images.githubusercontent.com/134745/43672491-af6f37b0-9763-11e8-82c2-25c1f57235d4.png)

Note that this PR does not add `preload` links for images (i.e. header image and featured image since these are theme-specific; this needs to be done in core/ see [#42438](https://core.trac.wordpress.org/ticket/42438).)

See also https://github.com/Automattic/amp-wp/pull/1289.

For optimizing fonts other than from Google Fonts, see https://github.com/ampproject/amp-toolbox/issues/76