### PR TITLE
Omit validation errors sanitized by filter or tree-shaking option

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -241,9 +241,10 @@ class AMP_Options_Menu {
 		?>
 		<fieldset>
 			<?php
-			$auto_sanitization         = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( array(
+			$auto_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( array(
 				'code' => 'non_existent',
 			) );
+			remove_filter( 'amp_validation_error_sanitized', array( 'AMP_Validation_Manager', 'filter_tree_shaking_validation_error_as_accepted' ) );
 			$tree_shaking_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( array(
 				'code' => AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE,
 			) );

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1102,7 +1102,7 @@ class AMP_Invalid_URL_Post_Type {
 			<div id="major-publishing-actions">
 				<div id="delete-action">
 					<a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $post->ID ) ); ?>">
-						<?php esc_html_e( 'Move to Trash', 'default' ); ?>
+						<?php esc_html_e( 'Forget', 'amp' ); ?>
 					</a>
 				</div>
 				<div id="publishing-action">

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -302,14 +302,12 @@ class AMP_Validation_Error_Taxonomy {
 			$forced = 'with_preview';
 		}
 
-		$is_forced_with_option = (
+		$is_forced = (
 			amp_is_canonical()
-			||
-			AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE === $error['code'] && AMP_Options_Manager::get_option( 'accept_tree_shaking' )
 			||
 			AMP_Options_Manager::get_option( 'force_sanitization' )
 		);
-		if ( $is_forced_with_option ) {
+		if ( $is_forced ) {
 			$forced = 'with_option';
 			$status = self::VALIDATION_ERROR_ACCEPTED_STATUS;
 		}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -186,6 +186,11 @@ class AMP_Validation_Manager {
 
 		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 100 );
 
+		// Add filter to auto-accept tree shaking validation error.
+		if ( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) || AMP_Options_Manager::get_option( 'force_sanitization' ) ) {
+			add_filter( 'amp_validation_error_sanitized', array( __CLASS__, 'filter_tree_shaking_validation_error_as_accepted' ), 10, 2 );
+		}
+
 		if ( self::$should_locate_sources ) {
 			self::add_validation_error_sourcing();
 		}
@@ -213,6 +218,20 @@ class AMP_Validation_Manager {
 	 */
 	public static function is_sanitization_forcibly_accepted() {
 		return amp_is_canonical() || AMP_Options_Manager::get_option( 'force_sanitization' );
+	}
+
+	/**
+	 * Filter a tree-shaking validation error as accepted for sanitization.
+	 *
+	 * @param bool  $sanitized Sanitized.
+	 * @param array $error     Error.
+	 * @return bool Sanitized.
+	 */
+	public static function filter_tree_shaking_validation_error_as_accepted( $sanitized, $error ) {
+		if ( AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE === $error['code'] ) {
+			$sanitized = true;
+		}
+		return $sanitized;
 	}
 
 	/**
@@ -693,20 +712,7 @@ class AMP_Validation_Manager {
 		$sanitized    = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS === $sanitization['status'];
 
 		// Ignore validation errors which are forcibly sanitized by filter or in special case if it is a tree shaking error and this is accepted by options.
-		$should_ignore = (
-			$sanitized
-			&&
-			(
-				'with_filter' === $sanitization['forced']
-				||
-				(
-					AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE === $error['code']
-					&&
-					( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) || AMP_Options_Manager::get_option( 'force_sanitization' ) )
-				)
-			)
-		);
-		if ( $should_ignore ) {
+		if ( $sanitized && 'with_filter' === $sanitization['forced'] ) {
 			return true;
 		}
 

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -224,7 +224,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 			'type'            => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 		);
 
-		// Test sanitized.
+		// Test forcibly sanitized with filter, resulting in no validation error being surfaced.
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		$this->assertEquals( $child, $parent->firstChild );
 		$sanitizer = new AMP_Iframe_Sanitizer(
@@ -234,14 +234,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		);
 		$sanitizer->remove_invalid_child( $child, array( 'foo' => 'bar' ) );
 		$this->assertEquals( null, $parent->firstChild );
-		$this->assertCount( 1, AMP_Validation_Manager::$validation_results );
-		$this->assertEquals(
-			array(
-				'error'     => $expected_error,
-				'sanitized' => true,
-			),
-			AMP_Validation_Manager::$validation_results[0]
-		);
+		$this->assertCount( 0, AMP_Validation_Manager::$validation_results );
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
 
 		// Test unsanitized.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1338,7 +1338,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	private function get_original_html() {
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		global $wp_widget_factory, $wp_scripts, $wp_styles;
 		$wp_scripts = null;
 		$wp_styles  = null;

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -401,6 +401,33 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_validated_environment().
+	 *
+	 * @covers \AMP_Invalid_URL_Post_Type::get_validated_environment()
+	 */
+	public function test_get_validated_environment() {
+		switch_theme( 'twentysixteen' );
+		update_option( 'active_plugins', array( 'foo/foo.php', 'bar.php' ) );
+		AMP_Options_Manager::update_option( 'accept_tree_shaking', true );
+		AMP_Options_Manager::update_option( 'force_sanitization', false );
+		$old_env = AMP_Invalid_URL_Post_Type::get_validated_environment();
+		$this->assertArrayHasKey( 'theme', $old_env );
+		$this->assertArrayHasKey( 'plugins', $old_env );
+		$this->assertArrayHasKey( 'options', $old_env );
+		$this->assertArrayHasKey( 'accept_tree_shaking', $old_env['options'] );
+		$this->assertTrue( $old_env['options']['accept_tree_shaking'] );
+		$this->assertEquals( 'twentysixteen', $old_env['theme'] );
+
+		switch_theme( 'twentyseventeen' );
+		update_option( 'active_plugins', array( 'foo/foo.php', 'baz.php' ) );
+		AMP_Options_Manager::update_option( 'accept_tree_shaking', false );
+		$new_env = AMP_Invalid_URL_Post_Type::get_validated_environment();
+		$this->assertNotEquals( $old_env, $new_env );
+		$this->assertFalse( $new_env['options']['accept_tree_shaking'] );
+		$this->assertEquals( 'twentyseventeen', $new_env['theme'] );
+	}
+
+	/**
 	 * Test get_post_staleness method.
 	 *
 	 * @covers AMP_Invalid_URL_Post_Type::get_post_staleness()

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -996,7 +996,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 
 		$this->assertContains( date_i18n( 'M j, Y @ H:i', strtotime( $post_storing_error->post_date ) ), $output );
 		$this->assertContains( 'Last checked:', $output );
-		$this->assertContains( 'Move to Trash', $output );
+		$this->assertContains( 'Forget', $output );
 		$this->assertContains( esc_url( get_delete_post_link( $post_storing_error->ID ) ), $output );
 		$this->assertContains( 'misc-pub-section', $output );
 	}

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -431,6 +431,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * Test get_post_staleness method.
 	 *
 	 * @covers AMP_Invalid_URL_Post_Type::get_post_staleness()
+	 * @covers AMP_Invalid_URL_Post_Type::get_validated_environment()
 	 */
 	public function test_get_post_staleness() {
 		$error = array( 'code' => 'foo' );

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -131,12 +131,27 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertEquals( 100, has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
 
 		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
+		$this->assertEquals( 10, has_filter( 'amp_validation_error_sanitized', array( self::TESTED_CLASS, 'filter_tree_shaking_validation_error_as_accepted' ) ) );
 
-		// Make sure should_locate_sources arg is recognized.
+		// Make sure should_locate_sources arg is recognized, as is disabling of tree-shaking.
+		remove_all_filters( 'amp_validation_error_sanitized' );
+		AMP_Options_Manager::update_option( 'force_sanitization', false );
+		AMP_Options_Manager::update_option( 'accept_tree_shaking', false );
 		AMP_Validation_Manager::init( array(
 			'should_locate_sources' => true,
 		) );
 		$this->assertEquals( 10, has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
+		$this->assertFalse( has_filter( 'amp_validation_error_sanitized', array( self::TESTED_CLASS, 'filter_tree_shaking_validation_error_as_accepted' ) ) );
+	}
+
+	/**
+	 * Test filter_tree_shaking_validation_error_as_accepted.
+	 *
+	 * @covers AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted()
+	 */
+	public function test_filter_tree_shaking_validation_error_as_accepted() {
+		$this->assertNull( AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted( null, array( 'code' => 'foo' ) ) );
+		$this->assertTrue( AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted( null, array( 'code' => AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE ) ) );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1292,8 +1292,6 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * Test process_markup.
 	 */
 	public function test_process_markup() {
-		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-
 		$this->set_capability();
 		$this->process_markup( $this->valid_amp_img );
 		$this->assertEquals( array(), AMP_Validation_Manager::$validation_results );


### PR DESCRIPTION
When CSS tree-shaking is accepted by an options or by filter, the `removed_unused_css_rules` validation error is always being shown on an invalid URL screen. Similarly, when a theme is configured to forcibly accept sanitization for other errors, such as an illegal CSS rule, as in the core theme sanitizer:

https://github.com/Automattic/amp-wp/blob/60fe63749e273c938d6ab2375ff89725ed1f2389/includes/sanitizers/class-amp-core-theme-sanitizer.php#L191-L201

These are also being shown always for every invalid URL. This adds noise and creates confusion. 

We should just omit such validation errors from ever being included in validation results so that they never show up. By omitting validation errors that are forcibly-accepted as sanitized by a filter, we avoid needlessly creating `amp_validation_error` taxonomy terms when they'll always be accepted anyway. This is particularly important for validation errors such as created by scripts with variable contents. Consider, for example, a template that does:

```php
<script>
var serverRandom = <?php echo wp_json_encode( wp_rand() ); ?>;
</script>
```

(For a more common scenario, consider the case when a nonce is output.) You may have considered adding a filter to automatically accept this validation error:

```php
add_filter( 'amp_validation_error_sanitized', function( $sanitized, $error ) {
	$is_random_script = (
		AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE === $error['code']
		&&
		'script' === $error['node_name']
		&&
		isset( $error['text'] )
		&&
		false !== strpos( $error['text'], 'var serverRandom' )
	);
	if ( $is_random_script ) {
		$sanitized = true;
	}
	return $sanitized;
}, 10, 2 );
```

However, what this results in is a new `amp_validation_error` term added to the database every time that the URL is re-validated. Since the text is random, then that validation error will become disassociated with the URL the next time it is checked, and another validation error will come and take its place. This repeats until many duplicated `amp_validation_error` terms fill up the database.

🎗 At some point we need to add a cronjob to delete `amp_validation_error` terms that have zero URLs associated with them.

So, the changes in this PR also prevent this from being a problem. Such filter-accepted validation errors will never see the light of day.

The changes in this PR extend the “staleness” determination beyond the active theme/plugins to include changes to whether tree shaking will be automatically accepted. In this way, if the user re-checks a URL after enabling auto tree-shaking then the validation error for tree shaking will no longer appear.

# Before

![image](https://user-images.githubusercontent.com/134745/45261424-c37d7900-b3b6-11e8-965f-d93545250b96.png)

# After

![image](https://user-images.githubusercontent.com/134745/45261430-d98b3980-b3b6-11e8-9b81-0f4a070b1dc6.png)
