### PR TITLE
Update i18n to make use of updated WP-CLI command

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,12 +14,6 @@
       {
         "pragma": "wp.element.createElement"
       }
-    ],
-    [
-      "@wordpress/babel-plugin-makepot",
-      {
-        "output": "languages/amp-js.pot"
-      }
     ]
   ],
   "env": {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,6 +92,8 @@ module.exports = function( grunt ) {
 		stdout = [];
 
 		grunt.task.run( 'shell:webpack_production' );
+		grunt.task.run( 'shell:makepot' );
+		grunt.task.run( 'shell:pot_to_php' );
 
 		spawnQueue.push(
 			{
@@ -178,17 +180,10 @@ module.exports = function( grunt ) {
 		'shell:create_build_zip'
 	] );
 
-	grunt.registerTask( 'build-release', [
-		'shell:makepot',
-		'shell:pot_to_php',
-		'build'
-	] );
-
 	grunt.registerTask( 'deploy', [
 		'jshint',
 		'shell:phpunit',
 		'shell:verify_matching_versions',
-		'build-release',
 		'wp_deploy'
 	] );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,11 +45,8 @@ module.exports = function( grunt ) {
 			webpack_production: {
 				command: 'cross-env BABEL_ENV=production webpack'
 			},
-			pot_to_php: {
-				command: 'npm run pot-to-php'
-			},
 			makepot: {
-				command: 'wp i18n make-pot .'
+				command: 'wp i18n make-pot . languages/amp.pot --include="$( git ls-files | grep -v test | tr \'\\n\' \',\' )"'
 			},
 			create_build_zip: {
 				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e amp.zip ]; then rm amp.zip; fi; cd build; zip -r ../amp.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/amp.zip"'
@@ -93,7 +90,6 @@ module.exports = function( grunt ) {
 
 		grunt.task.run( 'shell:webpack_production' );
 		grunt.task.run( 'shell:makepot' );
-		grunt.task.run( 'shell:pot_to_php' );
 
 		spawnQueue.push(
 			{
@@ -119,7 +115,6 @@ module.exports = function( grunt ) {
 			paths.push( 'assets/js/*-compiled.js' );
 			paths.push( 'vendor/composer/**' );
 			paths.push( 'vendor/sabberworm/php-css-parser/lib/**' );
-			paths.push( 'languages/amp-translations.php' );
 			paths.push( 'languages/amp.pot' );
 
 			grunt.task.run( 'clean' );

--- a/back-compat/templates-v0-3/meta-time.php
+++ b/back-compat/templates-v0-3/meta-time.php
@@ -3,6 +3,7 @@
 		<?php
 		echo esc_html(
 			sprintf(
+				/* translators: %s is the human-readable time difference */
 				_x( '%s ago', '%s = human-readable time difference', 'amp' ),
 				human_time_diff( $this->get( 'post_publish_timestamp' ), current_time( 'timestamp' ) )
 			)

--- a/blocks/utils.js
+++ b/blocks/utils.js
@@ -48,6 +48,7 @@ export function getLayoutControls( props, ampLayoutOptions ) {
 			<Notice key="showWidthNotice" status="error" isDismissible={ false }>
 				{
 					wp.i18n.sprintf(
+						/* translators: %s is the layout name */
 						__( 'Width is required for %s layout', 'amp' ),
 						ampLayout
 					)
@@ -65,6 +66,7 @@ export function getLayoutControls( props, ampLayoutOptions ) {
 			<Notice key="showHeightNotice" status="error" isDismissible={ false }>
 				{
 					wp.i18n.sprintf(
+						/* translators: %s is the layout name */
 						__( 'Height is required for %s layout', 'amp' ),
 						ampLayout
 					)

--- a/contributing.md
+++ b/contributing.md
@@ -33,14 +33,6 @@ npm run build
 
 This will create an `amp.zip` in the plugin directory which you can install. The contents of this ZIP are also located in the `build` directory which you can `rsync` somewhere as well.
 
-TO create a build of the plugin as it will be deployed to WordPress.org, run:
-
-```bash
-npm run build-release
-```
-
-Note that this will currently take much longer than a regular build because it generates the files required for translation. You also must have WP-CLI installed with the [`i18n-command` package](https://github.com/wp-cli/i18n-command).
-
 ## Updating Allowed Tags And Attributes
 
 The file `class-amp-allowed-tags-generated.php` has the AMP specification's allowed tags and attributes. It's used in sanitization.
@@ -106,7 +98,7 @@ When you push a commit to your PR, Travis CI will run the PHPUnit tests and snif
 
 Contributors who want to make a new release, follow these steps:
 
-1. Do `npm run build-release` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
+1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
 2. Bump plugin versions in `package.json` (×1), `package-lock.json` (×1, just do `npm install` first), `composer.json` (×1), and in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
 3. Add changelog entry to readme.
 4. Draft blog post about the new release.

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -204,7 +204,7 @@ class AMP_Post_Meta_Box {
 		);
 
 		if ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
-			$localization['i18n'] = gutenberg_get_jed_locale_data( 'amp' ); // @todo create a POT file.
+			$localization['i18n'] = gutenberg_get_jed_locale_data( 'amp' );
 		}
 
 		wp_localize_script(

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1728,7 +1728,7 @@ class AMP_Validation_Manager {
 		);
 
 		$data = wp_json_encode( array(
-			'i18n'                 => gutenberg_get_jed_locale_data( 'amp' ), // @todo POT file.
+			'i18n'                 => gutenberg_get_jed_locale_data( 'amp' ),
 			'ampValidityRestField' => self::VALIDITY_REST_FIELD_NAME,
 			'isCanonical'          => amp_is_canonical(),
 		) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,6 @@
       "integrity": "sha512-/9xLnYmohN/vD2gDnLS4cym8TUmrJu7DvZa/LELKzZjdPsvWVJiedsdu2SXNtb/DA7FGimqL2g0IoyhbNKLl8g==",
       "dev": true
     },
-    "@wordpress/babel-plugin-makepot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-1.0.1.tgz",
-      "integrity": "sha512-n0ifXqE4jbEWxz+tCj3IM2nPH9sgelQx2ApKTPJNrOOMJq29s6RRXcUYzN8g68rNakXAGuFLlIRmPzIGrA1wWA==",
-      "dev": true,
-      "requires": {
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.5"
-      }
-    },
     "@wordpress/i18n": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
  "scripts": {
   "pot-to-php": "pot-to-php languages/amp-js.pot languages/amp-translations.php amp",
   "build": "grunt build; grunt create-build-zip",
-  "build-release": "grunt build-release; grunt create-build-zip",
   "deploy": "grunt deploy",
   "dev": "cross-env BABEL_ENV=default webpack --watch"
  }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
  "license": "GPL-2.0+",
  "private": true,
  "devDependencies": {
+  "@wordpress/i18n": "^1.1.0",
   "babel-core": "^6.25.0",
   "babel-loader": "^7.1.1",
   "babel-plugin-transform-object-rest-spread": "^6.26.0",
   "babel-plugin-transform-react-jsx": "^6.24.1",
   "babel-plugin-transform-runtime": "^6.23.0",
-  "@wordpress/babel-plugin-makepot": "^1.0.1",
-  "@wordpress/i18n": "^1.1.0",
   "babel-preset-env": "^1.7.0",
   "cross-env": "^5.1.5",
   "eslint": "^4.19.1",
@@ -33,7 +32,6 @@
  },
  "main": "blocks/index.js",
  "scripts": {
-  "pot-to-php": "pot-to-php languages/amp-js.pot languages/amp-translations.php amp",
   "build": "grunt build; grunt create-build-zip",
   "deploy": "grunt deploy",
   "dev": "cross-env BABEL_ENV=default webpack --watch"

--- a/templates/meta-taxonomy.php
+++ b/templates/meta-taxonomy.php
@@ -1,7 +1,10 @@
 <?php $categories = get_the_category_list( _x( ', ', 'Used between list items, there is a space after the comma.', 'amp' ), '', $this->ID ); ?>
 <?php if ( $categories ) : ?>
 	<div class="amp-wp-meta amp-wp-tax-category">
-		<?php printf( esc_html__( 'Categories: %s', 'amp' ), $categories ); ?>
+		<?php
+		/* translators: %s is the categories */
+		printf( esc_html__( 'Categories: %s', 'amp' ), $categories );
+		?>
 	</div>
 <?php endif; ?>
 
@@ -14,6 +17,9 @@ $tags = get_the_tag_list(
 ); ?>
 <?php if ( $tags && ! is_wp_error( $tags ) ) : ?>
 	<div class="amp-wp-meta amp-wp-tax-tag">
-		<?php printf( esc_html__( 'Tags: %s', 'amp' ), $tags ); ?>
+		<?php
+		/* translators: %s is the tags */
+		printf( esc_html__( 'Tags: %s', 'amp' ), $tags );
+		?>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
- [ ] Do we need `load_plugin_textdomain( 'amp', false, 'languages/amp.pot' );`? Or is that unnecessary because of the `Domain Path` meta?
- [ ] Is it no longer to `pot-to-php` anymore because the POT file now has all JS and PHP strings?

Fixes #1327 