### PR TITLE
Fix extractor that forgot duplicate images

### DIFF
--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -30,8 +30,8 @@ class AMP_Image_Dimension_Extractor {
 		$extracted_dimensions = apply_filters( 'amp_extract_image_dimensions_batch', $extracted_dimensions );
 
 		// We need to return a map with the original (un-normalized URL) as we that to match nodes that need dimensions.
-		foreach ($url_map as $original_url => $normalized_url) {
-			$return_dimensions[$original_url] = $extracted_dimensions[$normalized_url];
+		foreach ( $url_map as $original_url => $normalized_url ) {
+			$return_dimensions[ $original_url ] = $extracted_dimensions[ $normalized_url ];
 		}
 
 		return $return_dimensions;

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -18,7 +18,7 @@ class AMP_Image_Dimension_Extractor {
 		foreach ( $urls as $original_url ) {
 			$normalized_url = self::normalize_url( $original_url );
 			if ( false !== $normalized_url ) {
-				$url_map[ $normalized_url ] = $original_url;
+				$url_map[ $original_url ] = $normalized_url;
 				$normalized_urls[] = $normalized_url;
 			} else {
 				// This is not a URL we can extract dimensions from, so default to false.
@@ -30,9 +30,8 @@ class AMP_Image_Dimension_Extractor {
 		$extracted_dimensions = apply_filters( 'amp_extract_image_dimensions_batch', $extracted_dimensions );
 
 		// We need to return a map with the original (un-normalized URL) as we that to match nodes that need dimensions.
-		foreach ( $extracted_dimensions as $normalized_url => $dimension ) {
-			$original_url = $url_map[ $normalized_url ];
-			$return_dimensions[ $original_url ] = $dimension;
+		foreach ($url_map as $original_url => $normalized_url) {
+			$return_dimensions[$original_url] = $extracted_dimensions[$normalized_url];
 		}
 
 		return $return_dimensions;

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -36,7 +36,6 @@ class AMP_Image_Dimension_Extractor {
 				$normalized_urls[] = $normalized_url;
 			} else {
 				// This is not a URL we can extract dimensions from, so default to false.
-				$url_map[ $original_url ]           = $original_url;
 				$return_dimensions[ $original_url ] = false;
 			}
 		}

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -70,12 +70,12 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 */
 	public function test__should_return_both_urls() {
 		$source_urls = array(
-			site_url('/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'),
+			site_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ),
 			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg',
 		);
 		$expected    = array(
-			site_url('/wp-content/uploads/2018/06/IMG_0183-300x300.jpg')              => false,
-			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'        => false,
+			site_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ) => false,
+			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'             => false,
 		);
 
 		$actual = AMP_Image_Dimension_Extractor::extract( $source_urls );

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -66,6 +66,24 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test should return both urls
+	 */
+	public function test__should_return_both_urls() {
+		$source_urls = array(
+			site_url('/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'),
+			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg',
+		);
+		$expected    = array(
+			site_url('/wp-content/uploads/2018/06/IMG_0183-300x300.jpg')              => false,
+			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'        => false,
+		);
+
+		$actual = AMP_Image_Dimension_Extractor::extract( $source_urls );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Test where processed URLs should match originals.
 	 */
 	public function test__should_return_original_urls() {


### PR DESCRIPTION
What happened:
In this case are two dimensionless images in one post with the same URI. One image of them includes additional the Host. The image with the URL is returned by the extractor with dimensions. Comparing to the other image - the image using the URI is returning without dimension.

The Post:

```html
<img class="alignnone size-medium wp-image-5" src="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" />

<img class="alignnone size-medium wp-image-5" src="/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" />
```


The Content:

```html
<p><amp-img class="alignnone size-medium wp-image-5 amp-wp-unknown-size amp-wp-unknown-height amp-wp-enforced-sizes" src="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" srcset="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg 300w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-150x150.jpg 150w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-100x100.jpg 100w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183.jpg 640w" sizes="(max-width: 300px) 100vw, 300px" height="400" layout="intrinsic"></amp-img></p>
<p><amp-img class="alignnone size-medium wp-image-5 amp-wp-enforced-sizes" src="/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" srcset="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg 300w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-150x150.jpg 150w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-100x100.jpg 100w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183.jpg 640w" sizes="(max-width: 300px) 100vw, 300px"></amp-img></p>
```

The height is missing in the second image.

What you expected to happen:


```html
<p><amp-img class="alignnone size-medium wp-image-5 amp-wp-unknown-size amp-wp-unknown-height amp-wp-enforced-sizes" src="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" srcset="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg 300w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-150x150.jpg 150w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-100x100.jpg 100w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183.jpg 640w" sizes="(max-width: 300px) 100vw, 300px" height="400" layout="intrinsic"></amp-img></p>
<p><amp-img class="alignnone size-medium wp-image-5 amp-wp-unknown-size amp-wp-unknown-height amp-wp-enforced-sizes" src="/wp-content/uploads/2018/06/IMG_0183-300x300.jpg" alt="" width="300" srcset="http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-300x300.jpg 300w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-150x150.jpg 150w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183-100x100.jpg 100w, http://localhost:8080/wp-content/uploads/2018/06/IMG_0183.jpg 640w" sizes="(max-width: 300px) 100vw, 300px" height="400" layout="intrinsic"></amp-img></p>
```


What's happening:

The Extractor normalizes the URLs and stores the original url under its normalized urls. As a result, one of the original url is lost. The reason for this is that the normalized url should point to two original url. That's not possible. 
Finally, the extractor iterates over the extracted dimensions. The extracted dimensions are just a subset of the original url. Only one original url is used.

Some possible resolutions:

The extractor stores the original urls as keys. The normalized url are stored as a value. That means we have no losses. 
In the end the extractor iterates over the original urls. For each original url he gets the normalized url and asks for its dimension. This dimension is saved for the original urls.

Anything else we need to know?:

AMP: 1.0-beta1
Wordpress: 4.9.7
Container: Wordpress:latest
Theme: Twenty Seventeen 1.6
OS: MacOS 10.13.5