### PR TITLE
Use all eligible post types when `all_templates_supported` is selected.

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -208,8 +208,12 @@ class AMP_Options_Manager {
 	 * @see add_settings_error()
 	 */
 	public static function check_supported_post_type_update_errors() {
-		$supported_types = self::get_option( 'supported_post_types', array() );
-		foreach ( AMP_Post_Type_Support::get_eligible_post_types() as $name ) {
+		$all_eligible_post_types = AMP_Post_Type_Support::get_eligible_post_types();
+		$supported_types         = self::get_option( 'all_templates_supported', false )
+			? $all_eligible_post_types
+			: self::get_option( 'supported_post_types', array() );
+
+		foreach ( $all_eligible_post_types as $name ) {
 			$post_type = get_post_type_object( $name );
 			if ( empty( $post_type ) ) {
 				continue;

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -209,17 +209,26 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	public function test_check_supported_post_type_update_errors() {
 		global $wp_settings_errors;
 		add_theme_support( 'amp' );
-		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		foreach ( get_post_types() as $post_type ) {
-			remove_post_type_support( $post_type, 'amp' );
-		}
-
 		register_post_type( 'foo', array(
 			'public' => true,
 			'label'  => 'Foo',
 		) );
-		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
 		AMP_Post_Type_Support::add_post_type_support();
+
+		// Test when 'all_templates_supported' is selected.
+		AMP_Options_Manager::update_option( 'all_templates_supported', true );
+		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
+		AMP_Options_Manager::check_supported_post_type_update_errors();
+		$this->assertEmpty( get_settings_errors() );
+
+		// Test when 'all_templates_supported' is not selected.
+		AMP_Options_Manager::update_option( 'all_templates_supported', false );
+		foreach ( get_post_types() as $post_type ) {
+			if ( 'foo' !== $post_type ) {
+				remove_post_type_support( $post_type, 'amp' );
+			}
+		}
+		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$this->assertEmpty( get_settings_errors() );
 


### PR DESCRIPTION
Per [issue 1302](https://github.com/Automattic/amp-wp/issues/1302#issuecomment-412910057), post type notices are being blasted when:

1. There are no options saved in the database AND
2. You switch from Classic to either Paired or Native.

The root cause for this problem is that the method `AMP_Options_Manager::check_supported_post_type_update_errors()` is only considering the selected post types when the `all_templates_supported` option is selected.

This PR fixes the problem by using all of the eligible post types (and not just the ones that are individually selected) when `all_templates_supported` option is selected.

Fixes #1302.