### PR TITLE
Fix including external stylesheets on Windows

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1042,6 +1042,21 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 				'file_path_not_found',
 			),
+			'amp_file_path_illegal_linux' => array(
+				content_url( '../../../../../../../../../../../../../../../bad.css' ),
+				null,
+				'file_path_not_allowed',
+			),
+			'amp_file_path_illegal_windows' => array(
+				content_url( '..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\bad.css' ),
+				null,
+				'file_path_not_allowed',
+			),
+			'amp_file_path_illegal_location' => array(
+				site_url( 'outside/root.css' ),
+				null,
+				'file_path_not_allowed',
+			),
 			'amp_external_file' => array(
 				'//s.w.org/wp-includes/css/dashicons.css',
 				false,
@@ -1152,7 +1167,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'bad_file'    => array(
 				home_url( '/bad.css' ),
-				array( 'file_path_not_found' ),
+				array( 'file_path_not_allowed' ),
 			),
 		);
 	}


### PR DESCRIPTION
* Remove needless `validate_file()` call.
* Fix usage of `strpos()` and include check for Windows and Linux relative paths.
* Add `file_path_not_allowed` error code in addition to existing `file_path_not_found` error code.

Build of plugin to test: [amp.zip](https://github.com/Automattic/amp-wp/files/2255361/amp.zip) (v1.0-beta1-8a0a172a-20180802T223339Z)

To test this build, deactivate and uninstall your existing AMP plugin. Then go to the Add New plugin admin screen. Click the “Upload Plugin” button at the top and select `amp.zip`:

![image](https://user-images.githubusercontent.com/134745/43614884-01a64bfe-966a-11e8-9ee3-4921818c3255.png)

Then activate the plugin and test.

Fixes #1310.