### PR TITLE
Fix deploy errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,13 @@ jobs:
       env: WP_VERSION=latest DEV_LIB_ONLY=composer,grunt
       script:
         - |
+          if ! command -v wp >/dev/null 2>&1; then
+            mkdir -p /tmp/wp-cli
+            wget -O /tmp/wp-cli/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x /tmp/wp-cli/wp
+            export PATH="/tmp/wp-cli:$PATH"
+            wp cli update --yes --nightly # Temporary until WP-CLI 2.1 or 2.0.1
+          fi
           eval "$(ssh-agent -s)"
           pantheon_branch=$( echo $TRAVIS_BRANCH | sed 's/^\([0-9]\)/v\1/' | sed 's/[^a-z0-9-]/-/' )
           echo "Initializing deployment to Pantheon branch: $pantheon_branch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 
 install:
   - if [[ $DEV_LIB_SKIP =~ composer ]]; then composer install --no-dev; fi
-  - nvm install 6 && nvm use 6
+  - nvm install 8.11.4 && nvm use 8.11.4
   - export DEV_LIB_PATH=dev-lib
   - source $DEV_LIB_PATH/travis.install.sh
 


### PR DESCRIPTION
Fixes build errors due to WP-CLI not being available and due to Node not being updated. Fixes regression introduced in #1329.

Example failing build: https://travis-ci.org/Automattic/amp-wp/jobs/416882586#L241