### PR TITLE
Update spec generation to file revision 712 (amphtml tag 1533692711873)

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -2,24 +2,14 @@
 This script is used to generate the 'class-amp-allowed-tags-generated.php'
 file that is used by the class AMP_Tag_And_Attribute_Sanitizer.
 
-Follow the steps below to generate a new version of the allowed tags class:
+A bash script, amphtml-update.sh, is provided to automatically run this script.  To run the bash script, type:
 
-- Download a copy of the latet AMPHTML repository from github:
+`bash amphtml-update.sh`
 
-	git clone git@github.com:ampproject/amphtml.git
+from within a Linux environment such as VVV.
 
-- Copy this file into the repo's validator subdirectory:
-
-	cp amp_wp_build.py amphtml/validator
-
-- Run the file from the validator subdirectory:
-	cd amphtml/validator;python amp_wp_build.py
-
-- The class-amp-allowed-tags-generated.php will be generated at:
-	amphtml/validator/amp_wp/class-amp-allowed-tags-generated.php
-
-- copy this file into the amp-wp plugin:
-	cp amp_wp/class-amp-allowed-tags-generated.php /path/to/wordpress/wp-content/plugins/amp-wp/includes/sanitizers/
+See the Updating Allowed Tags and Attributes section of the Contributing guide
+https://github.com/Automattic/amp-wp/blob/develop/contributing.md#updating-allowed-tags-and-attributes.
 
 Then have fun sanitizing your AMP posts!
 """

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -370,7 +370,7 @@ def GetTagSpec(tag_spec, attr_lists):
 						continue
 					css_spec['allowed_at_rules'].append( at_rule_spec.name )
 
-				for css_spec_field_name in ( 'allowed_declarations', 'font_url_spec', 'image_url_spec', 'validate_keyframes' ):
+				for css_spec_field_name in ( 'allowed_declarations', 'declaration', 'font_url_spec', 'image_url_spec', 'validate_keyframes' ):
 					if not hasattr( field_value, css_spec_field_name ):
 						continue
 					css_spec_field_value = getattr( field_value, css_spec_field_name )
@@ -522,12 +522,12 @@ def GetValues(attr_spec):
 		value_dict['mandatory'] = attr_spec.mandatory
 
 	# Add allowed value
-	if attr_spec.HasField('value'):
-		value_dict['value'] = attr_spec.value
+	if attr_spec.value:
+		value_dict['value'] = list( attr_spec.value )
 
 	# value_casei
-	if attr_spec.HasField('value_casei'):
-		value_dict['value_casei'] = attr_spec.value_casei
+	if attr_spec.value_casei:
+		value_dict['value_casei'] = list( attr_spec.value_casei )
 
 	# value_regex
 	if attr_spec.HasField('value_regex'):

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,8 +13,8 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 699;
-	private static $minimum_validator_revision_required = 346;
+	private static $spec_file_revision = 712;
+	private static $minimum_validator_revision_required = 348;
 
 	private static $allowed_tags = array(
 		'a' => array(
@@ -118,6 +118,7 @@ class AMP_Allowed_Tags_Generated {
 							'true',
 						),
 					),
+					'clearcolor' => array(),
 					'enablezoom' => array(
 						'value' => array(
 							'false',
@@ -1490,6 +1491,9 @@ class AMP_Allowed_Tags_Generated {
 					'max' => array(),
 					'media' => array(),
 					'min' => array(),
+					'minimum-nights' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'mode' => array(
 						'value_casei' => array(
 							'static',
@@ -1571,6 +1575,9 @@ class AMP_Allowed_Tags_Generated {
 					'max' => array(),
 					'media' => array(),
 					'min' => array(),
+					'minimum-nights' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'mode' => array(
 						'mandatory' => true,
 						'value_casei' => array(
@@ -2111,6 +2118,8 @@ class AMP_Allowed_Tags_Generated {
 		'amp-google-document-embed' => array(
 			array(
 				'attr_spec_list' => array(
+					'[src]' => array(),
+					'[title]' => array(),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -2651,6 +2660,8 @@ class AMP_Allowed_Tags_Generated {
 					'reset-on-refresh' => array(
 						'value' => array(
 							'',
+							'always',
+							'fetch',
 						),
 					),
 					'single-item' => array(),
@@ -2747,9 +2758,21 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'amp-next-page' => array(
 			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-next-page',
+					),
+					'spec_name' => 'amp-next-page with inline config',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
+					'unique' => true,
+				),
+			),
+			array(
 				'attr_spec_list' => array(
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -2762,6 +2785,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-next-page',
 					),
+					'spec_name' => 'amp-next-page with src attribute',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
 					'unique' => true,
 				),
@@ -4832,14 +4856,55 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'align' => array(),
+					'verify-error' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [verify-error]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'align' => array(),
+					'template' => array(
+						'mandatory' => true,
+					),
+					'verify-error' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [verify-error][template]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'align' => array(),
 					'submitting' => array(
-						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form',
 					'spec_name' => 'FORM DIV [submitting]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'align' => array(),
+					'submitting' => array(
+						'mandatory' => true,
+					),
+					'template' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submitting][template]',
 				),
 			),
 			array(
@@ -4894,17 +4959,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form',
 					'spec_name' => 'FORM DIV [submit-error][template]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'separator' => array(
-						'mandatory' => true,
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'amp-next-page',
-					'spec_name' => 'AMP-NEXT-PAGE > DIV [separator]',
 				),
 			),
 		),
@@ -10338,11 +10392,15 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
+						'deprecated_version' => array(
+							'0.1',
+						),
 						'is_custom_template' => true,
 						'name' => 'amp-mustache',
 						'requires_usage' => 2,
 						'version' => array(
 							'0.1',
+							'0.2',
 							'latest',
 						),
 					),
@@ -12150,8 +12208,10 @@ class AMP_Allowed_Tags_Generated {
 						'template',
 						'amp-date-picker',
 						'amp-story-auto-ads',
-						'form > div [submit-success][template]',
-						'form > div [submit-error][template]',
+						'form div [submit-success][template]',
+						'form div [submit-error][template]',
+						'form div [submitting][template]',
+						'form div [verify-error][template]',
 					),
 					'requires_extension' => array(
 						'amp-mustache',
@@ -12161,6 +12221,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'type' => array(
+						'dispatch_key' => 3,
 						'mandatory' => true,
 						'value' => array(
 							'amp-mustache',

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,8 +13,8 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 675;
-	private static $minimum_validator_revision_required = 338;
+	private static $spec_file_revision = 699;
+	private static $minimum_validator_revision_required = 346;
 
 	private static $allowed_tags = array(
 		'a' => array(
@@ -27,8 +27,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'ftp',
 								'geo',
 								'http',
@@ -63,10 +62,16 @@ class AMP_Allowed_Tags_Generated {
 					'role' => array(),
 					'tabindex' => array(),
 					'target' => array(
-						'value_regex' => '_blank|_self|_top',
+						'value' => array(
+							'_blank',
+							'_self',
+							'_top',
+						),
 					),
 					'type' => array(
-						'value_casei' => 'text/html',
+						'value_casei' => array(
+							'text/html',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -96,29 +101,42 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'alpha' => array(
-						'value_regex' => 'false|true',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'antialiasing' => array(
-						'value_regex' => 'false|true',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'autorotate' => array(
-						'value_regex' => 'false|true',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'enablezoom' => array(
-						'value_regex' => 'false|true',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'maxpixelratio' => array(
 						'value_regex' => '[+-]?(\\d*\\.)?\\d+',
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -144,14 +162,18 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'data-id' => array(
 						'mandatory' => true,
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -173,17 +195,25 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'animate' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'disable-session-states' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'expand-single-section' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -206,14 +236,16 @@ class AMP_Allowed_Tags_Generated {
 					'json' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rtc-config' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -254,19 +286,23 @@ class AMP_Allowed_Tags_Generated {
 					'data-multi-size' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'json' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rtc-config' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -311,18 +347,22 @@ class AMP_Allowed_Tags_Generated {
 					'data-enable-refresh' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'json' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -369,8 +409,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-share-media' => array(
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -379,8 +418,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-share-url' => array(
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -391,7 +429,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -419,7 +459,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_url' => array(
 							'allow_empty' => true,
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -439,10 +479,11 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'alt' => array(),
 					'attribution' => array(),
-					'controls' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'alternative_names' => array(
@@ -451,8 +492,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'http',
 								'https',
@@ -484,10 +524,14 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'trigger' => array(
-						'value' => 'visibility',
+						'value' => array(
+							'visibility',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -513,7 +557,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -542,7 +588,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -567,28 +615,40 @@ class AMP_Allowed_Tags_Generated {
 					'artist' => array(),
 					'artwork' => array(),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(),
 					'controlslist' => array(),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'muted' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'preload' => array(
-						'value_regex_casei' => 'auto|metadata|none|',
+						'value_casei' => array(
+							'auto',
+							'metadata',
+							'none',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -620,25 +680,33 @@ class AMP_Allowed_Tags_Generated {
 					'artwork' => array(),
 					'autoplay' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(),
 					'controlslist' => array(),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'muted' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -668,7 +736,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'type' => array(
 						'mandatory' => true,
@@ -696,12 +766,17 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '[0-9a-f]{24}',
 					),
 					'data-my-content' => array(
-						'value_regex' => '0|1',
+						'value' => array(
+							'0',
+							'1',
+						),
 					),
 					'data-name' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -745,16 +820,22 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'loop' => array(
-						'value_regex_casei' => 'false|number|true',
+						'value_casei' => array(
+							'false',
+							'number',
+							'true',
+						),
 					),
 					'noautoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -801,7 +882,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -832,14 +915,18 @@ class AMP_Allowed_Tags_Generated {
 					'[data-playlist-id]' => array(),
 					'[data-video-id]' => array(),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'data-account' => array(
 						'mandatory' => true,
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -871,7 +958,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -899,14 +988,16 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -932,27 +1023,40 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[slide]' => array(),
 					'arrows' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(),
 					'delay' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'dots' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'type' => array(
-						'value_regex' => 'slides|carousel',
+						'value' => array(
+							'slides',
+							'carousel',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -977,30 +1081,43 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[slide]' => array(),
 					'arrows' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(),
 					'delay' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'dots' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'lightbox' => array(
 						'mandatory' => true,
 					),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'type' => array(
-						'value_regex' => 'slides|carousel',
+						'value' => array(
+							'slides',
+							'carousel',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1029,7 +1146,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1050,16 +1169,28 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'autoplay' => array(),
 					'data-endscreen-enable' => array(
-						'value_regex' => 'true|false',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-info' => array(
-						'value_regex' => 'true|false',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-mute' => array(
-						'value_regex' => 'true|false',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-sharing-enable' => array(
-						'value_regex' => 'true|false',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-start' => array(
 						'value_regex' => '[0-9]+',
@@ -1068,7 +1199,10 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '([0-9a-f]{3}){1,2}',
 					),
 					'data-ui-logo' => array(
-						'value_regex' => 'true|false',
+						'value' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-videoid' => array(
 						'mandatory' => true,
@@ -1076,7 +1210,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1100,17 +1236,41 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'biggest-unit' => array(
-						'value_regex_casei' => 'days|hours|minutes|seconds',
+						'value_casei' => array(
+							'days',
+							'hours',
+							'minutes',
+							'seconds',
+						),
 					),
 					'end-date' => array(
 						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])',
 					),
 					'locale' => array(
-						'value_regex_casei' => 'de|en|es|fr|id|it|ja|ko|nl|pt|ru|th|tr|vi|zh-cn|zh-tw',
+						'value_casei' => array(
+							'de',
+							'en',
+							'es',
+							'fr',
+							'id',
+							'it',
+							'ja',
+							'ko',
+							'nl',
+							'pt',
+							'ru',
+							'th',
+							'tr',
+							'vi',
+							'zh-cn',
+							'zh-tw',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'offset-seconds' => array(
 						'value_regex' => '-?\\d+',
@@ -1122,7 +1282,9 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '\\d{10}',
 					),
 					'when-ended' => array(
-						'value_casei' => 'stop',
+						'value_casei' => array(
+							'stop',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1146,7 +1308,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'allow-blocked-ranges' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'blocked' => array(),
 					'day-size' => array(
@@ -1157,7 +1321,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'highlighted' => array(),
 					'input-selector' => array(),
@@ -1166,32 +1332,42 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'min' => array(),
 					'mode' => array(
-						'value_casei' => 'static',
+						'value_casei' => array(
+							'static',
+						),
 					),
 					'month-format' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'number-of-months' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'open-after-clear' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'open-after-select' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'type' => array(
-						'value_casei' => 'single',
+						'value_casei' => array(
+							'single',
+						),
 					),
 					'week-day-format' => array(),
 				),
@@ -1216,7 +1392,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'allow-blocked-ranges' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'blocked' => array(),
 					'day-size' => array(
@@ -1234,32 +1412,42 @@ class AMP_Allowed_Tags_Generated {
 					'min' => array(),
 					'mode' => array(
 						'mandatory' => true,
-						'value_casei' => 'overlay',
+						'value_casei' => array(
+							'overlay',
+						),
 					),
 					'month-format' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'number-of-months' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'open-after-clear' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'open-after-select' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'type' => array(
-						'value_casei' => 'single',
+						'value_casei' => array(
+							'single',
+						),
 					),
 					'week-day-format' => array(),
 				),
@@ -1279,7 +1467,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'allow-blocked-ranges' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'blocked' => array(),
 					'day-size' => array(
@@ -1291,7 +1481,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'highlighted' => array(),
 					'locale' => array(),
@@ -1299,26 +1491,34 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'min' => array(),
 					'mode' => array(
-						'value_casei' => 'static',
+						'value_casei' => array(
+							'static',
+						),
 					),
 					'month-format' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'number-of-months' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'open-after-clear' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'open-after-select' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1326,7 +1526,9 @@ class AMP_Allowed_Tags_Generated {
 					'start-input-selector' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value_casei' => 'range',
+						'value_casei' => array(
+							'range',
+						),
 					),
 					'week-day-format' => array(),
 				),
@@ -1351,7 +1553,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'allow-blocked-ranges' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'blocked' => array(),
 					'day-size' => array(
@@ -1369,26 +1573,34 @@ class AMP_Allowed_Tags_Generated {
 					'min' => array(),
 					'mode' => array(
 						'mandatory' => true,
-						'value_casei' => 'overlay',
+						'value_casei' => array(
+							'overlay',
+						),
 					),
 					'month-format' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'number-of-months' => array(
 						'value_regex' => '[0-9]+',
 					),
 					'open-after-clear' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'open-after-select' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1396,7 +1608,9 @@ class AMP_Allowed_Tags_Generated {
 					'start-input-selector' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value_casei' => 'range',
+						'value_casei' => array(
+							'range',
+						),
 					),
 					'week-day-format' => array(),
 				),
@@ -1421,14 +1635,16 @@ class AMP_Allowed_Tags_Generated {
 					'json' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rtc-config' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1469,19 +1685,23 @@ class AMP_Allowed_Tags_Generated {
 					'data-multi-size' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'json' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rtc-config' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1521,6 +1741,58 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-embedly-card' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-url' => array(
+						'mandatory' => true,
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-embedly-card',
+					),
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-embedly-card',
+				),
+			),
+		),
+		'amp-embedly-key' => array(
+			array(
+				'attr_spec_list' => array(
+					'value' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'requires_extension' => array(
+						'amp-embedly-card',
+					),
+					'unique' => true,
+				),
+			),
+		),
 		'amp-experiment' => array(
 			array(
 				'attr_spec_list' => array(),
@@ -1541,7 +1813,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1569,7 +1843,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1596,7 +1872,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1604,7 +1880,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1631,7 +1909,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1639,7 +1917,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1666,7 +1946,9 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'min-font-size' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1698,7 +1980,9 @@ class AMP_Allowed_Tags_Generated {
 					'font-weight' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'on-error-add-class' => array(),
 					'on-error-remove-class' => array(),
@@ -1728,7 +2012,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1743,7 +2029,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1767,10 +2055,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noautoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1798,7 +2090,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1819,14 +2113,16 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1859,7 +2155,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1885,34 +2183,51 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'allow' => array(),
 					'allowfullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'allowpaymentrequest' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'allowtransparency' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'frameborder' => array(
-						'value_regex' => '0|1',
+						'value' => array(
+							'0',
+							'1',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'referrerpolicy' => array(),
 					'resizable' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'sandbox' => array(),
 					'scrolling' => array(
-						'value_regex' => 'auto|yes|no',
+						'value' => array(
+							'auto',
+							'no',
+							'yes',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'https',
 							),
@@ -1942,13 +2257,15 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'data-src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -1957,17 +2274,21 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rotate-to-fullscreen' => array(
-						'value_regex' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -1993,7 +2314,9 @@ class AMP_Allowed_Tags_Generated {
 					'controls' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2023,7 +2346,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'placeholder' => array(),
 					'src' => array(
@@ -2033,8 +2358,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'http',
 								'https',
@@ -2066,7 +2390,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2095,7 +2421,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2122,7 +2450,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -2132,7 +2460,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -2159,7 +2487,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2217,7 +2547,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2242,7 +2574,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2264,11 +2598,20 @@ class AMP_Allowed_Tags_Generated {
 		'amp-lightbox' => array(
 			array(
 				'attr_spec_list' => array(
+					'animate-in' => array(
+						'value_casei' => array(
+							'fade-in',
+							'fly-in-bottom',
+							'fly-in-top',
+						),
+					),
 					'controls' => array(),
 					'from' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'scrollable' => array(),
 				),
@@ -2289,23 +2632,33 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[src]' => array(),
 					'[state]' => array(),
+					'binding' => array(
+						'value' => array(
+							'always',
+							'no',
+							'refresh',
+						),
+					),
 					'credentials' => array(),
 					'items' => array(),
 					'max-items' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'reset-on-refresh' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'single-item' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -2326,47 +2679,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-list',
 					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'[src]' => array(
-						'mandatory' => true,
-					),
-					'credentials' => array(),
-					'items' => array(),
-					'max-items' => array(),
-					'media' => array(),
-					'noloading' => array(
-						'value' => '',
-					),
-					'single-item' => array(),
-					'src' => array(
-						'blacklisted_value_regex' => '__amp_source_origin',
-						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
-								'https',
-							),
-						),
-					),
-					'template' => array(),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							6,
-							2,
-							3,
-							7,
-							1,
-							4,
-						),
-					),
-					'requires_extension' => array(
-						'amp-list',
-					),
-					'spec_name' => 'AMP-LIST [SRC]',
 				),
 			),
 		),
@@ -2381,13 +2693,17 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '\\d{5,}',
 					),
 					'disabled' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'id' => array(
 						'mandatory' => true,
 					),
 					'sort' => array(
-						'value_regex' => 'ascending',
+						'value' => array(
+							'ascending',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2412,7 +2728,9 @@ class AMP_Allowed_Tags_Generated {
 					'inline' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2429,7 +2747,17 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'amp-next-page' => array(
 			array(
-				'attr_spec_list' => array(),
+				'attr_spec_list' => array(
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
 				'tag_spec' => array(
 					'requires_extension' => array(
 						'amp-next-page',
@@ -2450,23 +2778,35 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[^=/?:]+',
 					),
 					'data-mode' => array(
-						'value_regex' => 'api|static',
+						'value' => array(
+							'api',
+							'static',
+						),
 					),
 					'data-origin' => array(
 						'value_url' => array(
 							'allow_empty' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 								'http',
 							),
 						),
 					),
 					'data-streamtype' => array(
-						'value_regex' => 'album|audio|live|playlist|playlist-marked|video',
+						'value' => array(
+							'album',
+							'audio',
+							'live',
+							'playlist',
+							'playlist-marked',
+							'video',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2497,7 +2837,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2531,7 +2873,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2563,7 +2907,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2595,10 +2941,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'reset-on-resize' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2625,7 +2975,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2652,10 +3004,14 @@ class AMP_Allowed_Tags_Generated {
 					'allow-ssr-img' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'referrerpolicy' => array(
-						'value' => 'no-referrer',
+						'value' => array(
+							'no-referrer',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
@@ -2663,7 +3019,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_url' => array(
 							'allow_empty' => true,
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -2686,18 +3042,29 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-comments' => array(
-						'value_regex_casei' => 'false|true',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-item' => array(),
 					'data-item-info' => array(
-						'value_regex_casei' => 'false|true',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-share-buttons' => array(
-						'value_regex_casei' => 'false|true',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(),
 				),
@@ -2722,10 +3089,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'once' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'target' => array(),
 					'viewport-margins' => array(
@@ -2753,7 +3124,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2776,21 +3149,32 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-embedlive' => array(
-						'value_regex_casei' => 'false|true',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-embedparent' => array(
-						'value_regex_casei' => 'false|true',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'data-embedtype' => array(
 						'mandatory' => true,
-						'value_regex_casei' => 'comment|post',
+						'value_casei' => array(
+							'comment',
+							'post',
+						),
 					),
 					'data-src' => array(
 						'mandatory' => true,
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2819,7 +3203,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2841,21 +3227,31 @@ class AMP_Allowed_Tags_Generated {
 					'[disabled]' => array(),
 					'[selected]' => array(),
 					'disabled' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'form' => array(),
 					'keyboard-select-mode' => array(
-						'value_regex_casei' => 'focus|none|select',
+						'value_casei' => array(
+							'focus',
+							'none',
+							'select',
+						),
 					),
 					'media' => array(),
 					'multiple' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'name' => array(
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2883,10 +3279,15 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'side' => array(
-						'value_regex' => 'left|right',
+						'value' => array(
+							'left',
+							'right',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -2909,7 +3310,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'ftp',
 								'http',
 								'https',
@@ -2931,7 +3332,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'type' => array(
 						'mandatory' => true,
@@ -2971,11 +3374,16 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]+',
 					),
 					'data-visual' => array(
-						'value_regex' => 'true|false',
+						'value_casei' => array(
+							'false',
+							'true',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3004,7 +3412,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'data-mode' => array(
 						'mandatory' => true,
-						'value_regex_casei' => 'playlist|video',
+						'value_casei' => array(
+							'playlist',
+							'video',
+						),
 					),
 					'data-player-id' => array(
 						'mandatory' => true,
@@ -3016,7 +3427,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3047,7 +3460,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3067,7 +3480,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3091,7 +3506,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'background-audio' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3099,7 +3514,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'bookend-config-src' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3107,7 +3522,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'poster-landscape-src' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3116,7 +3531,7 @@ class AMP_Allowed_Tags_Generated {
 					'poster-portrait-src' => array(
 						'mandatory' => true,
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3124,7 +3539,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'poster-square-src' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3136,7 +3551,7 @@ class AMP_Allowed_Tags_Generated {
 					'publisher-logo-src' => array(
 						'mandatory' => true,
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3144,7 +3559,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'standalone' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'title' => array(
 						'mandatory' => true,
@@ -3176,11 +3593,13 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'layout' => array(
 						'mandatory' => true,
-						'value' => 'nodisplay',
+						'value' => array(
+							'nodisplay',
+						),
 					),
 					'src' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3226,7 +3645,12 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'template' => array(
 						'mandatory' => true,
-						'value_regex' => 'fill|horizontal|thirds|vertical',
+						'value' => array(
+							'fill',
+							'horizontal',
+							'thirds',
+							'vertical',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3240,7 +3664,7 @@ class AMP_Allowed_Tags_Generated {
 					'auto-advance-after' => array(),
 					'background-audio' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3271,7 +3695,9 @@ class AMP_Allowed_Tags_Generated {
 					'locale' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3303,7 +3729,9 @@ class AMP_Allowed_Tags_Generated {
 					'data-tweetid' => array(),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3331,7 +3759,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_url' => array(
 							'allow_empty' => false,
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3340,17 +3768,21 @@ class AMP_Allowed_Tags_Generated {
 						'value_url' => array(
 							'allow_empty' => false,
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'enctype' => array(
-						'value' => 'application/x-www-form-urlencoded',
+						'value' => array(
+							'application/x-www-form-urlencoded',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3386,46 +3818,67 @@ class AMP_Allowed_Tags_Generated {
 					'artwork' => array(),
 					'attribution' => array(),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controlslist' => array(),
 					'crossorigin' => array(),
 					'disableremoteplayback' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'lightbox' => array(),
 					'lightbox-thumbnail-id' => array(
 						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
 					),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'muted' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noaudio' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'placeholder' => array(),
 					'poster' => array(),
 					'preload' => array(
-						'value_regex' => 'auto|metadata|none|',
+						'value' => array(
+							'auto',
+							'metadata',
+							'none',
+							'',
+						),
 					),
 					'rotate-to-fullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3471,44 +3924,65 @@ class AMP_Allowed_Tags_Generated {
 					'artwork' => array(),
 					'attribution' => array(),
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controls' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'controlslist' => array(),
 					'crossorigin' => array(),
 					'disableremoteplayback' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'loop' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'media' => array(),
 					'muted' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noaudio' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'placeholder' => array(),
 					'poster' => array(
 						'mandatory' => true,
 					),
 					'preload' => array(
-						'value_regex' => 'auto|metadata|none|',
+						'value' => array(
+							'auto',
+							'metadata',
+							'none',
+							'',
+						),
 					),
 					'rotate-to-fullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3538,7 +4012,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'autoplay' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'data-videoid' => array(
 						'mandatory' => true,
@@ -3546,7 +4022,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3573,7 +4051,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3601,7 +4081,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3625,24 +4107,28 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'id' => array(
 						'mandatory' => true,
-						'value_regex' => 'amp-web-push',
+						'value' => array(
+							'amp-web-push',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'permission-dialog-url' => array(
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3651,7 +4137,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -3675,11 +4161,17 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'visibility' => array(
 						'mandatory' => true,
-						'value_regex' => 'blocked|subscribed|unsubscribed',
+						'value' => array(
+							'blocked',
+							'subscribed',
+							'unsubscribed',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3704,10 +4196,14 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'rotate-to-fullscreen' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3737,7 +4233,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3764,7 +4262,10 @@ class AMP_Allowed_Tags_Generated {
 					'[data-videoid]' => array(),
 					'autoplay' => array(),
 					'credentials' => array(
-						'value_regex_casei' => 'include|omit',
+						'value_casei' => array(
+							'include',
+							'omit',
+						),
 					),
 					'data-live-channelid' => array(
 						'value_regex' => '[^=/?:]+',
@@ -3778,7 +4279,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'media' => array(),
 					'noloading' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3822,7 +4325,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'https',
 							),
@@ -3846,10 +4349,16 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'href' => array(
-						'value' => '/',
+						'value' => array(
+							'/',
+						),
 					),
 					'target' => array(
-						'value_regex_casei' => '_blank|_self|_top',
+						'value_casei' => array(
+							'_blank',
+							'_self',
+							'_top',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3886,8 +4395,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -3921,7 +4429,9 @@ class AMP_Allowed_Tags_Generated {
 					'[type]' => array(),
 					'[value]' => array(),
 					'disabled' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'name' => array(
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
@@ -3939,7 +4449,9 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 					),
 					'open-button' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'role' => array(),
 					'tabindex' => array(),
@@ -4270,8 +4782,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -4327,8 +4838,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_parent' => 'form',
-					'spec_name' => 'FORM > DIV [submitting]',
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submitting]',
 				),
 			),
 			array(
@@ -4339,8 +4850,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_parent' => 'form',
-					'spec_name' => 'FORM > DIV [submit-success]',
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submit-success]',
 				),
 			),
 			array(
@@ -4354,8 +4865,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_parent' => 'form',
-					'spec_name' => 'FORM > DIV [submit-success][template]',
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submit-success][template]',
 				),
 			),
 			array(
@@ -4366,8 +4877,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_parent' => 'form',
-					'spec_name' => 'FORM > DIV [submit-error]',
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submit-error]',
 				),
 			),
 			array(
@@ -4381,8 +4892,8 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_parent' => 'form',
-					'spec_name' => 'FORM > DIV [submit-error][template]',
+					'mandatory_ancestor' => 'form',
+					'spec_name' => 'FORM DIV [submit-error][template]',
 				),
 			),
 			array(
@@ -5133,8 +5644,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -5171,8 +5681,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -5180,31 +5689,39 @@ class AMP_Allowed_Tags_Generated {
 					'action-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'autocomplete' => array(),
 					'custom-validation-reporting' => array(
-						'value_regex' => 'as-you-go|interact-and-submit|show-all-on-submit|show-first-on-submit',
+						'value' => array(
+							'as-you-go',
+							'interact-and-submit',
+							'show-all-on-submit',
+							'show-first-on-submit',
+						),
 					),
 					'enctype' => array(),
 					'method' => array(
-						'value_casei' => 'get',
+						'value_casei' => array(
+							'get',
+						),
 					),
 					'name' => array(),
 					'novalidate' => array(),
 					'target' => array(
 						'mandatory' => true,
-						'value_regex_casei' => '_blank|_top',
+						'value_casei' => array(
+							'_blank',
+							'_top',
+						),
 					),
 					'verify-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -5228,32 +5745,40 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
 					),
 					'autocomplete' => array(),
 					'custom-validation-reporting' => array(
-						'value_regex' => 'as-you-go|interact-and-submit|show-all-on-submit|show-first-on-submit',
+						'value' => array(
+							'as-you-go',
+							'interact-and-submit',
+							'show-all-on-submit',
+							'show-first-on-submit',
+						),
 					),
 					'enctype' => array(),
 					'method' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'post',
+						'value_casei' => array(
+							'post',
+						),
 					),
 					'name' => array(),
 					'novalidate' => array(),
 					'target' => array(
-						'value_regex_casei' => '_blank|_top',
+						'value_casei' => array(
+							'_blank',
+							'_top',
+						),
 					),
 					'verify-xhr' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -5517,8 +6042,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -5647,7 +6171,9 @@ class AMP_Allowed_Tags_Generated {
 							'amp',
 						),
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -5669,23 +6195,32 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'frameborder' => array(
-						'value_regex' => '0|1',
+						'value' => array(
+							'0',
+							'1',
+						),
 					),
 					'height' => array(),
 					'name' => array(),
 					'referrerpolicy' => array(),
 					'resizable' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'sandbox' => array(),
 					'scrolling' => array(
-						'value_regex' => 'auto|yes|no',
+						'value' => array(
+							'auto',
+							'yes',
+							'no',
+						),
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'https',
 							),
@@ -5785,8 +6320,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '(^|\\s)data:image\\/svg\\+xml',
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'http',
 								'https',
@@ -5819,8 +6353,7 @@ class AMP_Allowed_Tags_Generated {
 					'longdesc' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -5834,7 +6367,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'https',
 							),
@@ -5964,7 +6497,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'file',
+						'value_casei' => array(
+							'file',
+						),
 					),
 					'value' => array(),
 					'width' => array(),
@@ -6028,7 +6563,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'password',
+						'value_casei' => array(
+							'password',
+						),
 					),
 					'value' => array(),
 					'width' => array(),
@@ -6047,8 +6584,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -6258,8 +6794,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -6286,7 +6821,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6312,7 +6849,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6320,8 +6859,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -6332,7 +6870,9 @@ class AMP_Allowed_Tags_Generated {
 					'rel' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'canonical',
+						'value_casei' => array(
+							'canonical',
+						),
 					),
 					'sizes' => array(),
 					'target' => array(),
@@ -6349,7 +6889,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6357,8 +6899,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
 						'value_url' => array(
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -6368,7 +6909,9 @@ class AMP_Allowed_Tags_Generated {
 					'rel' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'manifest',
+						'value_casei' => array(
+							'manifest',
+						),
 					),
 					'sizes' => array(),
 					'target' => array(),
@@ -6384,7 +6927,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'as' => array(),
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6394,7 +6939,9 @@ class AMP_Allowed_Tags_Generated {
 					'rel' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'preload',
+						'value_casei' => array(
+							'preload',
+						),
 					),
 					'sizes' => array(),
 					'target' => array(),
@@ -6421,10 +6968,14 @@ class AMP_Allowed_Tags_Generated {
 					'rel' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'stylesheet',
+						'value_casei' => array(
+							'stylesheet',
+						),
 					),
 					'type' => array(
-						'value_casei' => 'text/css',
+						'value_casei' => array(
+							'text/css',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6436,7 +6987,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6447,7 +7000,9 @@ class AMP_Allowed_Tags_Generated {
 					'itemprop' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'sameas',
+						'value_casei' => array(
+							'sameas',
+						),
 					),
 					'media' => array(),
 					'sizes' => array(),
@@ -6462,7 +7017,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6486,7 +7043,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'charset' => array(
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 					'color' => array(),
 					'crossorigin' => array(),
@@ -6706,7 +7265,9 @@ class AMP_Allowed_Tags_Generated {
 					'charset' => array(
 						'dispatch_key' => 1,
 						'mandatory' => true,
-						'value_casei' => 'utf-8',
+						'value_casei' => array(
+							'utf-8',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6741,7 +7302,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => 'viewport',
+						'value' => array(
+							'viewport',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6768,7 +7331,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'x-ua-compatible',
+						'value_casei' => array(
+							'x-ua-compatible',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6786,7 +7351,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'apple-itunes-app',
+						'value_casei' => array(
+							'apple-itunes-app',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6803,7 +7370,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-experiments-opt-in',
+						'value_casei' => array(
+							'amp-experiments-opt-in',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6816,7 +7385,7 @@ class AMP_Allowed_Tags_Generated {
 					'content' => array(
 						'mandatory' => true,
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -6824,7 +7393,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-3p-iframe-src',
+						'value_casei' => array(
+							'amp-3p-iframe-src',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6841,7 +7412,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-experiment-token',
+						'value_casei' => array(
+							'amp-experiment-token',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6857,7 +7430,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-link-variable-allowed-origin',
+						'value_casei' => array(
+							'amp-link-variable-allowed-origin',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6873,7 +7448,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-google-client-id-api',
+						'value_casei' => array(
+							'amp-google-client-id-api',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6886,7 +7463,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-ad-doubleclick-sra',
+						'value_casei' => array(
+							'amp-ad-doubleclick-sra',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6912,12 +7491,16 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'value_casei' => 'text/html; charset=utf-8',
+						'value_casei' => array(
+							'text/html; charset=utf-8',
+						),
 					),
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'content-type',
+						'value_casei' => array(
+							'content-type',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6934,7 +7517,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'content-language',
+						'value_casei' => array(
+							'content-language',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6951,7 +7536,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'pics-label',
+						'value_casei' => array(
+							'pics-label',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6968,7 +7555,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'imagetoolbar',
+						'value_casei' => array(
+							'imagetoolbar',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6981,12 +7570,16 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'value_casei' => 'text/css',
+						'value_casei' => array(
+							'text/css',
+						),
 					),
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'content-style-type',
+						'value_casei' => array(
+							'content-style-type',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -6999,12 +7592,16 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'content-script-type',
+						'value_casei' => array(
+							'content-script-type',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7021,7 +7618,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'origin-trial',
+						'value_casei' => array(
+							'origin-trial',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7038,7 +7637,9 @@ class AMP_Allowed_Tags_Generated {
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'resource-type',
+						'value_casei' => array(
+							'resource-type',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7051,12 +7652,17 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'content' => array(
 						'mandatory' => true,
-						'value_regex_casei' => 'off|on',
+						'value_casei' => array(
+							'off',
+							'on',
+						),
 					),
 					'http-equiv' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'x-dns-prefetch-control',
+						'value_casei' => array(
+							'x-dns-prefetch-control',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7073,7 +7679,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-ad-enable-refresh',
+						'value_casei' => array(
+							'amp-ad-enable-refresh',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7089,7 +7697,9 @@ class AMP_Allowed_Tags_Generated {
 					'name' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-to-amp-navigation',
+						'value_casei' => array(
+							'amp-to-amp-navigation',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -7199,7 +7809,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'reversed' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'start' => array(
 						'value_regex' => '[0-9]*',
@@ -7433,8 +8045,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -7646,8 +8257,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -7741,8 +8351,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -7899,16 +8508,22 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'src' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => 'https://cdn.ampproject.org/v0.js',
+						'value' => array(
+							'https://cdn.ampproject.org/v0.js',
+						),
 					),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'cdata' => array(
@@ -7931,7 +8546,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'application/ld+json',
+						'value_casei' => array(
+							'application/ld+json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -7949,12 +8566,16 @@ class AMP_Allowed_Tags_Generated {
 					'id' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value_casei' => 'amp-rtc',
+						'value_casei' => array(
+							'amp-rtc',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -7974,7 +8595,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -7992,41 +8615,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-3d-gltf',
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => '',
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => 'text/javascript',
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'allowed_versions' => array(
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-3q-player',
 					),
 				),
 			),
@@ -8034,22 +8640,51 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-3q-player',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-access-laterpay',
+						'requires_usage' => 3,
+						'version' => array(
 							'0.1',
 							'0.2',
 							'latest',
 						),
-						'name' => 'amp-access-laterpay',
-						'requires_usage' => 3,
 					),
 					'requires_extension' => array(
 						'amp-access',
@@ -8060,21 +8695,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-access-scroll',
 						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 					'requires_extension' => array(
 						'amp-access',
@@ -8085,22 +8724,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-access',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8109,12 +8752,16 @@ class AMP_Allowed_Tags_Generated {
 					'id' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => 'amp-access',
+						'value' => array(
+							'amp-access',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8127,7 +8774,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'requires_extension' => array(
 						'amp-access',
-						'amp-analytics',
 					),
 					'spec_name' => 'amp-access extension .json script',
 					'unique' => true,
@@ -8137,22 +8783,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-accordion',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8160,22 +8810,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-ad',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 					'spec_name' => 'amp-ad extension .js script',
 				),
@@ -8184,20 +8838,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-addthis',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-addthis',
 					),
 				),
 			),
@@ -8205,22 +8863,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-analytics',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8230,7 +8892,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8252,22 +8916,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-anim',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8275,20 +8943,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-animation',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-animation',
 					),
 				),
 			),
@@ -8298,7 +8970,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8319,22 +8993,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-apester-media',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8342,21 +9020,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-app-banner',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8364,22 +9046,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-audio',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8387,20 +9073,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-auto-ads',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8408,20 +9098,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-beopinion',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8429,21 +9123,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-bind',
 						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8453,7 +9151,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8477,20 +9177,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-bodymovin-animation',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-bodymovin-animation',
 					),
 				),
 			),
@@ -8498,22 +9202,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-brid-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8521,22 +9229,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-brightcove',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8544,20 +9256,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-byside-content',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8565,21 +9281,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-call-tracking',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8587,22 +9307,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-carousel',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8610,20 +9334,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-consent',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-consent',
 					),
 				),
 			),
@@ -8633,7 +9361,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8655,22 +9385,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-dailymotion',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8678,20 +9412,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-date-countdown',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8699,20 +9437,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-date-picker',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8720,22 +9462,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-dynamic-css-classes',
 						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8743,22 +9489,51 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-embedly-card',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-experiment',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8768,7 +9543,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -8787,20 +9564,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-facebook-comments',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8808,20 +9589,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-facebook-like',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8829,20 +9614,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-facebook-page',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8850,22 +9639,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-facebook',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8873,22 +9666,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-fit-text',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8896,22 +9693,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-font',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8919,22 +9720,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-form',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8942,21 +9747,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-fx-collection',
 						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8964,22 +9773,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-fx-flying-carpet',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -8987,20 +9800,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-geo',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-geo',
 					),
 				),
 			),
@@ -9010,7 +9827,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -9032,22 +9851,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-gfycat',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9055,20 +9878,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-gist',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9076,20 +9903,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-google-document-embed',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9097,20 +9928,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-hulu',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9118,22 +9953,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-iframe',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9141,20 +9980,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-ima-video',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9162,22 +10005,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-image-lightbox',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9185,20 +10032,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-imgur',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9206,22 +10057,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-instagram',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9229,22 +10084,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-install-serviceworker',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9252,21 +10111,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-izlesene',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9274,22 +10137,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-jwplayer',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9297,22 +10164,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-kaltura-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9320,21 +10191,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-lightbox-gallery',
 						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9342,22 +10217,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-lightbox',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9365,22 +10244,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-list',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9388,21 +10271,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-live-list',
+						'requires_usage' => 2,
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-live-list',
-						'requires_usage' => 2,
 					),
 					'mandatory_parent' => 'head',
 					'unique_warning' => true,
@@ -9412,20 +10299,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-mathml',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-mathml',
 					),
 				),
 			),
@@ -9433,23 +10324,27 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'is_custom_template' => true,
 						'name' => 'amp-mustache',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9457,20 +10352,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-next-page',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-next-page',
 					),
 				),
 			),
@@ -9479,7 +10378,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -9495,20 +10396,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-nexxtv-player',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-nexxtv-player',
 					),
 				),
 			),
@@ -9516,22 +10421,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-o2-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9539,20 +10448,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-ooyala-player',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9560,20 +10473,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-orientation-observer',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9581,20 +10498,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-pan-zoom',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9602,22 +10523,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-pinterest',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9625,20 +10550,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-playbuzz',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9646,20 +10575,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-position-observer',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9667,22 +10600,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-reach-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9690,21 +10627,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-reddit',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9712,20 +10653,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-riddle-quiz',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9733,21 +10678,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-selector',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9755,22 +10704,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-sidebar',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9778,22 +10731,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-social-share',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9801,22 +10758,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-soundcloud',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9824,22 +10785,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-springboard-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9847,25 +10812,29 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'1.0',
-							'latest',
-						),
-						'deprecated_versions' => array(
+						'deprecated_version' => array(
 							'0.1',
 						),
 						'name' => 'amp-sticky-ad',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'1.0',
+							'latest',
+						),
 					),
 				),
 			),
@@ -9873,20 +10842,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-story-auto-ads',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-story-auto-ads',
 					),
 				),
 			),
@@ -9896,7 +10869,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -9918,21 +10893,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-story',
+						'version' => array(
 							'0.1',
 							'1.0',
 							'latest',
 						),
-						'name' => 'amp-story',
 					),
 				),
 			),
@@ -9942,7 +10921,9 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -9965,21 +10946,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-subscriptions',
+						'requires_usage' => 3,
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-subscriptions',
-						'requires_usage' => 3,
 					),
 				),
 			),
@@ -9988,12 +10973,16 @@ class AMP_Allowed_Tags_Generated {
 					'id' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
-						'value' => 'amp-subscriptions',
+						'value' => array(
+							'amp-subscriptions',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value_casei' => 'application/json',
+						'value_casei' => array(
+							'application/json',
+						),
 					),
 				),
 				'cdata' => array(
@@ -10015,21 +11004,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-subscriptions-google',
+						'requires_usage' => 3,
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-subscriptions-google',
-						'requires_usage' => 3,
 					),
 					'requires_extension' => array(
 						'amp-subscriptions',
@@ -10040,20 +11033,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-timeago',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-timeago',
 					),
 				),
 			),
@@ -10061,22 +11058,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-twitter',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10084,22 +11085,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-user-notification',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10107,21 +11112,25 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-video',
+						'requires_usage' => 3,
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-video',
-						'requires_usage' => 3,
 					),
 					'spec_name' => 'amp-video extension .js script',
 				),
@@ -10130,22 +11139,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-vimeo',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10153,22 +11166,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-vine',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10176,20 +11193,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-vk',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10197,20 +11218,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-web-push',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10218,20 +11243,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'name' => 'amp-wistia-player',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10239,20 +11268,24 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
+						'name' => 'amp-yotpo',
+						'version' => array(
 							'0.1',
 							'latest',
 						),
-						'name' => 'amp-yotpo',
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-yotpo',
 				),
@@ -10261,22 +11294,26 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/javascript',
+						'value_casei' => array(
+							'text/javascript',
+						),
 					),
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
-						'allowed_versions' => array(
-							'0.1',
-							'latest',
-						),
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-youtube',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
 					),
 				),
 			),
@@ -10293,7 +11330,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'expanded' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -10427,7 +11466,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -10449,7 +11488,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -10470,7 +11509,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -10493,7 +11532,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -10517,7 +11556,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -10594,11 +11633,15 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'amp-custom' => array(
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 					'type' => array(
-						'value_casei' => 'text/css',
+						'value_casei' => array(
+							'text/css',
+						),
 					),
 				),
 				'cdata' => array(
@@ -10613,11 +11656,10 @@ class AMP_Allowed_Tags_Generated {
 							'media',
 							'supports',
 						),
-						'allowed_declarations' => array(),
+						'declaration' => array(),
 						'font_url_spec' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 								'http',
 								'data',
@@ -10625,8 +11667,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'image_url_spec' => array(
 							'allow_empty' => true,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 								'http',
 								'data',
@@ -10647,10 +11688,27 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'nonce' => array(),
+				),
+				'cdata' => array(
+					'cdata_regex' => 'body ?{opacity: ?0}',
+				),
+				'tag_spec' => array(
+					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
+					'mandatory_parent' => 'head',
+					'spec_name' => 'head > style[amp-boilerplate] - old variant',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
 					'amp-boilerplate' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 				),
@@ -10670,7 +11728,9 @@ class AMP_Allowed_Tags_Generated {
 					'amp-boilerplate' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'nonce' => array(),
 				),
@@ -10691,7 +11751,9 @@ class AMP_Allowed_Tags_Generated {
 					'amp-keyframes' => array(
 						'dispatch_key' => 1,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 				),
 				'cdata' => array(
@@ -10701,7 +11763,7 @@ class AMP_Allowed_Tags_Generated {
 							'media',
 							'supports',
 						),
-						'allowed_declarations' => array(
+						'declaration' => array(
 							'animation-timing-function',
 							'offset-distance',
 							'opacity',
@@ -10803,7 +11865,10 @@ class AMP_Allowed_Tags_Generated {
 					'unicode-bidi' => array(),
 					'vector-effect' => array(),
 					'version' => array(
-						'value_regex' => '1.0|1.1',
+						'value' => array(
+							'1.0',
+							'1.1',
+						),
 					),
 					'viewbox' => array(),
 					'visibility' => array(),
@@ -10989,7 +12054,10 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 					'bgcolor' => array(),
 					'border' => array(
-						'value_regex' => '0|1',
+						'value' => array(
+							'0',
+							'1',
+						),
 					),
 					'cellpadding' => array(),
 					'cellspacing' => array(),
@@ -11026,13 +12094,17 @@ class AMP_Allowed_Tags_Generated {
 					'date-template' => array(
 						'dispatch_key' => 1,
 						'mandatory' => true,
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'dates' => array(),
 					'default' => array(),
 					'type' => array(
 						'mandatory' => true,
-						'value' => 'amp-mustache',
+						'value' => array(
+							'amp-mustache',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -11051,7 +12123,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'type' => array(
 						'mandatory' => true,
-						'value' => 'amp-mustache',
+						'value' => array(
+							'amp-mustache',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -11066,7 +12140,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'type' => array(
 						'mandatory' => true,
-						'value' => 'amp-mustache',
+						'value' => array(
+							'amp-mustache',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -11086,7 +12162,9 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'type' => array(
 						'mandatory' => true,
-						'value' => 'amp-mustache',
+						'value' => array(
+							'amp-mustache',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -11310,8 +12388,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -11411,10 +12488,17 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
-						'value_regex' => 'captions|chapters|descriptions|metadata',
+						'value' => array(
+							'captions',
+							'chapters',
+							'descriptions',
+							'metadata',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11422,7 +12506,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11437,11 +12521,15 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
 						'mandatory' => true,
-						'value_casei' => 'subtitles',
+						'value_casei' => array(
+							'subtitles',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11449,7 +12537,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11466,10 +12554,17 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
-						'value_regex' => 'captions|chapters|descriptions|metadata',
+						'value' => array(
+							'captions',
+							'chapters',
+							'descriptions',
+							'metadata',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11477,7 +12572,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11492,11 +12587,15 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
 						'mandatory' => true,
-						'value_casei' => 'subtitles',
+						'value_casei' => array(
+							'subtitles',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11504,7 +12603,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11524,10 +12623,17 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'[srclang]' => array(),
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
-						'value_regex' => 'captions|chapters|descriptions|metadata',
+						'value' => array(
+							'captions',
+							'chapters',
+							'descriptions',
+							'metadata',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11535,7 +12641,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11553,11 +12659,15 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'[srclang]' => array(),
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
 						'mandatory' => true,
-						'value_casei' => 'subtitles',
+						'value_casei' => array(
+							'subtitles',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11565,7 +12675,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11585,10 +12695,17 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'[srclang]' => array(),
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
-						'value_regex' => 'captions|chapters|descriptions|metadata',
+						'value' => array(
+							'captions',
+							'chapters',
+							'descriptions',
+							'metadata',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11596,7 +12713,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11614,11 +12731,15 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'[srclang]' => array(),
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
 						'mandatory' => true,
-						'value_casei' => 'subtitles',
+						'value_casei' => array(
+							'subtitles',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11626,7 +12747,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11646,11 +12767,15 @@ class AMP_Allowed_Tags_Generated {
 					'[src]' => array(),
 					'[srclang]' => array(),
 					'default' => array(
-						'value' => '',
+						'value' => array(
+							'',
+						),
 					),
 					'kind' => array(
 						'mandatory' => true,
-						'value_casei' => 'subtitles',
+						'value_casei' => array(
+							'subtitles',
+						),
 					),
 					'label' => array(),
 					'src' => array(
@@ -11658,7 +12783,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'https',
 							),
 						),
@@ -11752,8 +12877,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -11962,8 +13086,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'value_url' => array(
 							'allow_empty' => false,
-							'allow_relative' => true,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -12006,7 +13129,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
 							'allow_relative' => false,
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'data',
 								'https',
 							),
@@ -12137,7 +13260,7 @@ class AMP_Allowed_Tags_Generated {
 		'amp-access-style' => array(),
 		'amp-access-template' => array(),
 		'amp-fx' => array(
-			'value_regex_casei' => 'fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax',
+			'value_regex_casei' => '(fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax)(\\s|fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax)*',
 		),
 		'aria-activedescendant' => array(),
 		'aria-atomic' => array(),
@@ -12183,10 +13306,14 @@ class AMP_Allowed_Tags_Generated {
 		'dir' => array(),
 		'draggable' => array(),
 		'fallback' => array(
-			'value' => '',
+			'value' => array(
+				'',
+			),
 		),
 		'hidden' => array(
-			'value' => '',
+			'value' => array(
+				'',
+			),
 		),
 		'i-amp-access-id' => array(),
 		'id' => array(
@@ -12202,7 +13329,9 @@ class AMP_Allowed_Tags_Generated {
 		'on' => array(),
 		'overflow' => array(),
 		'placeholder' => array(
-			'value' => '',
+			'value' => array(
+				'',
+			),
 		),
 		'prefix' => array(),
 		'property' => array(),
@@ -12217,15 +13346,24 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'subscriptions-action' => array(),
 		'subscriptions-actions' => array(
-			'value' => '',
+			'value' => array(
+				'',
+			),
 		),
 		'subscriptions-decorate' => array(),
 		'subscriptions-dialog' => array(
-			'value' => '',
+			'value' => array(
+				'',
+			),
 		),
 		'subscriptions-display' => array(),
 		'subscriptions-section' => array(
-			'value_regex_casei' => 'actions|content|content-not-granted|loading',
+			'value_casei' => array(
+				'actions',
+				'content',
+				'content-not-granted',
+				'loading',
+			),
 		),
 		'subscriptions-service' => array(),
 		'tabindex' => array(),
@@ -12234,7 +13372,17 @@ class AMP_Allowed_Tags_Generated {
 		'typeof' => array(),
 		'validation-for' => array(),
 		'visible-when-invalid' => array(
-			'value_regex' => 'badInput|customError|patternMismatch|rangeOverflow|rangeUnderflow|stepMismatch|tooLong|typeMismatch|valueMissing',
+			'value' => array(
+				'badInput',
+				'customError',
+				'patternMismatch',
+				'rangeOverflow',
+				'rangeUnderflow',
+				'stepMismatch',
+				'tooLong',
+				'typeMismatch',
+				'valueMissing',
+			),
 		),
 		'vocab' => array(),
 	);

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -40,7 +40,7 @@ abstract class AMP_Rule_Spec {
 	 */
 	const ALLOW_EMPTY             = 'allow_empty';
 	const ALLOW_RELATIVE          = 'allow_relative';
-	const ALLOWED_PROTOCOL        = 'allowed_protocol';
+	const ALLOWED_PROTOCOL        = 'protocol';
 	const ALTERNATIVE_NAMES       = 'alternative_names';
 	const BLACKLISTED_VALUE_REGEX = 'blacklisted_value_regex';
 	const DISALLOWED_DOMAIN       = 'disallowed_domain';

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -558,7 +558,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$stylesheet = $this->process_stylesheet( $stylesheet, array(
 			'allowed_at_rules'   => $cdata_spec['css_spec']['allowed_at_rules'],
-			'property_whitelist' => $cdata_spec['css_spec']['allowed_declarations'],
+			'property_whitelist' => $cdata_spec['css_spec']['declaration'],
 			'validate_keyframes' => $cdata_spec['css_spec']['validate_keyframes'],
 		) );
 
@@ -653,7 +653,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$stylesheet = $this->process_stylesheet( $stylesheet, array(
 			'allowed_at_rules'   => $this->style_custom_cdata_spec['css_spec']['allowed_at_rules'],
-			'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['allowed_declarations'],
+			'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['declaration'],
 			'stylesheet_url'     => $href,
 			'stylesheet_path'    => $css_file_path,
 		) );
@@ -1619,7 +1619,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$stylesheet = $this->process_stylesheet( $rule, array(
 			'allowed_at_rules'   => array(),
-			'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['allowed_declarations'],
+			'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['declaration'],
 		) );
 
 		$element->removeAttribute( 'style' );

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -208,7 +208,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                  or if it did not find any HTML elements to convert to AMP equivalents.
 	 */
 	public function get_scripts() {
-		return array_fill_keys( $this->script_components, true );
+		return array_fill_keys( array_unique( $this->script_components ), true );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -326,11 +326,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 						AMP_Rule_Spec::MANDATORY => true,
 					);
 
+					$versions = array_unique( array_merge(
+						isset( $extension_spec['allowed_versions'] ) ? $extension_spec['allowed_versions'] : array(),
+						isset( $extension_spec['version'] ) ? $extension_spec['version'] : array()
+					) );
+
 					$rule_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['src'] = array(
 						AMP_Rule_Spec::VALUE_REGEX => implode( '', array(
 							'^',
 							preg_quote( 'https://cdn.ampproject.org/v0/' . $extension_spec['name'] . '-' ),
-							'(' . implode( '|', $extension_spec['allowed_versions'] ) . ')',
+							'(' . implode( '|', $versions ) . ')',
 							'\.js$',
 						) ),
 					);
@@ -542,6 +547,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $cdata_spec['blacklisted_cdata_regex'] ) ) {
 			if ( preg_match( '@' . $cdata_spec['blacklisted_cdata_regex']['regex'] . '@u', $element->textContent ) ) {
 				return new WP_Error( $cdata_spec['blacklisted_cdata_regex']['error_message'] );
+			}
+		} elseif ( isset( $cdata_spec['cdata_regex'] ) ) {
+			$delimiter = false === strpos( $cdata_spec['cdata_regex'], '@' ) ? '@' : '#';
+			if ( ! preg_match( $delimiter . $cdata_spec['cdata_regex'] . $delimiter . 'u', $element->textContent ) ) {
+				return new WP_Error( 'cdata_regex' );
 			}
 		}
 		return true;
@@ -1045,33 +1055,43 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * This takes into account boolean attributes where value can match name (e.g. selected="selected").
 	 *
 	 * @since 0.7.0
+	 * @since 1.0.0 The spec value is now an array.
 	 *
-	 * @param string $attr_name  Attribute name.
-	 * @param string $attr_value Attribute value.
-	 * @param string $spec_value Attribute spec value.
+	 * @param string       $attr_name   Attribute name.
+	 * @param string       $attr_value  Attribute value.
+	 * @param string|array $spec_values Attribute spec value(s).
 	 * @return bool Is value valid.
 	 */
-	private function check_matching_attribute_value( $attr_name, $attr_value, $spec_value ) {
-		if ( $spec_value === $attr_value ) {
-			return true;
+	private function check_matching_attribute_value( $attr_name, $attr_value, $spec_values ) {
+		if ( is_string( $spec_values ) ) {
+			$spec_values = (array) $spec_values;
 		}
+		foreach ( $spec_values as $spec_value ) {
+			if ( $spec_value === $attr_value ) {
+				return true;
+			}
 
-		// Check for boolean attribute.
-		return (
-			'' === $spec_value
-			&&
-			in_array( $attr_name, AMP_Rule_Spec::$boolean_attributes, true )
-			&&
-			strtolower( $attr_value ) === strtolower( $attr_name )
-		);
+			// Check for boolean attribute.
+			$is_bool_match = (
+				'' === $spec_value
+				&&
+				in_array( $attr_name, AMP_Rule_Spec::$boolean_attributes, true )
+				&&
+				strtolower( $attr_value ) === strtolower( $attr_name )
+			);
+			if ( $is_bool_match ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
 	 * Check if attribute has a value rule determine if its value matches ignoring case.
 	 *
-	 * @param DOMElement       $node           Node.
-	 * @param string           $attr_name      Attribute name.
-	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
+	 * @param DOMElement   $node           Node.
+	 * @param string       $attr_name      Attribute name.
+	 * @param array|string $attr_spec_rule Attribute spec rule.
 	 *
 	 * @return string:
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
@@ -1080,17 +1100,20 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *                                        is no rule for this attribute.
 	 */
 	private function check_attr_spec_rule_value_casei( $node, $attr_name, $attr_spec_rule ) {
-		/**
-		 * Check 'value_casei' - case insensitive
-		 */
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_CASEI ] ) ) {
-			$rule_value = strtolower( $attr_spec_rule[ AMP_Rule_Spec::VALUE_CASEI ] );
+		if ( ! isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_CASEI ] ) ) {
+			return AMP_Rule_Spec::NOT_APPLICABLE;
+		}
+
+		$result      = AMP_Rule_Spec::NOT_APPLICABLE;
+		$rule_values = (array) $attr_spec_rule[ AMP_Rule_Spec::VALUE_CASEI ];
+		foreach ( $rule_values as $rule_value ) {
+			$rule_value = strtolower( $rule_value );
 			if ( $node->hasAttribute( $attr_name ) ) {
 				$attr_value = strtolower( $node->getAttribute( $attr_name ) );
 				if ( $attr_value === (string) $rule_value ) {
 					return AMP_Rule_Spec::PASS;
 				} else {
-					return AMP_Rule_Spec::FAIL;
+					$result = AMP_Rule_Spec::FAIL;
 				}
 			} elseif ( isset( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] ) ) {
 				foreach ( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $alternative_name ) {
@@ -1099,13 +1122,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 						if ( $attr_value === (string) $rule_value ) {
 							return AMP_Rule_Spec::PASS;
 						} else {
-							return AMP_Rule_Spec::FAIL;
+							$result = AMP_Rule_Spec::FAIL;
 						}
 					}
 				}
 			}
 		}
-		return AMP_Rule_Spec::NOT_APPLICABLE;
+		return $result;
 	}
 
 	/**

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -168,7 +168,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attribute_value' => '_blank',
 					'include_attr' => true,
 					'include_attr_value' => true,
-					'func_name' => 'check_attr_spec_rule_value_regex',
+					'func_name' => 'check_attr_spec_rule_value',
 				),
 				'expected' => AMP_Rule_Spec::PASS,
 			),
@@ -180,7 +180,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attribute_value' => '_blankzzz',
 					'include_attr' => true,
 					'include_attr_value' => true,
-					'func_name' => 'check_attr_spec_rule_value_regex',
+					'func_name' => 'check_attr_spec_rule_value',
 				),
 				'expected' => AMP_Rule_Spec::FAIL,
 			),
@@ -207,7 +207,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attribute_value' => 'false',
 					'include_attr' => true,
 					'include_attr_value' => true,
-					'func_name' => 'check_attr_spec_rule_value_regex_casei',
+					'func_name' => 'check_attr_spec_rule_value_casei',
 				),
 				'expected' => AMP_Rule_Spec::PASS,
 			),
@@ -219,7 +219,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attribute_value' => 'FALSE',
 					'include_attr' => true,
 					'include_attr_value' => true,
-					'func_name' => 'check_attr_spec_rule_value_regex_casei',
+					'func_name' => 'check_attr_spec_rule_value_casei',
 				),
 				'expected' => AMP_Rule_Spec::PASS,
 			),
@@ -231,7 +231,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attribute_value' => 'invalid',
 					'include_attr' => true,
 					'include_attr_value' => true,
-					'func_name' => 'check_attr_spec_rule_value_regex_casei',
+					'func_name' => 'check_attr_spec_rule_value_casei',
 				),
 				'expected' => AMP_Rule_Spec::FAIL,
 			),
@@ -1447,7 +1447,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1463,7 +1463,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1479,7 +1479,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1495,7 +1495,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'attr_name'      => 'attribute1',
 					'attr_spec_rule' => array(
 						'value_url' => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1514,7 +1514,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 							'attribute1_alternative1',
 						),
 						'value_url'         => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),
@@ -1533,7 +1533,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 							'attribute1_alternative1',
 						),
 						'value_url'         => array(
-							'allowed_protocol' => array(
+							'protocol' => array(
 								'http',
 								'https',
 							),

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -763,6 +763,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-date-picker' ),
 			),
 
+			'amp_date_picker_range' => array(
+				'<amp-date-picker type="range" minimum-nights="2" mode="overlay" id="range-date-picker" on=" select: AMP.setState({ dates: event.dates, startDate: event.start, endDate: event.end })" format="YYYY-MM-DD" open-after-select min="2017-10-26" start-input-selector="#range-start" end-input-selector="#range-end" class="example-picker space-between"><div class="ampstart-input"><input class="border-none p0" id="range-start" placeholder="Start date"></div><div class="ampstart-input"><input class="border-none p0" id="range-end" placeholder="End date"></div><button class="ampstart-btn caps" on="tap:range-date-picker.clear">Clear</button><template type="amp-mustache" info-template><span [text]="(startDate &amp;&amp; endDate ? \'You picked \' + startDate.date + \' as start date and \' + endDate.date + \' as end date.\' : \'You will see your chosen dates here.\')"> You will see your chosen dates here.</span></template></amp-date-picker>',
+				null, // No change.
+				array( 'amp-date-picker', 'amp-bind', 'amp-mustache' ),
+			),
+
 			'amp-img-layout-allowed' => array(
 				implode( '', array(
 					'<amp-img src="/img1.png" width="50" height="50" layout="fill"></amp-img>',
@@ -847,6 +853,24 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-yotpo width="550" height="700" layout="responsive" data-app-key="liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5" data-widget-type="MainWidget" data-product-id="9408616206" data-name="hockey skates" data-url="https://ranabram.myshopify.com/products/hockey-skates" data-image-url="https://ichef.bbci.co.uk/news/320/media/images/83351000/jpg/_83351965_explorer273lincolnshirewoldssouthpicturebynicholassilkstone.jpg" data-descriptipn="skates" data-yotpo-element-id="1"></amp-yotpo>',
 				null,
 				array( 'amp-yotpo' ),
+			),
+
+			'amp-embedly' => array(
+				'<amp-embedly-key value="12af2e3543ee432ca35ac30a4b4f656a" layout="nodisplay"></amp-embedly-key><amp-embedly-card data-url="https://twitter.com/AMPhtml/status/986750295077040128" layout="responsive" width="150" height="80" data-card-theme="dark" data-card-controls="0"></amp-embedly-card>',
+				null,
+				array( 'amp-embedly-card' ),
+			),
+
+			'amp-lightbox' => array(
+				'<amp-lightbox id="my-lightbox" animate-in="fly-in-top" layout="nodisplay"><div class="lightbox" on="tap:my-lightbox.close" role="button" tabindex="0"><h1>Hello World!</h1></div></amp-lightbox>',
+				null,
+				array( 'amp-lightbox' ),
+			),
+
+			'amp-fom-messages' => array(
+				'<form action-xhr="https://example.com/" method="post"><fieldset><input type="text" name="firstName"></fieldset><div verify-error=""><template type="amp-mustache">There is a mistake in the form!{{#verifyErrors}}{{message}}{{/verifyErrors}}</template></div><div submitting=""><template type="amp-mustache">Form submitting... Thank you for waiting {{name}}.</template></div><div submit-success=""><template type="amp-mustache">Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}to confirm! After that we\'ll start sending you weekly articles on {{#interests}}<b>{{name}}</b> {{/interests}}.</template></div><div submit-error><template type="amp-mustache">Oops! {{name}}, {{message}}.</template></div></form>',
+				null,
+				array( 'amp-form', 'amp-mustache' ),
 			),
 		);
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -533,8 +533,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'leave_attribute_on_node_with_present_mandatory_parent' => array(
-				'<form action="form.php" target="_top"><div submit-success>This is a test.</div></form>',
-				'<form action="form.php" target="_top"><div submit-success>This is a test.</div></form>',
+				'<form action-xhr="form.php" method="post" target="_top"><div submit-success>This is a test.</div></form>',
+				null,
 				array( 'amp-form' ),
 			),
 


### PR DESCRIPTION
This is a follow-up on #1312. Since there are validator spec changes another PR was needed to deal with them.

* Update spec reader to account for spec format changes.
* Add support for `amp-embedly-card` and `amp-embedly-key`.
* Add `minimum-nights` attribute to `amp-date-picker`.
* Add `animate-in` attribute to `amp-lightbox`.
* Add `submitting` and `verify-error` to `form`.
* Add more `amp-fx` values.

- [x] Verify updates to accommodate spec changes are correct.
- [x] Add changelog.
- [x] Add tests.

Fixes #1330.