### PR TITLE
Add confirmation dialog when leaving invalid URL screen with unsaved changes

### DIFF
--- a/assets/js/amp-invalid-url-post-edit-screen.js
+++ b/assets/js/amp-invalid-url-post-edit-screen.js
@@ -1,0 +1,60 @@
+/* exported ampInvalidUrlPostEditScreen */
+
+var ampInvalidUrlPostEditScreen = ( function() { // eslint-disable-line no-unused-vars
+	var component;
+
+	component = {
+		data: {
+			l10n: {
+				unsaved_changes: ''
+			}
+		}
+	};
+
+	/**
+	 * Boot.
+	 *
+	 * @param {Object} data Data.
+	 * @param {Object} data.l10n Translations.
+	 */
+	component.boot = function boot( data ) {
+		Object.assign( component.data, data );
+		component.watchForUnsavedChanges();
+	};
+
+	/**
+	 * Watch for unsaved changes.
+	 *
+	 * Add an beforeunload warning when attempting to leave the page when there are unsaved changes,
+	 * unless the user is pressing the trash link or update button.
+	 */
+	component.watchForUnsavedChanges = function watchForUnsavedChanges() {
+		var onChange = function( event ) {
+			if ( event.target.matches( 'select' ) ) {
+				document.getElementById( 'amp_validation_errors' ).removeEventListener( 'change', onChange );
+
+				window.addEventListener( 'beforeunload', component.onBeforeUnload );
+
+				// Remove prompt when clicking trash or update.
+				document.querySelector( '#major-publishing-actions' ).addEventListener( 'click', function() {
+					window.removeEventListener( 'beforeunload', component.onBeforeUnload );
+				} );
+			}
+		};
+		document.getElementById( 'amp_validation_errors' ).addEventListener( 'change', onChange );
+	};
+
+	/**
+	 * Show message at beforeunload.
+	 *
+	 * @param {Event} event - The beforeunload event.
+	 * @return {string} Message.
+	 */
+	component.onBeforeUnload = function onBeforeUnload( event ) {
+		event.preventDefault();
+		event.returnValue = component.data.l10n.unsaved_changes;
+		return component.data.l10n.unsaved_changes;
+	};
+
+	return component;
+}() );

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -128,11 +128,15 @@ class AMP_Invalid_URL_Post_Type {
 	public static function add_admin_hooks() {
 		add_filter( 'dashboard_glance_items', array( __CLASS__, 'filter_dashboard_glance_items' ) );
 		add_action( 'rightnow_end', array( __CLASS__, 'print_dashboard_glance_styles' ) );
+
+		// Edit post screen hooks.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_edit_post_screen_scripts' ) );
 		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
 		add_action( 'edit_form_top', array( __CLASS__, 'print_url_as_title' ) );
+
+		// Post list screen hooks.
 		add_filter( 'the_title', array( __CLASS__, 'filter_the_title_in_post_list_table' ), 10, 2 );
 		add_action( 'restrict_manage_posts', array( __CLASS__, 'render_post_filters' ), 10, 2 );
-
 		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', array( __CLASS__, 'add_post_columns' ) );
 		add_action( 'manage_posts_custom_column', array( __CLASS__, 'output_custom_column' ), 10, 2 );
 		add_filter( 'post_row_actions', array( __CLASS__, 'filter_row_actions' ), 10, 2 );
@@ -1008,6 +1012,19 @@ class AMP_Invalid_URL_Post_Type {
 		$redirect = remove_query_arg( wp_removable_query_args(), $redirect );
 		wp_safe_redirect( add_query_arg( $args, $redirect ) );
 		exit();
+	}
+
+	/**
+	 * Enqueue scripts for the edit post screen.
+	 */
+	public static function enqueue_edit_post_screen_scripts() {
+		$current_screen = get_current_screen();
+		if ( 'post' !== $current_screen->base || self::POST_TYPE_SLUG !== $current_screen->post_type ) {
+			return;
+		}
+
+		// Eliminate autosave since it is only relevant for the content editor.
+		wp_dequeue_script( 'autosave' );
 	}
 
 	/**

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1025,6 +1025,19 @@ class AMP_Invalid_URL_Post_Type {
 
 		// Eliminate autosave since it is only relevant for the content editor.
 		wp_dequeue_script( 'autosave' );
+
+		$handle = 'amp-invalid-url-post-edit-screen';
+		wp_enqueue_script( $handle, amp_get_asset_url( "js/$handle.js" ), array(), AMP__VERSION, true );
+		$data = array(
+			'l10n' => array(
+				'unsaved_changes' => __( 'You have unsaved changes. Are you sure you want to leave?', 'amp' ),
+			),
+		);
+		wp_add_inline_script(
+			$handle,
+			sprintf( 'document.addEventListener( "DOMContentLoaded", function() { ampInvalidUrlPostEditScreen.boot( %s ); } );', wp_json_encode( $data ) ),
+			'after'
+		);
 	}
 
 	/**

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+// phpcs:disable WordPress.Variables.GlobalVariables.OverrideProhibited
+
 /**
  * Tests for AMP_Invalid_URL_Post_Type class.
  *
@@ -83,11 +85,13 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 
 		$this->assertEquals( 10, has_filter( 'dashboard_glance_items', array( self::TESTED_CLASS, 'filter_dashboard_glance_items' ) ) );
 		$this->assertEquals( 10, has_action( 'rightnow_end', array( self::TESTED_CLASS, 'print_dashboard_glance_styles' ) ) );
+
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( self::TESTED_CLASS, 'enqueue_edit_post_screen_scripts' ) ) );
 		$this->assertEquals( 10, has_action( 'add_meta_boxes', array( self::TESTED_CLASS, 'add_meta_boxes' ) ) );
 		$this->assertEquals( 10, has_action( 'edit_form_top', array( self::TESTED_CLASS, 'print_url_as_title' ) ) );
-		$this->assertEquals( 10, has_filter( 'the_title', array( self::TESTED_CLASS, 'filter_the_title_in_post_list_table' ) ) );
-		$this->assertEquals( 10, has_filter( 'restrict_manage_posts', array( self::TESTED_CLASS, 'render_post_filters' ), 10, 2 ) );
 
+		$this->assertEquals( 10, has_filter( 'the_title', array( self::TESTED_CLASS, 'filter_the_title_in_post_list_table' ) ) );
+		$this->assertEquals( 10, has_filter( 'restrict_manage_posts', array( self::TESTED_CLASS, 'render_post_filters' ) ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG . '_posts_columns', array( self::TESTED_CLASS, 'add_post_columns' ) ) );
 		$this->assertEquals( 10, has_action( 'manage_posts_custom_column', array( self::TESTED_CLASS, 'output_custom_column' ) ) );
 		$this->assertEquals( 10, has_filter( 'post_row_actions', array( self::TESTED_CLASS, 'filter_row_actions' ) ) );
@@ -934,6 +938,25 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
 		$this->assertStringEndsWith( 'action=edit&amp_taxonomy_terms_updated=1&amp_remaining_errors=0', $exception->getMessage() );
+	}
+
+	/**
+	 * Test for enqueue_edit_post_screen_scripts()
+	 *
+	 * @covers \AMP_Invalid_URL_Post_Type::enqueue_edit_post_screen_scripts()
+	 */
+	public function test_enqueue_edit_post_screen_scripts() {
+		wp_enqueue_script( 'autosave' );
+		set_current_screen( 'index.php' );
+		AMP_Invalid_URL_Post_Type::enqueue_edit_post_screen_scripts();
+		$this->assertTrue( wp_script_is( 'autosave', 'enqueued' ) );
+
+		global $pagenow;
+		$pagenow = 'post.php';
+		set_current_screen( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG );
+		AMP_Invalid_URL_Post_Type::enqueue_edit_post_screen_scripts();
+		$this->assertFalse( wp_script_is( 'autosave', 'enqueued' ) );
+		$pagenow = null;
 	}
 
 	/**

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -950,12 +950,14 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 		set_current_screen( 'index.php' );
 		AMP_Invalid_URL_Post_Type::enqueue_edit_post_screen_scripts();
 		$this->assertTrue( wp_script_is( 'autosave', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'amp-invalid-url-post-edit-screen', 'enqueued' ) );
 
 		global $pagenow;
 		$pagenow = 'post.php';
 		set_current_screen( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG );
 		AMP_Invalid_URL_Post_Type::enqueue_edit_post_screen_scripts();
 		$this->assertFalse( wp_script_is( 'autosave', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'amp-invalid-url-post-edit-screen', 'enqueued' ) );
 		$pagenow = null;
 	}
 


### PR DESCRIPTION
When a user changes a `select` dropdown to change a validation error status, and then they try to leave the page without clicking Update (or Forget), this now will appear:

![image](https://user-images.githubusercontent.com/134745/45262099-861fe800-b3c4-11e8-8656-e23dba487eeb.png)

Also remove `autosave` script from being included on the screen.