### PR TITLE
Skip check_supported_post_type_update_errors if all templates supported

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -208,12 +208,14 @@ class AMP_Options_Manager {
 	 * @see add_settings_error()
 	 */
 	public static function check_supported_post_type_update_errors() {
-		$all_eligible_post_types = AMP_Post_Type_Support::get_eligible_post_types();
-		$supported_types         = self::get_option( 'all_templates_supported', false )
-			? $all_eligible_post_types
-			: self::get_option( 'supported_post_types', array() );
 
-		foreach ( $all_eligible_post_types as $name ) {
+		// If all templates are supported then skip check since all post types are also supported. This option only applies with native/paired theme support.
+		if ( self::get_option( 'all_templates_supported', false ) && 'disabled' !== self::get_option( 'theme_support' ) ) {
+			return;
+		}
+
+		$supported_types = self::get_option( 'supported_post_types', array() );
+		foreach ( AMP_Post_Type_Support::get_eligible_post_types() as $name ) {
 			$post_type = get_post_type_object( $name );
 			if ( empty( $post_type ) ) {
 				continue;

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -216,28 +216,44 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		AMP_Post_Type_Support::add_post_type_support();
 
 		// Test when 'all_templates_supported' is selected.
+		AMP_Options_Manager::update_option( 'theme_support', 'native' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$this->assertEmpty( get_settings_errors() );
 
 		// Test when 'all_templates_supported' is not selected.
+		AMP_Options_Manager::update_option( 'theme_support', 'native' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		foreach ( get_post_types() as $post_type ) {
 			if ( 'foo' !== $post_type ) {
-				remove_post_type_support( $post_type, 'amp' );
+				remove_post_type_support( $post_type, amp_get_slug() );
 			}
 		}
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$this->assertEmpty( get_settings_errors() );
 
-		// Activation error.
-		remove_post_type_support( 'foo', amp_get_slug() );
+		// Test when 'all_templates_supported' is not selected, and theme support is also disabled.
+		add_post_type_support( 'post', amp_get_slug() );
+		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
+		AMP_Options_Manager::update_option( 'all_templates_supported', false );
+		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
-		$errors = get_settings_errors();
-		$this->assertCount( 1, $errors );
-		$error = current( $errors );
+		$settings_errors    = get_settings_errors();
+		$wp_settings_errors = array();
+		$this->assertCount( 1, $settings_errors );
+		$this->assertEquals( 'foo_deactivation_error', $settings_errors[0]['code'] );
+
+		// Activation error.
+		remove_post_type_support( 'post', amp_get_slug() );
+		remove_post_type_support( 'foo', amp_get_slug() );
+		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
+		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
+		AMP_Options_Manager::check_supported_post_type_update_errors();
+		$settings_errors = get_settings_errors();
+		$this->assertCount( 1, $settings_errors );
+		$error = current( $settings_errors );
 		$this->assertEquals( 'foo_activation_error', $error['code'] );
 		$wp_settings_errors = array();
 


### PR DESCRIPTION
This is a follow-up to #1338 for #1302.

When Jetpack's custom content types enabled, I found I was still getting the error messages unexpectedly:

<img width="755" alt="screen shot 2018-08-16 at 6 35 00 am" src="https://user-images.githubusercontent.com/134745/44212919-785aa800-a121-11e8-9fa4-a6a5ffcd33e4.png">

The fix seems to be that we need to skip the check if the `all_templates_supported` option is enabled (which is only available in the native/paired theme modes).