### PR TITLE
Store validation errors in order of occurrence in document

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -255,7 +255,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		while ( ! empty( $this->stack ) ) {
 
 			// Get the next node to process.
-			$node = array_pop( $this->stack );
+			$node = array_shift( $this->stack );
 
 			/**
 			 * Process this node.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1524,8 +1524,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-latest.js" async custom-element="amp-mathml"></script>',
 
 			// Note these are single-quoted because they are injected after the DOM has been re-serialized, so the type and src attributes come from WP_Scripts::do_item().
-			'<script src="https://cdn.ampproject.org/v0/amp-ad-latest.js" async="" custom-element="amp-ad"></script>',
 			'<script src="https://cdn.ampproject.org/v0/amp-audio-latest.js" async="" custom-element="amp-audio"></script>',
+			'<script src="https://cdn.ampproject.org/v0/amp-ad-latest.js" async="" custom-element="amp-ad"></script>',
 
 			'<link rel="icon" href="http://example.org/favicon.png" sizes="32x32">',
 			'<link rel="icon" href="http://example.org/favicon.png" sizes="192x192">',

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1060,16 +1060,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 </div>
 EOB;
 		$expected_errors[] = array(
-			'node_name'       => 'bazfoo',
-			'parent_name'     => 'div',
-			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
-		$expected_errors[] = array(
 			'node_name'       => 'invalid_p',
 			'parent_name'     => 'div',
 			'code'            => 'invalid_element',
 			'node_attributes' => array( 'id' => 'invalid' ),
+		);
+		$expected_errors[] = array(
+			'node_name'       => 'bazfoo',
+			'parent_name'     => 'div',
+			'code'            => 'invalid_element',
+			'node_attributes' => array(),
 		);
 		$content[]         = <<<EOB
 <ul>


### PR DESCRIPTION
I'm noticing that validation errors listed on the Invalid Page screen are in reverse order from how they appear in the document. A validation error with meta viewport is at the bottom of the list, and the validation error for a custom script in the page is appearing near the top of the validation error list. Nevertheless, a CSS validation error is appearing before, so I think it is an issue with how the whitelist sanitizer is iterating over the DOM backwards. In particular, `array_pop()` is being used instead of `array_shift()` in:

https://github.com/Automattic/amp-wp/blob/8c4f8ea0b17f3f1e9faf621e4a0bfa11748a8f04/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L255-L273

Switching these around fixes the problem.