### PR TITLE
Prevent store_validation_errors from clobbering global post when empty invalid_url_post supplied

### DIFF
--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -360,9 +360,11 @@ class AMP_Invalid_URL_Post_Type {
 	public static function store_validation_errors( $validation_errors, $url, $args = array() ) {
 		$url  = remove_query_arg( amp_get_slug(), $url ); // Only ever store the canonical version.
 		$slug = md5( $url );
-		if ( isset( $args['invalid_url_post'] ) ) {
+		$post = null;
+		if ( ! empty( $args['invalid_url_post'] ) ) {
 			$post = get_post( $args['invalid_url_post'] );
-		} else {
+		}
+		if ( ! $post ) {
 			$post = get_page_by_path( $slug, OBJECT, self::POST_TYPE_SLUG );
 			if ( ! $post ) {
 				$post = get_page_by_path( $slug . '__trashed', OBJECT, self::POST_TYPE_SLUG );

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -288,6 +288,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Invalid_URL_Post_Type::store_validation_errors()
 	 */
 	public function test_store_validation_errors() {
+		global $post;
 		add_theme_support( 'amp', array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
@@ -335,9 +336,13 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 
 		$invalid_url_post_id = AMP_Invalid_URL_Post_Type::store_validation_errors(
 			$errors,
-			get_permalink( $post )
+			get_permalink( $post ),
+			array(
+				'invalid_url_post' => 0,
+			)
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
+		$this->assertNotEquals( $invalid_url_post_id, $post->ID, 'Passing an empty invalid_url_post should not re-use the global $post ever.' );
 
 		// Test resurrection from trash.
 		wp_trash_post( $invalid_url_post_id );


### PR DESCRIPTION
Another fix for regression introduced #1426. See also #1428.

When creating a post in Gutenberg and publishing, and then making a change to then update, at that point the invalid URL post replaces the post you're editing.

The issue is that I switched from a boolean check here https://github.com/Automattic/amp-wp/pull/1426/files#diff-57518db0811ee918fee17d27459ed4ecL358:

![image](https://user-images.githubusercontent.com/134745/45568968-086c3a00-b813-11e8-817e-ce2dfca81658.png)

So switching back to an `empty()` check fixes the problem.
