### PR TITLE
Fix passing invalid_url_post into store_validation_errors()

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -574,7 +574,7 @@ class AMP_Validation_Manager {
 					$validity['url'],
 					array_merge(
 						array(
-							'invalid_url_post' => $post,
+							'invalid_url_post' => $invalid_url_post_id,
 						),
 						wp_array_slice_assoc( $validity, array( 'queried_object' ) )
 					)


### PR DESCRIPTION
Fixes regression introduced in #1426 (by me). Editing a post in the classic editor caused the post being edited to be replaced with the `amp_invalid_url` post. Bad.