### PR TITLE
Fix stretched logo and header issues in Twenty Sevetneen

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -767,6 +767,11 @@ class AMP_Theme_Support {
 			return 'amp';
 		} );
 
+		// Don't show loading indicator on custom logo since it makes most sense for larger images.
+		add_filter( 'get_custom_logo', function( $html ) {
+			return preg_replace( '/(?<=<img\s)/', ' noloading ', $html );
+		}, 1 );
+
 		/*
 		 * "AMP HTML documents MUST contain the AMP boilerplate code (head > style[amp-boilerplate] and noscript > style[amp-boilerplate])
 		 * in their head tag." {@link https://www.ampproject.org/docs/fundamentals/spec#required-markup AMP Required markup}

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -498,6 +498,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Get the (common) navigation outer height.
+	 *
+	 * @todo If the nav menu has many items and it spans multiple rows, this will be too small.
+	 * @link https://github.com/WordPress/wordpress-develop/blob/fd5ba80c5c3d9cf62348567073945e246285fbca/src/wp-content/themes/twentyseventeen/assets/js/global.js#L50
+	 *
+	 * @return int Navigation outer height.
+	 */
+	protected static function get_twentyseventeen_navigation_outer_height() {
+		return 72;
+	}
+
+	/**
 	 * Add required styles for video and image headers.
 	 *
 	 * This is currently used exclusively for Twenty Seventeen.
@@ -567,6 +579,13 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					display: none;
 				}
 
+				<?php if ( $is_front_page_layout && ! has_custom_header() ) : ?>
+					/* https://github.com/WordPress/wordpress-develop/blob/fd5ba80c5c3d9cf62348567073945e246285fbca/src/wp-content/themes/twentyseventeen/assets/js/global.js#L92-L94 */
+					.site-branding {
+						margin-bottom: <?php echo (int) AMP_Core_Theme_Sanitizer::get_twentyseventeen_navigation_outer_height(); ?>px;
+					}
+				<?php endif; ?>
+
 				@media screen and (min-width: 48em) {
 					/* Note that adjustHeaderHeight() is irrelevant with this change */
 					<?php if ( ! $is_front_page_layout ) : ?>
@@ -578,7 +597,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					/* Initial styles that amp-animations for navigationTopShow and navigationTopHide will override */
 					.navigation-top.site-navigation-fixed {
 						opacity: 0;
-						transform: translateY( -72px );
+						transform: translateY( -<?php echo (int) AMP_Core_Theme_Sanitizer::get_twentyseventeen_navigation_outer_height(); ?>px );
 						display: block;
 					}
 				}
@@ -659,7 +678,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'media'     => '(min-width: 48em)',
 					'keyframes' => array(
 						'opacity'   => 0.0,
-						'transform' => 'translateY( -72px )',
+						'transform' => sprintf( 'translateY( -%dpx )', self::get_twentyseventeen_navigation_outer_height() ),
 					),
 				),
 			),

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -823,6 +823,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( ! $parsed || ! isset( $parsed['stylesheet'] ) || ! is_array( $parsed['stylesheet'] ) ) {
 			$parsed = $this->prepare_stylesheet( $stylesheet, $options );
 
+			/*
+			 * When an object cache is not available, we cache with an expiration to prevent the options table from
+			 * getting filled infinitely. On the other hand, if an external object cache is available then we don't
+			 * set an expiration because it should implement LRU cache expulsion policy.
+			 */
 			if ( wp_using_ext_object_cache() ) {
 				wp_cache_set( $cache_key, $parsed, $cache_group );
 			} else {


### PR DESCRIPTION
# Problem

Per https://github.com/Automattic/amp-wp/issues/1305#issuecomment-415970615, on Twenty Seventeen when uploading a square logo I see the following in non-AMP:

![image](https://user-images.githubusercontent.com/134745/44618842-7df77280-a832-11e8-9011-8aed44e04297.png)

```html
<img
	width="253" 
	height="250" 
	src="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png" 
	class="custom-logo" 
	alt="WordPress Develop" 
	itemprop="logo" 
	srcset="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png 253w, https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1-100x100.png 100w" 
	sizes="100vw" 
/>
```

In AMP, however, this comes out as:

![image](https://user-images.githubusercontent.com/134745/44618845-8cde2500-a832-11e8-9879-99212bc3c7d6.png)

```html
<amp-img 
	width="253" 
	height="250" 
	src="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png" 
	class="custom-logo amp-wp-enforced-sizes" 
	alt="WordPress Develop" 
	itemprop="logo" 
	srcset="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png 253w, https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1-100x100.png 100w" 
	sizes="100vw" 
	layout="intrinsic"
></amp-img>
```

# Solution

The `max-height` of the `.custom-logo-link img` is defined as being 80px, unless there is header media in which case it is 200px. Issues related to vertically-squashed images can be avoided if we just make sure that the image has this height to begin with.

The `sizes` attribute also has to be removed from the Custom Logo image.

```html
<amp-img
	noloading=""
	width="80.96"
	height="80"
	src="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png"
	class="custom-logo amp-wp-enforced-sizes"
	alt="WordPress Develop"
	itemprop="logo"
	srcset="https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1.png 253w, https://src.wordpress-develop.test/wp-content/uploads/2018/05/cropped-amp-brand-blue10x-1-100x100.png 100w"
	layout="intrinsic"
></amp-img>
```

# Other Changes

* Add `noloading` to the custom logo since the loading indicator is really best suited for larger images. (h/t @sebastianbenz)
* Fix height of header on Twenty Seventeen when there is no header image/video set.

See also #1321.