### PR TITLE
Improve post processor response cache

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2013,9 +2013,7 @@ class AMP_Theme_Support {
 	 */
 	private static function check_for_cache_misses() {
 		// If the cache miss threshold is exceeded, return true.
-		$cache_miss_url     = get_option( self::CACHE_MISS_URL_OPTION, false );
-		$exceeded_threshold = ! empty( $cache_miss_url );
-		if ( $exceeded_threshold ) {
+		if ( self::exceeded_cache_miss_threshold() ) {
 			return array( true, null );
 		}
 
@@ -2048,6 +2046,18 @@ class AMP_Theme_Support {
 		if ( get_option( self::CACHE_MISS_URL_OPTION ) ) {
 			delete_option( self::CACHE_MISS_URL_OPTION );
 		}
+	}
+
+	/**
+	 * Checks if cache miss threshold has been exceeded.
+	 *
+	 * @since 1.0
+	 *
+	 * @return bool
+	 */
+	public static function exceeded_cache_miss_threshold() {
+		$url = get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false );
+		return ! empty( $url );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -156,6 +156,8 @@ class AMP_Theme_Support {
 		 * action to template_redirect--the wp action--is used instead.
 		 */
 		add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
+
+		add_action( 'amp_reenable_response_cache', array( __CLASS__, 'reset_cache_miss_url_option' ) );
 	}
 
 	/**
@@ -2037,6 +2039,17 @@ class AMP_Theme_Support {
 		update_option( self::CACHE_MISS_URL_OPTION, amp_get_current_url() );
 		AMP_Options_Manager::update_option( 'enable_response_caching', false );
 		return array( true, null );
+	}
+
+	/**
+	 * Reset the cache miss URL option.
+	 *
+	 * @since 1.0
+	 */
+	public static function reset_cache_miss_url_option() {
+		if ( get_option( self::CACHE_MISS_URL_OPTION ) ) {
+			delete_option( self::CACHE_MISS_URL_OPTION );
+		}
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -113,13 +113,6 @@ class AMP_Theme_Support {
 	protected static $support_added_via_option = false;
 
 	/**
-	 * Post-processor cache key.
-	 *
-	 * @var string
-	 */
-	public static $post_processor_cache_key;
-
-	/**
 	 * Initialize.
 	 *
 	 * @since 0.7
@@ -1782,11 +1775,10 @@ class AMP_Theme_Support {
 		$ampless_url = amp_remove_endpoint( $current_url );
 
 		// When response caching is enabled, determine if it should be turned off for cache misses.
-		$caches_for_url                 = null;
-		self::$post_processor_cache_key = null;
+		$caches_for_url = null;
 		if ( true === $args['enable_response_caching'] ) {
-			self::$post_processor_cache_key = md5( $current_url );
-			$caches_for_url                 = wp_cache_get( self::$post_processor_cache_key, self::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+			$post_processor_cache_key = md5( $current_url );
+			$caches_for_url           = wp_cache_get( $post_processor_cache_key, self::POST_PROCESSOR_CACHE_EFFECTIVENESS );
 
 			$args['enable_response_caching'] = (
 				empty( $caches_for_url )
@@ -1839,14 +1831,14 @@ class AMP_Theme_Support {
 				return $response_cache['body'];
 			}
 
-			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $caches_for_url ) {
+			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $post_processor_cache_key, $caches_for_url ) {
 				if ( empty( $caches_for_url ) ) {
 					$caches_for_url = array( $response_cache_key );
 				} else {
 					$caches_for_url[] = $response_cache_key;
 				}
 				wp_cache_set(
-					AMP_Theme_Support::$post_processor_cache_key,
+					$post_processor_cache_key,
 					$caches_for_url,
 					AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS,
 					MONTH_IN_SECONDS

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1780,6 +1780,15 @@ class AMP_Theme_Support {
 		if ( true === $args['enable_response_caching'] ) {
 			$post_processor_cache_key = md5( $current_url );
 			$caches_for_url           = wp_cache_get( $post_processor_cache_key, self::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+
+			// Turn off response caching when the number of cached URLs exceeds the threshold.
+			$args['enable_response_caching'] = (
+				empty( $caches_for_url )
+				||
+				! is_array( $caches_for_url )
+				||
+				count( $caches_for_url ) < self::CACHE_MISS_THRESHOLD
+			);
 		}
 
 		// Return cache if enabled and found.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -113,13 +113,6 @@ class AMP_Theme_Support {
 	protected static $support_added_via_option = false;
 
 	/**
-	 * Response cache key.
-	 *
-	 * @var string
-	 */
-	public static $response_cache_key;
-
-	/**
 	 * Post-processor cache key.
 	 *
 	 * @var string
@@ -1805,11 +1798,10 @@ class AMP_Theme_Support {
 		}
 
 		// Return cache if enabled and found.
-		$cache_response           = null;
-		self::$response_cache_key = '';
+		$cache_response = null;
 		if ( true === $args['enable_response_caching'] ) {
 			// Set response cache hash, the data values dictates whether a new hash key should be generated or not.
-			self::$response_cache_key = md5( wp_json_encode( array(
+			$response_cache_key = md5( wp_json_encode( array(
 				$args,
 				$response,
 				self::$sanitizer_classes,
@@ -1817,7 +1809,7 @@ class AMP_Theme_Support {
 				AMP__VERSION,
 			) ) );
 
-			$response_cache = wp_cache_get( self::$response_cache_key, self::RESPONSE_CACHE_GROUP );
+			$response_cache = wp_cache_get( $response_cache_key, self::RESPONSE_CACHE_GROUP );
 
 			// Make sure that all of the validation errors should be sanitized in the same way; if not, then the cached body should be discarded.
 			$blocking_error_count = 0;
@@ -1847,11 +1839,11 @@ class AMP_Theme_Support {
 				return $response_cache['body'];
 			}
 
-			$cache_response = function( $body, $validation_results ) use ( $caches_for_url ) {
+			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $caches_for_url ) {
 				if ( empty( $caches_for_url ) ) {
-					$caches_for_url = array( AMP_Theme_Support::$response_cache_key );
+					$caches_for_url = array( $response_cache_key );
 				} else {
-					$caches_for_url[] = AMP_Theme_Support::$response_cache_key;
+					$caches_for_url[] = $response_cache_key;
 				}
 				wp_cache_set(
 					AMP_Theme_Support::$post_processor_cache_key,
@@ -1861,7 +1853,7 @@ class AMP_Theme_Support {
 				);
 
 				return wp_cache_set(
-					AMP_Theme_Support::$response_cache_key,
+					$response_cache_key,
 					compact( 'body', 'validation_results' ),
 					AMP_Theme_Support::RESPONSE_CACHE_GROUP,
 					MONTH_IN_SECONDS

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2056,7 +2056,7 @@ class AMP_Theme_Support {
 	 * @return bool
 	 */
 	public static function exceeded_cache_miss_threshold() {
-		$url = get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false );
+		$url = get_option( self::CACHE_MISS_URL_OPTION, false );
 		return ! empty( $url );
 	}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -156,8 +156,6 @@ class AMP_Theme_Support {
 		 * action to template_redirect--the wp action--is used instead.
 		 */
 		add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
-
-		add_action( 'amp_reenable_response_cache', array( __CLASS__, 'reset_cache_miss_url_option' ) );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2033,8 +2033,9 @@ class AMP_Theme_Support {
 			return array( $exceeded_threshold, $cache_miss_urls );
 		}
 
-		// When the threshold is exceeded, store the URL for cache miss.
+		// When the threshold is exceeded, store the URL for cache miss and turn off response caching.
 		update_option( self::CACHE_MISS_URL_OPTION, amp_get_current_url() );
+		AMP_Options_Manager::update_option( 'enable_response_caching', false );
 		return array( true, null );
 	}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -27,11 +27,18 @@ class AMP_Theme_Support {
 	const RESPONSE_CACHE_GROUP = 'amp-response';
 
 	/**
-	 * Post-processor cache group name.
+	 * Post-processor cache effectiveness group name.
 	 *
 	 * @var string
 	 */
-	const POST_PROCESSOR_CACHE_EFFECTIVENESS = 'post_processor_cache_effectiveness';
+	const POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP = 'post_processor_cache_effectiveness_group';
+
+	/**
+	 * Post-processor cache effectiveness key name.
+	 *
+	 * @var string
+	 */
+	const POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY = 'post_processor_cache_effectiveness';
 
 	/**
 	 * Cache miss threshold for determining when to disable post-processor cache.
@@ -1775,11 +1782,9 @@ class AMP_Theme_Support {
 		$ampless_url = amp_remove_endpoint( $current_url );
 
 		// When response caching is enabled, determine if it should be turned off for cache misses.
-		$caches_for_url           = null;
-		$post_processor_cache_key = '';
+		$caches_for_url = null;
 		if ( true === $args['enable_response_caching'] ) {
-			$post_processor_cache_key = md5( $current_url );
-			$caches_for_url           = wp_cache_get( $post_processor_cache_key, self::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+			$caches_for_url = wp_cache_get( self::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY, self::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP );
 			if ( is_array( $caches_for_url ) ) {
 				$args['enable_response_caching'] = (
 					empty( $caches_for_url )
@@ -1833,12 +1838,12 @@ class AMP_Theme_Support {
 				return $response_cache['body'];
 			}
 
-			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $post_processor_cache_key, $caches_for_url ) {
+			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $caches_for_url ) {
 				$caches_for_url[] = $response_cache_key;
 				wp_cache_set(
-					$post_processor_cache_key,
+					AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY,
 					$caches_for_url,
-					AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS,
+					AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP,
 					600 // 10 minute cache.
 				);
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1839,7 +1839,7 @@ class AMP_Theme_Support {
 					$post_processor_cache_key,
 					$caches_for_url,
 					AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS,
-					MONTH_IN_SECONDS
+					600 // 10 minute cache.
 				);
 
 				return wp_cache_set(

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1775,18 +1775,20 @@ class AMP_Theme_Support {
 		$ampless_url = amp_remove_endpoint( $current_url );
 
 		// When response caching is enabled, determine if it should be turned off for cache misses.
-		$caches_for_url = null;
+		$caches_for_url           = null;
+		$post_processor_cache_key = '';
 		if ( true === $args['enable_response_caching'] ) {
 			$post_processor_cache_key = md5( $current_url );
 			$caches_for_url           = wp_cache_get( $post_processor_cache_key, self::POST_PROCESSOR_CACHE_EFFECTIVENESS );
-
-			$args['enable_response_caching'] = (
-				empty( $caches_for_url )
-				||
-				! is_array( $caches_for_url )
-				||
-				count( $caches_for_url ) < self::CACHE_MISS_THRESHOLD
-			);
+			if ( is_array( $caches_for_url ) ) {
+				$args['enable_response_caching'] = (
+					empty( $caches_for_url )
+					||
+					count( $caches_for_url ) < self::CACHE_MISS_THRESHOLD
+				);
+			} else {
+				$caches_for_url = array();
+			}
 		}
 
 		// Return cache if enabled and found.
@@ -1832,11 +1834,7 @@ class AMP_Theme_Support {
 			}
 
 			$cache_response = function( $body, $validation_results ) use ( $response_cache_key, $post_processor_cache_key, $caches_for_url ) {
-				if ( empty( $caches_for_url ) ) {
-					$caches_for_url = array( $response_cache_key );
-				} else {
-					$caches_for_url[] = $response_cache_key;
-				}
+				$caches_for_url[] = $response_cache_key;
 				wp_cache_set(
 					$post_processor_cache_key,
 					$caches_for_url,

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -45,7 +45,7 @@ class AMP_Theme_Support {
 	 *
 	 * @var int
 	 */
-	const CACHE_MISS_THRESHOLD = 3;
+	const CACHE_MISS_THRESHOLD = 20;
 
 	/**
 	 * Cache miss URL option name.

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -349,7 +349,7 @@ class AMP_Options_Manager {
 			return;
 		}
 
-		if ( self::get_option( 'enable_response_caching' ) ) {
+		if ( ! self::show_response_cache_disabled_notice() ) {
 			return;
 		}
 
@@ -358,6 +358,23 @@ class AMP_Options_Manager {
 			esc_html__( "The AMP plugin's response cache disabled due to detecting randomly generated content.", 'amp' ),
 			esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ),
 			esc_html__( 'More details', 'amp' )
+		);
+	}
+
+	/**
+	 * Show the response cache disabled notice.
+	 *
+	 * @since 1.0
+	 *
+	 * @return bool
+	 */
+	public static function show_response_cache_disabled_notice() {
+		return (
+			wp_using_ext_object_cache()
+			&&
+			! self::get_option( 'enable_response_caching' )
+			&&
+			AMP_Theme_Support::exceeded_cache_miss_threshold()
 		);
 	}
 }

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -200,8 +200,11 @@ class AMP_Options_Manager {
 		// Store the current version with the options so we know the format.
 		$options['version'] = AMP__VERSION;
 
-		// Validate the caching option.
+		// Handle the caching option.
 		$options['enable_response_caching'] = ! empty( $new_options['enable_response_caching'] );
+		if ( $options['enable_response_caching'] ) {
+			do_action( 'amp_reenable_response_cache' );
+		}
 
 		return $options;
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -338,16 +338,15 @@ class AMP_Options_Manager {
 			return;
 		}
 
-		$cache_miss_url = get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false );
-		if ( empty( $cache_miss_url ) ) {
+		if ( self::get_option( 'enable_response_caching' ) ) {
 			return;
 		}
 
 		printf(
 			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
-			esc_html__( 'Response caching was disabled due to exceeding the cache miss threshold.', 'amp' ),
-			esc_url( $cache_miss_url ),
-			esc_html__( 'This URL is where it last occurred.', 'amp' )
+			esc_html__( "The AMP plugin's response cache disabled due to detecting randomly generated content.", 'amp' ),
+			esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ),
+			esc_html__( 'More details', 'amp' )
 		);
 	}
 }

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -201,7 +201,11 @@ class AMP_Options_Manager {
 		$options['version'] = AMP__VERSION;
 
 		// Handle the caching option.
-		$options['enable_response_caching'] = ! empty( $new_options['enable_response_caching'] );
+		$options['enable_response_caching'] = (
+			wp_using_ext_object_cache()
+			&&
+			! empty( $new_options['enable_response_caching'] )
+		);
 		if ( $options['enable_response_caching'] ) {
 			AMP_Theme_Support::reset_cache_miss_url_option();
 		}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -355,8 +355,8 @@ class AMP_Options_Manager {
 
 		printf(
 			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
-			esc_html__( "The AMP plugin's response cache disabled due to detecting randomly generated content.", 'amp' ),
-			esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ),
+			esc_html__( "The AMP plugin's post-processor cache disabled due to the detection of highly-variable content.", 'amp' ),
+			esc_url( 'https://github.com/Automattic/amp-wp/wiki/Post-Processor-Cache' ),
 			esc_html__( 'More details', 'amp' )
 		);
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -344,7 +344,7 @@ class AMP_Options_Manager {
 		}
 
 		printf(
-			'<div class="notice notice-warning"><p>%s <a href="%s">%s</a></p></div>',
+			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
 			esc_html__( 'Response caching was disabled due to exceeding the cache miss threshold.', 'amp' ),
 			esc_url( $cache_miss_url ),
 			esc_html__( 'This URL is where it last occurred.', 'amp' )

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -80,6 +80,7 @@ class AMP_Options_Manager {
 		if ( empty( $options ) ) {
 			$options = array();
 		}
+		self::$defaults['enable_response_caching'] = wp_using_ext_object_cache();
 		return array_merge( self::$defaults, $options );
 	}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -48,6 +48,7 @@ class AMP_Options_Manager {
 
 		add_action( 'update_option_' . self::OPTION_NAME, array( __CLASS__, 'maybe_flush_rewrite_rules' ), 10, 2 );
 		add_action( 'admin_notices', array( __CLASS__, 'persistent_object_caching_notice' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'render_cache_miss_notice' ) );
 	}
 
 	/**
@@ -318,5 +319,28 @@ class AMP_Options_Manager {
 				esc_html__( 'More details', 'amp' )
 			);
 		}
+	}
+
+	/**
+	 * Render the cache miss admin notice.
+	 *
+	 * @return void
+	 */
+	public static function render_cache_miss_notice() {
+		if ( 'toplevel_page_' . self::OPTION_NAME !== get_current_screen()->id ) {
+			return;
+		}
+
+		$cache_miss_url = get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false );
+		if ( empty( $cache_miss_url ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p>%s <a href="%s">%s</a></p></div>',
+			esc_html__( 'Response caching was disabled due to exceeding the cache miss threshold.', 'amp' ),
+			esc_url( $cache_miss_url ),
+			esc_html__( 'This URL is where it last occurred.', 'amp' )
+		);
 	}
 }

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -31,6 +31,7 @@ class AMP_Options_Manager {
 		'disable_admin_bar'       => false,
 		'all_templates_supported' => true,
 		'supported_templates'     => array( 'is_singular' ),
+		'enable_response_caching' => true,
 	);
 
 	/**
@@ -198,6 +199,9 @@ class AMP_Options_Manager {
 
 		// Store the current version with the options so we know the format.
 		$options['version'] = AMP__VERSION;
+
+		// Validate caching option.
+		$options['enable_response_caching'] = ! empty( $new_options['enable_response_caching'] );
 
 		return $options;
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -203,7 +203,7 @@ class AMP_Options_Manager {
 		// Handle the caching option.
 		$options['enable_response_caching'] = ! empty( $new_options['enable_response_caching'] );
 		if ( $options['enable_response_caching'] ) {
-			do_action( 'amp_reenable_response_cache' );
+			AMP_Theme_Support::reset_cache_miss_url_option();
 		}
 
 		return $options;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -200,7 +200,7 @@ class AMP_Options_Manager {
 		// Store the current version with the options so we know the format.
 		$options['version'] = AMP__VERSION;
 
-		// Validate caching option.
+		// Validate the caching option.
 		$options['enable_response_caching'] = ! empty( $new_options['enable_response_caching'] );
 
 		return $options;

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -415,18 +415,18 @@ class AMP_Options_Menu {
 		<fieldset>
 			<?php if ( AMP_Options_Manager::show_response_cache_disabled_notice() ) : ?>
 				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'The response cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
-					<p><?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s response cache was automatically disabled.', 'amp' ); ?>
-						<a href="<?php echo esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ); ?>"><?php esc_html_e( 'More details are available here.', 'amp' ); ?></a></p>
+					<p><?php esc_html_e( 'The post-processor cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
+					<p><?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s post-processor cache was automatically disabled.', 'amp' ); ?>
+						<a href="<?php echo esc_url( 'https://github.com/Automattic/amp-wp/wiki/Post-Processor-Cache' ); ?>"><?php esc_html_e( 'Read more', 'amp' ); ?></a>.</p>
 				</div>
 			<?php endif; ?>
 			<p>
 				<label for="enable_response_caching">
 					<input id="enable_response_caching" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[enable_response_caching]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'enable_response_caching' ) ); ?>>
-					<?php esc_html_e( 'Enable response caching.', 'amp' ); ?>
+					<?php esc_html_e( 'Enable post-processor caching.', 'amp' ); ?>
 				</label>
 			</p>
-			<p class="description"><?php esc_html_e( 'This will enable response caching to speed up processing an AMP web page.', 'amp' ); ?></p>
+			<p class="description"><?php esc_html_e( 'This will enable post-processor caching to speed up processing an AMP response after WordPress renders a template.', 'amp' ); ?></p>
 		</fieldset>
 		<?php
 	}

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -426,8 +426,7 @@ class AMP_Options_Menu {
 					<?php esc_html_e( 'Enable response caching.', 'amp' ); ?>
 				</label>
 			</p>
-			<p class="description">
-			</p>
+			<p class="description"><?php esc_html_e( 'This will enable response caching to speed up processing an AMP web page.', 'amp' ); ?></p>
 		</fieldset>
 		<?php
 	}

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -413,9 +413,11 @@ class AMP_Options_Menu {
 	public function render_caching() {
 		?>
 		<fieldset>
-			<?php if ( ! AMP_Options_Manager::get_option( 'enable_response_caching' ) ) : ?>
+			<?php if ( AMP_Options_Manager::show_response_cache_disabled_notice() ) : ?>
 				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'The response cache disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
+					<p><?php esc_html_e( 'The response cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
+					<p><?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s response cache was automatically disabled.', 'amp' ); ?>
+						<a href="<?php echo esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ); ?>"><?php esc_html_e( 'More details are available here.', 'amp' ); ?></a></p>
 				</div>
 			<?php endif; ?>
 			<p>
@@ -425,8 +427,6 @@ class AMP_Options_Menu {
 				</label>
 			</p>
 			<p class="description">
-				<?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s response cache was automatically disabled.', 'amp' ); ?>
-				<a href="<?php echo esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ); ?>"><?php esc_html_e( 'More details are available here.', 'amp' ); ?></a>
 			</p>
 		</fieldset>
 		<?php

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -413,7 +413,7 @@ class AMP_Options_Menu {
 		<fieldset>
 			<?php if ( ! AMP_Options_Manager::get_option( 'enable_response_caching' ) ) : ?>
 				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'Response caching was disabled due to exceeding the cache miss threshold.', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false ) ); ?>"><?php esc_html_e( 'This URL is where it last occurred.', 'amp' ); ?></a></p>
+					<p><?php esc_html_e( 'The response cache disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
 				</div>
 			<?php endif; ?>
 			<p>
@@ -423,7 +423,8 @@ class AMP_Options_Menu {
 				</label>
 			</p>
 			<p class="description">
-				<?php esc_html_e( 'This is a description to help them out.....', 'amp' ); ?>
+				<?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s response cache was automatically disabled.', 'amp' ); ?>
+				<a href="<?php echo esc_url( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache' ); ?>"><?php esc_html_e( 'More details are available here.', 'amp' ); ?></a>
 			</p>
 		</fieldset>
 		<?php

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -109,16 +109,18 @@ class AMP_Options_Menu {
 			)
 		);
 
-		add_settings_field(
-			'caching',
-			__( 'Caching', 'amp' ),
-			array( $this, 'render_caching' ),
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			array(
-				'class' => 'amp-caching-field',
-			)
-		);
+		if ( wp_using_ext_object_cache() ) {
+			add_settings_field(
+				'caching',
+				__( 'Caching', 'amp' ),
+				array( $this, 'render_caching' ),
+				AMP_Options_Manager::OPTION_NAME,
+				'general',
+				array(
+					'class' => 'amp-caching-field',
+				)
+			);
+		}
 
 		$submenus = array(
 			new AMP_Analytics_Options_Submenu( AMP_Options_Manager::OPTION_NAME ),

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -109,6 +109,17 @@ class AMP_Options_Menu {
 			)
 		);
 
+		add_settings_field(
+			'caching',
+			__( 'Caching', 'amp' ),
+			array( $this, 'render_caching' ),
+			AMP_Options_Manager::OPTION_NAME,
+			'general',
+			array(
+				'class' => 'amp-caching-field',
+			)
+		);
+
 		$submenus = array(
 			new AMP_Analytics_Options_Submenu( AMP_Options_Manager::OPTION_NAME ),
 		);
@@ -387,6 +398,34 @@ class AMP_Options_Menu {
 				})( jQuery );
 			</script>
 		<?php endif; ?>
+		<?php
+	}
+
+	/**
+	 * Render the caching settings section.
+	 *
+	 * @since 1.0
+	 *
+	 * @todo Change the messaging and description to be user-friendly and helpful.
+	 */
+	public function render_caching() {
+		?>
+		<fieldset>
+			<?php if ( ! AMP_Options_Manager::get_option( 'enable_response_caching' ) ) : ?>
+				<div class="notice notice-info notice-alt inline">
+					<p><?php esc_html_e( 'Response caching was disabled due to exceeding the cache miss threshold.', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, false ) ); ?>"><?php esc_html_e( 'This URL is where it last occurred.', 'amp' ); ?></a></p>
+				</div>
+			<?php endif; ?>
+			<p>
+				<label for="enable_response_caching">
+					<input id="enable_response_caching" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[enable_response_caching]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'enable_response_caching' ) ); ?>>
+					<?php esc_html_e( 'Enable response caching.', 'amp' ); ?>
+				</label>
+			</p>
+			<p class="description">
+				<?php esc_html_e( 'This is a description to help them out.....', 'amp' ); ?>
+			</p>
+		</fieldset>
 		<?php
 	}
 

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -100,6 +100,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'disable_admin_bar'       => false,
 				'all_templates_supported' => true,
 				'supported_templates'     => array( 'is_singular' ),
+				'enable_response_caching' => true,
 			),
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -88,7 +88,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 */
 	public function test_get_and_set_options() {
 		global $wp_settings_errors;
-
+		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 		AMP_Options_Manager::register_settings(); // Adds validate_options as filter.
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$this->assertEquals(
@@ -202,13 +202,15 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( $id, $entries );
 
 		// Test re-enabling response cache works.
-		wp_using_ext_object_cache( true ); // turn on external object cache flag.
-		add_action( 'amp_reenable_response_cache', array( 'AMP_Theme_Support', 'reset_cache_miss_url_option' ) );
 		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/test-post' );
 		AMP_Options_Manager::update_option( 'enable_response_caching', true );
 		$this->assertTrue( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 		$this->assertNull( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
-		wp_using_ext_object_cache( false ); // reset external object cache.
+		wp_using_ext_object_cache( false ); // turn off external object cache.
+		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/test-post' );
+		AMP_Options_Manager::update_option( 'enable_response_caching', true );
+		$this->assertFalse( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
+		$this->assertEquals( 'http://example.org/test-post', get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
 	}
 
 	/**
@@ -320,6 +322,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 */
 	public function test_render_cache_miss_notice() {
 		set_current_screen( 'toplevel_page_amp-options' );
+		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 
 		ob_start();
 		AMP_Options_Manager::render_cache_miss_notice();
@@ -337,5 +340,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		ob_start();
 		AMP_Options_Manager::render_cache_miss_notice();
 		$this->assertEmpty( ob_get_clean() );
+
+		wp_using_ext_object_cache( false ); // turn off external object cache flag.
 	}
 }

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -202,11 +202,13 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( $id, $entries );
 
 		// Test re-enabling response cache works.
+		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 		add_action( 'amp_reenable_response_cache', array( 'AMP_Theme_Support', 'reset_cache_miss_url_option' ) );
 		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/test-post' );
 		AMP_Options_Manager::update_option( 'enable_response_caching', true );
 		$this->assertTrue( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 		$this->assertNull( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
+		wp_using_ext_object_cache( false ); // reset external object cache.
 	}
 
 	/**

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -204,9 +204,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		// Test re-enabling response cache works.
 		add_action( 'amp_reenable_response_cache', array( 'AMP_Theme_Support', 'reset_cache_miss_url_option' ) );
 		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/test-post' );
-		$times_reenable_fired = did_action( 'amp_reenable_response_cache' );
 		AMP_Options_Manager::update_option( 'enable_response_caching', true );
-		$this->assertEquals( $times_reenable_fired + 1, did_action( 'amp_reenable_response_cache' ) );
 		$this->assertTrue( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 		$this->assertNull( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
 	}

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -369,8 +369,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		ob_start();
 		AMP_Options_Manager::render_cache_miss_notice();
 		$notice = ob_get_clean();
-		$this->assertContains( 'The AMP plugin&#039;s response cache disabled due to detecting randomly generated content.', $notice );
-		$this->assertContains( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache', $notice );
+		$this->assertContains( '<div class="notice notice-warning is-dismissible">', $notice );
 
 		// Test when enabled but not exceeded.
 		delete_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION );

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -300,13 +300,12 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::render_cache_miss_notice();
 		$this->assertEmpty( ob_get_clean() );
 
-		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/sample-post' );
+		AMP_Options_Manager::update_option( 'enable_response_caching', false );
 		ob_start();
 		AMP_Options_Manager::render_cache_miss_notice();
-		$notice   = ob_get_clean();
-		$expected = 'Response caching was disabled due to exceeding the cache miss threshold.';
-		$this->assertContains( $expected, $notice );
-		$this->assertContains( 'http://example.org/sample-post', $notice );
+		$notice = ob_get_clean();
+		$this->assertContains( 'The AMP plugin&#039;s response cache disabled due to detecting randomly generated content.', $notice );
+		$this->assertContains( 'https://github.com/Automattic/amp-wp/wiki/Response-cache#automatically-disabling-of-the-response-cache', $notice );
 
 		set_current_screen( 'edit.php' );
 

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -276,4 +276,31 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		wp_using_ext_object_cache( false );
 	}
+
+	/**
+	 * Test for render_cache_miss_notice()
+	 *
+	 * @covers AMP_Options_Manager::render_cache_miss_notice()
+	 */
+	public function test_render_cache_miss_notice() {
+		set_current_screen( 'toplevel_page_amp-options' );
+
+		ob_start();
+		AMP_Options_Manager::render_cache_miss_notice();
+		$this->assertEmpty( ob_get_clean() );
+
+		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, 'http://example.org/sample-post' );
+		ob_start();
+		AMP_Options_Manager::render_cache_miss_notice();
+		$notice   = ob_get_clean();
+		$expected = 'Response caching was disabled due to exceeding the cache miss threshold.';
+		$this->assertContains( $expected, $notice );
+		$this->assertContains( 'http://example.org/sample-post', $notice );
+
+		set_current_screen( 'edit.php' );
+
+		ob_start();
+		AMP_Options_Manager::render_cache_miss_notice();
+		$this->assertEmpty( ob_get_clean() );
+	}
 }

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1577,11 +1577,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			// When we've met the threshold, check that caching did not happen.
 			if ( $num_calls > AMP_Theme_Support::CACHE_MISS_THRESHOLD ) {
 				$this->assertEquals( $num_calls - 1, count( $caches_for_url ) );
-				$this->assertEmpty( AMP_Theme_Support::$response_cache_key );
 			} else {
 				$this->assertEquals( $num_calls, count( $caches_for_url ) );
-				$this->assertNotEmpty( AMP_Theme_Support::$response_cache_key );
-				$this->assertNotEmpty( wp_cache_get( AMP_Theme_Support::$response_cache_key, AMP_Theme_Support::RESPONSE_CACHE_GROUP ) );
 			}
 
 			$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1559,8 +1559,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Test post-processor cache effectiveness in AMP_Theme_Support::prepare_response().
 	 */
 	public function test_post_processor_cache_effectiveness() {
-		$original_html = $this->get_original_html();
-		$args          = array( 'enable_response_caching' => true );
+		$original_html            = $this->get_original_html();
+		$args                     = array( 'enable_response_caching' => true );
+		$current_url              = amp_get_current_url();
+		$post_processor_cache_key = md5( $current_url );
 		$this->reset_post_processor_cache_effectiveness();
 
 		// Test the response is not cached after exceeding the cache miss threshold.
@@ -1572,7 +1574,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			AMP_Validation_Manager::$validation_results = array();
 			AMP_Theme_Support::prepare_response( $original_html, $args );
 
-			$caches_for_url = wp_cache_get( AMP_Theme_Support::$post_processor_cache_key, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+			$caches_for_url = wp_cache_get( $post_processor_cache_key, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS );
 
 			// When we've met the threshold, check that caching did not happen.
 			if ( $num_calls > AMP_Theme_Support::CACHE_MISS_THRESHOLD ) {

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1559,10 +1559,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Test post-processor cache effectiveness in AMP_Theme_Support::prepare_response().
 	 */
 	public function test_post_processor_cache_effectiveness() {
-		$original_html            = $this->get_original_html();
-		$args                     = array( 'enable_response_caching' => true );
-		$current_url              = amp_get_current_url();
-		$post_processor_cache_key = md5( $current_url );
+		$original_html = $this->get_original_html();
+		$args          = array( 'enable_response_caching' => true );
 		$this->reset_post_processor_cache_effectiveness();
 
 		// Test the response is not cached after exceeding the cache miss threshold.
@@ -1574,7 +1572,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			AMP_Validation_Manager::$validation_results = array();
 			AMP_Theme_Support::prepare_response( $original_html, $args );
 
-			$caches_for_url = wp_cache_get( $post_processor_cache_key, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+			$caches_for_url = wp_cache_get( AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP );
 
 			// When we've met the threshold, check that caching did not happen.
 			if ( $num_calls > AMP_Theme_Support::CACHE_MISS_THRESHOLD ) {
@@ -1691,7 +1689,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Reset cached URLs in post-processor cache effectiveness.
 	 */
 	private function reset_post_processor_cache_effectiveness() {
-		wp_cache_delete( md5( amp_get_current_url() ), AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS );
+		wp_cache_delete( AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1579,9 +1579,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			if ( $num_calls > AMP_Theme_Support::CACHE_MISS_THRESHOLD ) {
 				$this->assertEquals( AMP_Theme_Support::CACHE_MISS_THRESHOLD, count( $caches_for_url ) );
 				$this->assertEquals( amp_get_current_url(), $cache_miss_url );
+
+				// Check that response caching was automatically disabled.
+				$this->assertFalse( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 			} else {
 				$this->assertEquals( $num_calls, count( $caches_for_url ) );
 				$this->assertFalse( $cache_miss_url );
+				$this->assertTrue( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 			}
 
 			$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1561,6 +1561,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_post_processor_cache_effectiveness() {
 		$original_html = $this->get_original_html();
 		$args          = array( 'enable_response_caching' => true );
+		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 		$this->reset_post_processor_cache_effectiveness();
 
 		// Test the response is not cached after exceeding the cache miss threshold.
@@ -1590,6 +1591,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 			$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );
 		}
+
+		// Reset.
+		wp_using_ext_object_cache( false );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1522,19 +1522,23 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$first_response = $call_prepare_response();
 		$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );
 		$this->assertContains( '<html amp>', $first_response ); // Note: AMP because sanitized validation errors.
+		$this->reset_post_processor_cache_effectiveness();
 
 		// Test that response cache is return upon second call.
 		$this->assertEquals( $first_response, $call_prepare_response() );
 		$this->assertSame( 0, $this->get_server_timing_header_count() );
+		$this->reset_post_processor_cache_effectiveness();
 
 		// Test new cache upon argument change.
 		$prepare_response_args['test_reset_by_arg'] = true;
 		$call_prepare_response();
 		$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );
+		$this->reset_post_processor_cache_effectiveness();
 
 		// Test response is cached.
 		$call_prepare_response();
 		$this->assertSame( 0, $this->get_server_timing_header_count() );
+		$this->reset_post_processor_cache_effectiveness();
 
 		// Test that response is no longer cached due to a change whether validation errors are sanitized.
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
@@ -1542,6 +1546,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$prepared_html = $call_prepare_response();
 		$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );
 		$this->assertContains( '<html>', $prepared_html ); // Note: no AMP because unsanitized validation error.
+		$this->reset_post_processor_cache_effectiveness();
 
 		// And test response is cached.
 		$call_prepare_response();
@@ -1572,12 +1577,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 			// When we've met the threshold, check that caching did not happen.
 			if ( $num_calls > AMP_Theme_Support::CACHE_MISS_THRESHOLD ) {
-				// @todo change count to -1.
-				$this->assertEquals( $num_calls, count( $caches_for_url ) );
+				$this->assertEquals( $num_calls - 1, count( $caches_for_url ) );
 				// @todo Need to check if the response was not cached.
 			} else {
 				$this->assertEquals( $num_calls, count( $caches_for_url ) );
-				// Need to check if the response was cached.
+				// @todo Need to check if the response was cached.
 			}
 
 			$this->assertGreaterThan( 0, $this->get_server_timing_header_count() );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1413,6 +1413,17 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test exceeded_cache_miss_threshold
+	 *
+	 * @covers AMP_Theme_Support::exceeded_cache_miss_threshold()
+	 */
+	public function test_exceeded_cache_miss_threshold() {
+		$this->assertFalse( AMP_Theme_Support::exceeded_cache_miss_threshold() );
+		add_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, site_url() );
+		$this->assertTrue( AMP_Theme_Support::exceeded_cache_miss_threshold() );
+	}
+
+	/**
 	 * Test prepare_response.
 	 *
 	 * @global WP_Widget_Factory $wp_widget_factory


### PR DESCRIPTION
Randomly generated content can occur on a web page.  When that happens, the response will differ for each request causing cache misses for the plugin's AMP response cache.  As @westonruter notes in Issue #1239:

>the object cache will get polluted with values that never get used.

This PR detects continual cache misses by caching the page's URL and then comparing the number of cached URLs to a threshold.  When that threshold is exceeded, it disables the response cache and then notifies the admin.

TODO
- [x] Detect continual cache misses
- [x] Disable caching
- [x] Notify
- [x] Provide a UI to reset the option's value and re-enable response caching.

Closes #1239.