### PR TITLE
Ensure AMP status in admin bar reflects previewed accepted state

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1478,7 +1478,12 @@ class AMP_Validation_Manager {
 			$error_count = 0;
 			foreach ( self::$validation_results as $validation_result ) {
 				$validation_status = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $validation_result['error'] );
-				if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS !== $validation_status['term_status'] ) {
+
+				$is_unaccepted = 'with_preview' === $validation_status['forced'] ?
+					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS !== $validation_status['status']
+					:
+					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS !== $validation_status['term_status'];
+				if ( $is_unaccepted ) {
 					$error_count++;
 				}
 			}


### PR DESCRIPTION
Given an invalid AMP page with validation errors as follows:

![image](https://user-images.githubusercontent.com/134745/45198378-22a68680-b21b-11e8-95d3-6099944c7a9c.png)

At the moment the admin bar looks as follows when the rejected validation error is flipped to accepted:

![image](https://user-images.githubusercontent.com/134745/45198411-45d13600-b21b-11e8-9442-695b23f5cc60.png)

This change ensures that the status in the admin bar looks instead as:

![image](https://user-images.githubusercontent.com/134745/45198430-58e40600-b21b-11e8-9b5e-35554489893e.png)
