### PR TITLE
Preserve whitespace when serializing the DOM as HTML

### DIFF
--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -69,20 +69,20 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'multiple_same_iframe' => array(
-				'
+				trim( '
 <iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
 <iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
 <iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
-				',
+				' ),
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'multiple_different_iframes' => array(
-				'
+				trim( '
 <iframe src="https://example.com/embed/12345" width="500" height="281"></iframe>
 <iframe src="https://example.com/embed/67890" width="280" height="501"></iframe>
 <iframe src="https://example.com/embed/11111" width="700" height="601"></iframe>
-				',
+				' ),
 				'<amp-iframe src="https://example.com/embed/12345" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/67890" width="280" height="501" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/11111" width="700" height="601" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 			'iframe_in_p_tag' => array(

--- a/tests/test-amp-instagram-embed.php
+++ b/tests/test-amp-instagram-embed.php
@@ -108,12 +108,12 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                   => array(
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>',
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
 			),
 
 			'blockquote_embed_notautop'          => array(
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>',
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram> ',
 			),
 		);
 	}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1263,4 +1263,35 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$stylesheets[1]
 		);
 	}
+
+	/**
+	 * Test CSS with Unicode characters.
+	 *
+	 * @covers \AMP_DOM_Utils::get_content_from_dom_node()
+	 */
+	public function test_unicode_stylesheet() {
+		add_theme_support( 'amp' );
+		AMP_Theme_Support::init();
+		AMP_Theme_Support::finish_init();
+
+		ob_start();
+		?>
+		<!DOCTYPE html>
+		<html amp>
+			<head>
+				<meta charset="utf-8">
+				<?php wp_print_styles( array( 'dashicons' ) ); ?>
+				<style>span::after { content:"⚡️"; }</style>
+			</head>
+			<body>
+				<span class="dashicons dashicons-admin-customizer"></span>
+			</body>
+		</html>
+		<?php
+		$original_html  = trim( ob_get_clean() );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
+
+		$this->assertContains( ".dashicons-admin-customizer:before{content:\"\xEF\x95\x80\"}", $sanitized_html );
+		$this->assertContains( 'span::after{content:"⚡️"}', $sanitized_html );
+	}
 }

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -943,7 +943,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'style_amp_keyframes_last_child'   => array(
 				'<b>before</b> <style amp-keyframes>@keyframes anim1 {}</style> between <style amp-keyframes>@keyframes anim2 {}</style> as <b>after</b>',
-				'<b>before</b> between  as <b>after</b><style amp-keyframes="">@keyframes anim1{}@keyframes anim2{}</style>',
+				'<b>before</b>  between  as <b>after</b><style amp-keyframes="">@keyframes anim1{}@keyframes anim2{}</style>',
 				array(),
 			),
 

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -108,12 +108,12 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                 => array(
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>',
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
 			),
 
 			'blockquote_embed_not_autop'       => array(
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>',
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter> ',
 			),
 		);
 	}

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -288,22 +288,19 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 * Test preserving whitespace when serializing DOMDocument as HTML string.
 	 *
 	 * @covers \AMP_DOM_Utils::get_content_from_dom_node()
-	 * @covers \AMP_DOM_Utils::get_content_from_dom
+	 * @covers \AMP_DOM_Utils::get_content_from_dom()
 	 * @link https://github.com/Automattic/amp-wp/issues/1304
 	 */
 	public function test_whitespace_preservation() {
-		$body = " start <ul><li>First</li><li>Second</li></ul><pre>\t* one\n\t* two\n\t* three</pre> end ";
+		$body = " start <ul><li>First</li><li>Second</li></ul><style>pre::before { content:'⚡️'; }</style><script type=\"application/json\">\"⚡️\"</script><pre>\t* one\n\t* two\n\t* three</pre> end ";
 		$html = "<html><head><meta charset=\"utf-8\"></head><body data-foo=\"&gt;\">$body</body></html>";
-		$dom  = AMP_DOM_Utils::get_dom( "<!DOCTYPE html>$html" );
 
-		$this->assertEquals(
-			$html,
-			AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement )
-		);
+		$dom = AMP_DOM_Utils::get_dom( "<!DOCTYPE html>$html" );
 
-		$this->assertEquals(
-			$body,
-			AMP_DOM_Utils::get_content_from_dom( $dom )
-		);
+		$output = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
+		$this->assertEquals( $html, $output );
+
+		$output = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEquals( $body, $output );
 	}
 }

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -283,4 +283,27 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 
 		$this->assertSame( PREG_NO_ERROR, preg_last_error(), 'Probably failed when backtrack limit was exhausted.' );
 	}
+
+	/**
+	 * Test preserving whitespace when serializing DOMDocument as HTML string.
+	 *
+	 * @covers \AMP_DOM_Utils::get_content_from_dom_node()
+	 * @covers \AMP_DOM_Utils::get_content_from_dom
+	 * @link https://github.com/Automattic/amp-wp/issues/1304
+	 */
+	public function test_whitespace_preservation() {
+		$body = " start <ul><li>First</li><li>Second</li></ul><pre>\t* one\n\t* two\n\t* three</pre> end ";
+		$html = "<html><head><meta charset=\"utf-8\"></head><body data-foo=\"&gt;\">$body</body></html>";
+		$dom  = AMP_DOM_Utils::get_dom( "<!DOCTYPE html>$html" );
+
+		$this->assertEquals(
+			$html,
+			AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement )
+		);
+
+		$this->assertEquals(
+			$body,
+			AMP_DOM_Utils::get_content_from_dom( $dom )
+		);
+	}
 }

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1608,13 +1608,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		ob_start();
 		?>
 		<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-		<html><head><?php wp_head(); ?></head><body><?php wp_footer(); ?></body></html>
+		<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><?php wp_head(); ?></head><body><?php wp_footer(); ?></body></html>
 		<?php
 		$original_html  = trim( ob_get_clean() );
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
 
 		$this->assertStringStartsWith( '<!DOCTYPE html>', $sanitized_html );
 		$this->assertContains( '<html amp', $sanitized_html );
+		$this->assertContains( '<meta charset="utf-8">', $sanitized_html );
 	}
 
 	/**


### PR DESCRIPTION
Add workaround to prevent PHP from adding whitespace to format the serialization of HTML. This prevents bugs related to spaces being added between elements which can break layouts. For example, without this fix, the following HTML:
```html
<style>
.cols-test > li {
    width: 50%;
    display: inline-block;
    outline: solid 1px red;
}
</style>
<ul class="cols-test"><li>column 1</li><li>column 2</li></ul>
```
Which should get rendered as:
![image](https://user-images.githubusercontent.com/134745/43612947-ab104a1c-9662-11e8-89a9-7b75fba28747.png)

Will get serialized instead as:

```html
<ul class="cols-test">
<li>column 1</li>
<li>column 2</li>
</ul>
```

And displayed as (with text selected to show whitespace insertion):

![image](https://user-images.githubusercontent.com/134745/43613148-36a43afc-9663-11e8-8626-ecb633781dd3.png)

For some more background on the changes here, see https://stackoverflow.com/q/51660286/93579

Fixes #1304.