### PR TITLE
Work around syntax error caused by the pot-to-php script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function( grunt ) {
 				command: 'npm run pot-to-php'
 			},
 			makepot: {
-				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js"'
+				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/\'\'/*"'
 			},
 			create_build_zip: {
 				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e amp.zip ]; then rm amp.zip; fi; cd build; zip -r ../amp.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/amp.zip"'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
 				command: 'cross-env BABEL_ENV=production webpack'
 			},
 			pot_to_php: {
-				command: 'npm run pot-to-php'
+				command: 'npm run pot-to-php && php -l languages/amp-translations.php'
 			},
 			makepot: {
 				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/\\\'\\\'/*"'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function( grunt ) {
 				command: 'npm run pot-to-php && php -l languages/amp-translations.php'
 			},
 			makepot: {
-				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/\\\'\\\'/*"'
+				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/null/*"' // The --file-comment is a temporary workaround for <https://github.com/Automattic/amp-wp/issues/1416>.
 			},
 			create_build_zip: {
 				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e amp.zip ]; then rm amp.zip; fi; cd build; zip -r ../amp.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/amp.zip"'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function( grunt ) {
 				command: 'npm run pot-to-php'
 			},
 			makepot: {
-				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/\'\'/*"'
+				command: 'wp i18n make-pot . languages/amp-js.pot --include="*.js" --file-comment="*/\\\'\\\'/*"'
 			},
 			create_build_zip: {
 				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e amp.zip ]; then rm amp.zip; fi; cd build; zip -r ../amp.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/amp.zip"'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
  "main": "blocks/index.js",
  "scripts": {
   "pot-to-php": "pot-to-php languages/amp-js.pot languages/amp-translations.php amp",
-  "build": "grunt build; grunt create-build-zip",
+  "build": "grunt build && grunt create-build-zip",
   "deploy": "grunt deploy",
   "dev": "cross-env BABEL_ENV=default webpack --watch"
  }


### PR DESCRIPTION
This is an attempt to fix #1416 for the time being.

I still have to look into how the pot-to-php script handles comments exactly and how it can be solved. We likely don't need that script anymore in the long run though.

Also, I need to find some time to look into the WP-CLI command. It should be possible to skip the file comment entirely by using `--file-comment=""` instead of using a somewhat hacky `--file-comment="*/\'\'/*"` workaround. This would also mostly eliminate the need to fix the pot-to-php script.

Fixes #1416.