### PR TITLE
Fetch CSS over HTTP when URL lacks extension; convert font CDN stylesheets @imports to convert to links instead of fetching

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -474,7 +474,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see WP_Styles::_css_href()
 	 *
 	 * @param string   $url The file URL.
-	 * @param string[] $allowed_extensions Allowed file extensions.
+	 * @param string[] $allowed_extensions Allowed file extensions for local files.
 	 * @return string|WP_Error Style's absolute validated filesystem path, or WP_Error when error.
 	 */
 	public function get_validated_url_file_path( $url, $allowed_extensions = array() ) {
@@ -513,7 +513,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$pattern = sprintf( '/\.(%s)$/i', implode( '|', $allowed_extensions ) );
 			if ( ! preg_match( $pattern, $url ) ) {
 				/* translators: %s: the file URL. */
-				return new WP_Error( 'disallowed_file_extension', sprintf( __( 'Skipped file which does not have an allowed file extension (%s).', 'amp' ), $url ) );
+				return new WP_Error( 'disallowed_file_extension', sprintf( __( 'File does not have an allowed file extension for filesystem access (%s).', 'amp' ), $url ) );
 			}
 		}
 
@@ -667,7 +667,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$css_file_path = $this->get_validated_url_file_path( $href, array( 'css', 'less', 'scss', 'sass' ) );
 
-		if ( is_wp_error( $css_file_path ) && 'external_file_url' === $css_file_path->get_error_code() ) {
+		if ( is_wp_error( $css_file_path ) && ( 'disallowed_file_extension' === $css_file_path->get_error_code() || 'external_file_url' === $css_file_path->get_error_code() ) ) {
 			$contents = $this->fetch_external_stylesheet( $normalized_url );
 			if ( is_wp_error( $contents ) ) {
 				$this->remove_invalid_child( $element, array(
@@ -866,7 +866,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$css_file_path = $this->get_validated_url_file_path( $import_stylesheet_url, array( 'css', 'less', 'scss', 'sass' ) );
 
-		if ( is_wp_error( $css_file_path ) && 'external_file_url' === $css_file_path->get_error_code() ) {
+		if ( is_wp_error( $css_file_path ) && ( 'disallowed_file_extension' === $css_file_path->get_error_code() || 'external_file_url' === $css_file_path->get_error_code() ) ) {
 			$contents = $this->fetch_external_stylesheet( $import_stylesheet_url );
 			if ( is_wp_error( $contents ) ) {
 				$error     = array(
@@ -1509,8 +1509,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					continue;
 				}
 
-				// Ensure file exists.
-				$path = $this->get_validated_url_file_path( $guessed_url );
+				// Ensure font file exists.
+				$path = $this->get_validated_url_file_path( $guessed_url, array( 'woff', 'woff2', 'ttf', 'otf', 'svg' ) );
 				if ( is_wp_error( $path ) ) {
 					continue;
 				}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -768,7 +768,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *     @type array    $allowed_at_rules            Allowed @-rules.
 	 *     @type bool     $validate_keyframes          Whether keyframes should be validated.
 	 * }
-	 * @return array Processed stylesheet.
+	 * @return array {
+	 *    Processed stylesheet.
+	 *
+	 *    @type array $stylesheet         Stylesheet parts, where arrays are tuples for declaration blocks.
+	 *    @type array $validation_results Validation results, array containing arrays with error and sanitized keys.
+	 *    @type array $imported_font_urls Imported font stylesheet URLs.
+	 * }
 	 */
 	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$parsed      = null;
@@ -861,6 +867,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( $this->allowed_font_src_regex && preg_match( $this->allowed_font_src_regex, $https_import_stylesheet_url ) ) {
 			$this->imported_font_urls[] = $https_import_stylesheet_url;
 			$css_list->remove( $item );
+			_doing_it_wrong(
+				'wp_enqueue_style',
+				esc_html( sprintf(
+					/* translators: %s is URL to font CDN */
+					__( 'It is not a best practice to use @import to load font CDN stylesheets. Please use wp_enqueue_style() to enqueue %s as its own separate script.', 'amp' ),
+					$import_stylesheet_url
+				) ),
+				'1.0'
+			);
 			return array();
 		}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -358,6 +358,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'external_link_without_css_file_extension' => array(
+				'<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="https://example.com/_static/??-eJx9kN1SAyEMhV9Iip3aOl44Pgs"></head><body><span>externally-styled</span></body></html>', // phpcs:ignore
+				array(
+					'span:before{content:"Returned from: https://example.com/_static/??-eJx9kN1SAyEMhV9Iip3aOl44Pgs"}',
+				),
+				array(),
+			),
 		);
 	}
 
@@ -373,6 +380,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		add_filter( 'locale', function() {
 			return 'en_US';
 		} );
+		add_filter( 'pre_http_request', function( $preempt, $request, $url ) {
+			unset( $request, $preempt );
+			$preempt = array(
+				'response' => array(
+					'code' => 200,
+				),
+				'body' => sprintf( 'span:before { content: "Returned from: %s"; }', $url ),
+			);
+			return $preempt;
+		}, 10, 3 );
 		$dom = AMP_DOM_Utils::get_dom( $source );
 
 		$error_codes = array();
@@ -1249,9 +1266,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$local_css_url   = admin_url( 'css/login.css' );
 		$import_font_url = 'https://fonts.googleapis.com/css?family=Merriweather:300|PT+Serif:400i|Open+Sans:800|Zilla+Slab:300,400,500|Montserrat:800|Muli:400&subset=cyrillic-ext,latin-ext,cyrillic,greek,greek-ext,vietnamese';
 		$import_css_url  = 'https://stylesheets.example.com/style.css';
-		$markup          = sprintf( '<html><head><link rel="stylesheet" href="%s"><style>@import url("%s"); body { color:red; }</style><style>@import "%s";</style></head><body>hello</body></html>', $local_css_url, $import_css_url, $import_font_url ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$import_css_url2 = 'https://stylesheets.example.com/dynamic-css/';
+		$markup          = sprintf(
+			'<html><head><link rel="stylesheet" href="%s"><style>@import url("%s"); body { color:red; }</style><style>@import "%s";</style><style>@import "%s";</style></head><body>hello</body></html>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+			$local_css_url,
+			$import_css_url,
+			$import_font_url,
+			$import_css_url2
+		);
 
-		add_filter( 'pre_http_request', function( $preempt, $request, $url ) use ( $import_css_url ) {
+		add_filter( 'pre_http_request', function( $preempt, $request, $url ) use ( $import_css_url, $import_css_url2 ) {
 			unset( $request );
 			if ( $url === $import_css_url ) {
 				$preempt = array(
@@ -1259,6 +1283,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'code' => 200,
 					),
 					'body' => 'html { background-color:lightblue; }',
+				);
+			} elseif ( $url === $import_css_url2 ) {
+				$preempt = array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body' => 'strong { background-color:red; }',
 				);
 			}
 			return $preempt;
@@ -1271,7 +1302,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		) );
 		$sanitizer->sanitize();
 		$stylesheets = array_values( $sanitizer->get_stylesheets() );
-		$this->assertCount( 3, $stylesheets );
+		$this->assertCount( 4, $stylesheets );
 		$this->assertRegExp(
 			'/' . implode( '.*', array(
 				preg_quote( 'input[type="checkbox"]:disabled' ),
@@ -1287,7 +1318,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			) ) . '/s',
 			$stylesheets[1]
 		);
-		$this->assertEmpty( $stylesheets[2] );
+
+		$this->assertEmpty( $stylesheets[2] ); // Since it was importing a font CDN URL.
+		$this->assertEquals( 'strong{background-color:red}', $stylesheets[3] );
 
 		$this->assertNotContains( '@import', $dom->getElementsByTagName( 'style' )->item( 0 )->textContent );
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1260,6 +1260,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	/**
 	 * Test CSS imports.
 	 *
+	 * @expectedIncorrectUsage wp_enqueue_style
 	 * @covers AMP_Style_Sanitizer::parse_import_stylesheet()
 	 */
 	public function test_css_import() {


### PR DESCRIPTION
If there is a stylesheet `link` with a URL which does not end in `css`, fetch it over HTTP instead of throwing a validation error.

Additionally, if there is a stylesheet that contains an `@import` to a stylesheet URL which is whitelisted CDN for fonts such as:

```css
@import "https://fonts.googleapis.com/css?family=Merriweather:300";
```

Then instead of fetching the CSS to inline, opt instead to convert into a normal `link` tag:

```html
<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Merriweather:300">
```

Fixes #1317