### PR TITLE
Filter the attachment image attributes for the Twenty Seventeen theme.

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -78,6 +78,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				'//header[@id = "masthead"]//a[ contains( @class, "menu-scroll-down" ) ]',
 			),
 			'set_twentyseventeen_quotes_icon'     => array(),
+			'add_twentyseventeen_attachment_image_attributes' => array(),
 		),
 
 		// Twenty Sixteen.
@@ -342,6 +343,30 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 			return $content;
 		} );
+	}
+
+	/**
+	 * Add filter to adjust the attachment image attributes to ensure attachment pages have a consistent <amp-img> rendering.
+	 *
+	 * This is only used in Twenty Seventeen.
+	 *
+	 * @since 1.0
+	 * @link https://github.com/WordPress/wordpress-develop/blob/ddc8f803c6e99118998191fd2ea24124feb53659/src/wp-content/themes/twentyseventeen/functions.php#L545:L554
+	 */
+	public static function add_twentyseventeen_attachment_image_attributes() {
+		add_filter( 'wp_get_attachment_image_attributes', function ( $attr, $attachment, $size ) {
+			if ( ! is_attachment() ) {
+				return $attr;
+			}
+
+			$sizes = wp_get_attachment_image_sizes( $attachment->ID, $size );
+			if ( false !== $sizes ) {
+				$attr['layout'] = 'responsive';
+				$attr['sizes']  = $sizes;
+			}
+
+			return $attr;
+		}, 11, 3 );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -361,8 +361,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 			$sizes = wp_get_attachment_image_sizes( $attachment->ID, $size );
 			if ( false !== $sizes ) {
-				$attr['layout'] = 'responsive';
-				$attr['sizes']  = $sizes;
+				$attr['sizes'] = $sizes;
 			}
 
 			return $attr;


### PR DESCRIPTION
Per issue #1237, the Twenty Seventeen theme is adding `$attr['sizes']  = '100vw';` which stretches images on the attachment page when in AMP mode.

AMP uses a combination of the `layout` and `sizes` attributes to determine how to set the inline style width.

This PR filters `'wp_get_attachment_image_attributes'` to change the layout to responsive and sizes to the calculated image sizes per `wp_get_attachment_image_sizes()`.

~- Changing the layout to responsive ensures the image renders within the parent container in all viewports.~
- Changing the `sizes` value provides the information AMP needs to set the inline width.

### Before

Notice the differences in non-AMP vs. AMP rendering _before_ this PR is applied.  The images are stretched due to the `sizes` and `layout` attributes.

Here is a 150x150 thumbnail image before this PR is applied:

![before-stretched-150x150](https://user-images.githubusercontent.com/7284611/43743827-f541c09c-999c-11e8-99fe-10beb8f72896.png)

Here is a 1200w image before this PR is applied:

![before-stretched-1200w](https://user-images.githubusercontent.com/7284611/43743539-ee6326ea-999b-11e8-9991-a9c5c613d413.png)

### After

Now let's compare both of the above images after applying this PR.  Notice the images render the same in non-AMP and AMP modes without stretching.

![after-stretched-150x150](https://user-images.githubusercontent.com/7284611/43743914-554dccd8-999d-11e8-97fb-c0d8a476f0f1.png)

![after-stretched-1200w](https://user-images.githubusercontent.com/7284611/43743919-591c6f5e-999d-11e8-87e6-0e65453f2e02.png)

### Is this a fix or bandaid?

There is an [open issue with the AMPHTML project](https://github.com/ampproject/amphtml/issues/17053) about images being stretched.  IMO this PR fixes the layout and sizes for the Twenty Seventeen theme as it is adjusting the sizes to `100vw` when on the attachment page.  Therefore, I think this PR could be rolled in without worrying about the changes from the open issue.