### PR TITLE
Update admin screen access

### DIFF
--- a/assets/src/amp-validation-error-detail-toggle.js
+++ b/assets/src/amp-validation-error-detail-toggle.js
@@ -6,7 +6,7 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Localized data
  */
-import { btnAriaLabel, errorIndexLink, errorIndexAnchor } from 'amp-validation-i18n';
+import { btnAriaLabel } from 'amp-validation-i18n';
 
 const OPEN_CLASS = 'is-open';
 
@@ -61,21 +61,7 @@ function addToggleListener() {
 	} );
 }
 
-// @todo This should be harmonized with the approach in PHP via AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url().
-function addViewErrorsByTypeLinkButton() {
-	if ( 'undefined' === typeof errorIndexAnchor || 'undefined' === typeof errorIndexLink ) {
-		return;
-	}
-	const heading = document.querySelector( '.wp-heading-inline' );
-	const link = document.createElement( 'a' );
-	link.innerText = errorIndexAnchor;
-	link.setAttribute( 'href', errorIndexLink );
-	link.setAttribute( 'class', 'page-title-action' );
-	heading.after( link );
-}
-
 domReady( () => {
 	addToggleButtons();
 	addToggleListener();
-	addViewErrorsByTypeLinkButton();
 } );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -111,6 +111,10 @@ class AMP_Options_Manager {
 	public static function validate_options( $new_options ) {
 		$options = self::get_options();
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return $options;
+		}
+
 		// Theme support.
 		$recognized_theme_supports = array(
 			'disabled',

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -55,7 +55,7 @@ class AMP_Options_Menu {
 		add_menu_page(
 			__( 'AMP Options', 'amp' ),
 			__( 'AMP', 'amp' ),
-			'manage_options',
+			'edit_posts',
 			AMP_Options_Manager::OPTION_NAME,
 			array( $this, 'render_screen' ),
 			self::ICON_BASE64_SVG
@@ -65,7 +65,7 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::OPTION_NAME,
 			__( 'AMP Settings', 'amp' ),
 			__( 'General', 'amp' ),
-			'manage_options',
+			'edit_posts',
 			AMP_Options_Manager::OPTION_NAME
 		);
 
@@ -157,7 +157,7 @@ class AMP_Options_Menu {
 				<?php endif; ?>
 			</p>
 		<?php else : ?>
-			<fieldset>
+			<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 				<?php if ( $builtin_support ) : ?>
 					<div class="notice notice-success notice-alt inline">
 						<p><?php esc_html_e( 'Your active theme is known to work well in paired or native mode.', 'amp' ); ?></p>
@@ -239,7 +239,7 @@ class AMP_Options_Menu {
 	 */
 	public function render_validation_handling() {
 		?>
-		<fieldset>
+		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<?php
 			$auto_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( array(
 				'code' => 'non_existent',
@@ -344,7 +344,7 @@ class AMP_Options_Menu {
 		?>
 
 		<?php if ( ! isset( $theme_support_args['available_callback'] ) ) : ?>
-			<fieldset id="all_templates_supported_fieldset">
+			<fieldset id="all_templates_supported_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 				<?php if ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] ) : ?>
 					<div class="notice notice-info notice-alt inline">
 						<p>
@@ -371,7 +371,7 @@ class AMP_Options_Menu {
 			</div>
 		<?php endif; ?>
 
-		<fieldset id="supported_post_types_fieldset">
+		<fieldset id="supported_post_types_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<?php $element_name = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]'; ?>
 			<h4 class="title"><?php esc_html_e( 'Content Types', 'amp' ); ?></h4>
 			<p>
@@ -397,7 +397,7 @@ class AMP_Options_Menu {
 		</fieldset>
 
 		<?php if ( ! isset( $theme_support_args['available_callback'] ) ) : ?>
-			<fieldset id="supported_templates_fieldset">
+			<fieldset id="supported_templates_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 				<style>
 					#supported_templates_fieldset ul ul {
 						margin-left: 40px;
@@ -464,7 +464,7 @@ class AMP_Options_Menu {
 	 */
 	public function render_caching() {
 		?>
-		<fieldset>
+		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<?php if ( AMP_Options_Manager::show_response_cache_disabled_notice() ) : ?>
 				<div class="notice notice-info notice-alt inline">
 					<p><?php esc_html_e( 'The post-processor cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
@@ -553,14 +553,21 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::check_supported_post_type_update_errors();
 		}
 		?>
+		<?php if ( ! current_user_can( 'manage_options' ) ) : ?>
+			<div class="notice notice-info">
+				<p><?php esc_html_e( 'You do not have permission to modify these settings. They are shown here for your reference. Please contact your administrator to make changes.', 'amp' ); ?></p>
+			</div>
+		<?php endif; ?>
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>
-			<form action="options.php" method="post">
+			<form id="amp-settings" action="options.php" method="post">
 				<?php
 				settings_fields( AMP_Options_Manager::OPTION_NAME );
 				do_settings_sections( AMP_Options_Manager::OPTION_NAME );
-				submit_button();
+				if ( current_user_can( 'manage_options' ) ) {
+					submit_button();
+				}
 				?>
 			</form>
 		</div>

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -137,6 +137,7 @@ class AMP_Invalid_URL_Post_Type {
 		add_action( 'edit_form_top', array( __CLASS__, 'print_url_as_title' ) );
 
 		// Post list screen hooks.
+		add_action( 'admin_notices', array( __CLASS__, 'render_link_to_error_index_screen' ) );
 		add_filter( 'the_title', array( __CLASS__, 'filter_the_title_in_post_list_table' ), 10, 2 );
 		add_action( 'restrict_manage_posts', array( __CLASS__, 'render_post_filters' ), 10, 2 );
 		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', array( __CLASS__, 'add_post_columns' ) );
@@ -203,11 +204,39 @@ class AMP_Invalid_URL_Post_Type {
 			'amp-validation-error-detail-toggle',
 			'ampValidationI18n',
 			array(
-				'btnAriaLabel'     => esc_attr__( 'Toggle all sources', 'amp' ),
-				'errorIndexLink'   => get_admin_url( null, 'edit-tags.php?taxonomy=amp_validation_error&post_type=amp_invalid_url' ),
-				'errorIndexAnchor' => esc_html__( 'View Error Index', 'amp' ),
+				'btnAriaLabel' => esc_attr__( 'Toggle all sources', 'amp' ),
 			)
 		);
+	}
+
+	/**
+	 * On the 'Invalid URLs' screen, renders a link to the 'Error Index' page.
+	 *
+	 * @see AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen()
+	 * @todo Do cap check for the post type.
+	 */
+	public static function render_link_to_error_index_screen() {
+		if ( ! ( get_current_screen() && 'edit' === get_current_screen()->base && self::POST_TYPE_SLUG === get_current_screen()->post_type ) ) {
+			return;
+		}
+
+		$id = 'link-errors-index';
+
+		printf(
+			'<a href="%s" hidden class="page-title-action" id="%s" style="margin-left: 1rem;">%s</a>',
+			esc_url( get_admin_url( null, 'edit-tags.php?taxonomy=' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '&post_type=' . self::POST_TYPE_SLUG ) ),
+			esc_attr( $id ),
+			esc_html__( 'View Error Index', 'amp' )
+		);
+
+		?>
+		<script>
+			jQuery( function( $ ) {
+				// Move the link to after the heading, as it also looks like there's no action for this.
+				$( <?php echo wp_json_encode( '#' . $id ); ?> ).removeAttr( 'hidden' ).insertAfter( $( '.wp-heading-inline' ) );
+			} );
+		</script>
+		<?php
 	}
 
 	/**

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -213,10 +213,14 @@ class AMP_Invalid_URL_Post_Type {
 	 * On the 'Invalid URLs' screen, renders a link to the 'Error Index' page.
 	 *
 	 * @see AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen()
-	 * @todo Do cap check for the post type.
 	 */
 	public static function render_link_to_error_index_screen() {
 		if ( ! ( get_current_screen() && 'edit' === get_current_screen()->base && self::POST_TYPE_SLUG === get_current_screen()->post_type ) ) {
+			return;
+		}
+
+		$taxonomy_object = get_taxonomy( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		if ( ! current_user_can( $taxonomy_object->cap->manage_terms ) ) {
 			return;
 		}
 
@@ -869,7 +873,7 @@ class AMP_Invalid_URL_Post_Type {
 
 		foreach ( $items as $item ) {
 			$post = get_post( $item );
-			if ( empty( $post ) ) {
+			if ( empty( $post ) || ! current_user_can( 'edit_post', $post->ID ) ) {
 				continue;
 			}
 
@@ -1048,11 +1052,18 @@ class AMP_Invalid_URL_Post_Type {
 				if ( ! $post || self::POST_TYPE_SLUG !== $post->post_type ) {
 					throw new Exception( 'invalid_post' );
 				}
+				if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+					throw new Exception( 'unauthorized' );
+				}
 				$url = self::get_url_from_post( $post );
 			} elseif ( isset( $_GET['url'] ) ) {
 				$url = wp_validate_redirect( esc_url_raw( wp_unslash( $_GET['url'] ) ), null );
 				if ( ! $url ) {
 					throw new Exception( 'illegal_url' );
+				}
+				// Don't let non-admins create new amp_invalid_url posts.
+				if ( ! current_user_can( 'manage_options' ) ) {
+					throw new Exception( 'unauthorized' );
 				}
 			}
 
@@ -1162,9 +1173,6 @@ class AMP_Invalid_URL_Post_Type {
 	 */
 	public static function handle_validation_error_status_update() {
 		check_admin_referer( self::UPDATE_POST_TERM_STATUS_ACTION, self::UPDATE_POST_TERM_STATUS_ACTION . '_nonce' );
-		if ( ! AMP_Validation_Manager::has_cap() ) {
-			wp_die( esc_html__( 'You do not have permissions to validate an AMP URL. Did you get logged out?', 'amp' ) );
-		}
 
 		if ( empty( $_POST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] ) || ! is_array( $_POST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] ) ) {
 			return;
@@ -1173,6 +1181,11 @@ class AMP_Invalid_URL_Post_Type {
 		if ( ! $post || self::POST_TYPE_SLUG !== $post->post_type ) {
 			return;
 		}
+
+		if ( ! AMP_Validation_Manager::has_cap() || ! current_user_can( 'edit_post', $post->ID ) ) {
+			wp_die( esc_html__( 'You do not have permissions to validate an AMP URL. Did you get logged out?', 'amp' ) );
+		}
+
 		$updated_count = 0;
 
 		$has_pre_term_description_filter = has_filter( 'pre_term_description', 'wp_filter_kses' );
@@ -1808,7 +1821,7 @@ class AMP_Invalid_URL_Post_Type {
 			);
 		}
 
-		if ( 'trash' !== $post->post_status ) {
+		if ( 'trash' !== $post->post_status && current_user_can( 'edit_post', $post->ID ) ) {
 			$url = self::get_url_from_post( $post );
 			if ( $url ) {
 				$actions['view'] = sprintf(

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -93,13 +93,6 @@ class AMP_Validation_Error_Taxonomy {
 	const NO_FILTER_VALUE = -1;
 
 	/**
-	 * The ID for the link to the Errors by URL.
-	 *
-	 * @var string
-	 */
-	const ID_LINK_ERRORS_BY_URL = 'link-errors-url';
-
-	/**
 	 * Validation code for an invalid element.
 	 *
 	 * @var string
@@ -588,7 +581,7 @@ class AMP_Validation_Error_Taxonomy {
 		add_action( 'load-edit-tags.php', array( __CLASS__, 'add_error_type_clauses_filter' ) );
 		add_action( 'load-edit-tags.php', array( __CLASS__, 'add_order_clauses_from_description_json' ) );
 		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), array( __CLASS__, 'render_taxonomy_filters' ) );
-		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), array( __CLASS__, 'render_link_to_errors_by_url' ) );
+		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), array( __CLASS__, 'render_link_to_invalid_urls_screen' ) );
 		add_action( 'load-edit-tags.php', function() {
 			add_filter( 'user_has_cap', array( __CLASS__, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ), 10, 3 );
 		} );
@@ -908,31 +901,36 @@ class AMP_Validation_Error_Taxonomy {
 	}
 
 	/**
-	 * On the 'Error Index' taxonomy page, renders a link to the 'Errors by URL' page.
+	 * On the 'Error Index' screen, renders a link to the 'Invalid URLs' page.
+	 *
+	 * @see AMP_Invalid_URL_Post_Type::render_link_to_error_index_screen()
+	 * @todo Do cap check for the taxonomy.
 	 *
 	 * @param string $taxonomy_name The name of the taxonomy.
 	 */
-	public static function render_link_to_errors_by_url( $taxonomy_name ) {
+	public static function render_link_to_invalid_urls_screen( $taxonomy_name ) {
 		if ( self::TAXONOMY_SLUG !== $taxonomy_name ) {
 			return;
 		}
 
+		$id = 'link-errors-url';
+
 		printf(
-			'<a href="%s" class="page-title-action" id="%s" style="margin-left: 1rem;">%s</a>',
-			esc_attr( add_query_arg(
+			'<a href="%s" class="page-title-action" id="%s" hidden style="margin-left: 1rem;">%s</a>',
+			esc_url( add_query_arg(
 				'post_type',
 				AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG,
 				admin_url( 'edit.php' )
 			) ),
-			esc_attr( self::ID_LINK_ERRORS_BY_URL ),
+			esc_attr( $id ),
 			esc_html__( 'View Invalid URLs', 'amp' )
 		);
 
 		?>
 		<script>
 			jQuery( function( $ ) {
-				// Move the link to 'View errors by URL' to after the heading, as it also looks like there's no action for this.
-				$( '#<?php echo self::ID_LINK_ERRORS_BY_URL; // WPCS: XSS OK. ?>' ).insertAfter( $( '.wp-heading-inline' ) );
+				// Move the link to after the heading, as it also looks like there's no action for this.
+				$( <?php echo wp_json_encode( '#' . $id ); ?> ).removeAttr( 'hidden' ).insertAfter( $( '.wp-heading-inline' ) );
 			} );
 		</script>
 		<?php

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -904,12 +904,16 @@ class AMP_Validation_Error_Taxonomy {
 	 * On the 'Error Index' screen, renders a link to the 'Invalid URLs' page.
 	 *
 	 * @see AMP_Invalid_URL_Post_Type::render_link_to_error_index_screen()
-	 * @todo Do cap check for the taxonomy.
 	 *
 	 * @param string $taxonomy_name The name of the taxonomy.
 	 */
 	public static function render_link_to_invalid_urls_screen( $taxonomy_name ) {
 		if ( self::TAXONOMY_SLUG !== $taxonomy_name ) {
+			return;
+		}
+
+		$post_type_object = get_post_type_object( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG );
+		if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
 			return;
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -312,6 +312,11 @@ class AMP_Validation_Manager {
 			}
 		}
 
+		$user_can_revalidate = $amp_invalid_url_post ? current_user_can( 'edit_post', $amp_invalid_url_post->ID ) : current_user_can( 'manage_options' );
+		if ( ! $user_can_revalidate ) {
+			return;
+		}
+
 		// @todo The amp_invalid_url post should probably only be accessible to users who can manage_options, or limit access to a post if the user has the cap to edit the queried object?
 		$validate_url = AMP_Invalid_URL_Post_Type::get_recheck_url( $amp_invalid_url_post ? $amp_invalid_url_post : $amp_url );
 

--- a/tests/test-amp-analytics-options.php
+++ b/tests/test-amp-analytics-options.php
@@ -8,6 +8,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		AMP_Options_Manager::register_settings();
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 	}
 
 	private $vendor = 'googleanalytics';

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -87,6 +87,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::reset_cache_miss_url_option()
 	 */
 	public function test_get_and_set_options() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+
 		global $wp_settings_errors;
 		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 		AMP_Options_Manager::register_settings(); // Adds validate_options as filter.

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -1011,6 +1011,26 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test render_link_to_error_index_screen.
+	 *
+	 * @covers \AMP_Invalid_URL_Post_Type::render_link_to_error_index_screen()
+	 */
+	public function test_render_link_to_error_index_screen() {
+		global $current_screen;
+		set_current_screen( 'index.php' );
+		ob_start();
+		AMP_Invalid_URL_Post_Type::render_link_to_error_index_screen();
+		$this->assertEmpty( ob_get_clean() );
+
+		set_current_screen( 'edit.php' );
+		$current_screen->post_type = AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG;
+		ob_start();
+		AMP_Invalid_URL_Post_Type::render_link_to_error_index_screen();
+		$output = ob_get_clean();
+		$this->assertContains( 'View Error Index', $output );
+	}
+
+	/**
 	 * Test for add_meta_boxes()
 	 *
 	 * @covers \AMP_Invalid_URL_Post_Type::add_meta_boxes()

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -540,19 +540,19 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_link_to_errors_by_url.
+	 * Test render_link_to_invalid_urls_screen.
 	 *
-	 * @covers \AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url()
+	 * @covers \AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen()
 	 */
-	public function test_render_link_to_errors_by_url() {
-		// When passing the wrong $taxomomy argument, this should not render anything.
+	public function test_render_link_to_invalid_urls_screen() {
+		// When passing the wrong $taxonomy argument, this should not render anything.
 		ob_start();
-		AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url( 'category' );
+		AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen( 'category' );
 		$this->assertEmpty( ob_get_clean() );
 
 		// When passing the correct taxonomy, this should render the link.
 		ob_start();
-		AMP_Validation_Error_Taxonomy::render_link_to_errors_by_url( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
 		$output = ob_get_clean();
 		$this->assertContains( 'View Invalid URLs', $output );
 		$this->assertContains(

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -545,6 +545,8 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen()
 	 */
 	public function test_render_link_to_invalid_urls_screen() {
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+
 		// When passing the wrong $taxonomy argument, this should not render anything.
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen( 'category' );


### PR DESCRIPTION
While the AMP validation screens are generally available to users who can `edit_posts`, in reality this should be tightened up to just administrators, with authors then only able to access the `amp_invalid_url` screens with just the posts that they themselves were responsible for creating in the course of creating regular posts.

* Only show reciprocal links on Invalid URLs and Error Index screens when user has authorization, respectively.
* Do not show the recheck row action for invalid URLs if they do not have permission.
* Hide AMP admin bar link if user doesn't have authorization.
* Harmonize approach for adding wp-heading-inline links. See https://github.com/Automattic/amp-wp/pull/1397#discussion_r217902283.
* Allow non-admin users to access AMP settings screen, but let all fields be disabled so that they can only see how it is configured.
* Do not give non-admins access to the Error Index screen.