### PR TITLE
[amp-stories sub-task] Add background color to amp-story-page block

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -1,14 +1,3 @@
-
-.editor-block-list__layout {
-	background-color: #ffdddd;
-}
-.editor-block-list__layout .editor-block-list__layout {
-	background-color: white;
-}
 div[data-type="amp/amp-story-page"] {
 	background-color: #ddffdd;
 }
-div[data-type="amp/amp-story-grid-layer"] {
-	background-color: #ddddff;
-}
-

--- a/blocks/amp-story/amp-story-page.js
+++ b/blocks/amp-story/amp-story-page.js
@@ -113,7 +113,7 @@ export default registerBlockType(
 			return [
 				<InspectorControls key='controls'>
 					<PanelColorSettings
-						title={ __( 'Page Background Color Settings', 'amp' ) }
+						title={ __( 'Background Color Settings', 'amp' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{

--- a/blocks/amp-story/amp-story-page.js
+++ b/blocks/amp-story/amp-story-page.js
@@ -113,13 +113,13 @@ export default registerBlockType(
 			return [
 				<InspectorControls key='controls'>
 					<PanelColorSettings
-						title={ __( 'Background Color Settings' ) }
+						title={ __( 'Page Background Color Settings', 'amp' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{
 								value: attributes.backgroundColor,
 								onChange: onChangeBackgroundColor,
-								label: __( 'AMP Page Background Color', 'amp' )
+								label: __( 'Background Color', 'amp' )
 							}
 						] }
 					/>

--- a/blocks/amp-story/amp-story-page.js
+++ b/blocks/amp-story/amp-story-page.js
@@ -6,7 +6,9 @@ const {
 	registerBlockType
 } = wp.blocks;
 const {
-	InnerBlocks
+	InnerBlocks,
+	PanelColorSettings,
+	InspectorControls
 } = wp.editor;
 const { select } = wp.data;
 const { getBlock } = select( 'core/editor' );
@@ -62,6 +64,10 @@ export default registerBlockType(
 				source: 'attribute',
 				selector: 'amp-story-page',
 				attribute: 'id'
+			},
+			backgroundColor: {
+				type: 'string',
+				default: '#ffffff'
 			}
 		},
 
@@ -78,10 +84,13 @@ export default registerBlockType(
 		 * */
 
 		edit( props ) {
-			const { setAttributes } = props;
+			const { setAttributes, attributes } = props;
+			const onChangeBackgroundColor = newBackgroundColor => {
+				setAttributes( { backgroundColor: newBackgroundColor } );
+			};
 
 			// If the page ID is not set, add one.
-			if ( ! props.attributes.id ) {
+			if ( ! attributes.id ) {
 				setAttributes( { id: uuid() } );
 			}
 			const block = getBlock( props.clientId );
@@ -101,15 +110,30 @@ export default registerBlockType(
 				grids = 1;
 			}
 
-			return (
+			return [
+				<InspectorControls key='controls'>
+					<PanelColorSettings
+						title={ __( 'Background Color Settings' ) }
+						initialOpen={ false }
+						colorSettings={ [
+							{
+								value: attributes.backgroundColor,
+								onChange: onChangeBackgroundColor,
+								label: __( 'AMP Page Background Color', 'amp' )
+							}
+						] }
+					/>
+				</InspectorControls>,
 				// Get the template dynamically.
-				<InnerBlocks key='contents' template={ getStoryPageTemplate( grids, hasCTALayer ) } allowedBlocks={ ALLOWED_BLOCKS } />
-			);
+				<div key="contents" style={{ backgroundColor: attributes.backgroundColor }}>
+					<InnerBlocks template={ getStoryPageTemplate( grids, hasCTALayer ) } allowedBlocks={ ALLOWED_BLOCKS } />
+				</div>
+			];
 		},
 
 		save( { attributes } ) {
 			return (
-				<amp-story-page id={ attributes.id }>
+				<amp-story-page style={{ backgroundColor: attributes.backgroundColor }} id={ attributes.id }>
 					<InnerBlocks.Content />
 				</amp-story-page>
 			);


### PR DESCRIPTION
This is a sub-PR of #1215 and should be merged to that PR.

The goal of this PR is to add background color setting for the `amp-story-page` block. The default color is white.

![screen shot 2018-08-29 at 6 05 48 pm](https://user-images.githubusercontent.com/3294597/44797369-b6db7280-abb7-11e8-8747-2418670dc1cb.png)
