### PR TITLE
[WIP] Initialize all_templates_supported on upgrade to avoid erroneous notices.

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -147,6 +147,7 @@ function amp_init() {
 	AMP_Theme_Support::init();
 	AMP_Post_Type_Support::add_post_type_support();
 	add_filter( 'request', 'amp_force_query_var_value' );
+	add_action( 'admin_init', 'AMP_Options_Manager::init' );
 	add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
 	add_action( 'wp_loaded', 'amp_editor_core_blocks' );
 	add_action( 'wp_loaded', 'amp_post_meta_box' );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -18,6 +18,13 @@ class AMP_Options_Manager {
 	const OPTION_NAME = 'amp-options';
 
 	/**
+	 * Option name for the AMP version.
+	 *
+	 * @var string
+	 */
+	const AMP_VERSION_OPTION = 'amp-version';
+
+	/**
 	 * Default option values.
 	 *
 	 * @var array
@@ -32,6 +39,25 @@ class AMP_Options_Manager {
 		'all_templates_supported' => true,
 		'supported_templates'     => array( 'is_singular' ),
 	);
+
+	/**
+	 * Initialize the options manager.
+	 *
+	 * @since 1.0
+	 */
+	public static function init() {
+		// Initialize options on version change.
+		if ( AMP__VERSION === get_option( self::AMP_VERSION_OPTION ) ) {
+			return;
+		}
+
+		$options = get_option( self::OPTION_NAME, array() );
+		if ( empty( $options ) ) {
+			self::update_option( 'all_templates_supported', false );
+		}
+
+		update_option( self::AMP_VERSION_OPTION, AMP__VERSION );
+	}
 
 	/**
 	 * Register settings.

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -25,6 +25,31 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 */
 	public function test_constants() {
 		$this->assertEquals( 'amp-options', AMP_Options_Manager::OPTION_NAME );
+		$this->assertEquals( 'amp-version', AMP_Options_Manager::AMP_VERSION_OPTION );
+	}
+
+	/**
+	 * Test init.
+	 *
+	 * @covers AMP_Options_Manager::init()
+	 */
+	public function test_init() {
+		// Test when options are empty.
+		$this->assertNull( get_option( AMP_Options_Manager::AMP_VERSION_OPTION, null ) );
+		$this->assertEmpty( get_option( AMP_Options_Manager::OPTION_NAME ) );
+		AMP_Options_Manager::init();
+		$this->assertEquals( AMP__VERSION, get_option( AMP_Options_Manager::AMP_VERSION_OPTION ) );
+		$this->assertArraySubset( array( 'all_templates_supported' => false ), get_option( AMP_Options_Manager::OPTION_NAME ) );
+
+		// Test when options where previously saved.
+		update_option( AMP_Options_Manager::AMP_VERSION_OPTION, '0.7.2' );
+		update_option( AMP_Options_Manager::OPTION_NAME, array(
+			'theme_support'        => 'disabled',
+			'supported_post_types' => array( 'post' ),
+			'analytics'            => array(),
+		) );
+		AMP_Options_Manager::init();
+		$this->assertArrayNotHasKey( 'all_templates_supported', get_option( AMP_Options_Manager::OPTION_NAME ) );
 	}
 
 	/**


### PR DESCRIPTION
Erroneous notices blast the AMP settings page when the following conditions occur:

1. Upgrading the plugin AND no options were previously saved AND 
2. Switching from Classic to either Paired or Native.

As noted in [Issue 1302](https://github.com/Automattic/amp-wp/issues/1302#issuecomment-412138544), this edge case occurs because the Options Manager sets`all_templates_supported` option to `true` as a default.
  
When the plugin's version changes and the options are empty (meaning no options were stored previously), then `set all_templates_supported` to `false`.

Fixes #1302.