### PR TITLE
Expose and store queried object for validated URL; show edit link

### DIFF
--- a/includes/class-amp-cli.php
+++ b/includes/class-amp-cli.php
@@ -576,16 +576,21 @@ class AMP_CLI {
 			self::$wp_cli_progress->tick();
 		}
 
-		AMP_Invalid_URL_Post_Type::store_validation_errors( $validity['validation_errors'], $validity['url'] );
+		$validation_errors = wp_list_pluck( $validity['results'], 'error' );
+		AMP_Invalid_URL_Post_Type::store_validation_errors(
+			$validation_errors,
+			$validity['url'],
+			wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+		);
 		$unaccepted_error_count = count( array_filter(
-			$validity['validation_errors'],
+			$validation_errors,
 			function( $error ) {
 				$validation_status = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error );
 				return AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPTED_STATUS !== $validation_status['term_status'];
 			}
 		) );
 
-		if ( count( $validity['validation_errors'] ) > 0 ) {
+		if ( count( $validation_errors ) > 0 ) {
 			self::$total_errors++;
 		}
 		if ( $unaccepted_error_count > 0 ) {

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -346,17 +346,22 @@ class AMP_Invalid_URL_Post_Type {
 	 *
 	 * If there are no validation errors provided, then any existing amp_invalid_url post is deleted.
 	 *
-	 * @param array       $validation_errors Validation errors.
-	 * @param string      $url               URL on which the validation errors occurred. Will be normalized to non-AMP version.
-	 * @param int|WP_Post $post              Post to update. Optional. If empty, then post is looked up by URL.
+	 * @param array  $validation_errors Validation errors.
+	 * @param string $url               URL on which the validation errors occurred. Will be normalized to non-AMP version.
+	 * @param array  $args {
+	 *     Args.
+	 *
+	 *     @type int|WP_Post $invalid_url_post Post to update. Optional. If empty, then post is looked up by URL.
+	 *     @type array       $queried_object   Queried object, including keys for type and id. May be empty.
+	 * }
 	 * @return int|WP_Error $post_id The post ID of the custom post type used, or WP_Error on failure.
 	 * @global WP $wp
 	 */
-	public static function store_validation_errors( $validation_errors, $url, $post = null ) {
+	public static function store_validation_errors( $validation_errors, $url, $args = array() ) {
 		$url  = remove_query_arg( amp_get_slug(), $url ); // Only ever store the canonical version.
 		$slug = md5( $url );
-		if ( $post ) {
-			$post = get_post( $post );
+		if ( isset( $args['invalid_url_post'] ) ) {
+			$post = get_post( $args['invalid_url_post'] );
 		} else {
 			$post = get_page_by_path( $slug, OBJECT, self::POST_TYPE_SLUG );
 			if ( ! $post ) {
@@ -458,6 +463,9 @@ class AMP_Invalid_URL_Post_Type {
 		wp_set_object_terms( $post_id, wp_list_pluck( $terms, 'term_id' ), AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
 
 		update_post_meta( $post_id, '_amp_validated_environment', self::get_validated_environment() );
+		if ( isset( $args['queried_object'] ) ) {
+			update_post_meta( $post_id, '_amp_queried_object', $args['queried_object'] );
+		}
 
 		return $post_id;
 	}
@@ -714,9 +722,14 @@ class AMP_Invalid_URL_Post_Type {
 				continue;
 			}
 
-			self::store_validation_errors( $validity['validation_errors'], $validity['url'], $post );
+			$validation_errors = wp_list_pluck( $validity['results'], 'error' );
+			self::store_validation_errors(
+				$validation_errors,
+				$validity['url'],
+				wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+			);
 			$unaccepted_error_count = count( array_filter(
-				$validity['validation_errors'],
+				$validation_errors,
 				function( $error ) {
 					return ! AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error );
 				}
@@ -890,14 +903,24 @@ class AMP_Invalid_URL_Post_Type {
 				throw new Exception( esc_html( $validity->get_error_code() ) );
 			}
 
-			$stored = self::store_validation_errors( $validity['validation_errors'], $validity['url'], $post );
+			$errors = wp_list_pluck( $validity['results'], 'error' );
+			$stored = self::store_validation_errors(
+				$errors,
+				$validity['url'],
+				array_merge(
+					array(
+						'invalid_url_post' => $post,
+					),
+					wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+				)
+			);
 			if ( is_wp_error( $stored ) ) {
 				throw new Exception( esc_html( $stored->get_error_code() ) );
 			}
 			$redirect = get_edit_post_link( $stored, 'raw' );
 
 			$error_count = count( array_filter(
-				$validity['validation_errors'],
+				$errors,
 				function ( $error ) {
 					return ! AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error );
 				}
@@ -949,10 +972,20 @@ class AMP_Invalid_URL_Post_Type {
 			return $validity;
 		}
 
+		$validation_errors  = wp_list_pluck( $validity['results'], 'error' );
 		$validation_results = array();
-		self::store_validation_errors( $validity['validation_errors'], $validity['url'], $post->ID );
-		foreach ( $validity['validation_errors'] as $error ) {
-			$sanitized = AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error );
+		self::store_validation_errors(
+			$validation_errors,
+			$validity['url'],
+			array_merge(
+				array(
+					'invalid_url_post' => $post,
+				),
+				wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+			)
+		);
+		foreach ( $validation_errors  as $error ) {
+			$sanitized = AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error ); // @todo Consider re-using $validity['results'][x]['sanitized'], unless auto-sanitize is causing problem.
 
 			$validation_results[] = compact( 'error', 'sanitized' );
 		}
@@ -1154,6 +1187,32 @@ class AMP_Invalid_URL_Post_Type {
 						}
 						?>
 						<?php self::display_invalid_url_validation_error_counts_summary( $post ); ?>
+					</div>
+
+					<div class="misc-pub-section">
+						<?php
+						$view_label     = __( 'View URL', 'amp' );
+						$queried_object = get_post_meta( $post->ID, '_amp_queried_object', true );
+						if ( isset( $queried_object['id'] ) && isset( $queried_object['type'] ) ) {
+							$after = ' | ';
+							if ( 'post' === $queried_object['type'] && get_post( $queried_object['id'] ) && post_type_exists( get_post( $queried_object['id'] )->post_type ) ) {
+								$post_type_object = get_post_type_object( get_post( $queried_object['id'] )->post_type );
+								edit_post_link( $post_type_object->labels->edit_item, '', $after, $queried_object['id'] );
+								$view_label = $post_type_object->labels->view_item;
+							} elseif ( 'term' === $queried_object['type'] && get_term( $queried_object['id'] ) && taxonomy_exists( get_term( $queried_object['id'] )->taxonomy ) ) {
+								$taxonomy_object = get_taxonomy( get_term( $queried_object['id'] )->taxonomy );
+								edit_term_link( $taxonomy_object->labels->edit_item, '', $after, get_term( $queried_object['id'] ) );
+								$view_label = $taxonomy_object->labels->view_item;
+							} elseif ( 'user' === $queried_object['type'] ) {
+								$link = get_edit_user_link( $queried_object['id'] );
+								if ( $link ) {
+									printf( '<a href="%s">%s</a>%s', esc_url( $link ), esc_html__( 'Edit User', 'amp' ), esc_html( $after ) );
+								}
+								$view_label = __( 'View User', 'amp' );
+							}
+						}
+						printf( '<a href="%s">%s</a>', esc_url( self::get_url_from_post( $post ) ), esc_html( $view_label ) );
+						?>
 					</div>
 				</div>
 			</div>

--- a/tests/test-class-amp-cli.php
+++ b/tests/test-class-amp-cli.php
@@ -467,24 +467,27 @@ class Test_AMP_CLI extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Adds the AMP_VALIDATION_RESULTS: comment to the <html> body.
+	 * Adds the AMP_VALIDATION: comment to the <html> body.
 	 *
 	 * @return array The response, with a comment in the body.
 	 */
 	public function add_comment() {
-		$mock_validation_results = array(
-			array(
-				'error'     => array(
-					'code' => 'foo',
+		$mock_validation = array(
+			'results' => array(
+				array(
+					'error'     => array(
+						'code' => 'foo',
+					),
+					'sanitized' => false,
 				),
-				'sanitized' => false,
 			),
+			'url'     => home_url( '/' ),
 		);
 
 		return array(
 			'body'     => sprintf(
 				'<html amp><head></head><body></body><!--%s--></html>',
-				'AMP_VALIDATION_RESULTS:' . wp_json_encode( $mock_validation_results )
+				'AMP_VALIDATION:' . wp_json_encode( $mock_validation )
 			),
 			'response' => array(
 				'code'    => 200,

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -345,10 +345,23 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			$invalid_url_post_id,
 			AMP_Invalid_URL_Post_Type::store_validation_errors(
 				$errors,
-				get_permalink( $post )
+				get_permalink( $post ),
+				array(
+					'queried_object' => array(
+						'type' => 'post',
+						'id'   => $post->ID,
+					),
+				)
 			)
 		);
 		$this->assertEquals( 'publish', get_post_status( $invalid_url_post_id ) );
+		$this->assertEquals(
+			array(
+				'type' => 'post',
+				'id'   => $post->ID,
+			),
+			get_post_meta( $invalid_url_post_id, '_amp_queried_object', true )
+		);
 
 		// Test passing specific post to override the URL.
 		$this->assertEquals(
@@ -356,7 +369,9 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			AMP_Invalid_URL_Post_Type::store_validation_errors(
 				$errors,
 				home_url( '/something/else/' ),
-				$invalid_url_post_id
+				array(
+					'invalid_url_post' => $invalid_url_post_id,
+				)
 			)
 		);
 
@@ -629,14 +644,16 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode( array_map(
-						function( $error ) {
-							return array_merge(
-								compact( 'error' ),
-								array( 'sanitized' => false )
-							);
-						},
-						$that->get_mock_errors()
+					'AMP_VALIDATION:' . wp_json_encode( array(
+						'results' => array_map(
+							function( $error ) {
+								return array_merge(
+									compact( 'error' ),
+									array( 'sanitized' => false )
+								);
+							},
+							$that->get_mock_errors()
+						),
 					) )
 				),
 			);
@@ -752,14 +769,16 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode( array_map(
-						function( $error ) {
-							return array_merge(
-								compact( 'error' ),
-								array( 'sanitized' => false )
-							);
-						},
-						$that->get_mock_errors()
+					'AMP_VALIDATION:' . wp_json_encode( array(
+						'results' => array_map(
+							function( $error ) {
+								return array_merge(
+									compact( 'error' ),
+									array( 'sanitized' => false )
+								);
+							},
+							$that->get_mock_errors()
+						),
 					) )
 				),
 			);
@@ -875,8 +894,8 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode(
-						array(
+					'AMP_VALIDATION:' . wp_json_encode( array(
+						'results' => array(
 							array(
 								'sanitized' => false,
 								'error'     => array(
@@ -889,8 +908,8 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 									'code' => 'baz',
 								),
 							),
-						)
-					)
+						),
+					) )
 				),
 			);
 		} );
@@ -934,14 +953,14 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode(
-						array(
+					'AMP_VALIDATION:' . wp_json_encode( array(
+						'results' => array(
 							array(
 								'sanitized' => false,
 								'error'     => $error,
 							),
-						)
-					)
+						),
+					) )
 				),
 			);
 		} );

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -423,7 +423,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		// PUT request.
 		add_filter( 'pre_http_request', function() {
 			return array(
-				'body'     => '<html><body></body><!--AMP_VALIDATION_RESULTS:[]--></html>',
+				'body'     => '<html><body></body><!--AMP_VALIDATION:{"results":[]}--></html>',
 				'response' => array(
 					'code'    => 200,
 					'message' => 'ok',
@@ -1085,17 +1085,18 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		);
 		AMP_Validation_Manager::$validation_results = $validation_results;
 
-		// should_validate_response() will be false, so finalize_validation() won't append the AMP_VALIDATION_RESULTS comment.
+		// should_validate_response() will be false, so finalize_validation() won't append the _RESULTS comment.
 		AMP_Validation_Manager::finalize_validation( $dom );
-		$this->assertNotContains( 'AMP_VALIDATION_RESULTS:[', $dom->documentElement->lastChild->nodeValue );
+		$this->assertNotContains( 'AMP_VALIDATION:{', $dom->documentElement->lastChild->nodeValue );
 
-		// Ensure that should_validate_response() is true, so finalize_validation() will append the AMP_VALIDATION_RESULTS comment.
+		// Ensure that should_validate_response() is true, so finalize_validation() will append the AMP_VALIDATION comment.
 		$post = $this->factory()->post->create(); // WPCS: global override ok.
 		$_GET[ AMP_Validation_Manager::VALIDATE_QUERY_VAR ] = 1;
 		$this->set_capability();
 		AMP_Validation_Manager::finalize_validation( $dom );
-		$this->assertContains( 'AMP_VALIDATION_RESULTS:[', $dom->documentElement->lastChild->nodeValue );
-		$this->assertContains( wp_json_encode( $validation_results, 128 ), $dom->documentElement->lastChild->nodeValue );
+		$this->assertTrue( (bool) preg_match( '#AMP_VALIDATION:({.+})#s', $dom->documentElement->lastChild->nodeValue, $matches ) );
+		$returned_valudation = json_decode( $matches[1], true );
+		$this->assertEquals( $validation_results, $returned_valudation['results'] );
 	}
 
 	/**
@@ -1132,22 +1133,25 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertEquals( 'no_published_post_url_available', $r->get_error_code() );
 		remove_filter( 'amp_pre_get_permalink', '__return_empty_string' );
 
-		$validation_error   = array(
+		$validation_error = array(
 			'code' => 'example',
 		);
-		$validation_results = array(
-			array(
-				'error'     => $validation_error,
-				'sanitized' => false,
+
+		$validation = array(
+			'results' => array(
+				array(
+					'error'     => $validation_error,
+					'sanitized' => false,
+				),
 			),
 		);
 
 		$this->factory()->post->create();
-		$filter = function() use ( $validation_results ) {
+		$filter = function() use ( $validation ) {
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode( $validation_results )
+					'AMP_VALIDATION:' . wp_json_encode( $validation )
 				),
 			);
 		};
@@ -1199,23 +1203,24 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 				),
 				$url
 			);
-			$validation_results = array();
+			$validation = array( 'results' => array() );
 			foreach ( $validation_errors as $error ) {
 				$sanitized            = false;
-				$validation_results[] = compact( 'error', 'sanitized' );
+				$validation['results'][] = compact( 'error', 'sanitized' );
 			}
 
 			return array(
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
-					'AMP_VALIDATION_RESULTS:' . wp_json_encode( $validation_results )
+					'AMP_VALIDATION:' . wp_json_encode( $validation )
 				),
 			);
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 		$r = AMP_Validation_Manager::validate_url( $validated_url );
 		$this->assertInternalType( 'array', $r );
-		$this->assertEquals( $validation_errors, $r['validation_errors'] );
+		$this->assertEquals( $validated_url, $r['url'] );
+		$this->assertEquals( $validation_errors, wp_list_pluck( $r['results'], 'error' ) );
 		remove_filter( 'pre_http_request', $filter );
 	}
 


### PR DESCRIPTION
Applies the following part of the [design](https://sketch.cloud/s/VoDKr/all/page-1/amp-validation-errors-for-amp-test-embeds-notification-message-on-the-top-right) from #1365:

![image](https://user-images.githubusercontent.com/134745/45458426-76e0b900-b6a8-11e8-868c-87311d50fe51.png)
