### PR TITLE
Add embed support for Twitter timelines via new amp-twitter attributes

### DIFF
--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -11,7 +11,14 @@
  *  Much of this class is borrowed from Jetpack embeds
  */
 class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
-	const URL_PATTERN = '#http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)#i';
+
+	/**
+	 * URL pattern for a Tweet URL.
+	 *
+	 * @since 0.2
+	 * @var string
+	 */
+	const URL_PATTERN = '#https?:\/\/twitter\.com(?:\/\#\!\/|\/)(?P<username>[a-zA-Z0-9_]{1,20})\/status(?:es)?\/(?P<tweet>\d+)#i';
 
 	/**
 	 * URL pattern for a Twitter timeline.
@@ -19,7 +26,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @since 1.0
 	 * @var string
 	 */
-	const URL_PATTERN_TIMELINE = '#http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})($|\/(likes|lists)(\/([a-zA-Z0-9_]+))?)#i';
+	const URL_PATTERN_TIMELINE = '#https?:\/\/twitter\.com(?:\/\#\!\/|\/)(?P<username>[a-zA-Z0-9_]{1,20})(?:$|\/(?P<type>likes|lists)(\/(?P<id>[a-zA-Z0-9_-]+))?)#i';
 
 	/**
 	 * Tag.
@@ -39,7 +46,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_shortcode( 'tweet', array( $this, 'shortcode' ) );
+		add_shortcode( 'tweet', array( $this, 'shortcode' ) ); // Note: This is a Jetpack shortcode.
 		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
 		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, array( $this, 'oembed_timeline' ), -1 );
 	}
@@ -48,13 +55,15 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_shortcode( 'tweet' );
+		remove_shortcode( 'tweet' ); // Note: This is a Jetpack shortcode.
 		wp_embed_unregister_handler( 'amp-twitter', -1 );
 		wp_embed_unregister_handler( 'amp-twitter-timeline', -1 );
 	}
 
 	/**
 	 * Gets AMP-compliant markup for the Twitter shortcode.
+	 *
+	 * Note that this shortcode is is defined in Jetpack.
 	 *
 	 * @param array $attr The Twitter attributes.
 	 * @return string Twitter shortcode markup.
@@ -73,8 +82,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			$id = $attr['tweet'];
 		} else {
 			preg_match( self::URL_PATTERN, $attr['tweet'], $matches );
-			if ( isset( $matches[5] ) && is_numeric( $matches[5] ) ) {
-				$id = $matches[5];
+			if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
+				$id = $matches['tweet'];
 			}
 
 			if ( empty( $id ) ) {
@@ -100,17 +109,14 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @see \WP_Embed::shortcode()
 	 *
-	 * @param array  $matches URL pattern matches.
-	 * @param array  $attr    Shortcode attributes.
-	 * @param string $url     URL.
-	 * @param string $rawattr Unmodified shortcode attributes.
+	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed( $matches, $attr, $url, $rawattr ) {
+	public function oembed( $matches ) {
 		$id = false;
 
-		if ( isset( $matches[5] ) && is_numeric( $matches[5] ) ) {
-			$id = $matches[5];
+		if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
+			$id = $matches['tweet'];
 		}
 
 		if ( ! $id ) {
@@ -125,33 +131,30 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @since 1.0
 	 *
-	 * @param array  $matches URL pattern matches.
-	 * @param array  $attr    Shortcode attributes.
-	 * @param string $url     URL.
-	 * @param string $rawattr Unmodified shortcode attributes.
+	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed_timeline( $matches, $attr, $url, $rawattr ) {
-		if ( ! isset( $matches[3] ) ) {
+	public function oembed_timeline( $matches ) {
+		if ( ! isset( $matches['username'] ) ) {
 			return '';
 		}
 
 		$attributes = array(
 			'data-timeline-source-type' => 'profile',
-			'data-timeline-screen-name' => $matches[3],
+			'data-timeline-screen-name' => $matches['username'],
 		);
 
-		if ( isset( $matches[5] ) ) {
-			switch ( $matches[5] ) {
+		if ( isset( $matches['type'] ) ) {
+			switch ( $matches['type'] ) {
 				case 'likes':
 					$attributes['data-timeline-source-type'] = 'likes';
 					break;
 				case 'lists':
-					if ( ! isset( $matches[7] ) ) {
+					if ( ! isset( $matches['id'] ) ) {
 						return '';
 					}
 					$attributes['data-timeline-source-type']       = 'list';
-					$attributes['data-timeline-slug']              = $matches[7];
+					$attributes['data-timeline-slug']              = $matches['id'];
 					$attributes['data-timeline-owner-screen-name'] = $attributes['data-timeline-screen-name'];
 					unset( $attributes['data-timeline-screen-name'] );
 					break;
@@ -247,7 +250,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		/**
 		 * DOMNode
 		 *
-		 * @var DOMNode $anchors
+		 * @var DOMNodeList $anchors
 		 */
 		$anchors = $node->getElementsByTagName( 'a' );
 
@@ -259,7 +262,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		foreach ( $anchors as $anchor ) {
 			$found = preg_match( self::URL_PATTERN, $anchor->getAttribute( 'href' ), $matches );
 			if ( $found ) {
-				return $matches[5];
+				return $matches['tweet'];
 			}
 		}
 

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -25,8 +25,8 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'<p><amp-twitter data-timeline-source-type="likes" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
 			'timeline_url_with_list' => array(
-				'https://twitter.com/wordpress/lists/random-list' . PHP_EOL,
-				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random-list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
+				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
+				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random_list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
 
 			'shortcode_without_id' => array(

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -16,6 +16,19 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'<p><amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
 
+			'timeline_url_with_profile' => array(
+				'https://twitter.com/wordpress' . PHP_EOL,
+				'<p><amp-twitter data-timeline-source-type="profile" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
+			),
+			'timeline_url_with_likes' => array(
+				'https://twitter.com/wordpress/likes' . PHP_EOL,
+				'<p><amp-twitter data-timeline-source-type="likes" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
+			),
+			'timeline_url_with_list' => array(
+				'https://twitter.com/wordpress/lists/random-list' . PHP_EOL,
+				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random-list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
+			),
+
 			'shortcode_without_id' => array(
 				'[tweet]' . PHP_EOL,
 				'' . PHP_EOL,

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -28,6 +28,10 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random_list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
+			'timeline_url_with_list2'              => array(
+				'https://twitter.com/robertnyman/lists/web-gdes' . PHP_EOL,
+				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="web-gdes" data-timeline-owner-screen-name="robertnyman" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
+			),
 
 			'shortcode_without_id'                 => array(
 				'[tweet]' . PHP_EOL,

--- a/tests/test-amp-twitter-embed.php
+++ b/tests/test-amp-twitter-embed.php
@@ -3,49 +3,49 @@
 class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
 		return array(
-			'no_embed' => array(
+			'no_embed'                             => array(
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			),
-			'url_simple' => array(
+			'url_simple'                           => array(
 				'https://twitter.com/wordpress/status/987437752164737025' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
-			'url_with_big_tweet_id' => array(
+			'url_with_big_tweet_id'                => array(
 				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
 
-			'timeline_url_with_profile' => array(
+			'timeline_url_with_profile'            => array(
 				'https://twitter.com/wordpress' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="profile" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
-			'timeline_url_with_likes' => array(
+			'timeline_url_with_likes'              => array(
 				'https://twitter.com/wordpress/likes' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="likes" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
-			'timeline_url_with_list' => array(
+			'timeline_url_with_list'               => array(
 				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random_list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
 			),
 
-			'shortcode_without_id' => array(
+			'shortcode_without_id'                 => array(
 				'[tweet]' . PHP_EOL,
 				'' . PHP_EOL,
 			),
-			'shortcode_simple' => array(
+			'shortcode_simple'                     => array(
 				'[tweet 987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
 			),
-			'shortcode_with_tweet_attribute' => array(
+			'shortcode_with_tweet_attribute'       => array(
 				'[tweet tweet=987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
 			),
-			'shortcode_with_big_tweet_id' => array(
+			'shortcode_with_big_tweet_id'          => array(
 				'[tweet 705219971425574912]' . PHP_EOL,
 				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
 			),
-			'shortcode_with_url' => array(
+			'shortcode_with_url'                   => array(
 				'[tweet https://twitter.com/wordpress/status/987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
 			),
@@ -53,7 +53,7 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 				'[tweet https://twitter.com/wordpress/status/705219971425574912]' . PHP_EOL,
 				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
 			),
-			'shortcode_with_non_numeric_tweet_id' => array(
+			'shortcode_with_non_numeric_tweet_id'  => array(
 				'[tweet abcd]' . PHP_EOL,
 				'' . PHP_EOL,
 			),


### PR DESCRIPTION
`amp-twitter` now supports arbitrary data attributes for Twitter timelines, based on a required `data-timeline-source-type` attribute. All other arguments to pass along to the Twitter script must be provided as individual data attributes prefixed with "timeline-". As an example, if you set `data-timeline-source-type` to "profile", you also need to pass a `screenName` argument, which would need to happen via `data-timeline-screen-name`.

This PR adds support for Twitter timelines, by automatically parsing embed URLs into appropriate `amp-twitter` elements. The code supports `profile`, `likes` and `list` source types.

For reference:
* https://www.ampproject.org/docs/reference/components/amp-twitter
* https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-factory-functions