### PR TITLE
Remove version from package.json

### DIFF
--- a/bin/verify-version-consistency.php
+++ b/bin/verify-version-consistency.php
@@ -14,9 +14,6 @@ if ( 'cli' !== php_sapi_name() ) {
 
 $versions = array();
 
-$versions['package.json']      = json_decode( file_get_contents( dirname( __FILE__ ) . '/../package.json' ) )->version;
-$versions['package-lock.json'] = json_decode( file_get_contents( dirname( __FILE__ ) . '/../package-lock.json' ) )->version;
-
 $readme_txt = file_get_contents( dirname( __FILE__ ) . '/../readme.txt' );
 if ( ! preg_match( '/Stable tag:\s+(?P<version>\S+)/i', $readme_txt, $matches ) ) {
 	echo "Could not find stable tag in readme\n";

--- a/contributing.md
+++ b/contributing.md
@@ -99,7 +99,7 @@ When you push a commit to your PR, Travis CI will run the PHPUnit tests and snif
 Contributors who want to make a new release, follow these steps:
 
 1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
-2. Bump plugin versions in `package.json` (×1), `package-lock.json` (×1, just do `npm install` first), and in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
+2. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
 3. Add changelog entry to readme.
 4. Draft blog post about the new release.
 5. [Draft new release](https://github.com/Automattic/amp-wp/releases/new) on GitHub targeting the release branch, with the new plugin version as the tag and release title. Attaching the `amp.zip` build to the release. Include link to changelog in release tag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "amp-wp",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@types/jquery": {
       "version": "2.0.49",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "git",
   "url": "https://github.com/Automattic/amp-wp.git"
  },
- "version": "1.0.0",
  "license": "GPL-2.0+",
  "private": true,
  "devDependencies": {


### PR DESCRIPTION
This is similar to #1328 / #1333.

The `version` field (and actually `name` too) in `package.json` is _optional_ if you don't plan to publish your package.

Given that `private` is set to `true` in `package.json` to prevent accidental publication, there's no harm in omitting the version field.

This makes the release process a bit easier and less prone to mistakes when changing the version everywhere.