### PR TITLE
Fix URL protocol validation and parsing attribute values with multiple URLs

### DIFF
--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -1491,9 +1491,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'protocol_multiple_fail'    => array(
 				array(
-					'source'         => '<div attribute1="http://example.com, data://domain.com"></div>',
-					'node_tag_name'  => 'div',
-					'attr_name'      => 'attribute1',
+					'source'         => '<img srcset="http://example.com, data://domain.com">',
+					'node_tag_name'  => 'img',
+					'attr_name'      => 'srcset',
 					'attr_spec_rule' => array(
 						'value_url' => array(
 							'protocol' => array(
@@ -1586,9 +1586,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'disallowed_relative_multiple_pass'             => array(
 				array(
-					'source'         => '<div attribute1="http://example.com, http://domain.com/path/to/resource"></div>',
-					'node_tag_name'  => 'div',
-					'attr_name'      => 'attribute1',
+					'source'         => '<img srcset="http://example.com, http://domain.com/path/to/resource">',
+					'node_tag_name'  => 'img',
+					'attr_name'      => 'srcset',
 					'attr_spec_rule' => array(
 						'value_url' => array(
 							'allow_relative' => false,
@@ -1673,15 +1673,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			),
 			'disallowed_relative_alternative_multiple_fail' => array(
 				array(
-					'source'         => '<div attribute1_alternative1="http://domain.com,  /relative/path/to/resource"></div>',
+					'source'         => '<div source_set="http://domain.com,  /relative/path/to/resource"></div>',
 					'node_tag_name'  => 'div',
-					'attr_name'      => 'attribute1',
+					'attr_name'      => 'srcset',
 					'attr_spec_rule' => array(
 						'value_url'         => array(
 							'allow_relative' => false,
 						),
 						'alternative_names' => array(
-							'attribute1_alternative1'
+							'source_set',
 						),
 					),
 				),

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -97,6 +97,10 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<p>contents<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
 				'<p>contents</p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
+			'iframe_src_with_commas_and_colons'         => array(
+				'<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&z=15&l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen=""></iframe>',
+				'<amp-iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen="" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+			),
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -466,6 +466,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					'<a href="fb-messenger://example.com/path/to/content">Click me.</a>',
 					'<a href="webcal:foo">Click me.</a>',
 					'<a href="whatsapp:foo">Click me.</a>',
+					'<a href="web+mastodon:follow/@handle@instance">Click me.</a>',
 				) ),
 			),
 
@@ -630,7 +631,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp-img_with_good_protocols' => array(
-				'<amp-img src="https://example.com/resource1" srcset="https://example.com/resource1, https://example.com/resource2"></amp-img>',
+				'<amp-img src="https://example.com/resource1" srcset="https://example.com/resource1 320w, https://example.com/resource2 480w"></amp-img>',
+			),
+
+			'amp-img_with_relative_urls_containing_colons' => array(
+				'<amp-img src="/winning:yes.jpg" width="100" height="200"></amp-img>',
 			),
 
 			'allowed_tag_only' => array(


### PR DESCRIPTION
This is a follow-up on #983 to fix two problems:

1. URL protocol validation was failing when a URL contained a colon, as the plugin was incorrectly assuming everything before it was the scheme. The characters being checked for in the protocol were also incorrect.
2. URLs with commas were incorrectly raising validation errors. Attribute values containing URLs were always getting split by commas to handle the `srcset` case. However, this attribute is the only one that contains a comma-separated list of URLs (among other descriptors), so it doesn't make sense to split every attribute value by commas. This ensures that a URL containing a latitude and longitude separated by a comma won't require its comma to be URL-encoded as `%2C` to avoid sanitization.

Fixes #1410.