### PR TITLE
Add support for reference points and update spec to file revision 720 (v1534879991178)

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -330,7 +330,7 @@ def ParseRules(out_dir):
 				if tag_spec.HasField('deprecation'):
 					continue
 
-				# Ignore the special $REFERENCE_POINT tag
+				# Handle the special $REFERENCE_POINT tag
 				if '$REFERENCE_POINT' == tag_spec.tag_name:
 					reference_points[ tag_spec.spec_name ] = GetTagSpec(tag_spec, attr_lists)
 					continue

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1133,6 +1133,16 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'reference_points' => array(
+						'AMP-CAROUSEL lightbox [child]' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-CAROUSEL lightbox [lightbox-exclude]' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
 					'requires_extension' => array(
 						'amp-carousel',
 						'amp-lightbox-gallery',
@@ -2754,6 +2764,20 @@ class AMP_Allowed_Tags_Generated {
 							3,
 						),
 					),
+					'reference_points' => array(
+						'AMP-LIVE-LIST [items]' => array(
+							'mandatory' => true,
+							'unique' => true,
+						),
+						'AMP-LIVE-LIST [pagination]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-LIVE-LIST [update]' => array(
+							'mandatory' => true,
+							'unique' => true,
+						),
+					),
 					'requires_extension' => array(
 						'amp-live-list',
 					),
@@ -2790,6 +2814,16 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
+					'reference_points' => array(
+						'AMP-NEXT-PAGE > [separator]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'amp-next-page extension .json configuration' => array(
+							'mandatory' => true,
+							'unique' => true,
+						),
+					),
 					'requires_extension' => array(
 						'amp-next-page',
 					),
@@ -2812,6 +2846,12 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'reference_points' => array(
+						'AMP-NEXT-PAGE > [separator]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+					),
 					'requires_extension' => array(
 						'amp-next-page',
 					),
@@ -3327,6 +3367,16 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 						'amp-selector',
 					),
+					'reference_points' => array(
+						'AMP-SELECTOR child' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-SELECTOR option' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
 					'requires_extension' => array(
 						'amp-selector',
 					),
@@ -3696,6 +3746,12 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-story-page',
+					'reference_points' => array(
+						'AMP-STORY-CTA-LAYER animate-in' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
 				),
 			),
 		),
@@ -3714,6 +3770,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-story-page',
+					'reference_points' => array(
+						'AMP-STORY-GRID-LAYER animate-in' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-STORY-GRID-LAYER default' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
 				),
 			),
 		),
@@ -12376,6 +12442,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-story-auto-ads',
+					'reference_points' => array(
+						'AMP-STORY-GRID-LAYER animate-in' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-STORY-GRID-LAYER default' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
 					'requires_extension' => array(
 						'amp-mustache',
 					),
@@ -13595,6 +13671,305 @@ class AMP_Allowed_Tags_Generated {
 	);
 
 
+	private static $reference_points = array(
+		'AMP-CAROUSEL lightbox [child]' => array(
+			'attr_spec_list' => array(
+				'lightbox-thumbnail-id' => array(
+					'value_regex_casei' => '^[a-z][a-z\\d_-]*',
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-CAROUSEL lightbox [child]',
+			),
+		),
+		'AMP-CAROUSEL lightbox [lightbox-exclude]' => array(
+			'attr_spec_list' => array(
+				'lightbox-exclude' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-CAROUSEL lightbox [lightbox-exclude]',
+			),
+		),
+		'AMP-LIVE-LIST [items]' => array(
+			'attr_spec_list' => array(
+				'items' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'reference_points' => array(
+					'AMP-LIVE-LIST [items] item' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-LIVE-LIST [items]',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#items',
+			),
+		),
+		'AMP-LIVE-LIST [items] item' => array(
+			'attr_spec_list' => array(
+				'data-sort-time' => array(
+					'mandatory' => true,
+				),
+				'data-tombstone' => array(),
+				'data-update-time' => array(),
+				'id' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-LIVE-LIST [items] item',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#items',
+			),
+		),
+		'AMP-LIVE-LIST [pagination]' => array(
+			'attr_spec_list' => array(
+				'pagination' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-LIVE-LIST [pagination]',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#pagination',
+			),
+		),
+		'AMP-LIVE-LIST [update]' => array(
+			'attr_spec_list' => array(
+				'update' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-LIVE-LIST [update]',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#update',
+			),
+		),
+		'AMP-NEXT-PAGE > [separator]' => array(
+			'attr_spec_list' => array(
+				'separator' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'mandatory_parent' => 'amp-next-page',
+				'spec_name' => 'AMP-NEXT-PAGE > [separator]',
+			),
+		),
+		'AMP-SELECTOR child' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'reference_points' => array(
+					'AMP-SELECTOR child' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+					'AMP-SELECTOR option' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-SELECTOR child',
+			),
+		),
+		'AMP-SELECTOR option' => array(
+			'attr_spec_list' => array(
+				'disabled' => array(
+					'value' => array(
+						'',
+					),
+				),
+				'option' => array(
+					'mandatory' => true,
+				),
+				'selected' => array(
+					'value' => array(
+						'',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-SELECTOR option',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-selector',
+			),
+		),
+		'AMP-STORY-CTA-LAYER animate-in' => array(
+			'attr_spec_list' => array(
+				'animate-in' => array(
+					'value' => array(
+						'drop',
+						'fade-in',
+						'fly-in-bottom',
+						'fly-in-left',
+						'fly-in-right',
+						'fly-in-top',
+						'pan-down',
+						'pan-left',
+						'pan-right',
+						'pan-up',
+						'pulse',
+						'rotate-in-left',
+						'rotate-in-right',
+						'twirl-in',
+						'whoosh-in-left',
+						'whoosh-in-right',
+						'zoom-in',
+						'zoom-out',
+					),
+				),
+				'animate-in-after' => array(),
+				'animate-in-delay' => array(),
+				'animate-in-duration' => array(),
+			),
+			'tag_spec' => array(
+				'reference_points' => array(
+					'AMP-STORY-CTA-LAYER animate-in' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-STORY-CTA-LAYER animate-in',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+			),
+		),
+		'AMP-STORY-GRID-LAYER animate-in' => array(
+			'attr_spec_list' => array(
+				'animate-in' => array(
+					'value' => array(
+						'drop',
+						'fade-in',
+						'fly-in-bottom',
+						'fly-in-left',
+						'fly-in-right',
+						'fly-in-top',
+						'pan-down',
+						'pan-left',
+						'pan-right',
+						'pan-up',
+						'pulse',
+						'rotate-in-left',
+						'rotate-in-right',
+						'twirl-in',
+						'whoosh-in-left',
+						'whoosh-in-right',
+						'zoom-in',
+						'zoom-out',
+					),
+				),
+				'animate-in-after' => array(),
+				'animate-in-delay' => array(),
+				'animate-in-duration' => array(),
+			),
+			'tag_spec' => array(
+				'reference_points' => array(
+					'AMP-STORY-GRID-LAYER animate-in' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-STORY-GRID-LAYER animate-in',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+			),
+		),
+		'AMP-STORY-GRID-LAYER default' => array(
+			'attr_spec_list' => array(
+				'align-content' => array(
+					'value' => array(
+						'center',
+						'end',
+						'space-around',
+						'space-between',
+						'space-evenly',
+						'start',
+						'stretch',
+					),
+				),
+				'align-items' => array(
+					'value' => array(
+						'center',
+						'end',
+						'start',
+						'stretch',
+					),
+				),
+				'align-self' => array(
+					'value' => array(
+						'center',
+						'end',
+						'start',
+						'stretch',
+					),
+				),
+				'animate-in' => array(
+					'value' => array(
+						'drop',
+						'fade-in',
+						'fly-in-bottom',
+						'fly-in-left',
+						'fly-in-right',
+						'fly-in-top',
+						'pan-down',
+						'pan-left',
+						'pan-right',
+						'pan-up',
+						'pulse',
+						'rotate-in-left',
+						'rotate-in-right',
+						'twirl-in',
+						'whoosh-in-left',
+						'whoosh-in-right',
+						'zoom-in',
+						'zoom-out',
+					),
+				),
+				'animate-in-after' => array(),
+				'animate-in-delay' => array(),
+				'animate-in-duration' => array(),
+				'grid-area' => array(),
+				'justify-content' => array(
+					'value' => array(
+						'center',
+						'end',
+						'space-around',
+						'space-between',
+						'space-evenly',
+						'start',
+						'stretch',
+					),
+				),
+				'justify-items' => array(
+					'value' => array(
+						'center',
+						'end',
+						'start',
+						'stretch',
+					),
+				),
+				'justify-self' => array(
+					'value' => array(
+						'center',
+						'end',
+						'start',
+						'stretch',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'reference_points' => array(
+					'AMP-STORY-GRID-LAYER animate-in' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-STORY-GRID-LAYER default',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+			),
+		),
+	);
+
+
 	/**
 	 * Get allowed tags.
 	 *
@@ -13617,6 +13992,20 @@ class AMP_Allowed_Tags_Generated {
 	public static function get_allowed_tag( $node_name ) {
 		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
 			return self::$allowed_tags[ $node_name ];
+		}
+		return null;
+	}
+
+	/**
+	 * Get reference point spec.
+	 *
+	 * @since 1.0
+	 * @param string $tag_spec_name Tag spec name.
+	 * @return array|null Reference point spec, or null if does not exist.
+	 */
+	public static function get_reference_point_spec( $tag_spec_name ) {
+		if ( isset( self::$reference_points[ $tag_spec_name ] ) ) {
+			return self::$reference_points[ $tag_spec_name ];
 		}
 		return null;
 	}

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 712;
+	private static $spec_file_revision = 720;
 	private static $minimum_validator_revision_required = 348;
 
 	private static $allowed_tags = array(
@@ -1284,6 +1284,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'when-ended' => array(
 						'value_casei' => array(
+							'continue',
 							'stop',
 						),
 					),
@@ -2340,6 +2341,33 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-image-slider' => array(
+			array(
+				'attr_spec_list' => array(
+					'disable-hint-reappear' => array(),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							9,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-image-slider',
+					),
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
+				),
+			),
+		),
 		'amp-img' => array(
 			array(
 				'attr_spec_list' => array(
@@ -2598,6 +2626,7 @@ class AMP_Allowed_Tags_Generated {
 							9,
 							1,
 							4,
+							5,
 						),
 					),
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-layout',
@@ -2607,6 +2636,7 @@ class AMP_Allowed_Tags_Generated {
 		'amp-lightbox' => array(
 			array(
 				'attr_spec_list' => array(
+					'[open]' => array(),
 					'animate-in' => array(
 						'value_casei' => array(
 							'fade-in',
@@ -2951,6 +2981,11 @@ class AMP_Allowed_Tags_Generated {
 		'amp-pan-zoom' => array(
 			array(
 				'attr_spec_list' => array(
+					'disable-double-tap' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'initial-scale' => array(
 						'value_regex' => '[0-9]+(\\.[0-9]+)?',
 					),
@@ -4097,6 +4132,40 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-viqeo-player' => array(
+			array(
+				'attr_spec_list' => array(
+					'autoplay' => array(),
+					'data-profileid' => array(
+						'mandatory' => true,
+						'value_regex' => '[0-9a-f]*',
+					),
+					'data-videoid' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-viqeo-player',
+					),
+				),
+			),
+		),
 		'amp-vk' => array(
 			array(
 				'attr_spec_list' => array(
@@ -4959,6 +5028,30 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form',
 					'spec_name' => 'FORM DIV [submit-error][template]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'first' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-image-slider',
+					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [first]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'second' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-image-slider',
+					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [second]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
 				),
 			),
 		),
@@ -10099,6 +10192,31 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-image-slider',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-imgur',
 						'version' => array(
 							'0.1',
@@ -11264,6 +11382,31 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-viqeo-player',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-vk',
 						'version' => array(
 							'0.1',
@@ -11916,6 +12059,9 @@ class AMP_Allowed_Tags_Generated {
 					'stroke-miterlimit' => array(),
 					'stroke-opacity' => array(),
 					'stroke-width' => array(),
+					'style' => array(
+						'blacklisted_value_regex' => '!important',
+					),
 					'systemlanguage' => array(),
 					'text-anchor' => array(),
 					'text-decoration' => array(),

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -92,18 +92,6 @@ abstract class AMP_Rule_Spec {
 	);
 
 	/**
-	 *  It is mentioned in the documentation in several places that data-*
-	 *  is generally allowed, but there is no specific rule for it in the
-	 *  protoascii file, so we include it here.
-	 *
-	 * @var array
-	 */
-	public static $whitelisted_attr_regex = array(
-		'@^data-[a-zA-Z][\\w:.-]*$@uis',
-		'(update|item|pagination|option|selected|disabled)', // Allowed for live reference points.
-	);
-
-	/**
 	 * List of boolean attributes.
 	 *
 	 * @since 0.7

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -71,27 +71,6 @@ abstract class AMP_Rule_Spec {
 	);
 
 	/**
-	 * If a node type listed here is invalid, it and it's subtree will be
-	 * removed if it is invalid. This is mainly  because any children will be
-	 * non-functional without this parent.
-	 *
-	 * If a tag is not listed here, it will be replaced by its children if it
-	 * is invalid.
-	 *
-	 * @todo There are other nodes that should probably be listed here as well.
-	 *
-	 * @var array
-	 */
-	public static $node_types_to_remove_if_invalid = array(
-		'form',
-		'input',
-		'link',
-		'meta',
-		'style',
-		// Include 'script' here?
-	);
-
-	/**
 	 * List of boolean attributes.
 	 *
 	 * @since 0.7

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -240,7 +240,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Sanitize the <video> elements from the HTML contained in this instance's DOMDocument.
+	 * Sanitize the elements from the HTML contained in this instance's DOMDocument.
 	 *
 	 * @since 0.5
 	 */
@@ -339,6 +339,30 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 							'\.js$',
 						) ),
 					);
+				}
+
+				if ( ! empty( $node->parentNode ) && isset( $this->allowed_tags[ $node->parentNode->nodeName ] ) ) {
+					foreach ( $this->allowed_tags[ $node->parentNode->nodeName ] as $parent_rule_spec ) {
+						if ( empty( $parent_rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['reference_points'] ) ) {
+							continue;
+						}
+						foreach ( $parent_rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['reference_points'] as $reference_point_spec_name => $reference_point_spec_instance_attrs ) {
+							$reference_point = AMP_Allowed_Tags_Generated::get_reference_point_spec( $reference_point_spec_name );
+							if ( empty( $reference_point[ AMP_Rule_Spec::ATTR_SPEC_LIST ] ) ) {
+								// @todo Need to come up with a solution for 'AMP-SELECTOR child'.
+								continue;
+							}
+							foreach ( $reference_point[ AMP_Rule_Spec::ATTR_SPEC_LIST ] as $attr_name => $reference_point_spec_attr ) {
+								$reference_point_spec_attr = array_merge(
+									$reference_point_spec_attr,
+									$reference_point_spec_instance_attrs
+								);
+								unset( $reference_point_spec_attr['mandatory'] );
+
+								$rule_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ][ $attr_name ] = $reference_point_spec_attr;
+							}
+						}
+					}
 				}
 
 				$rule_spec_list_to_validate[ $id ] = $rule_spec;

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -350,7 +350,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Process a node by sanitizing and/or validating it per.
+	 * Process a node by checking if an element and its attributes are valid, and removing them when invalid.
+	 *
+	 * Attributes which are not valid are removed. Elements which are not allowed are also removed,
+	 * including elements which miss mandatory attributes.
 	 *
 	 * @param DOMNode $node Node.
 	 */

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1508,13 +1508,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return bool Return true if attribute name is valid for this attr_spec_list, false otherwise.
 	 */
 	private function is_amp_allowed_attribute( $attr_name, $attr_spec_list ) {
-		if ( isset( $attr_spec_list[ $attr_name ] ) ) {
+		if ( isset( $attr_spec_list[ $attr_name ] ) || 'data-' === substr( $attr_name, 0, 5 ) ) {
 			return true;
-		}
-		foreach ( AMP_Rule_Spec::$whitelisted_attr_regex as $whitelisted_attr_regex ) {
-			if ( preg_match( $whitelisted_attr_regex, $attr_name ) ) {
-				return true;
-			}
 		}
 
 		$is_allowed_alt_name_attr = (

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -548,7 +548,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		}
 		$source = '<' . $data['tag_name'] . ' ' . $attribute . '>Some test content</' . $data['tag_name'] . '>';
 
-		$attr_spec_list = $this->allowed_tags[ $data['tag_name'] ][ $data['rule_spec_index'] ]['attr_spec_list'];
+		$attr_spec_list = array_merge( $this->globally_allowed_attrs, $this->allowed_tags[ $data['tag_name'] ][ $data['rule_spec_index'] ]['attr_spec_list'] );
 		if ( isset( $this->allowed_tags[ $data['tag_name'] ][ $data['rule_spec_index'] ]['tag_spec']['amp_layout'] ) ) {
 			$attr_spec_list = array_merge( $attr_spec_list, $this->layout_allowed_attrs );
 		}

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -560,11 +560,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			}
 		}
 
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
-		$node = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
+		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
+		$attr      = $node->getAttributeNode( $data['attribute_name'] );
 
-		$got = $this->invoke_method( $sanitizer, $data['func_name'], array( $data['attribute_name'], $attr_spec_list ) );
+		$got = $this->invoke_method( $sanitizer, $data['func_name'], array( $attr, $attr_spec_list ) );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $source, wp_json_encode( $data ) ) );
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -953,7 +953,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp-pan-zoom' => array(
-				'<amp-layout layout="responsive" width="4" height="3"><amp-pan-zoom layout="fill"><svg> ... </svg></amp-pan-zoom></amp-layout>',
+				'<amp-layout layout="responsive" width="4" height="3"><amp-pan-zoom layout="fill" disable-double-tap><svg> ... </svg></amp-pan-zoom></amp-layout>',
 				null,
 				array( 'amp-pan-zoom' ),
 			),
@@ -971,15 +971,27 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp-lightbox' => array(
-				'<amp-lightbox id="my-lightbox" animate-in="fly-in-top" layout="nodisplay"><div class="lightbox" on="tap:my-lightbox.close" role="button" tabindex="0"><h1>Hello World!</h1></div></amp-lightbox>',
+				'<amp-lightbox id="my-lightbox" [open]="true" animate-in="fly-in-top" layout="nodisplay"><div class="lightbox" on="tap:my-lightbox.close" role="button" tabindex="0"><h1>Hello World!</h1></div></amp-lightbox>',
 				null,
-				array( 'amp-lightbox' ),
+				array( 'amp-lightbox', 'amp-bind' ),
 			),
 
 			'amp-fom-messages' => array(
 				'<form action-xhr="https://example.com/" method="post"><fieldset><input type="text" name="firstName"></fieldset><div verify-error=""><template type="amp-mustache">There is a mistake in the form!{{#verifyErrors}}{{message}}{{/verifyErrors}}</template></div><div submitting=""><template type="amp-mustache">Form submitting... Thank you for waiting {{name}}.</template></div><div submit-success=""><template type="amp-mustache">Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}to confirm! After that we\'ll start sending you weekly articles on {{#interests}}<b>{{name}}</b> {{/interests}}.</template></div><div submit-error><template type="amp-mustache">Oops! {{name}}, {{message}}.</template></div></form>',
 				null,
 				array( 'amp-form', 'amp-mustache' ),
+			),
+
+			'amp-viqeo-player' => array(
+				'<amp-viqeo-player data-profileid="184" data-videoid="b51b70cdbb06248f4438" width="640" height="360" layout="responsive"></amp-viqeo-player>',
+				null,
+				array( 'amp-viqeo-player' ),
+			),
+
+			'amp-image-slider' => array(
+				'<amp-image-slider layout="responsive" width="100" height="200"><amp-img src="/green-apple.jpg" alt="A green apple"></amp-img><amp-img src="/red-apple.jpg" alt="A red apple"></amp-img><div first>This apple is green</div><div second>This apple is red</div></amp-image-slider>',
+				null,
+				array( 'amp-image-slider' ),
 			),
 		);
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -214,6 +214,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-playbuzz' ),
 			),
 
+			'amp-next-page' => array(
+				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
+				null,
+				array( 'amp-next-page' ),
+			),
+
 			'amp-position-observer' => array(
 				'<amp-position-observer intersection-ratios="1"></amp-position-observer>',
 				null, // No change.
@@ -917,6 +923,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
+		preg_match_all( '#<.+?>#', $expected, $expected_matches );
+		preg_match_all( '#<.+?>#', $content, $content_matches );
+		$this->assertEquals(
+			$expected_matches,
+			$content_matches
+		);
 		$this->assertEquals( $expected, $content );
 		$this->assertEqualSets( $scripts, array_keys( $sanitizer->get_scripts() ) );
 	}
@@ -1017,6 +1029,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
+		preg_match_all( '#<.+?>#', $expected, $expected_matches );
+		preg_match_all( '#<.+?>#', $content, $content_matches );
+		$this->assertEquals(
+			$expected_matches,
+			$content_matches
+		);
 		$this->assertEquals( $expected, $content );
 		$this->assertEqualSets( $scripts, array_keys( $sanitizer->get_scripts() ) );
 	}

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -214,20 +214,25 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-playbuzz' ),
 			),
 
+			// AMP-NEXT-PAGE > [separator].
 			'reference-point-amp-next-page-separator' => array(
 				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
 				null,
 				array( 'amp-next-page' ),
 			),
 
-			/*
-			 * @todo This is not in the deployed validator yet.
-			 * 'reference-point-amp-carousel-lightbox-exclude' => array(
-			 * 	'<amp-carousel width="400" height="300" layout="responsive" type="slides" lightbox=""><amp-img src="/awesome.png" width="300" height="300" lightbox=""></amp-img><amp-img src="/awesome.png" width="300" height="300" lightbox-exclude=""></amp-img></amp-carousel>',
-			 * 	null,
-			 * 	array( 'amp-carousel' ),
-			 * ),
-			 */
+			// amp-next-page extension .json configuration.
+			'reference-point-amp-next-page-json-config' => array(
+				'<amp-next-page><script type="application/json">{"pages": []}</script></amp-next-page>',
+				null,
+				array( 'amp-next-page' ),
+			),
+
+			'reference-point-amp-carousel-lightbox-exclude' => array(
+				'<amp-carousel width="400" height="300" layout="responsive" type="slides" lightbox=""><amp-img src="/awesome.png" width="300" height="300" lightbox=""></amp-img><amp-img src="/awesome.png" width="300" height="300" lightbox-exclude=""></amp-img></amp-carousel>',
+				null,
+				array( 'amp-carousel', 'amp-lightbox-gallery' ),
+			),
 
 			'reference-point-lightbox-thumbnail-id' => array(
 				'<amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>',
@@ -805,7 +810,46 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			// Adapted from <https://www.ampproject.org/docs/reference/components/amp-selector>.
 			'reference-points-amp_selector_and_carousel_with_boolean_attributes' => array(
-				'<form action="/" method="get" target="_blank" id="form1"><amp-selector layout="container" name="single_image_select"><ul><li><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img></li><li><amp-img src="/img2.png" width="50" height="50" option="2" disabled></amp-img></li><li option="na" selected>None of the Above</li></ul></amp-selector><amp-selector layout="container" name="multi_image_select" multiple><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img><amp-img src="/img2.png" width="50" height="50" option="2"></amp-img><amp-img src="/img3.png" width="50" height="50" option="3"></amp-img></amp-selector><amp-selector layout="container" name="multi_image_select_1" multiple><amp-carousel id="carousel-1" width="200" height="60" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d" disabled></amp-img></amp-carousel></amp-selector></form><amp-selector layout="container" name="multi_image_select_2" multiple form="form1"><amp-carousel id="carousel-1" width="400" height="300" type="slides" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d"></amp-img></amp-carousel></amp-selector>',
+				str_replace(
+					array( "\n", "\t" ),
+					'',
+					'
+					<form action="/" method="get" target="_blank" id="form1">
+						<amp-selector layout="container" name="single_image_select">
+							<ul>
+								<li>
+									<amp-img src="/img1.png" width="50" height="50" option="1"></amp-img>
+								</li>
+								<li>
+									<amp-img src="/img2.png" width="50" height="50" option="2" disabled></amp-img>
+								</li>
+								<li option="na" selected>None of the Above</li>
+							</ul>
+						</amp-selector>
+						<amp-selector layout="container" name="multi_image_select" multiple>
+							<amp-img src="/img1.png" width="50" height="50" option="1"></amp-img>
+							<amp-img src="/img2.png" width="50" height="50" option="2"></amp-img>
+							<amp-img src="/img3.png" width="50" height="50" option="3"></amp-img>
+						</amp-selector>
+						<amp-selector layout="container" name="multi_image_select_1" multiple>
+							<amp-carousel id="carousel-1" width="200" height="60" controls>
+								<amp-img src="/img1.png" width="80" height="60" option="a"></amp-img>
+								<amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img>
+								<amp-img src="/img3.png" width="80" height="60" option="c"></amp-img>
+								<amp-img src="/img4.png" width="80" height="60" option="d" disabled></amp-img>
+							</amp-carousel>
+						</amp-selector>
+					</form>
+					<amp-selector layout="container" name="multi_image_select_2" multiple form="form1">
+						<amp-carousel id="carousel-1" width="400" height="300" type="slides" controls>
+							<amp-img src="/img1.png" width="80" height="60" option="a"></amp-img>
+							<amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img>
+							<amp-img src="/img3.png" width="80" height="60" option="c"></amp-img>
+							<amp-img src="/img4.png" width="80" height="60" option="d"></amp-img>
+						</amp-carousel>
+					</amp-selector>
+					'
+				),
 				null, // No change.
 				array( 'amp-selector', 'amp-form', 'amp-carousel' ),
 			),

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -214,10 +214,69 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-playbuzz' ),
 			),
 
-			'amp-next-page' => array(
+			'reference-point-amp-next-page-separator' => array(
 				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
 				null,
 				array( 'amp-next-page' ),
+			),
+
+			/*
+			 * @todo This is not in the deployed validator yet.
+			 * 'reference-point-amp-carousel-lightbox-exclude' => array(
+			 * 	'<amp-carousel width="400" height="300" layout="responsive" type="slides" lightbox=""><amp-img src="/awesome.png" width="300" height="300" lightbox=""></amp-img><amp-img src="/awesome.png" width="300" height="300" lightbox-exclude=""></amp-img></amp-carousel>',
+			 * 	null,
+			 * 	array( 'amp-carousel' ),
+			 * ),
+			 */
+
+			'reference-point-lightbox-thumbnail-id' => array(
+				'<amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>',
+				null,
+				array(),
+			),
+
+			'reference-points-amp-live-list' => array(
+				'<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"><button update on="tap:my-live-list.update">You have updates!</button><div items></div><div pagination></div></amp-live-list>',
+				null,
+				array( 'amp-live-list' ),
+			),
+
+			'reference-points-amp-story' => array(
+				str_replace(
+					array( "\n", "\t" ),
+					'',
+					'
+					<amp-story standalone title="My Story" publisher="The AMP Team" publisher-logo-src="https://example.com/logo/1x1.png" poster-portrait-src="https://example.com/my-story/poster/3x4.jpg" poster-square-src="https://example.com/my-story/poster/1x1.jpg" poster-landscape-src="https://example.com/my-story/poster/4x3.jpg" background-audio="my.mp3">
+						<amp-story-page id="my-first-page">
+							<amp-story-grid-layer template="fill">
+								<amp-img id="object1" animate-in="rotate-in-left" src="https://example.ampproject.org/helloworld/bg1.jpg" width="900" height="1600">
+								</amp-img>
+							</amp-story-grid-layer>
+							<amp-story-grid-layer template="vertical">
+								<h1 animate-in="fly-in-left" animate-in-duration="0.5s" animate-in-delay="0.4s" animate-in-after="object1">Hello, amp-story!</h1>
+							</amp-story-grid-layer>
+						</amp-story-page>
+						<amp-story-page id="my-second-page">
+							<amp-story-grid-layer template="thirds">
+								<amp-img grid-area="bottom-third" src="https://example.ampproject.org/helloworld/bg2.gif" width="900" height="1600">
+								</amp-img>
+							</amp-story-grid-layer>
+							<amp-story-grid-layer template="vertical">
+								<h1>The End</h1>
+							</amp-story-grid-layer>
+						</amp-story-page>
+						<amp-story-bookend src="bookendv1.json" layout="nodisplay"></amp-story-bookend>
+					</amp-story>
+					'
+				),
+				null,
+				array( 'amp-story' ),
+			),
+
+			'reference-points-bad' => array(
+				'<div lightbox-thumbnail-id update items pagination separator option selected disabled>BAD REFERENCE POINTS</div>',
+				'<div>BAD REFERENCE POINTS</div>',
+				array(),
 			),
 
 			'amp-position-observer' => array(
@@ -745,8 +804,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			// Adapted from <https://www.ampproject.org/docs/reference/components/amp-selector>.
-			'amp_selector_and_carousel_with_boolean_attributes' => array(
-				'<form action="/" method="get" target="_blank" id="form1"><amp-selector layout="container" name="single_image_select"><ul><li><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img></li><li><amp-img src="/img2.png" width="50" height="50" option="2"></amp-img></li><li option="na" selected>None of the Above</li></ul></amp-selector><amp-selector layout="container" name="multi_image_select" multiple><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img><amp-img src="/img2.png" width="50" height="50" option="2"></amp-img><amp-img src="/img3.png" width="50" height="50" option="3"></amp-img></amp-selector><amp-selector layout="container" name="multi_image_select_1" multiple><amp-carousel id="carousel-1" width="200" height="60" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d" disabled></amp-img></amp-carousel></amp-selector></form><amp-selector layout="container" name="multi_image_select_2" multiple form="form1"><amp-carousel id="carousel-1" width="400" height="300" type="slides" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d"></amp-img></amp-carousel></amp-selector>',
+			'reference-points-amp_selector_and_carousel_with_boolean_attributes' => array(
+				'<form action="/" method="get" target="_blank" id="form1"><amp-selector layout="container" name="single_image_select"><ul><li><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img></li><li><amp-img src="/img2.png" width="50" height="50" option="2" disabled></amp-img></li><li option="na" selected>None of the Above</li></ul></amp-selector><amp-selector layout="container" name="multi_image_select" multiple><amp-img src="/img1.png" width="50" height="50" option="1"></amp-img><amp-img src="/img2.png" width="50" height="50" option="2"></amp-img><amp-img src="/img3.png" width="50" height="50" option="3"></amp-img></amp-selector><amp-selector layout="container" name="multi_image_select_1" multiple><amp-carousel id="carousel-1" width="200" height="60" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d" disabled></amp-img></amp-carousel></amp-selector></form><amp-selector layout="container" name="multi_image_select_2" multiple form="form1"><amp-carousel id="carousel-1" width="400" height="300" type="slides" controls><amp-img src="/img1.png" width="80" height="60" option="a"></amp-img><amp-img src="/img2.png" width="80" height="60" option="b" selected></amp-img><amp-img src="/img3.png" width="80" height="60" option="c"></amp-img><amp-img src="/img4.png" width="80" height="60" option="d"></amp-img></amp-carousel></amp-selector>',
 				null, // No change.
 				array( 'amp-selector', 'amp-form', 'amp-carousel' ),
 			),


### PR DESCRIPTION
* Add support for handling reference points in validator spec, including support for attributes used by `amp-next-page`, `amp-story`, `amp-lightbox-gallery`, and `amp-live-list`. This removes hard-coded list of whitelisted attribute pattern which were erroneously being allowed on every element, not just the descendants of elements with reference points.
* Add special case for handling reference points for `amp-selector` since its attributes can be added to any descendant not just direct children.
* Add components for `amp-image-slider` and `amp-viqeo-player`.
* Add `when-ended=continue` to `amp-date-countdown`.
* Add `[open]` to `amp-lightbox`.
* Add `disable-double-tap` to `amp-pan-zoom`.