### PR TITLE
Ensure expected notice is hidden when theme support enabled by theme

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -291,15 +291,33 @@ class AMP_Options_Menu {
 			<?php endif; ?>
 
 			<script>
-				jQuery( 'input[type=radio][name="amp-options[theme_support]"]' ).change( function() {
-					jQuery( '.amp-force-sanitize' ).toggleClass( 'hidden', 'native' === this.value );
-					jQuery( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === this.value );
-					jQuery( '.amp-force-sanitize-canonical' ).toggleClass( 'hidden', 'native' !== this.value );
-					jQuery( '#force_sanitization' ).trigger( 'change' );
-				} ).filter( ':checked' ).trigger( 'change' );
-				jQuery( '#force_sanitization' ).change( function() {
-					jQuery( '.amp-tree-shaking' ).toggleClass( 'hidden', this.checked && 'native' !== jQuery( 'input[type=radio][name="amp-options[theme_support]"]:checked' ).val() );
-				} ).trigger( 'change' );
+			(function( $ ) {
+				var getThemeSupportMode = function() {
+					var checkedInput = $( 'input[type=radio][name="amp-options[theme_support]"]:checked' );
+					if ( 0 === checkedInput.length ) {
+						return <?php echo wp_json_encode( amp_is_canonical() ? 'native' : 'paired' ); ?>;
+					}
+					return checkedInput.val();
+				};
+
+				var updateTreeShakingHiddenClass = function() {
+					var checkbox = $( '#force_sanitization' );
+					$( '.amp-tree-shaking' ).toggleClass( 'hidden', checkbox.prop( 'checked' ) && 'native' !== getThemeSupportMode() );
+				};
+
+				var updateHiddenClasses = function() {
+					var themeSupportMode = getThemeSupportMode();
+					$( '.amp-force-sanitize' ).toggleClass( 'hidden', 'native' === themeSupportMode );
+					$( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === themeSupportMode );
+					$( '.amp-force-sanitize-canonical' ).toggleClass( 'hidden', 'native' !== themeSupportMode );
+					updateTreeShakingHiddenClass();
+				};
+
+				$( 'input[type=radio][name="amp-options[theme_support]"]' ).change( updateHiddenClasses );
+				$( '#force_sanitization' ).change( updateTreeShakingHiddenClass );
+
+				updateHiddenClasses();
+			})( jQuery );
 			</script>
 
 			<p>


### PR DESCRIPTION
Fixes #1358.

# Before

## When `native` support added by theme

```php
add_theme_support('amp');
```

![image](https://user-images.githubusercontent.com/134745/44760740-158be800-aaf5-11e8-9598-ca6982e50384.png)

The notice appears but the checkbox should be hidden.

## When `paired` support added by theme

```php
add_theme_support( 'amp', array(
	'paired' => true,
) );
```

![image](https://user-images.githubusercontent.com/134745/44760776-410ed280-aaf5-11e8-846f-58f859ce1093.png)

The checkbox appears but the notice should be hidden.

# After

## Native mode ✅ 

![image](https://user-images.githubusercontent.com/134745/44760810-5b48b080-aaf5-11e8-90e7-9de120743f71.png)

## Paired mode ✅ 

![image](https://user-images.githubusercontent.com/134745/44760820-64d21880-aaf5-11e8-8342-b4f6f2485a23.png)