### PR TITLE
Prevent validation of auto-drafts, including when merely accessing New Post screen

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -461,6 +461,8 @@ class AMP_Validation_Manager {
 			&&
 			! wp_is_post_revision( $post )
 			&&
+			'auto-draft' !== $post->post_status
+			&&
 			! isset( self::$posts_pending_frontend_validation[ $post_id ] )
 		);
 		if ( $should_validate_post ) {

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -283,6 +283,11 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertFalse( has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
 		$this->assertEmpty( AMP_Validation_Manager::validate_queued_posts_on_frontend() );
 
+		$auto_draft = $this->factory()->post->create_and_get( array( 'post_status' => 'auto-draft' ) );
+		AMP_Validation_Manager::handle_save_post_prompting_validation( $auto_draft->ID );
+		$this->assertFalse( has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
+		$this->assertEmpty( AMP_Validation_Manager::validate_queued_posts_on_frontend() );
+
 		$post = $this->factory()->post->create_and_get( array( 'post_type' => 'post' ) );
 		AMP_Validation_Manager::handle_save_post_prompting_validation( $post->ID );
 		$this->assertEquals( 10, has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );


### PR DESCRIPTION
When testing #1297 I found that the frontend post validation logic is being invoked for `auto-draft` posts. When accessing the New Post screen an auto-draft is created immediately, and this is resulting in that validation loopback request to the frontend to check the validity of a post that has nothing in it yet. Validation needs to be prevented for such posts; it should only be done once a post is saved as a draft.