### PR TITLE
[amp-stories sub-task] UI Fixes

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -134,12 +134,11 @@ div[data-amp-position="lower-third"] {
 	bottom: 0;
 }
 
-.editor-block-list__block .editor-block-list__block .editor-block-list__block.is-selected {
-	z-index: 90;
-}
-
-.editor-block-list__block .editor-block-list__block .editor-block-list__block:not(.is-selected) {
-	overflow: hidden;
+div[data-type="amp/amp-story-grid-layer"] .wp-block-image .block-library-image__resize-handler-right,
+div[data-type="amp/amp-story-grid-layer"] .wp-block-image .block-library-image__resize-handler-bottom,
+div[data-type="amp/amp-story-cta-layer"] .wp-block-image .block-library-image__resize-handler-right,
+div[data-type="amp/amp-story-cta-layer"] .wp-block-image .block-library-image__resize-handler-bottom {
+	display: none;
 }
 
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected,

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -40,7 +40,8 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	margin: 0;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"].editor-block-list__block .editor-block-list__block-edit, .editor-block-list__layout .editor-block-list__layout .editor-block-list__block .editor-block-list__block-edit {
+.editor-block-list__layout div[data-type="amp/amp-story-page"].editor-block-list__block .editor-block-list__block-edit,
+.editor-block-list__layout .editor-block-list__layout .editor-block-list__block .editor-block-list__block-edit {
 	margin: 0;
 }
 
@@ -56,11 +57,10 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 
 .amp-grid-template .editor-block-list__layout:first-of-type {
 	display: grid;
-	overflow: hidden;
 	padding: 68px 32px 32px;
 }
 
-.amp-grid-template .editor-block-list__layout:first-of-type * {
+.amp-grid-template .editor-block-list__layout:first-of-type *:not(.editor-block-toolbar) {
 	margin: 0;
 	box-sizing: border-box;
 }
@@ -134,6 +134,10 @@ div[data-amp-position="lower-third"] {
 	bottom: 0;
 }
 
+.editor-block-list__block .editor-block-list__block .editor-block-list__block:not(.is-selected) {
+	overflow: hidden;
+}
+
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected,
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected .editor-block-list__block {
 	border: 1px dotted #99c2e0;
@@ -143,6 +147,10 @@ div[data-amp-position="lower-third"] {
 	z-index: 0;
 }
 
+.editor-block-list__layout div[data-type="amp/amp-story-grid-layer"]:not(.is-selected):not(.is-selected-parent) .editor-block-list__block p[data-is-placeholder-visible="true"] ~ p {
+	display: none;
+}
+
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected ~ div[data-type="amp/amp-story-grid-layer"],
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected-parent ~ div[data-type="amp/amp-story-grid-layer"],
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected ~ div[data-type="amp/amp-story-cta-layer"],
@@ -150,7 +158,7 @@ div[data-amp-position="lower-third"] {
 	display: none;
 }
 
-.edit-post-visual-editor ul.editor-selectors {
+.edit-post-visual-editor .editor-block-list__block ul.editor-selectors {
 	position: absolute;
 	right: -155px;
 	bottom: 0;

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -134,11 +134,9 @@ div[data-amp-position="lower-third"] {
 	bottom: 0;
 }
 
-div[data-type="amp/amp-story-grid-layer"] .wp-block-image .block-library-image__resize-handler-right,
-div[data-type="amp/amp-story-grid-layer"] .wp-block-image .block-library-image__resize-handler-bottom,
-div[data-type="amp/amp-story-cta-layer"] .wp-block-image .block-library-image__resize-handler-right,
-div[data-type="amp/amp-story-cta-layer"] .wp-block-image .block-library-image__resize-handler-bottom {
-	display: none;
+div[data-type="amp/amp-story-grid-layer"] .block-library-image__resizer {
+	max-width: 318px !important;
+	max-height: 533px !important;
 }
 
 .editor-block-list__layout div[data-type="amp/amp-story-grid-layer"].is-selected,

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -134,6 +134,10 @@ div[data-amp-position="lower-third"] {
 	bottom: 0;
 }
 
+.editor-block-list__block .editor-block-list__block .editor-block-list__block.is-selected {
+	z-index: 90;
+}
+
 .editor-block-list__block .editor-block-list__block .editor-block-list__block:not(.is-selected) {
 	overflow: hidden;
 }

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -23,6 +23,11 @@ class AMP_Story_Post_Type {
 	 * @return void
 	 */
 	public static function register() {
+
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
 		register_post_type(
 			self::POST_TYPE_SLUG,
 			array(
@@ -76,6 +81,8 @@ class AMP_Story_Post_Type {
 			)
 		);
 
+		add_filter( 'post_row_actions', array( __CLASS__, 'remove_classic_editor_link' ), 11, 2 );
+
 		add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'filter_kses_allowed_html' ), 10, 2 );
 
 		// Forcibly sanitize all validation errors.
@@ -102,6 +109,20 @@ class AMP_Story_Post_Type {
 		add_image_size( 'amp-story-poster-landscape', 400, 300, true );
 
 		add_filter( 'template_include', array( __CLASS__, 'filter_template_include' ) );
+	}
+
+	/**
+	 * Remove classic editor action from AMP Story listing.
+	 *
+	 * @param array   $actions AMP Story row actions.
+	 * @param WP_Post $post WP_Post object.
+	 * @return array Actions.
+	 */
+	public static function remove_classic_editor_link( $actions, $post ) {
+		if ( 'amp_story' === $post->post_type ) {
+			unset( $actions['classic'] );
+		}
+		return $actions;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes some of the issues found when testing:
- Disables amp-story post type when Gutenberg is not active;
- Hides `Classic Editor` action for `amp_story` post type;
- Hides placeholders for non-active layers;
- Limits resizing to 318px of width and 533px of height;
