### PR TITLE
Fix the allowed attributes for `amp-position-observer`

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -2519,7 +2519,7 @@ class AMP_Allowed_Tags_Generated {
 					'noloading' => array(
 						'value' => '',
 					),
-					'target' => array(),
+					'target-id' => array(),
 					'viewport-margins' => array(
 						'value_regex' => '^(\\d+$|\\d+px$|\\d+vh$)|((\\d+|\\d+px|\\d+vh)\\s{1}(\\d+$|\\d+px$|\\d+vh$))',
 					),


### PR DESCRIPTION
I tried to use `amp-position-observer` with the plugin earlier and noticed that it strips out the `target-id` attribute as invalid. That is because the whitelist for that tag only allows a `target` attribute which appears to be wrong to me. [The AMP documentation states that `target-id` is the correct name of the attribute.](https://www.ampproject.org/docs/reference/components/amp-position-observer#target-id-(optional))