### PR TITLE
Fix inability to move link element due to assigned parent

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1571,6 +1571,9 @@ class AMP_Theme_Support {
 				continue;
 			}
 			foreach ( $links[ $rel ] as $link ) {
+				if ( $link->parentNode ) {
+					$link->parentNode->removeChild( $link ); // So we can move it.
+				}
 				$head->insertBefore( $link, $previous_node->nextSibling );
 				$previous_node = $link;
 			}


### PR DESCRIPTION
I was adding some more preload links to the `head` and I noticed some of them stopped showing up. In looking at the log I found:

> PHP Warning:  DOMNode::insertBefore(): Couldn't add newnode as the previous sibling of refnode

In JS you can freely move nodes around the tree without removing them first. In PHP (libxml) it seems it requires that they be removed from the DOM before re-inserting them. While I was doing this in other places in the `ensure_required_markup` method, I neglected to do it fully here.