### PR TITLE
Add filters on taxonomy and post page

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -436,6 +436,11 @@ abstract class AMP_Base_Sanitizer {
 			if ( ! isset( $error['code'] ) ) {
 				$error['code'] = AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE;
 			}
+
+			if ( ! isset( $error['type'] ) ) {
+				$error['type'] = 'script' === $node->nodeName ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+			}
+
 			$error['node_attributes'] = array();
 			foreach ( $node->attributes as $attribute ) {
 				$error['node_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
@@ -455,6 +460,9 @@ abstract class AMP_Base_Sanitizer {
 		} elseif ( $node instanceof DOMAttr ) {
 			if ( ! isset( $error['code'] ) ) {
 				$error['code'] = AMP_Validation_Error_Taxonomy::INVALID_ATTRIBUTE_CODE;
+			}
+			if ( ! isset( $error['type'] ) ) {
+				$error['type'] = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
 			}
 			$error['element_attributes'] = array();
 			if ( $node->parentNode && $node->parentNode->hasAttributes() ) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -463,7 +463,7 @@ abstract class AMP_Base_Sanitizer {
 			}
 			if ( ! isset( $error['type'] ) ) {
 				// If this is an attribute that begins with on, like onclick, it should be a js_error.
-				$error['type'] = preg_match( '/^on[a-zA-Z]/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE;
+				$error['type'] = preg_match( '/^on\w+/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE;
 			}
 			$error['element_attributes'] = array();
 			if ( $node->parentNode && $node->parentNode->hasAttributes() ) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -438,7 +438,7 @@ abstract class AMP_Base_Sanitizer {
 			}
 
 			if ( ! isset( $error['type'] ) ) {
-				$error['type'] = 'script' === $node->nodeName ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+				$error['type'] = 'script' === $node->nodeName ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE;
 			}
 
 			$error['node_attributes'] = array();
@@ -463,7 +463,7 @@ abstract class AMP_Base_Sanitizer {
 			}
 			if ( ! isset( $error['type'] ) ) {
 				// If this is an attribute that begins with on, like onclick, it should be a js_error.
-				$error['type'] = preg_match( '/^on[a-zA-Z]/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+				$error['type'] = preg_match( '/^on[a-zA-Z]/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE;
 			}
 			$error['element_attributes'] = array();
 			if ( $node->parentNode && $node->parentNode->hasAttributes() ) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -462,7 +462,8 @@ abstract class AMP_Base_Sanitizer {
 				$error['code'] = AMP_Validation_Error_Taxonomy::INVALID_ATTRIBUTE_CODE;
 			}
 			if ( ! isset( $error['type'] ) ) {
-				$error['type'] = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+				// If this is an attribute that begins with on, like onclick, it should be a js_error.
+				$error['type'] = preg_match( '/^on[a-zA-Z]/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
 			}
 			$error['element_attributes'] = array();
 			if ( $node->parentNode && $node->parentNode->hasAttributes() ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -673,6 +673,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$this->remove_invalid_child( $element, array(
 					'code'    => $css_file_path->get_error_code(),
 					'message' => $css_file_path->get_error_message(),
+					'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				) );
 				return;
 			} else {
@@ -682,6 +683,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$this->remove_invalid_child( $element, array(
 				'code'    => $css_file_path->get_error_code(),
 				'message' => $css_file_path->get_error_message(),
+				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			) );
 			return;
 		} else {
@@ -691,6 +693,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( false === $stylesheet ) {
 			$this->remove_invalid_child( $element, array(
 				'code' => 'stylesheet_file_missing',
+				'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			) );
 			return;
 		}
@@ -887,6 +890,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$error     = array(
 					'code'    => $contents->get_error_code(),
 					'message' => $contents->get_error_message(),
+					'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				);
 				$sanitized = $this->should_sanitize_validation_error( $error );
 				if ( $sanitized ) {
@@ -901,6 +905,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$error     = array(
 				'code'    => $css_file_path->get_error_code(),
 				'message' => $css_file_path->get_error_message(),
+				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			);
 			$sanitized = $this->should_sanitize_validation_error( $error );
 			if ( $sanitized ) {
@@ -988,6 +993,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$error = array(
 				'code'    => 'css_parse_error',
 				'message' => $exception->getMessage(),
+				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			);
 
 			/*
@@ -1239,6 +1245,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$error     = array(
 						'code'    => 'illegal_css_at_rule',
 						'at_rule' => $css_item->atRuleName(),
+						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
@@ -1259,6 +1266,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$error     = array(
 						'code'    => 'illegal_css_at_rule',
 						'at_rule' => $css_item->atRuleName(),
+						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
@@ -1275,6 +1283,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$error     = array(
 						'code'    => 'illegal_css_at_rule',
 						'at_rule' => $css_item->atRuleName(),
+						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
@@ -1290,6 +1299,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$error     = array(
 					'code'    => 'illegal_css_at_rule',
 					'at_rule' => $css_item->atRuleName(),
+					'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				);
 				$sanitized = $this->should_sanitize_validation_error( $error );
 				$results[] = compact( 'error', 'sanitized' );
@@ -1297,6 +1307,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$error     = array(
 					'code' => 'unrecognized_css',
 					'item' => get_class( $css_item ),
+					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				);
 				$sanitized = $this->should_sanitize_validation_error( $error );
 				$results[] = compact( 'error', 'sanitized' );
@@ -1382,6 +1393,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => $property->getValue(),
+						'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
@@ -1398,6 +1410,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => (string) $property->getValue(),
+						'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
@@ -1556,6 +1569,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$error     = array(
 						'code' => 'unrecognized_css',
 						'item' => get_class( $rules ),
+						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
@@ -1578,6 +1592,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 							'code'           => 'illegal_css_property',
 							'property_name'  => $property->getRule(),
 							'property_value' => (string) $property->getValue(),
+							'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 						);
 						$sanitized = $this->should_sanitize_validation_error( $error );
 						if ( $sanitized ) {
@@ -1623,6 +1638,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				} else {
 					$error     = array(
 						'code' => 'illegal_css_important',
+						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					);
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
@@ -1901,6 +1917,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! $body ) {
 				$this->should_sanitize_validation_error( array(
 					'code' => 'missing_body_element',
+					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				) );
 			} else {
 				$style_element = $this->dom->createElement( 'style' );
@@ -1997,6 +2014,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( $is_too_much_css && $should_tree_shake && empty( $this->args['accept_tree_shaking'] ) ) {
 			$should_tree_shake = $this->should_sanitize_validation_error( array(
 				'code' => self::TREE_SHAKING_ERROR_CODE,
+				'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			) );
 		}
 
@@ -2066,6 +2084,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $final_size + $sheet_size > $stylesheet_set['cdata_spec']['max_bytes'] ) {
 				$validation_error = array(
 					'code' => 'excessive_css',
+					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				);
 				if ( isset( $pending_stylesheet['sources'] ) ) {
 					$validation_error['sources'] = $pending_stylesheet['sources'];

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1366,16 +1366,10 @@ class AMP_Invalid_URL_Post_Type {
 	 * @param string $which     The location for the markup, either 'top' or 'bottom'.
 	 */
 	public static function render_post_filters( $post_type, $which ) {
-		if (
-			self::POST_TYPE_SLUG !== $post_type
-			||
-			'top' !== $which
-		) {
-			return;
+		if ( self::POST_TYPE_SLUG === $post_type && 'top' === $which ) {
+			AMP_Validation_Error_Taxonomy::render_error_status_filter();
+			AMP_Validation_Error_Taxonomy::render_error_type_filter();
 		}
-
-		AMP_Validation_Error_Taxonomy::render_error_status_filter();
-		AMP_Validation_Error_Taxonomy::render_error_type_filter();
 	}
 
 	/**

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -131,7 +131,7 @@ class AMP_Invalid_URL_Post_Type {
 		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
 		add_action( 'edit_form_top', array( __CLASS__, 'print_url_as_title' ) );
 		add_filter( 'the_title', array( __CLASS__, 'filter_the_title_in_post_list_table' ), 10, 2 );
-		add_action( 'restrict_manage_posts', array( __CLass__, 'render_post_filters' ), 10, 2 );
+		add_action( 'restrict_manage_posts', array( __CLASS__, 'render_post_filters' ), 10, 2 );
 
 		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', array( __CLASS__, 'add_post_columns' ) );
 		add_action( 'manage_posts_custom_column', array( __CLASS__, 'output_custom_column' ), 10, 2 );

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -131,8 +131,8 @@ class AMP_Invalid_URL_Post_Type {
 		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
 		add_action( 'edit_form_top', array( __CLASS__, 'print_url_as_title' ) );
 		add_filter( 'the_title', array( __CLASS__, 'filter_the_title_in_post_list_table' ), 10, 2 );
+		add_action( 'restrict_manage_posts', array( __CLass__, 'render_post_filters' ), 10, 2 );
 
-		add_filter( 'views_edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'filter_views_edit' ) );
 		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', array( __CLASS__, 'add_post_columns' ) );
 		add_action( 'manage_posts_custom_column', array( __CLASS__, 'output_custom_column' ), 10, 2 );
 		add_filter( 'post_row_actions', array( __CLASS__, 'filter_row_actions' ), 10, 2 );
@@ -495,122 +495,6 @@ class AMP_Invalid_URL_Post_Type {
 		}
 
 		return $staleness;
-	}
-
-	/**
-	 * Add views for filtering validation errors by status.
-	 *
-	 * @param array $views Views.
-	 * @return array Views
-	 */
-	public static function filter_views_edit( $views ) {
-		unset( $views['publish'] );
-
-		$args = array(
-			'post_type'              => self::POST_TYPE_SLUG,
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-		);
-
-		$with_new_query      = new WP_Query( array_merge(
-			$args,
-			array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS )
-		) );
-		$with_rejected_query = new WP_Query( array_merge(
-			$args,
-			array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECTED_STATUS )
-		) );
-		$with_accepted_query = new WP_Query( array_merge(
-			$args,
-			array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS )
-		) );
-
-		$current_url = remove_query_arg(
-			array_merge(
-				wp_removable_query_args(),
-				array( 's' ) // For some reason behavior of posts list table is to not persist the search query.
-			),
-			wp_unslash( $_SERVER['REQUEST_URI'] )
-		);
-
-		$current_status = null;
-		if ( isset( $_GET[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ) { // WPCS: CSRF ok.
-			$value = intval( $_GET[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR ] ); // WPCS: CSRF ok.
-			if ( in_array( $value, array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECTED_STATUS ), true ) ) {
-				$current_status = $value;
-			}
-		}
-
-		$views['new'] = sprintf(
-			'<a href="%s" class="%s">%s</a>',
-			esc_url(
-				add_query_arg(
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR,
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS,
-					$current_url
-				)
-			),
-			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS === $current_status ? 'current' : '',
-			sprintf(
-				/* translators: %s: the post count. */
-				_nx(
-					'With New Errors <span class="count">(%s)</span>',
-					'With New Errors <span class="count">(%s)</span>',
-					$with_new_query->found_posts,
-					'posts',
-					'amp'
-				),
-				number_format_i18n( $with_new_query->found_posts )
-			)
-		);
-
-		$views['rejected'] = sprintf(
-			'<a href="%s" class="%s">%s</a>',
-			esc_url(
-				add_query_arg(
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR,
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECTED_STATUS,
-					$current_url
-				)
-			),
-			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECTED_STATUS === $current_status ? 'current' : '',
-			sprintf(
-				/* translators: %s: the post count. */
-				_nx(
-					'With Rejected Errors <span class="count">(%s)</span>',
-					'With Rejected Errors <span class="count">(%s)</span>',
-					$with_rejected_query->found_posts,
-					'posts',
-					'amp'
-				),
-				number_format_i18n( $with_rejected_query->found_posts )
-			)
-		);
-
-		$views['accepted'] = sprintf(
-			'<a href="%s" class="%s">%s</a>',
-			esc_url(
-				add_query_arg(
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR,
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS,
-					$current_url
-				)
-			),
-			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS === $current_status ? 'current' : '',
-			sprintf(
-				/* translators: %s: the post count. */
-				_nx(
-					'With Accepted Errors <span class="count">(%s)</span>',
-					'With Accepted Errors <span class="count">(%s)</span>',
-					$with_accepted_query->found_posts,
-					'posts',
-					'amp'
-				),
-				number_format_i18n( $with_accepted_query->found_posts )
-			)
-		);
-
-		return $views;
 	}
 
 	/**
@@ -1473,6 +1357,25 @@ class AMP_Invalid_URL_Post_Type {
 			$title = preg_replace( '#^(\w+:)?//[^/]+#', '', $title );
 		}
 		return $title;
+	}
+
+	/**
+	 * Renders the filters on the invalid URL post type edit.php page.
+	 *
+	 * @param string $post_type The slug of the post type.
+	 * @param string $which     The location for the markup, either 'top' or 'bottom'.
+	 */
+	public static function render_post_filters( $post_type, $which ) {
+		if (
+			self::POST_TYPE_SLUG !== $post_type
+			||
+			'top' !== $which
+		) {
+			return;
+		}
+
+		AMP_Validation_Error_Taxonomy::render_error_status_filter();
+		AMP_Validation_Error_Taxonomy::render_error_type_filter();
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -612,14 +612,21 @@ class AMP_Validation_Error_Taxonomy {
 			self::TAXONOMY_SLUG === $tax->name
 			&&
 			isset( $_POST['post_type'] ) && AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG === $_POST['post_type'] // WPCS: CSRF OK.
-			&&
-			! empty( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) // WPCS: CSRF OK.
 		) {
-			return add_query_arg(
-				self::VALIDATION_ERROR_TYPE_QUERY_VAR,
-				sanitize_text_field( wp_unslash( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ), // WPCS: CSRF OK.
-				$url
-			);
+			if ( isset( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) { // WPCS: CSRF OK.
+				$url = add_query_arg(
+					self::VALIDATION_ERROR_TYPE_QUERY_VAR,
+					sanitize_text_field( wp_unslash( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ), // WPCS: CSRF OK.
+					$url
+				);
+			}
+			if ( isset( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ) { // WPCS: CSRF OK.
+				$url = add_query_arg(
+					self::VALIDATION_ERROR_STATUS_QUERY_VAR,
+					sanitize_text_field( wp_unslash( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ), // WPCS: CSRF OK.
+					$url
+				);
+			}
 		}
 
 		return $url;
@@ -683,10 +690,19 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 
-		$error_type_filter_value = isset( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
-		$div_id                  = 'amp-tax-filter';
+		$error_type_filter_value   = isset( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
+		$error_status_filter_value = isset( $_REQUEST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
+		$div_id                    = 'amp-tax-filter';
 		?>
 		<div id="<?php echo esc_attr( $div_id ); ?>" class="alignleft actions">
+			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error status', 'amp' ); ?></label>
+			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">
+				<option value="-1"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php esc_html_e( 'New Error', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php esc_html_e( 'Accepted Error', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php esc_html_e( 'Rejected Error', 'amp' ); ?></option>
+			</select>
+
 			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error type', 'amp' ); ?></label>
 			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>">
 				<option value="-1"><?php esc_html_e( 'All Error Types', 'amp' ); ?></option>
@@ -694,7 +710,7 @@ class AMP_Validation_Error_Taxonomy {
 				<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>><?php esc_html_e( 'JS Error', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>><?php esc_html_e( 'CSS Error', 'amp' ); ?></option>
 			</select>
-			<input name="filter_action" type="submit" id="doaction" class="button action" value="<?php esc_html_e( 'Filter', 'amp' ); ?>">
+			<input name="filter_action" type="submit" id="doaction" class="button action" value="<?php esc_html_e( 'Apply Filter', 'amp' ); ?>">
 		</div>
 
 		<script>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -843,14 +843,18 @@ class AMP_Validation_Error_Taxonomy {
 		global $wp_query;
 		$screen_base = get_current_screen()->base;
 
-		// The taxonomy page.
+
 		if ( 'edit-tags' === $screen_base ) {
+			// The taxonomy page.
+			$possible_with_text  = '';
 			$total_term_count    = self::get_validation_error_count();
 			$rejected_term_count = self::get_validation_error_count( array( 'group' => self::VALIDATION_ERROR_REJECTED_STATUS ) );
 			$accepted_term_count = self::get_validation_error_count( array( 'group' => self::VALIDATION_ERROR_ACCEPTED_STATUS ) );
 			$new_term_count      = $total_term_count - $rejected_term_count - $accepted_term_count;
-			// The post page.
+
 		} elseif ( 'edit' === $screen_base ) {
+			// The post page should have <option> text like 'With New Errors'.
+			$possible_with_text = esc_html__( 'With', 'amp' );
 			$args = array(
 				'post_type'              => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
 				'update_post_meta_cache' => false,
@@ -891,14 +895,15 @@ class AMP_Validation_Error_Taxonomy {
 			<?php
 			if ( $new_term_count ) :
 				$new_term_text = sprintf(
-					/* translators: %s: the new term count. */
+					/* translators: %s: possibly the word With, %s: the new term count. */
 					_nx(
-						'New Error <span class="count">(%s)</span>',
-						'New Errors <span class="count">(%s)</span>',
+						'%1$s New Error <span class="count">(%2$s)</span>',
+						'%1$s New Errors <span class="count">(%2$s)</span>',
 						$new_term_count,
 						'terms',
 						'amp'
 					),
+					$possible_with_text,
 					number_format_i18n( $new_term_count )
 				);
 				?>
@@ -907,14 +912,15 @@ class AMP_Validation_Error_Taxonomy {
 			<?php
 			if ( $accepted_term_count ) :
 				$accepted_term_text = sprintf(
-					/* translators: %s: the accepted term count. */
+					/* translators: %s: possibly the word With, %s: the accepted term count. */
 					_nx(
-						'Accepted Error <span class="count">(%s)</span>',
-						'Accepted Errors <span class="count">(%s)</span>',
+						'%1$s Accepted Error <span class="count">(%2$s)</span>',
+						'%1$s Accepted Errors <span class="count">(%2$s)</span>',
 						$accepted_term_count,
 						'terms',
 						'amp'
 					),
+					$possible_with_text,
 					number_format_i18n( $accepted_term_count )
 				);
 				?>
@@ -923,14 +929,15 @@ class AMP_Validation_Error_Taxonomy {
 			endif;
 			if ( $rejected_term_count ) :
 				$rejected_term_text = sprintf(
-					/* translators: %s: the rejected term count. */
+					/* translators: %s: possibly the word With, %s: the rejected term count. */
 					_nx(
-						'Rejected Error <span class="count">(%s)</span>',
-						'Rejected Errors <span class="count">(%s)</span>',
+						'%1$s Rejected Error <span class="count">(%2$s)</span>',
+						'%1$s Rejected Errors <span class="count">(%2$s)</span>',
 						$rejected_term_count,
 						'terms',
 						'amp'
 					),
+					$possible_with_text,
 					number_format_i18n( $rejected_term_count )
 				);
 				?>
@@ -957,15 +964,44 @@ class AMP_Validation_Error_Taxonomy {
 	 */
 	public static function render_error_type_filter() {
 		$error_type_filter_value = isset( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
+		$screen_base             = get_current_screen()->base;
+
+		/*
+		 * On the 'Errors by URL' page, the <option> text should be different.
+		 * For example, it should be 'With JS Errors' instead of 'JS Errors'.
+		 */
+		$possible_with_text = 'edit' === $screen_base ? __( 'With', 'amp' ) : '';
 
 		?>
 		<label for="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error type', 'amp' ); ?></label>
 		<select name="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>">
-			<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Error Types', 'amp' ); ?></option>
-			<option value="<?php echo esc_attr( self::HTML_ELEMENT_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ELEMENT_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML (Element) Error', 'amp' ); ?></option>
-			<option value="<?php echo esc_attr( self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML (Attribute) Error', 'amp' ); ?></option>
-			<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>><?php esc_html_e( 'JS Error', 'amp' ); ?></option>
-			<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>><?php esc_html_e( 'CSS Error', 'amp' ); ?></option>
+			<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>">
+				<?php esc_html_e( 'All Error Types', 'amp' ); ?>
+			</option>
+			<option value="<?php echo esc_attr( self::HTML_ELEMENT_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ELEMENT_ERROR_TYPE ); ?>>
+				<?php
+				/* translators: %s: possibly the word With */
+				echo esc_html( sprintf( __( '%s HTML (Element) Errors', 'amp' ), $possible_with_text ) );
+				?>
+			</option>
+			<option value="<?php echo esc_attr( self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>>
+				<?php
+				/* translators: %s: possibly the word With */
+				echo esc_html( sprintf( __( '%s HTML (Attribute) Errors', 'amp' ), $possible_with_text ) );
+				?>
+			</option>
+			<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>>
+				<?php
+				/* translators: %s: possibly the word With */
+				echo esc_html( sprintf( __( '%s JS Errors', 'amp' ), $possible_with_text ) );
+				?>
+			</option>
+			<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>>
+				<?php
+				/* translators: %s: possibly the word With */
+				echo esc_html( sprintf( __( '%s CSS Errors', 'amp' ), $possible_with_text ) );
+				?>
+			</option>
 		</select>
 		<?php
 	}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -887,6 +887,9 @@ class AMP_Validation_Error_Taxonomy {
 
 		$error_status_filter_value = isset( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ? intval( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) : ''; // WPCS: CSRF OK.
 
+		if ( 0 === $new_term_count && 0 === $accepted_term_count && 0 === $rejected_term_count ) {
+			return;
+		}
 		?>
 		<label for="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error status', 'amp' ); ?></label>
 		<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -888,103 +888,94 @@ class AMP_Validation_Error_Taxonomy {
 
 		$error_status_filter_value = isset( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ? intval( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) : ''; // WPCS: CSRF OK.
 
-		if ( 0 === $new_term_count && 0 === $accepted_term_count && 0 === $rejected_term_count ) {
-			return;
-		}
 		?>
 		<label for="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error status', 'amp' ); ?></label>
 		<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">
 			<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
 			<?php
-			if ( $new_term_count ) :
-				if ( 'edit' === $screen_base ) {
-					$new_term_text = sprintf(
-						/* translators: %s: the new term count. */
-						_nx(
-							'With New Error <span class="count">(%s)</span>',
-							'With New Errors <span class="count">(%s)</span>',
-							$new_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $new_term_count )
-					);
-				} else {
-					$new_term_text = sprintf(
-						/* translators: %s: the new term count. */
-						_nx(
-							'New Error <span class="count">(%s)</span>',
-							'New Errors <span class="count">(%s)</span>',
-							$new_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $new_term_count )
-					);
-				}
-				?>
-				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php echo wp_kses_post( $new_term_text ); ?></option>
-			<?php endif; ?>
+			if ( 'edit' === $screen_base ) {
+				$new_term_text = sprintf(
+					/* translators: %s: the new term count. */
+					_nx(
+						'With New Error <span class="count">(%s)</span>',
+						'With New Errors <span class="count">(%s)</span>',
+						$new_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $new_term_count )
+				);
+			} else {
+				$new_term_text = sprintf(
+					/* translators: %s: the new term count. */
+					_nx(
+						'New Error <span class="count">(%s)</span>',
+						'New Errors <span class="count">(%s)</span>',
+						$new_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $new_term_count )
+				);
+			}
+			?>
+			<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php echo wp_kses_post( $new_term_text ); ?></option>
 			<?php
-			if ( $accepted_term_count ) :
-				if ( 'edit' === $screen_base ) {
-					$accepted_term_text = sprintf(
-						/* translators: %s: the accepted term count. */
-						_nx(
-							'With Accepted Error <span class="count">(%s)</span>',
-							'With Accepted Errors <span class="count">(%s)</span>',
-							$accepted_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $accepted_term_count )
-					);
-				} else {
-					$accepted_term_text = sprintf(
-						/* translators: %s: the accepted term count. */
-						_nx(
-							'Accepted Error <span class="count">(%s)</span>',
-							'Accepted Errors <span class="count">(%s)</span>',
-							$accepted_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $accepted_term_count )
-					);
-				}
-				?>
-				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php echo wp_kses_post( $accepted_term_text ); ?></option>
-				<?php
-			endif;
-			if ( $rejected_term_count ) :
-				if ( 'edit' === $screen_base ) {
-					$rejected_term_text = sprintf(
-						/* translators: %s: the rejected term count. */
-						_nx(
-							'With Rejected Error <span class="count">(%s)</span>',
-							'With Rejected Errors <span class="count">(%s)</span>',
-							$rejected_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $rejected_term_count )
-					);
-				} else {
-					$rejected_term_text = sprintf(
-						/* translators: %s: the rejected term count. */
-						_nx(
-							'Rejected Error <span class="count">(%s)</span>',
-							'Rejected Errors <span class="count">(%s)</span>',
-							$rejected_term_count,
-							'terms',
-							'amp'
-						),
-						number_format_i18n( $rejected_term_count )
-					);
-				}
-				?>
-				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php echo wp_kses_post( $rejected_term_text ); ?></option>
-			<?php endif; ?>
+			if ( 'edit' === $screen_base ) {
+				$accepted_term_text = sprintf(
+					/* translators: %s: the accepted term count. */
+					_nx(
+						'With Accepted Error <span class="count">(%s)</span>',
+						'With Accepted Errors <span class="count">(%s)</span>',
+						$accepted_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $accepted_term_count )
+				);
+			} else {
+				$accepted_term_text = sprintf(
+					/* translators: %s: the accepted term count. */
+					_nx(
+						'Accepted Error <span class="count">(%s)</span>',
+						'Accepted Errors <span class="count">(%s)</span>',
+						$accepted_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $accepted_term_count )
+				);
+			}
+			?>
+			<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php echo wp_kses_post( $accepted_term_text ); ?></option>
+			<?php
+			if ( 'edit' === $screen_base ) {
+				$rejected_term_text = sprintf(
+					/* translators: %s: the rejected term count. */
+					_nx(
+						'With Rejected Error <span class="count">(%s)</span>',
+						'With Rejected Errors <span class="count">(%s)</span>',
+						$rejected_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $rejected_term_count )
+				);
+			} else {
+				$rejected_term_text = sprintf(
+					/* translators: %s: the rejected term count. */
+					_nx(
+						'Rejected Error <span class="count">(%s)</span>',
+						'Rejected Errors <span class="count">(%s)</span>',
+						$rejected_term_count,
+						'terms',
+						'amp'
+					),
+					number_format_i18n( $rejected_term_count )
+				);
+			}
+			?>
+			<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php echo wp_kses_post( $rejected_term_text ); ?></option>
 		</select>
 		<?php
 	}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -76,6 +76,31 @@ class AMP_Validation_Error_Taxonomy {
 	const INVALID_ATTRIBUTE_CODE = 'invalid_attribute';
 
 	/**
+	 * The 'type' of error that applies to most errors with the 'code' of 'invalid_element' and 'invalid_attribute'.
+	 *
+	 * Except for 'invalid_element' errors for a <script>, which have the JS_ERROR_TYPE.
+	 * This allows filtering by type in the taxonomy page, like displaying only HTML errors, or only CSS errors.
+	 *
+	 * @var string
+	 */
+	const HTML_ERROR_TYPE = 'html_error';
+
+	/**
+	 * The 'type' of error that applies to the error 'code' of 'invalid_element' when the node is a <script>.
+	 * This applies both when enqueuing a script, and when a <script> is echoed directly.
+	 *
+	 * @var string
+	 */
+	const JS_ERROR_TYPE = 'js_error';
+
+	/**
+	 * The 'type' of all CSS errors, no matter what the 'code'.
+	 *
+	 * @var string
+	 */
+	const CSS_ERROR_TYPE = 'css_error';
+
+	/**
 	 * The key for removed elements.
 	 *
 	 * @var string

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -452,8 +452,8 @@ class AMP_Validation_Error_Taxonomy {
 			return $where;
 		}
 
-		$error_status = $query->get( self::VALIDATION_ERROR_STATUS_QUERY_VAR );
-		$error_type   = $query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR );
+		$error_status = sanitize_key( $query->get( self::VALIDATION_ERROR_STATUS_QUERY_VAR ) );
+		$error_type   = sanitize_key( $query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR ) );
 
 		/*
 		 * Selecting the 'All Statuses' <option> sends a value of '-1' to indicate that this should not filter.
@@ -705,7 +705,7 @@ class AMP_Validation_Error_Taxonomy {
 		) {
 			$url = add_query_arg(
 				self::VALIDATION_ERROR_TYPE_QUERY_VAR,
-				sanitize_text_field( wp_unslash( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ), // WPCS: CSRF OK.
+				sanitize_key( wp_unslash( $_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ), // WPCS: CSRF OK.
 				$url
 			);
 		}
@@ -722,7 +722,7 @@ class AMP_Validation_Error_Taxonomy {
 		) {
 			$url = add_query_arg(
 				self::VALIDATION_ERROR_STATUS_QUERY_VAR,
-				sanitize_text_field( wp_unslash( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ), // WPCS: CSRF OK.
+				intval( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), // WPCS: CSRF OK.
 				$url
 			);
 		}
@@ -752,7 +752,7 @@ class AMP_Validation_Error_Taxonomy {
 	}
 
 	/**
-	 * Filters amp_validation_error term query by type, like in the 'AMP Validation Errors' taxonomy page.
+	 * Adds filter for amp_validation_error term query by type, like in the 'AMP Validation Errors' taxonomy page.
 	 * Allows viewing only a certain type at a time, like only JS errors.
 	 */
 	public static function add_error_type_clauses_filter() {
@@ -760,7 +760,7 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 
-		$type = strval( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ); // WPCS: CSRF ok.
+		$type = sanitize_key( wp_unslash( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ); // WPCS: CSRF ok.
 		if ( ! in_array( $type, self::get_error_types(), true ) ) {
 			return;
 		}
@@ -860,7 +860,7 @@ class AMP_Validation_Error_Taxonomy {
 				'update_post_term_cache' => false,
 			);
 
-			$error_type = $wp_query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR );
+			$error_type = sanitize_key( $wp_query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR ) );
 			if ( $error_type && in_array( $error_type, self::get_error_types(), true ) ) {
 				$args[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] = $error_type;
 			}
@@ -1005,8 +1005,7 @@ class AMP_Validation_Error_Taxonomy {
 	 * and the validation error taxonomy page (Errors by Type).
 	 */
 	public static function render_error_type_filter() {
-		$error_type_filter_value = isset( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
-		$screen_base             = get_current_screen()->base;
+		$error_type_filter_value = isset( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ? sanitize_key( wp_unslash( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ) ) : ''; // WPCS: CSRF OK.
 
 		/*
 		 * On the 'Errors by URL' page, the <option> text should be different.

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -721,14 +721,53 @@ class AMP_Validation_Error_Taxonomy {
 			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error status', 'amp' ); ?></label>
 			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">
 				<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
-				<?php if ( $new_term_count ) : ?>
-					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php esc_html_e( 'New Error', 'amp' ); ?></option>
+				<?php
+				if ( $new_term_count ) :
+					$new_term_text = sprintf(
+						/* translators: %s: the new term count. */
+						_nx(
+							'New Error <span class="count">(%s)</span>',
+							'New Errors <span class="count">(%s)</span>',
+							$new_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $new_term_count )
+					);
+					?>
+					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php echo wp_kses_post( $new_term_text ); ?></option>
 				<?php endif; ?>
-				<?php if ( $accepted_term_count ) : ?>
-					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php esc_html_e( 'Accepted Error', 'amp' ); ?></option>
-				<?php endif; ?>
-				<?php if ( $rejected_term_count ) : ?>
-					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php esc_html_e( 'Rejected Error', 'amp' ); ?></option>
+				<?php
+				if ( $accepted_term_count ) :
+					$accepted_term_text = sprintf(
+						/* translators: %s: the accepted term count. */
+						_nx(
+							'Accepted Error <span class="count">(%s)</span>',
+							'Accepted Errors <span class="count">(%s)</span>',
+							$accepted_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $accepted_term_count )
+					);
+					?>
+					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php echo wp_kses_post( $accepted_term_text ); ?></option>
+					<?php
+				endif;
+				if ( $rejected_term_count ) :
+					$rejected_term_text = sprintf(
+						/* translators: %s: the rejected term count. */
+						_nx(
+							'Rejected Error <span class="count">(%s)</span>',
+							'Rejected Errors <span class="count">(%s)</span>',
+							$rejected_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $rejected_term_count )
+					);
+					?>
+					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php echo wp_kses_post( $rejected_term_text ); ?></option>
 				<?php endif; ?>
 			</select>
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -848,17 +848,13 @@ class AMP_Validation_Error_Taxonomy {
 		$screen_base = get_current_screen()->base;
 
 		if ( 'edit-tags' === $screen_base ) {
-			// The taxonomy page.
-			$possible_with_text  = '';
 			$total_term_count    = self::get_validation_error_count();
 			$rejected_term_count = self::get_validation_error_count( array( 'group' => self::VALIDATION_ERROR_REJECTED_STATUS ) );
 			$accepted_term_count = self::get_validation_error_count( array( 'group' => self::VALIDATION_ERROR_ACCEPTED_STATUS ) );
 			$new_term_count      = $total_term_count - $rejected_term_count - $accepted_term_count;
 
 		} elseif ( 'edit' === $screen_base ) {
-			// The post page should have <option> text like 'With New Errors'.
-			$possible_with_text = esc_html__( 'With', 'amp' );
-			$args               = array(
+			$args = array(
 				'post_type'              => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
@@ -901,52 +897,91 @@ class AMP_Validation_Error_Taxonomy {
 			<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
 			<?php
 			if ( $new_term_count ) :
-				$new_term_text = sprintf(
-					/* translators: %s: possibly the word With, %s: the new term count. */
-					_nx(
-						'%1$s New Error <span class="count">(%2$s)</span>',
-						'%1$s New Errors <span class="count">(%2$s)</span>',
-						$new_term_count,
-						'terms',
-						'amp'
-					),
-					$possible_with_text,
-					number_format_i18n( $new_term_count )
-				);
+				if ( 'edit' === $screen_base ) {
+					$new_term_text = sprintf(
+						/* translators: %s: the new term count. */
+						_nx(
+							'With New Error <span class="count">(%s)</span>',
+							'With New Errors <span class="count">(%s)</span>',
+							$new_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $new_term_count )
+					);
+				} else {
+					$new_term_text = sprintf(
+						/* translators: %s: the new term count. */
+						_nx(
+							'New Error <span class="count">(%s)</span>',
+							'New Errors <span class="count">(%s)</span>',
+							$new_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $new_term_count )
+					);
+				}
 				?>
 				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php echo wp_kses_post( $new_term_text ); ?></option>
 			<?php endif; ?>
 			<?php
 			if ( $accepted_term_count ) :
-				$accepted_term_text = sprintf(
-					/* translators: %s: possibly the word With, %s: the accepted term count. */
-					_nx(
-						'%1$s Accepted Error <span class="count">(%2$s)</span>',
-						'%1$s Accepted Errors <span class="count">(%2$s)</span>',
-						$accepted_term_count,
-						'terms',
-						'amp'
-					),
-					$possible_with_text,
-					number_format_i18n( $accepted_term_count )
-				);
+				if ( 'edit' === $screen_base ) {
+					$accepted_term_text = sprintf(
+						/* translators: %s: the accepted term count. */
+						_nx(
+							'With Accepted Error <span class="count">(%s)</span>',
+							'With Accepted Errors <span class="count">(%s)</span>',
+							$accepted_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $accepted_term_count )
+					);
+				} else {
+					$accepted_term_text = sprintf(
+						/* translators: %s: the accepted term count. */
+						_nx(
+							'Accepted Error <span class="count">(%s)</span>',
+							'Accepted Errors <span class="count">(%s)</span>',
+							$accepted_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $accepted_term_count )
+					);
+				}
 				?>
 				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_ACCEPTED_STATUS ); ?>><?php echo wp_kses_post( $accepted_term_text ); ?></option>
 				<?php
 			endif;
 			if ( $rejected_term_count ) :
-				$rejected_term_text = sprintf(
-					/* translators: %s: possibly the word With, %s: the rejected term count. */
-					_nx(
-						'%1$s Rejected Error <span class="count">(%2$s)</span>',
-						'%1$s Rejected Errors <span class="count">(%2$s)</span>',
-						$rejected_term_count,
-						'terms',
-						'amp'
-					),
-					$possible_with_text,
-					number_format_i18n( $rejected_term_count )
-				);
+				if ( 'edit' === $screen_base ) {
+					$rejected_term_text = sprintf(
+						/* translators: %s: the rejected term count. */
+						_nx(
+							'With Rejected Error <span class="count">(%s)</span>',
+							'With Rejected Errors <span class="count">(%s)</span>',
+							$rejected_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $rejected_term_count )
+					);
+				} else {
+					$rejected_term_text = sprintf(
+						/* translators: %s: the rejected term count. */
+						_nx(
+							'Rejected Error <span class="count">(%s)</span>',
+							'Rejected Errors <span class="count">(%s)</span>',
+							$rejected_term_count,
+							'terms',
+							'amp'
+						),
+						number_format_i18n( $rejected_term_count )
+					);
+				}
 				?>
 				<option value="<?php echo esc_attr( self::VALIDATION_ERROR_REJECTED_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_REJECTED_STATUS ); ?>><?php echo wp_kses_post( $rejected_term_text ); ?></option>
 			<?php endif; ?>
@@ -977,8 +1012,7 @@ class AMP_Validation_Error_Taxonomy {
 		 * On the 'Errors by URL' page, the <option> text should be different.
 		 * For example, it should be 'With JS Errors' instead of 'JS Errors'.
 		 */
-		$possible_with_text = 'edit' === $screen_base ? __( 'With', 'amp' ) : '';
-
+		$screen_base = get_current_screen()->base;
 		?>
 		<label for="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error type', 'amp' ); ?></label>
 		<select name="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>">
@@ -986,28 +1020,32 @@ class AMP_Validation_Error_Taxonomy {
 				<?php esc_html_e( 'All Error Types', 'amp' ); ?>
 			</option>
 			<option value="<?php echo esc_attr( self::HTML_ELEMENT_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ELEMENT_ERROR_TYPE ); ?>>
-				<?php
-				/* translators: %s: possibly the word With */
-				echo esc_html( sprintf( __( '%s HTML (Element) Errors', 'amp' ), $possible_with_text ) );
-				?>
+				<?php if ( 'edit' === $screen_base ) : ?>
+					<?php esc_html_e( 'With HTML (Element) Errors', 'amp' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'HTML (Element) Errors', 'amp' ); ?>
+				<?php endif; ?>
 			</option>
 			<option value="<?php echo esc_attr( self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>>
-				<?php
-				/* translators: %s: possibly the word With */
-				echo esc_html( sprintf( __( '%s HTML (Attribute) Errors', 'amp' ), $possible_with_text ) );
-				?>
+				<?php if ( 'edit' === $screen_base ) : ?>
+					<?php esc_html_e( 'With HTML (Attribute) Errors', 'amp' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'HTML (Attribute) Errors', 'amp' ); ?>
+				<?php endif; ?>
 			</option>
 			<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>>
-				<?php
-				/* translators: %s: possibly the word With */
-				echo esc_html( sprintf( __( '%s JS Errors', 'amp' ), $possible_with_text ) );
-				?>
+				<?php if ( 'edit' === $screen_base ) : ?>
+					<?php esc_html_e( 'With JS Errors', 'amp' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'JS Errors', 'amp' ); ?>
+				<?php endif; ?>
 			</option>
 			<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>>
-				<?php
-				/* translators: %s: possibly the word With */
-				echo esc_html( sprintf( __( '%s CSS Errors', 'amp' ), $possible_with_text ) );
-				?>
+				<?php if ( 'edit' === $screen_base ) : ?>
+					<?php esc_html_e( 'With CSS Errors', 'amp' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'CSS Errors', 'amp' ); ?>
+				<?php endif; ?>
 			</option>
 		</select>
 		<?php

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -747,7 +747,7 @@ class AMP_Validation_Error_Taxonomy {
 	}
 
 	/**
-	 * Filter amp_validation_error term query by type, like in the 'AMP Validation Errors' taxonomy page.
+	 * Filters amp_validation_error term query by type, like in the 'AMP Validation Errors' taxonomy page.
 	 * Allows viewing only a certain type at a time, like only JS errors.
 	 */
 	public static function add_error_type_clauses_filter() {
@@ -773,8 +773,7 @@ class AMP_Validation_Error_Taxonomy {
 	 *
 	 * Similar to what appears on /wp-admin/edit.php for posts and pages,
 	 * this outputs <select> elements to choose the error status and type,
-	 * and a 'Filter' submit button that allows filtering for that type.
-	 * This allows viewing one type at a time, like only JS errors.
+	 * and a 'Filter' submit button that filters for them.
 	 *
 	 * @param string $taxonomy_name The name of the taxonomy.
 	 */
@@ -796,10 +795,10 @@ class AMP_Validation_Error_Taxonomy {
 		<script>
 			( function ( $ ) {
 				$( function() {
-					// Move the filter after the 'Bulk Actions' <select>, as it looks like there's no way to do this with simply an action.
+					// Move the filter UI after the 'Bulk Actions' <select>, as it looks like there's no way to do this with only an action.
 					$( '#<?php echo $div_id; // WPCS: XSS OK. ?>' ).insertAfter( $( '.tablenav.top .bulkactions' ) );
 
-					// Move the link to 'View errors by URL' to after the heading, as there is no hook to output it there.
+					// Move the link to 'View errors by URL' to after the heading, as it also looks like there's no action for this.
 					$( '#<?php echo self::ID_LINK_ERRORS_BY_URL; // WPCS: XSS OK. ?>' ).insertAfter( $( '.wp-heading-inline' ) );
 				} );
 			} )( jQuery );
@@ -854,7 +853,7 @@ class AMP_Validation_Error_Taxonomy {
 		} elseif ( 'edit' === $screen_base ) {
 			// The post page should have <option> text like 'With New Errors'.
 			$possible_with_text = esc_html__( 'With', 'amp' );
-			$args = array(
+			$args               = array(
 				'post_type'              => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
@@ -876,6 +875,7 @@ class AMP_Validation_Error_Taxonomy {
 				array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_REJECTED_STATUS )
 			) );
 			$rejected_term_count = $with_rejected_query->found_posts;
+
 			$with_accepted_query = new WP_Query( array_merge(
 				$args,
 				array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_ACCEPTED_STATUS )

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -672,7 +672,7 @@ class AMP_Validation_Error_Taxonomy {
 	 * It then passes that value to the redirect URL as a query var,
 	 * So that the taxonomy page will be filtered for that error type.
 	 *
-	 * @see AMP_Validation_Error_Taxonomy::add_error_type_clauses_filter() for the filtering of the 'where' clause, based on that query var.
+	 * @see AMP_Validation_Error_Taxonomy::add_error_type_clauses_filter() for the filtering of the 'where' clause, based on the query vars.
 	 * @param string      $url The $url to redirect to.
 	 * @param WP_Taxonomy $tax The WP_Taxonomy object.
 	 * @return string The filtered URL.
@@ -694,7 +694,7 @@ class AMP_Validation_Error_Taxonomy {
 			&&
 			in_array(
 				$_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ], // WPCS: CSRF OK.
-				self::get_error_types(),
+				array_merge( self::get_error_types(), array( strval( self::NO_FILTER_VALUE ) ) ),
 				true
 			)
 		) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -895,7 +895,7 @@ class AMP_Validation_Error_Taxonomy {
 		$taxonomy_caps = (object) get_taxonomy( self::TAXONOMY_SLUG )->cap; // Yes, cap is an object not an array.
 		add_submenu_page(
 			AMP_Options_Manager::OPTION_NAME,
-			esc_html__( 'Errors by Type', 'amp' ),
+			$menu_item_label,
 			$menu_item_label,
 			$taxonomy_caps->manage_terms,
 			// The following esc_attr() is sadly needed due to <https://github.com/WordPress/wordpress-develop/blob/4.9.5/src/wp-admin/menu-header.php#L201>.

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -93,14 +93,26 @@ class AMP_Validation_Error_Taxonomy {
 	const INVALID_ATTRIBUTE_CODE = 'invalid_attribute';
 
 	/**
-	 * The 'type' of error that applies to most errors with the 'code' of 'invalid_element' and 'invalid_attribute'.
+	 * The 'type' of error for invalid HTML elements, like <frame>.
 	 *
+	 * These usually have the 'code' of 'invalid_element'.
 	 * Except for 'invalid_element' errors for a <script>, which have the JS_ERROR_TYPE.
-	 * This allows filtering by type in the taxonomy page, like displaying only HTML errors, or only CSS errors.
+	 * This allows filtering by type in the taxonomy page, like displaying only HTML element errors, or only CSS errors.
 	 *
 	 * @var string
 	 */
-	const HTML_ERROR_TYPE = 'html_error';
+	const HTML_ELEMENT_ERROR_TYPE = 'html_element_error';
+
+	/**
+	 * The 'type' of error for invalid HTML attributes.
+	 *
+	 * These usually have the 'code' of 'invalid_attribute'.
+	 * Banned attributes include i-amp-*.
+	 * But on* attributes, like onclick, have the JS_ERROR_TYPE.
+	 *
+	 * @var string
+	 */
+	const HTML_ATTRIBUTE_ERROR_TYPE = 'html_attribute_error';
 
 	/**
 	 * The 'type' of error that applies to the error 'code' of 'invalid_element' when the node is a <script>.
@@ -695,7 +707,7 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		$type = strval( $_GET[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] ); // WPCS: CSRF ok.
-		if ( ! in_array( $type, array( self::HTML_ERROR_TYPE, self::JS_ERROR_TYPE, self::CSS_ERROR_TYPE ), true ) ) {
+		if ( ! in_array( $type, array( self::HTML_ELEMENT_ERROR_TYPE, self::HTML_ATTRIBUTE_ERROR_TYPE, self::JS_ERROR_TYPE, self::CSS_ERROR_TYPE ), true ) ) {
 			return;
 		}
 		add_filter( 'terms_clauses', function( $clauses, $taxonomies ) use ( $type ) {
@@ -789,7 +801,8 @@ class AMP_Validation_Error_Taxonomy {
 			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error type', 'amp' ); ?></label>
 			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>">
 				<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Error Types', 'amp' ); ?></option>
-				<option value="<?php echo esc_attr( self::HTML_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML Error', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::HTML_ELEMENT_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ELEMENT_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML (Element) Error', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ATTRIBUTE_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML (Attribute) Error', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>><?php esc_html_e( 'JS Error', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>><?php esc_html_e( 'CSS Error', 'amp' ); ?></option>
 			</select>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -843,7 +843,6 @@ class AMP_Validation_Error_Taxonomy {
 		global $wp_query;
 		$screen_base = get_current_screen()->base;
 
-
 		if ( 'edit-tags' === $screen_base ) {
 			// The taxonomy page.
 			$possible_with_text  = '';

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -164,13 +164,13 @@ class AMP_Validation_Error_Taxonomy {
 
 		register_taxonomy( self::TAXONOMY_SLUG, AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG, array(
 			'labels'             => array(
-				'name'                  => _x( 'AMP Validation Errors', 'taxonomy general name', 'amp' ),
+				'name'                  => _x( 'Errors by Type', 'taxonomy general name', 'amp' ),
 				'singular_name'         => _x( 'AMP Validation Error', 'taxonomy singular name', 'amp' ),
 				'search_items'          => __( 'Search AMP Validation Errors', 'amp' ),
 				'all_items'             => __( 'All AMP Validation Errors', 'amp' ),
 				'edit_item'             => __( 'Edit AMP Validation Error', 'amp' ),
 				'update_item'           => __( 'Update AMP Validation Error', 'amp' ),
-				'menu_name'             => __( 'Validation Errors', 'amp' ),
+				'menu_name'             => __( 'Errors by Type', 'amp' ),
 				'back_to_items'         => __( 'Back to AMP Validation Errors', 'amp' ),
 				'popular_items'         => __( 'Frequent Validation Errors', 'amp' ),
 				'view_item'             => __( 'View Validation Error', 'amp' ),
@@ -884,7 +884,7 @@ class AMP_Validation_Error_Taxonomy {
 	 * Show AMP validation errors under AMP admin menu.
 	 */
 	public static function add_admin_menu_validation_error_item() {
-		$menu_item_label = esc_html__( 'Validation Errors', 'amp' );
+		$menu_item_label = esc_html__( 'Errors by Type', 'amp' );
 		$new_error_count = self::get_validation_error_count( array(
 			'group' => self::VALIDATION_ERROR_NEW_STATUS,
 		) );
@@ -895,7 +895,7 @@ class AMP_Validation_Error_Taxonomy {
 		$taxonomy_caps = (object) get_taxonomy( self::TAXONOMY_SLUG )->cap; // Yes, cap is an object not an array.
 		add_submenu_page(
 			AMP_Options_Manager::OPTION_NAME,
-			esc_html__( 'Validation Errors', 'amp' ),
+			esc_html__( 'Errors by Type', 'amp' ),
 			$menu_item_label,
 			$taxonomy_caps->manage_terms,
 			// The following esc_attr() is sadly needed due to <https://github.com/WordPress/wordpress-develop/blob/4.9.5/src/wp-admin/menu-header.php#L201>.

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -69,6 +69,16 @@ class AMP_Validation_Error_Taxonomy {
 	const VALIDATION_ERROR_TYPE_QUERY_VAR = 'amp_validation_error_type';
 
 	/**
+	 * The <option> value to not filter at all, like for 'All Statuses'.
+	 *
+	 * This is also used in WP_List_Table, like for the 'Bulk Actions' option.
+	 * When this is present, this ensures that this isn't filtered.
+	 *
+	 * @var int
+	 */
+	const NO_FILTER_VALUE = -1;
+
+	/**
 	 * Validation code for an invalid element.
 	 *
 	 * @var string
@@ -622,7 +632,11 @@ class AMP_Validation_Error_Taxonomy {
 			if (
 				isset( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) // WPCS: CSRF OK.
 				&&
-				in_array( intval( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), array( self::VALIDATION_ERROR_NEW_STATUS, self::VALIDATION_ERROR_ACCEPTED_STATUS, self::VALIDATION_ERROR_REJECTED_STATUS ), true ) // WPCS: CSRF OK.
+				in_array(
+					intval( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), // WPCS: CSRF OK.
+					array( self::VALIDATION_ERROR_NEW_STATUS, self::VALIDATION_ERROR_ACCEPTED_STATUS, self::VALIDATION_ERROR_REJECTED_STATUS, self::NO_FILTER_VALUE ),
+					true
+				)
 			) {
 				$url = add_query_arg(
 					self::VALIDATION_ERROR_STATUS_QUERY_VAR,
@@ -693,7 +707,6 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 
-
 		// Only display <option> for each status if it actually has errors associated with it.
 		$total_term_count          = self::get_validation_error_count();
 		$rejected_term_count       = self::get_validation_error_count( array( 'group' => self::VALIDATION_ERROR_REJECTED_STATUS ) );
@@ -707,7 +720,7 @@ class AMP_Validation_Error_Taxonomy {
 		<div id="<?php echo esc_attr( $div_id ); ?>" class="alignleft actions">
 			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error status', 'amp' ); ?></label>
 			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">
-				<option value="-1"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Statuses', 'amp' ); ?></option>
 				<?php if ( $new_term_count ) : ?>
 					<option value="<?php echo esc_attr( self::VALIDATION_ERROR_NEW_STATUS ); ?>" <?php selected( $error_status_filter_value, self::VALIDATION_ERROR_NEW_STATUS ); ?>><?php esc_html_e( 'New Error', 'amp' ); ?></option>
 				<?php endif; ?>
@@ -721,7 +734,7 @@ class AMP_Validation_Error_Taxonomy {
 
 			<label for="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" class="screen-reader-text"><?php esc_html_e( 'Filter by error type', 'amp' ); ?></label>
 			<select name="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_TYPE_QUERY_VAR ); ?>">
-				<option value="-1"><?php esc_html_e( 'All Error Types', 'amp' ); ?></option>
+				<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All Error Types', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::HTML_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::HTML_ERROR_TYPE ); ?>><?php esc_html_e( 'HTML Error', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::JS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::JS_ERROR_TYPE ); ?>><?php esc_html_e( 'JS Error', 'amp' ); ?></option>
 				<option value="<?php echo esc_attr( self::CSS_ERROR_TYPE ); ?>" <?php selected( $error_type_filter_value, self::CSS_ERROR_TYPE ); ?>><?php esc_html_e( 'CSS Error', 'amp' ); ?></option>

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -251,7 +251,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$expected_error['node_name'] = 'link';
 		unset( $expected_error['node_attributes']['src'] );
 		$expected_error['node_attributes']['href'] = 'http://example.com/bad.css?ver=__normalized__';
-		$expected_error['type']                    = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+		$expected_error['type']                    = AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE;
 		add_filter( 'amp_validation_error_sanitized', '__return_false' );
 		AMP_Validation_Manager::reset_validation_results();
 		$parent->appendChild( $child );

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -296,7 +296,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 								'id'     => 'bar',
 								'onload' => 'someFunc()',
 							),
-						'type'               => AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
+						'type'               => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 					),
 					$error
 				);
@@ -323,7 +323,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 								'id'     => 'bar',
 								'onload' => 'someFunc()',
 							),
-						'type'               => AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
+						'type'               => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 					),
 					$error
 				);

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -221,6 +221,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'foo'             => 'bar',
 			'sources'         => null,
+			'type'            => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 		);
 
 		// Test sanitized.
@@ -250,6 +251,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$expected_error['node_name'] = 'link';
 		unset( $expected_error['node_attributes']['src'] );
 		$expected_error['node_attributes']['href'] = 'http://example.com/bad.css?ver=__normalized__';
+		$expected_error['type']                    = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
 		add_filter( 'amp_validation_error_sanitized', '__return_false' );
 		AMP_Validation_Manager::reset_validation_results();
 		$parent->appendChild( $child );
@@ -294,6 +296,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 								'id'     => 'bar',
 								'onload' => 'someFunc()',
 							),
+						'type'               => AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
 					),
 					$error
 				);
@@ -320,6 +323,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 								'id'     => 'bar',
 								'onload' => 'someFunc()',
 							),
+						'type'               => AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
 					),
 					$error
 				);

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1114,7 +1114,8 @@ EOB;
 			$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom, array(
 				'validation_error_callback' => function( $error, $context ) use ( $that, $expected_errors, &$error_index ) {
 					$expected = $expected_errors[ $error_index ];
-					$tag      = $expected['node_name'];
+					$expected['type'] = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+					$tag = $expected['node_name'];
 					$that->assertEquals( $expected, $error );
 					$that->assertInstanceOf( 'DOMElement', $context['node'] );
 					$that->assertEquals( $tag, $context['node']->tagName );

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1114,7 +1114,7 @@ EOB;
 			$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom, array(
 				'validation_error_callback' => function( $error, $context ) use ( $that, $expected_errors, &$error_index ) {
 					$expected = $expected_errors[ $error_index ];
-					$expected['type'] = AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE;
+					$expected['type'] = AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE;
 					$tag = $expected['node_name'];
 					$that->assertEquals( $expected, $error );
 					$that->assertInstanceOf( 'DOMElement', $context['node'] );

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -86,8 +86,8 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'add_meta_boxes', array( self::TESTED_CLASS, 'add_meta_boxes' ) ) );
 		$this->assertEquals( 10, has_action( 'edit_form_top', array( self::TESTED_CLASS, 'print_url_as_title' ) ) );
 		$this->assertEquals( 10, has_filter( 'the_title', array( self::TESTED_CLASS, 'filter_the_title_in_post_list_table' ) ) );
+		$this->assertEquals( 10, has_filter( 'restrict_manage_posts', array( self::TESTED_CLASS, 'render_post_filters' ), 10, 2 ) );
 
-		$this->assertEquals( 10, has_filter( 'views_edit-' . AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG, array( self::TESTED_CLASS, 'filter_views_edit' ) ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG . '_posts_columns', array( self::TESTED_CLASS, 'add_post_columns' ) ) );
 		$this->assertEquals( 10, has_action( 'manage_posts_custom_column', array( self::TESTED_CLASS, 'output_custom_column' ) ) );
 		$this->assertEquals( 10, has_filter( 'post_row_actions', array( self::TESTED_CLASS, 'filter_row_actions' ) ) );
@@ -431,66 +431,6 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 		// Re-storing results updates freshness.
 		AMP_Invalid_URL_Post_Type::store_validation_errors( array( $error ), home_url( '/' ), $invalid_url_post_id );
 		$this->assertEmpty( AMP_Invalid_URL_Post_Type::get_post_staleness( $invalid_url_post_id ) );
-	}
-
-	/**
-	 * Test filter_views_edit.
-	 *
-	 * @covers \AMP_Invalid_URL_Post_Type::filter_views_edit()
-	 */
-	public function test_filter_views_edit() {
-		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php?post_type=amp_invalid_url&amp_validation_error_status=0';
-
-		add_theme_support( 'amp', array( 'paired' => true ) );
-		AMP_Validation_Manager::init();
-		AMP_Validation_Error_Taxonomy::add_admin_hooks();
-		$post = $this->factory()->post->create();
-		$this->assertEmpty( AMP_Invalid_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ) ) );
-
-		add_filter( 'amp_validation_error_sanitized', function( $sanitized, $error ) {
-			if ( 'accepted' === $error['code'] ) {
-				$sanitized = true;
-			} elseif ( 'rejected' === $error['code'] ) {
-				$sanitized = false;
-			}
-			return $sanitized;
-		}, 10, 2 );
-
-		$errors = array(
-			array( 'code' => 'accepted' ),
-			array( 'code' => 'rejected' ),
-			array( 'code' => 'new' ),
-		);
-
-		$invalid_url_post_id = AMP_Invalid_URL_Post_Type::store_validation_errors(
-			$errors,
-			get_permalink( $post )
-		);
-		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
-
-		$views = AMP_Invalid_URL_Post_Type::filter_views_edit( array(
-			'publish' => 'Published',
-		) );
-
-		$this->assertArrayNotHasKey( 'publish', $views );
-		$this->assertContains( '(1)', $views['new'] );
-		$this->assertContains( '(1)', $views['rejected'] );
-		$this->assertContains( '(1)', $views['accepted'] );
-
-		$terms = get_terms( array( 'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ) );
-		foreach ( $terms as $term ) {
-			wp_update_term( $term->term_id, AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array(
-				'term_group' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS,
-			) );
-		}
-
-		$views = AMP_Invalid_URL_Post_Type::filter_views_edit( array(
-			'publish' => 'Published',
-		) );
-		$this->assertArrayNotHasKey( 'publish', $views );
-		$this->assertContains( '(0)', $views['new'] );
-		$this->assertContains( '(0)', $views['rejected'] );
-		$this->assertContains( '(1)', $views['accepted'] );
 	}
 
 	/**
@@ -1133,6 +1073,55 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			'post_type' => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
 		) );
 		$this->assertEquals( '/baz', AMP_Invalid_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post_correct_post_type ) );
+	}
+
+	/**
+	 * Test render_post_filters.
+	 *
+	 * @covers \AMP_Validation_Error_Taxonomy::render_post_filters()
+	 */
+	public function test_render_post_filters() {
+		set_current_screen( 'edit.php' );
+		$number_of_errors = 20;
+		for ( $i = 0; $i < $number_of_errors; $i++ ) {
+			$invalid_url_post      = $this->factory()->post->create( array( 'post_type' => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ) );
+			$validation_error_term = $this->factory()->term->create( array(
+				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
+				'description' => wp_json_encode( $this->get_mock_errors() ),
+				'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS,
+			) );
+
+			// Associate the validation error term with a URL.
+			wp_set_post_terms(
+				$invalid_url_post,
+				$validation_error_term,
+				AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG
+			);
+		}
+
+		$new_error_count               = sprintf(
+			'New Errors <span class="count">(%d)</span>',
+			$number_of_errors
+		);
+		$correct_post_type             = AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG;
+		$wrong_post_type               = 'page';
+		$correct_which_second_argument = 'top';
+		$wrong_which_second_argument   = 'bottom';
+
+		// This has an incorrect post type as the first argument, so it should not output anything.
+		ob_start();
+		AMP_Invalid_URL_Post_Type::render_post_filters( $wrong_post_type, $correct_which_second_argument );
+		$this->assertEmpty( ob_get_clean() );
+
+		// This has an incorrect second argument, so again it should not output anything.
+		ob_start();
+		AMP_Invalid_URL_Post_Type::render_post_filters( $correct_post_type, $wrong_which_second_argument );
+		$this->assertEmpty( ob_get_clean() );
+
+		// This is now on the invalid URL post type edit.php screen, so it should output a <select> element.
+		ob_start();
+		AMP_Invalid_URL_Post_Type::render_post_filters( $correct_post_type, $correct_which_second_argument );
+		$this->assertContains( $new_error_count, ob_get_clean() );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -461,6 +461,14 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::render_taxonomy_filter()
 	 */
 	public function test_render_taxonomy_filter() {
+		AMP_Validation_Error_Taxonomy::register();
+		// Create one new error.
+		$this->factory()->term->create( array(
+			'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
+			'description' => wp_json_encode( $this->get_mock_error() ),
+			'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS,
+		) );
+
 		// When passing the wrong $taxonomy_name to the method, it should not output anything.
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_taxonomy_filter( 'category' );
@@ -482,6 +490,19 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		foreach ( $expected_to_contain as $expected ) {
 			$this->assertContains( $expected, $markup );
 		}
+
+		// When there is one new error, the <option> for this status in the filter should have (1) after the status name.
+		$this->assertContains( 'New Error <span class="count">(1)</span>', $markup );
+
+		// When there are two new errors, the <option> text should be plural, and have a count of (2).
+		$this->factory()->term->create( array(
+			'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
+			'description' => wp_json_encode( $this->get_mock_error() ),
+			'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS,
+		) );
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_taxonomy_filter( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		$this->assertContains( 'New Errors <span class="count">(2)</span>', ob_get_clean() );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -360,6 +360,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_group_terms_clauses_filter' ) ) );
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_error_type_clauses_filter' ) ) );
 		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'render_taxonomy_filters' ) ) ) );
+		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'render_link_to_errors_by_url' ) ) ) );
 		$this->assertEquals( 10, has_filter( 'user_has_cap', array( self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ) ) );
 		$this->assertEquals( 10, has_filter( 'terms_clauses', array( self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', array( self::TESTED_CLASS, 'add_admin_notices' ) ) );
@@ -519,6 +520,32 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_taxonomy_filters( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
 		$this->assertContains( 'New Errors <span class="count">(2)</span>', ob_get_clean() );
+	}
+
+	/**
+	 * Test render_link_to_errors_by_url.
+	 *
+	 * @covers \AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url()
+	 */
+	public function test_render_link_to_errors_by_url() {
+		// When passing the wrong $taxomomy argument, this should not render anything.
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url( 'category' );
+		$this->assertEmpty( ob_get_clean() );
+
+		// When passing the correct taxonomy, this should render the link.
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		$output = ob_get_clean();
+		$this->assertContains( 'View errors by URL', $output );
+		$this->assertContains(
+			add_query_arg(
+				'post_type',
+				AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
+				admin_url( 'edit.php' )
+			),
+			$output
+		);
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -387,8 +387,8 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( $initial_url, AMP_Validation_Error_Taxonomy::add_term_filter_query_var( $initial_url, $wrong_taxonomy ) );
 
 		// The $_POST has the VALIDATION_ERROR_TYPE_QUERY_VAR, but does not have a $taxonomy of AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG.
-		$query_var_value = AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE;
-		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ] = $query_var_value;
+		$type_query_var_value = AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE;
+		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ] = $type_query_var_value;
 		$this->assertEquals( $initial_url, AMP_Validation_Error_Taxonomy::add_term_filter_query_var( $initial_url, $wrong_taxonomy ) );
 
 		// The $_POST has the taxonomy, but does not have the right 'post_type'.
@@ -400,7 +400,18 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$_POST['post_type'] = AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG;
 		$expected_url       = add_query_arg(
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR,
-			$query_var_value,
+			$type_query_var_value,
+			$initial_url
+		);
+		$this->assertEquals( $expected_url, AMP_Validation_Error_Taxonomy::add_term_filter_query_var( $initial_url, $correct_taxonomy ) );
+
+		// The $_POST has a value for the accepted status, so this method should pass that to the redirect URL as a query var.
+		$status_query_var_value = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS;
+		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR ] = $status_query_var_value;
+		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ]   = null;
+		$expected_url = add_query_arg(
+			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR,
+			$status_query_var_value,
 			$initial_url
 		);
 		$this->assertEquals( $expected_url, AMP_Validation_Error_Taxonomy::add_term_filter_query_var( $initial_url, $correct_taxonomy ) );

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -331,7 +331,6 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'tag_row_actions', array( self::TESTED_CLASS, 'filter_tag_row_actions' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', array( self::TESTED_CLASS, 'add_admin_menu_validation_error_item' ) ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_custom_column', array( self::TESTED_CLASS, 'filter_manage_custom_columns' ) ) );
-		$this->assertEquals( 10, has_filter( 'views_edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'filter_views_edit' ) ) );
 		$this->assertEquals( 10, has_filter( 'posts_where', array( self::TESTED_CLASS, 'filter_posts_where_for_validation_error_status' ) ) );
 		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'handle_validation_error_update' ) ) );
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'handle_inline_edit_request' ) ) );
@@ -618,29 +617,6 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		);
 		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );
-	}
-
-	/**
-	 * Test filter_views_edit.
-	 *
-	 * @covers \AMP_Validation_Error_Taxonomy::filter_views_edit()
-	 */
-	public function test_filter_views_edit() {
-		AMP_Validation_Error_Taxonomy::register();
-		$views = AMP_Validation_Error_Taxonomy::filter_views_edit( array() );
-		$this->assertContains( 'Accepted', $views['accepted'] );
-		$this->assertContains( '(0)', $views['accepted'] );
-
-		$this->assertContains( 'All', $views['all'] );
-		$this->assertContains( '(0)', $views['all'] );
-
-		$this->assertContains( 'New', $views['new'] );
-		$this->assertContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $views['new'] );
-		$this->assertContains( '(0)', $views['new'] );
-
-		$this->assertContains( 'Rejected', $views['rejected'] );
-		$this->assertContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $views['rejected'] );
-		$this->assertContains( '(0)', $views['rejected'] );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -505,7 +505,8 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 
 		$expected_to_contain = array(
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR,
-			AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
+			AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE,
+			AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE,
 			AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 			AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 			'<script>',

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -60,7 +60,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( array( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ), $taxonomy_object->object_type );
 
 		$labels = $taxonomy_object->labels;
-		$this->assertEquals( 'AMP Validation Errors', $labels->name );
+		$this->assertEquals( 'Errors by Type', $labels->name );
 		$this->assertEquals( 'AMP Validation Error', $labels->singular_name );
 		$this->assertEquals( 'Search AMP Validation Errors', $labels->search_items );
 		$this->assertEquals( 'All AMP Validation Errors', $labels->all_items );

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -276,12 +276,23 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( $initial_where, AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query ) );
 
 		// The entire conditional should now be true, so this should filter the WHERE clause.
-		$wp_query->set( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, 1 );
+		$error_status = 1;
+		$wp_query->set( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $error_status );
 		$filtered_where = AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query );
 		$this->assertContains( 'SELECT 1', $filtered_where );
 		$this->assertContains( 'INNER JOIN', $filtered_where );
 		$this->assertContains( $wpdb->term_relationships, $filtered_where );
 		$this->assertContains( $wpdb->term_taxonomy, $filtered_where );
+		$this->assertContains( strval( $error_status ), $filtered_where );
+
+		// Now that there is a query var for error type, that should also appear in the filtered WHERE clause.
+		$error_type         = 'js_error';
+		$escaped_error_type = 'js\\\\_error';
+		$wp_query->set( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR, $error_type );
+		$filtered_where = AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query );
+		$this->assertContains( 'SELECT 1', $filtered_where );
+		$this->assertContains( strval( $error_status ), $filtered_where );
+		$this->assertContains( $escaped_error_type, $filtered_where );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -658,6 +658,15 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 			),
 			$markup
 		);
+
+		// On the edit-tags.php page, the <option> text should not have 'With', like 'With JS Errors'.
+		$this->assertNotContains( 'With', $markup );
+
+		// On the edit.php page (Errors by URL), the <option> text should have 'With', like 'With JS Errors'.
+		set_current_screen( 'edit.php' );
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_taxonomy_filters( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		$this->assertContains( 'With', ob_get_clean() );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -324,6 +324,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'redirect_term_location', array( self::TESTED_CLASS, 'add_term_filter_query_var' ) ) );
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_group_terms_clauses_filter' ) ) );
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_error_type_clauses_filter' ) ) );
+		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'render_taxonomy_filter' ) ) ) );
 		$this->assertEquals( 10, has_filter( 'user_has_cap', array( self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ) ) );
 		$this->assertEquals( 10, has_filter( 'terms_clauses', array( self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', array( self::TESTED_CLASS, 'add_admin_notices' ) ) );
@@ -442,6 +443,35 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		// If $taxonomies does not have the AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, the filter should return the clauses unchanged.
 		$taxonomies = array( 'post_tag' );
 		$this->assertEquals( $initial_clauses, apply_filters( $tested_filter, $initial_clauses, $taxonomies ) );
+	}
+
+	/**
+	 * Test render_taxonomy_filter.
+	 *
+	 * @covers \AMP_Validation_Error_Taxonomy::render_taxonomy_filter()
+	 */
+	public function test_render_taxonomy_filter() {
+		// When passing the wrong $taxonomy_name to the method, it should not output anything.
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_taxonomy_filter( 'category' );
+		$this->assertEmpty( ob_get_clean() );
+
+		// With the correct taxonomy name, the strings below should be present.
+		ob_start();
+		AMP_Validation_Error_Taxonomy::render_taxonomy_filter( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		$markup = ob_get_clean();
+
+		$expected_to_contain = array(
+			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR,
+			AMP_Validation_Error_Taxonomy::HTML_ERROR_TYPE,
+			AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
+			AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
+			'<script>',
+		);
+
+		foreach ( $expected_to_contain as $expected ) {
+			$this->assertContains( $expected, $markup );
+		}
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -605,6 +605,18 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_error_types.
+	 *
+	 * @covers \AMP_Validation_Error_Taxonomy::get_error_types()
+	 */
+	public function test_get_error_types() {
+		$this->assertEquals(
+			array( 'html_element_error', 'html_attribute_error', 'js_error', 'css_error' ),
+			AMP_Validation_Error_Taxonomy::get_error_types()
+		);
+	}
+
+	/**
 	 * Test render_error_type_filter.
 	 *
 	 * @covers \AMP_Validation_Error_Taxonomy::render_error_type_filter()

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -535,10 +535,19 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 
 		$number_of_errors = 10;
 		for ( $i = 0; $i < $number_of_errors; $i++ ) {
-			$this->factory()->term->create( array(
+			$invalid_url_post      = $this->factory()->post->create( array( 'post_type' => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ) );
+			$validation_error_term = $this->factory()->term->create( array(
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $this->get_mock_error() ),
+				'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_STATUS,
 			) );
+
+			// Associate the validation error term with a URL so that it appears in a query.
+			wp_set_post_terms(
+				$invalid_url_post,
+				$validation_error_term,
+				AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG
+			);
 		}
 
 		/*

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -562,15 +562,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		AMP_Validation_Error_Taxonomy::render_error_status_filter();
 		$this->assertEmpty( ob_get_clean() );
 
-		/*
-		 * This is now on the correct screen, so it shouldn't be empty anymore.
-		 * When no validation error exists, there should not be an <option> for any specific error status, like 'New Error'.
-		 */
 		set_current_screen( 'edit.php' );
-		ob_start();
-		AMP_Validation_Error_Taxonomy::render_error_status_filter();
-		$this->assertNotContains( 'New Error', ob_get_clean() );
-
 		$number_of_errors = 10;
 		for ( $i = 0; $i < $number_of_errors; $i++ ) {
 			$invalid_url_post      = $this->factory()->post->create( array( 'post_type' => AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ) );

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -55,7 +55,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertFalse( $taxonomy_object->hierarchical );
 		$this->assertTrue( $taxonomy_object->show_in_menu );
 		$this->assertFalse( $taxonomy_object->meta_box_cb );
-		$this->assertEquals( 'AMP Validation Errors', $taxonomy_object->label );
+		$this->assertEquals( 'Errors by Type', $taxonomy_object->label );
 		$this->assertEquals( 'do_not_allow', $taxonomy_object->cap->assign_terms );
 		$this->assertEquals( array( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ), $taxonomy_object->object_type );
 
@@ -66,7 +66,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$this->assertEquals( 'All AMP Validation Errors', $labels->all_items );
 		$this->assertEquals( 'Edit AMP Validation Error', $labels->edit_item );
 		$this->assertEquals( 'Update AMP Validation Error', $labels->update_item );
-		$this->assertEquals( 'Validation Errors', $labels->menu_name );
+		$this->assertEquals( 'Errors by Type', $labels->menu_name );
 		$this->assertEquals( 'Back to AMP Validation Errors', $labels->back_to_items );
 		$this->assertEquals( 'Frequent Validation Errors', $labels->popular_items );
 		$this->assertEquals( 'View Validation Error', $labels->view_item );
@@ -610,10 +610,10 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
 		$expected_submenu = array(
-			'Validation Errors',
+			'Errors by Type',
 			'manage_categories',
 			'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_invalid_url',
-			'Validation Errors',
+			'Errors by Type',
 		);
 		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter,
Could you please review this PR for error status and type filters?

Because `amp_validation_error` terms now has a `type` in the `description`, you might want to delete from your local environment all of the `amp_invalid_url` posts and `amp_validation_error` terms. And then run the [WP-CLI validation](https://github.com/Automattic/amp-wp/pull/1183#issuecomment-416790196) again.


* Adds status and type filters to the `amp_invalid_url` post (edit.php) and `amp_validation_error` taxonomy (edit-tags.php) pages. This modifies the existing status links from before.
<img width="813" alt="filters-on-both-pages" src="https://user-images.githubusercontent.com/4063887/45004224-795c5800-afb0-11e8-9b5f-fa8e585affb0.png">


* [Applies](https://github.com/Automattic/amp-wp/pull/1373#issuecomment-417131336) the new 'Errors by Type' terminology from the [design](https://sketch.cloud/s/Vow17/all/page-1/amp-validation-errors).
* Based on @westonruter's [suggestion](https://github.com/Automattic/amp-wp/issues/1360#issuecomment-416448944) in #1360, this adds a `type` to the `amp_validation_error` term `description`.
* There are now 4 error types, stored in the description: `html_element_error`, `html_attribute_error`, `js_error`, and `css_error`.

Closes #1360, #1363.