### PR TITLE
Update minimum PHP version from 5.3.2 to 5.3.6

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -25,7 +25,7 @@ function _amp_print_php_version_admin_notice() {
 	</div>
 	<?php
 }
-if ( version_compare( phpversion(), '5.3.2', '<' ) ) {
+if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
 	add_action( 'admin_notices', '_amp_print_php_version_admin_notice' );
 	return;
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.2 || ^7.0",
+        "php": "^5.3.6 || ^7.0",
         "sabberworm/php-css-parser": "dev-master"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "70bedbb485620508056d424a8eaf04e2",
+    "content-hash": "33d4c9d9bf48285e6557d79a6b4b7601",
     "packages": [
         {
             "name": "sabberworm/php-css-parser",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/PHP-CSS-Parser.git",
-                "reference": "f453b4b534d06e9b4512388f801413a4fa9a9d42"
+                "reference": "bd0c481ba28ccd54bbbb1846a69ead237cd26cd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/f453b4b534d06e9b4512388f801413a4fa9a9d42",
-                "reference": "f453b4b534d06e9b4512388f801413a4fa9a9d42",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/bd0c481ba28ccd54bbbb1846a69ead237cd26cd8",
+                "reference": "bd0c481ba28ccd54bbbb1846a69ead237cd26cd8",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
             "support": {
                 "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
             },
-            "time": "2018-09-03 17:23:45"
+            "time": "2018-09-06 16:11:27"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -275,7 +275,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.3.2 || ^7.0"
+        "php": "^5.3.6 || ^7.0"
     },
     "platform-dev": []
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,7 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	    <testsuite name="Test Tag and Attribute Sanitizer Private Methods">
-	      <file phpVersion="5.3.2" phpVersionOperator=">=">./tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php</file>
+	      <file phpVersion="5.3.6" phpVersionOperator=">=">./tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php</file>
 	    </testsuite>
 	</testsuites>
 	<filter>

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 **Tested up to:** 4.9  
 **Stable tag:** 0.7.2  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
-**Requires PHP:** 5.3.2  
+**Requires PHP:** 5.3.6  
 
 [![Build Status](https://travis-ci.org/Automattic/amp-wp.svg?branch=master)](https://travis-ci.org/Automattic/amp-wp) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) 
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 4.9
 Stable tag: 0.7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Requires PHP: 5.3.2
+Requires PHP: 5.3.6
 
 Enable Accelerated Mobile Pages (AMP) on your WordPress site.
 


### PR DESCRIPTION
The `$node` attribute for `DOMDocument::saveHTML()` was added in 5.3.6 (for some reason). So this is the required minimum version.

Fixes #1406.

Also updates PHP-CSS-Parser from upstream to include:

* https://github.com/sabberworm/PHP-CSS-Parser/pull/141: Add support for CSS4 alpha channels in hex notation
* https://github.com/sabberworm/PHP-CSS-Parser/pull/142: Suppress "Unexpected end of document" in lenient mode