### PR TITLE
Enable AMP on New Post

### DIFF
--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -111,7 +111,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			if ( meta && meta.amp_status && window.wpAmpEditor.possibleStati.includes( meta.amp_status ) ) {
 				return 'enabled' === meta.amp_status;
 			}
-			return false;
+			return window.wpAmpEditor.defaultStatus;
 		},
 
 		/**


### PR DESCRIPTION
When first loading a new post, AMP status has not been set yet been saved as meta.  Though the Enable AMP toggle shows it as enabled, it's using `window.wpAmpEditor.defaultStatus` to set the default status.

This PR uses that same strategy for block validation.