### PR TITLE
Add missing amp-block-validation dependency.

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -197,22 +197,21 @@ class AMP_Post_Meta_Box {
 		$status_and_errors = $this->get_status_and_errors( $post );
 		$enabled_status    = $status_and_errors['status'];
 		$error_messages    = $this->get_error_messages( $status_and_errors['status'], $status_and_errors['errors'] );
-		$localization      = array(
+		$script_data       = array(
 			'possibleStati' => array( self::ENABLED_STATUS, self::DISABLED_STATUS ),
 			'defaultStatus' => $enabled_status,
 			'errorMessages' => $error_messages,
 		);
 
 		if ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
-			$localization['i18n'] = gutenberg_get_jed_locale_data( 'amp' );
+			$script_data['i18n'] = gutenberg_get_jed_locale_data( 'amp' );
 		}
 
-		wp_localize_script(
+		wp_add_inline_script(
 			self::BLOCK_ASSET_HANDLE,
-			'wpAmpEditor',
-			$localization
+			sprintf( 'var wpAmpEditor = %s;', wp_json_encode( $script_data ) ),
+			'before'
 		);
-
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1742,7 +1742,7 @@ class AMP_Validation_Manager {
 		wp_enqueue_script(
 			$slug,
 			amp_get_asset_url( "js/{$slug}.js" ),
-			array( 'underscore' ),
+			array( 'underscore', AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ),
 			AMP__VERSION,
 			true
 		);

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -105,8 +105,11 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE, $block_script->handle );
 		$this->assertEquals( amp_get_asset_url( 'js/' . AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE . '.js' ), $block_script->src );
 		$this->assertEquals( AMP__VERSION, $block_script->ver );
-		$this->assertContains( 'wpAmpEditor', $block_script->extra['data'] );
-		$this->assertContains( AMP_Post_Meta_Box::ENABLED_STATUS, $block_script->extra['data'] );
+		$this->assertInternalType( 'array', $block_script->extra['before'] );
+
+		$matches = preg_grep( '/wpAmpEditor/', $block_script->extra['before'] );
+		$this->assertCount( 1, $matches );
+		$this->assertContains( AMP_Post_Meta_Box::ENABLED_STATUS, array_shift( $matches ) );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1255,7 +1255,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$script        = wp_scripts()->registered[ $slug ];
 		$inline_script = $script->extra['after'][1];
 		$this->assertContains( 'js/amp-block-validation.js', $script->src );
-		$this->assertEquals( array( 'underscore' ), $script->deps );
+		$this->assertEqualSets( array( 'underscore', AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ), $script->deps );
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, wp_scripts()->queue, true ) );
 		$this->assertContains( 'ampBlockValidation.boot', $inline_script );


### PR DESCRIPTION
Currently, in Gutenberg I receive an error in the console because the `amp-block-validation.js` file tries to access the `wpAmpEditor` global. That global is set via `wp_localize_script()` attached to the `amp-block-editor-toggle-compiled.js` file. As the latter is not a dependency of `amp-block-validation`, it may load later, causing the error to be thrown.

By adding `amp-block-editor-toggle-compiled.js`, this issue can be fixed. As a side observation, we might also want to replace `wp_localize_script()` with a call to `wp_add_inline_script()`, but that isn't part of the bugfix, so I didn't include it here.