### PR TITLE
Display byte size before amp-custom sources instead of after

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1746,7 +1746,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! ( $pending_stylesheet['node'] instanceof DOMElement ) ) {
 					continue;
 				}
-				$message  = sprintf( '% 6dB: ', $pending_stylesheet['size'] );
+				$message  = sprintf( '% 6d B: ', $pending_stylesheet['size'] );
 				$message .= $pending_stylesheet['node']->nodeName;
 				if ( $pending_stylesheet['node']->getAttribute( 'id' ) ) {
 					$message .= '#' . $pending_stylesheet['node']->getAttribute( 'id' );

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1740,6 +1740,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$this->amp_custom_style_element->appendChild( $this->dom->createTextNode( $css ) );
 
 			$included_size    = 0;
+			$excluded_size    = 0;
 			$included_sources = array();
 			foreach ( $stylesheet_sets['custom']['pending_stylesheets'] as $i => $pending_stylesheet ) {
 				if ( ! ( $pending_stylesheet['node'] instanceof DOMElement ) ) {
@@ -1764,19 +1765,23 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$included_size     += $pending_stylesheet['size'];
 				} else {
 					$excluded_sources[] = $message;
+					$excluded_size     += $pending_stylesheet['size'];
 				}
 			}
 			$comment = '';
 			if ( ! empty( $included_sources ) ) {
 				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n" . implode( "\n", $included_sources ) . "\n";
 				/* translators: %d is number of bytes */
-				$comment .= sprintf( esc_html__( 'Total size: %d bytes', 'amp' ), $included_size ) . "\n";
+				$comment .= sprintf( esc_html__( 'Total included size: %d bytes', 'amp' ), $included_size ) . "\n";
 			}
 			if ( ! empty( $excluded_sources ) ) {
 				if ( $comment ) {
 					$comment .= "\n";
 				}
 				$comment .= esc_html__( 'The following stylesheets are too large to be included in style[amp-custom]:', 'amp' ) . "\n" . implode( "\n", $excluded_sources ) . "\n";
+
+				/* translators: %d is number of bytes */
+				$comment .= sprintf( esc_html__( 'Total excluded size: %d bytes', 'amp' ), $excluded_size ) . "\n";
 			}
 			if ( $comment ) {
 				$this->amp_custom_style_element->parentNode->insertBefore(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1745,7 +1745,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! ( $pending_stylesheet['node'] instanceof DOMElement ) ) {
 					continue;
 				}
-				$message = $pending_stylesheet['node']->nodeName;
+				$message  = sprintf( '% 6dB: ', $pending_stylesheet['size'] );
+				$message .= $pending_stylesheet['node']->nodeName;
 				if ( $pending_stylesheet['node']->getAttribute( 'id' ) ) {
 					$message .= '#' . $pending_stylesheet['node']->getAttribute( 'id' );
 				}
@@ -1757,11 +1758,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						$message .= sprintf( '[%s=%s]', $attribute->nodeName, $attribute->nodeValue );
 					}
 				}
-				$message .= sprintf(
-					/* translators: %d is number of bytes */
-					_n( ' (%d byte)', ' (%d bytes)', $pending_stylesheet['size'], 'amp' ),
-					$pending_stylesheet['size']
-				);
 
 				if ( ! empty( $pending_stylesheet['included'] ) ) {
 					$included_sources[] = $message;
@@ -1772,7 +1768,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 			$comment = '';
 			if ( ! empty( $included_sources ) ) {
-				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n- " . implode( "\n- ", $included_sources ) . "\n";
+				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n" . implode( "\n", $included_sources ) . "\n";
 				/* translators: %d is number of bytes */
 				$comment .= sprintf( esc_html__( 'Total size: %d bytes', 'amp' ), $included_size ) . "\n";
 			}
@@ -1780,7 +1776,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( $comment ) {
 					$comment .= "\n";
 				}
-				$comment .= esc_html__( 'The following stylesheets are too large to be included in style[amp-custom]:', 'amp' ) . "\n- " . implode( "\n- ", $excluded_sources ) . "\n";
+				$comment .= esc_html__( 'The following stylesheets are too large to be included in style[amp-custom]:', 'amp' ) . "\n" . implode( "\n", $excluded_sources ) . "\n";
 			}
 			if ( $comment ) {
 				$this->amp_custom_style_element->parentNode->insertBefore(


### PR DESCRIPTION
To improve readability of the manifest of `style[amp-custom]`, move the byte size from the end to the beginning of the line. Also include the sum of bytes that are being excluded.

# Before

```
The style[amp-custom] element is populated with:
- style[amp-custom=] (0 bytes)
- link#twentysixteen-jetpack-css[rel=stylesheet][id=twentysixteen-jetpack-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/theme-tools/compat/twentysixteen.css?ver=6.2.1][type=text/css][media=all] (338 bytes)
- link#dashicons-css[rel=stylesheet][id=dashicons-css][href=https://src.wordpress-develop.test/wp-includes/css/dashicons.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all] (466 bytes)
- link#admin-bar-css[rel=stylesheet][id=admin-bar-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/admin-bar.css?ver=1.0-beta1][type=text/css][media=all] (17168 bytes)
- style#admin-bar-inline-css[id=admin-bar-inline-css][type=text/css] (127 bytes)
- link#wp-core-blocks-css[rel=stylesheet][id=wp-core-blocks-css][href=https://src.wordpress-develop.test/wp-content/plugins/gutenberg/build/core-blocks/style.css?ver=1533089052][type=text/css][media=all] (230 bytes)
- link#genericons-css[rel=stylesheet][id=genericons-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/_inc/genericons/genericons/genericons.css?ver=3.1][type=text/css][media=all] (1032 bytes)
- link#twentysixteen-style-css[rel=stylesheet][id=twentysixteen-style-css][href=https://src.wordpress-develop.test/wp-content/themes/twentysixteen/style.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all] (29839 bytes)
- style#twentysixteen-style-inline-css[id=twentysixteen-style-inline-css][type=text/css] (521 bytes)
- link#jetpack-widget-social-icons-styles-css[rel=stylesheet][id=jetpack-widget-social-icons-styles-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/widgets/social-icons/social-icons.css?ver=20170506][type=text/css][media=all] (205 bytes)
- link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.0-beta1][type=text/css][media=all] (64 bytes)
Total size: 49990 bytes

The following stylesheets are too large to be included in style[amp-custom]:
- style[type=text/css] (74 bytes)
- style#custom-background-css[type=text/css][id=custom-background-css] (45 bytes)
- style[type=text/css][media=print] (39 bytes)
- style[type=text/css][media=screen] (129 bytes)
- style (69 bytes)
- style[type=text/css] (1405 bytes)
- link#jetpack-responsive-videos-style-css[rel=stylesheet][id=jetpack-responsive-videos-style-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/theme-tools/responsive-videos/responsive-videos.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all] (162 bytes)
- link#mediaelement-css[rel=stylesheet][id=mediaelement-css][href=https://src.wordpress-develop.test/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.6-78496d1][type=text/css][media=all] (308 bytes)
```

# After

```
The style[amp-custom] element is populated with:
     0B: style[amp-custom=]
   338B: link#twentysixteen-jetpack-css[rel=stylesheet][id=twentysixteen-jetpack-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/theme-tools/compat/twentysixteen.css?ver=6.2.1][type=text/css][media=all]
   466B: link#dashicons-css[rel=stylesheet][id=dashicons-css][href=https://src.wordpress-develop.test/wp-includes/css/dashicons.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all]
 17168B: link#admin-bar-css[rel=stylesheet][id=admin-bar-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/admin-bar.css?ver=1.0-beta1][type=text/css][media=all]
   127B: style#admin-bar-inline-css[id=admin-bar-inline-css][type=text/css]
   230B: link#wp-core-blocks-css[rel=stylesheet][id=wp-core-blocks-css][href=https://src.wordpress-develop.test/wp-content/plugins/gutenberg/build/core-blocks/style.css?ver=1533089052][type=text/css][media=all]
  1032B: link#genericons-css[rel=stylesheet][id=genericons-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/_inc/genericons/genericons/genericons.css?ver=3.1][type=text/css][media=all]
 29839B: link#twentysixteen-style-css[rel=stylesheet][id=twentysixteen-style-css][href=https://src.wordpress-develop.test/wp-content/themes/twentysixteen/style.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all]
   521B: style#twentysixteen-style-inline-css[id=twentysixteen-style-inline-css][type=text/css]
   205B: link#jetpack-widget-social-icons-styles-css[rel=stylesheet][id=jetpack-widget-social-icons-styles-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/widgets/social-icons/social-icons.css?ver=20170506][type=text/css][media=all]
    64B: link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.0-beta1][type=text/css][media=all]
Total included size: 49990 bytes

The following stylesheets are too large to be included in style[amp-custom]:
    74B: style[type=text/css]
    45B: style#custom-background-css[type=text/css][id=custom-background-css]
    39B: style[type=text/css][media=print]
   129B: style[type=text/css][media=screen]
    69B: style
  1405B: style[type=text/css]
   162B: link#jetpack-responsive-videos-style-css[rel=stylesheet][id=jetpack-responsive-videos-style-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/theme-tools/responsive-videos/responsive-videos.css?ver=4.9.8-beta2-43516-src][type=text/css][media=all]
   308B: link#mediaelement-css[rel=stylesheet][id=mediaelement-css][href=https://src.wordpress-develop.test/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.6-78496d1][type=text/css][media=all]
Total excluded size: 768 bytes
```
