### PR TITLE
Improve validation and presentation of analytics form

### DIFF
--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -64,7 +64,7 @@ class AMP_Analytics_Options_Submenu_Page {
 								name="<?php echo esc_attr( $id_base . '[config]' ); ?>"
 								class="amp-analytics-input"
 								placeholder="{...}"
-								title="<?php esc_attr_e( 'A JSON object begins with a "{" and ends with a "}". Do not include any HTML tags like "<amp-analytics>" or "<script>".', 'amp' ); ?>"
+								title="<?php esc_attr_e( 'A JSON object begins with a &#8220;{&#8221; and ends with a &#8220;}&#8221;. Do not include any HTML tags like "<amp-analytics>" or "<script>".', 'amp' ); ?>"
 								required
 								><?php echo esc_textarea( $config ); ?></textarea>
 						</label>
@@ -115,6 +115,12 @@ class AMP_Analytics_Options_Submenu_Page {
 		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
 
 		$this->render_title();
+
+		?>
+		<p>
+			<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;.', 'amp' ) ); ?>
+		</p>
+		<?php
 
 		// Render entries stored in the DB.
 		foreach ( $analytics_entries as $entry_id => $entry ) {

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -94,7 +94,19 @@ class AMP_Analytics_Options_Submenu_Page {
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>
 			<p>
-				<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;.', 'amp' ) ); ?>
+				<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common configuration will look like the following, where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number:', 'amp' ) ); ?>
+
+				<pre>{
+	"vars": {
+		"account": "UA-XXXXX-Y"
+	},
+	"triggers": {
+		"trackPageview": {
+			"on": "visible",
+			"request": "pageview"
+		}
+	}
+}</pre>
 			</p>
 		</div><!-- .wrap -->
 		<?php

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -46,7 +46,7 @@ class AMP_Analytics_Options_Submenu_Page {
 					<p>
 						<label>
 							<?php esc_html_e( 'Type:', 'amp' ); ?>
-							<input class="option-input" type="text" name="<?php echo esc_attr( $id_base . '[type]' ); ?>" value="<?php echo esc_attr( $type ); ?>" />
+							<input class="option-input" type="text" name="<?php echo esc_attr( $id_base . '[type]' ); ?>" placeholder="<?php echo esc_attr_e( 'e.g. googleanalytics', 'amp' ); ?>" value="<?php echo esc_attr( $type ); ?>" />
 						</label>
 						<label>
 							<?php esc_html_e( 'ID:', 'amp' ); ?>
@@ -94,7 +94,7 @@ class AMP_Analytics_Options_Submenu_Page {
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>
 			<p>
-				<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common configuration will look like the following, where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number:', 'amp' ) ); ?>
+				<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
 
 				<pre>{
 	"vars": {

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -93,14 +93,17 @@ class AMP_Analytics_Options_Submenu_Page {
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>
+			<p>
+				<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;.', 'amp' ) ); ?>
+			</p>
 		</div><!-- .wrap -->
 		<?php
 	}
 
 	/**
-	 * Render.
+	 * Render styles.
 	 */
-	public function render() {
+	protected function render_styles() {
 		?>
 		<style>
 			.amp-analytics-input {
@@ -111,25 +114,12 @@ class AMP_Analytics_Options_Submenu_Page {
 			}
 		</style>
 		<?php
+	}
 
-		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
-
-		$this->render_title();
-
-		?>
-		<p>
-			<?php echo wp_kses_post( __( 'Please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a> for information on the required JSON configuration format. See also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;.', 'amp' ) ); ?>
-		</p>
-		<?php
-
-		// Render entries stored in the DB.
-		foreach ( $analytics_entries as $entry_id => $entry ) {
-			$this->render_entry( $entry_id, $entry['type'], $entry['config'] );
-		}
-
-		// Empty form for adding more entries.
-		$this->render_entry();
-
+	/**
+	 * Render scripts.
+	 */
+	protected function render_scripts() {
 		?>
 		<script>
 			Array.prototype.forEach.call( document.querySelectorAll( '.amp-analytics-input' ), function( textarea ) {
@@ -152,5 +142,26 @@ class AMP_Analytics_Options_Submenu_Page {
 			} );
 		</script>
 		<?php
+	}
+
+	/**
+	 * Render.
+	 */
+	public function render() {
+		$this->render_styles();
+
+		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
+
+		$this->render_title();
+
+		// Render entries stored in the DB.
+		foreach ( $analytics_entries as $entry_id => $entry ) {
+			$this->render_entry( $entry_id, $entry['type'], $entry['config'] );
+		}
+
+		// Empty form for adding more entries.
+		$this->render_entry();
+
+		$this->render_scripts();
 	}
 }

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -46,7 +46,7 @@ class AMP_Analytics_Options_Submenu_Page {
 					<p>
 						<label>
 							<?php esc_html_e( 'Type:', 'amp' ); ?>
-							<input class="option-input" type="text" name="<?php echo esc_attr( $id_base . '[type]' ); ?>" placeholder="<?php echo esc_attr_e( 'e.g. googleanalytics', 'amp' ); ?>" value="<?php echo esc_attr( $type ); ?>" />
+							<input class="option-input" type="text" required name="<?php echo esc_attr( $id_base . '[type]' ); ?>" placeholder="<?php esc_attr_e( 'e.g. googleanalytics', 'amp' ); ?>" value="<?php echo esc_attr( $type ); ?>" />
 						</label>
 						<label>
 							<?php esc_html_e( 'ID:', 'amp' ); ?>
@@ -101,7 +101,7 @@ class AMP_Analytics_Options_Submenu_Page {
 					<?php esc_html_e( 'Learn about analytics for AMP.', 'amp' ); ?>
 				</summary>
 				<p>
-					<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
+					<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a> and the AMP project\'s <a href="https://www.ampproject.org/docs/reference/components/amp-analytics" target="_blank">amp-analytics documentation</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; (see <a href="https://www.ampproject.org/docs/analytics/analytics-vendors" target="_blank">available vendors</a>) and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
 
 					<pre>{
 	"vars": {

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -87,16 +87,23 @@ class AMP_Analytics_Options_Submenu_Page {
 
 	/**
 	 * Render title.
+	 *
+	 * @param bool $has_entries Whether there are entries.
 	 */
-	public function render_title() {
+	public function render_title( $has_entries = false ) {
 		?>
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>
-			<p>
-				<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
 
-				<pre>{
+			<details <?php echo ! $has_entries ? 'open' : ''; ?>>
+				<summary>
+					<?php esc_html_e( 'Learn about analytics for AMP.', 'amp' ); ?>
+				</summary>
+				<p>
+					<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/Automattic/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
+
+					<pre>{
 	"vars": {
 		"account": "UA-XXXXX-Y"
 	},
@@ -107,7 +114,8 @@ class AMP_Analytics_Options_Submenu_Page {
 		}
 	}
 }</pre>
-			</p>
+				</p>
+			</details>
 		</div><!-- .wrap -->
 		<?php
 	}
@@ -164,7 +172,7 @@ class AMP_Analytics_Options_Submenu_Page {
 
 		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
 
-		$this->render_title();
+		$this->render_title( ! empty( $analytics_entries ) );
 
 		// Render entries stored in the DB.
 		foreach ( $analytics_entries as $entry_id => $entry ) {


### PR DESCRIPTION
When reviewing #1296 I was inspired with some quick wins to greatly facilitate the input of analytics data, which I expect will also lessen a lot of support topics on the issue.

* Use HTML5 form validation to prevent invalid JSON from being submitted and then lost when the page reloads.
* Parse the textarea value as JSON at input event to ensure JSON object is supplied.
* Add `required` attribute to the type and config fields to prevent empty values from being submitted.
* Add red border around invalid textures.
* Pretty-print saved JSON when rendering a config.
* Let initial value of analytics textarea be an empty object `{}`.
* Do client-side JSON validation.
* Add monospace font to texture.
* Add `{...}` as placeholder for textarea.
* Add intro text to explain required format for analytics JSON config. Let text be expanded when there are no entries saved.
* Add `googleanalytics` placeholder for type.

# Before:

![image](https://user-images.githubusercontent.com/134745/43499416-34134d3c-9500-11e8-9387-b1d7e0744f75.png)

![image](https://user-images.githubusercontent.com/134745/43499423-3db61856-9500-11e8-883f-5361edca6cfa.png)

# After:

![image](https://user-images.githubusercontent.com/134745/43547920-86ef9c22-9591-11e8-836a-e79c4f7e8357.png)

In the future we could go a step further and add the CodeMirror editor: https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/