### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.babelrc,.eslintrc,.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
While #1329 I noticed some differences in indentation styles, for instance between `.babelrc` and `.eslintrc`. One uses spaces, the other tabs.

An `.editorconfig` file helps configuring IDEs to use the right indentation style depending on file type. This way, there's no need to do this manually to follow the coding standards.

The proposed `.editorconfig` file matches the WordPress core coding standards and adds exceptions for hidden files like `.babelrc` and `.eslintrc`, as well as Markdown files (trailing whitespace for simple line breaks).

Fixes #51.