### PR TITLE
Normalize 'ver' query param in script/style validation errors to prevent recurrence after accepted

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -445,6 +445,13 @@ abstract class AMP_Base_Sanitizer {
 			if ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) ) {
 				$error['text'] = $node->textContent;
 			}
+
+			// Suppress 'ver' param from enqueued scripts and styles.
+			if ( 'script' === $node->nodeName && isset( $error['node_attributes']['src'] ) && false !== strpos( $error['node_attributes']['src'], 'ver=' ) ) {
+				$error['node_attributes']['src'] = add_query_arg( 'ver', '__normalized__', $error['node_attributes']['src'] );
+			} elseif ( 'link' === $node->nodeName && isset( $error['node_attributes']['href'] ) && false !== strpos( $error['node_attributes']['href'], 'ver=' ) ) {
+				$error['node_attributes']['href'] = add_query_arg( 'ver', '__normalized__', $error['node_attributes']['href'] );
+			}
 		} elseif ( $node instanceof DOMAttr ) {
 			if ( ! isset( $error['code'] ) ) {
 				$error['code'] = AMP_Validation_Error_Taxonomy::INVALID_ATTRIBUTE_CODE;

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -638,7 +638,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 			),
 			'latest_posts' => array(
 				'<!-- wp:latest-posts /-->',
-				'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"type":"plugin","name":"gutenberg","function":"render_block_core_latest_posts"}--><ul class="wp-block-latest-posts aligncenter"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"type":"plugin","name":"gutenberg","function":"render_block_core_latest_posts"}-->',
+				'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"type":"plugin","name":"gutenberg","function":"render_block_core_latest_posts"}--><ul class="wp-block-latest-posts"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"type":"plugin","name":"gutenberg","function":"render_block_core_latest_posts"}-->',
 				array(
 					'element' => 'ul',
 					'blocks'  => array( 'core/latest-posts' ),


### PR DESCRIPTION
A validation error for an enqueued script can look like this:

```json
{
    "code": "invalid_element",
    "node_attributes": {
        "src": "https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/widgets/google-translate/google-translate.js?ver=4.9.7-alpha-43298-src",
        "type": "text/javascript"
    },
    "node_name": "script",
    "parent_name": "body"
}
```

In this case for the Google Translate widget in Jetpack, the script is enqueued without any `ver` and so it will re-use whatever the current WordPress version is. If this validation error gets marked as accepted, then the next time that core is updated, a brand new validation error will be reported because the `ver` change causes the fingerprint (md5 hash) of the validation error to change. This problem would also apply when the a plugin supplies a `ver` that corresponds to the plugin's actual version, as each time the plugin is updated any accepted validation errors for its scripts will then need to be re-accepted.

While a `amp_validation_error` filter could be used to strip the `ver` query param from the URLs in such validation errors, this normalization seems like something that should be the default behavior in the plugin. This plugin will replace any `ver` query param values with `__normalized__`.