### PR TITLE
Checks for INTL_IDNA_VARIANT_UTS46

### DIFF
--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -201,7 +201,7 @@ class AMP_HTTP {
 		 */
 		foreach ( $domains as $domain ) {
 			if ( function_exists( 'idn_to_utf8' ) ) {
-				if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
+				if ( version_compare( PHP_VERSION, '5.4', '>=' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 					$domain = idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 ); // phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.idn_to_utf8_variantFound, PHPCompatibility.PHP.NewConstants.intl_idna_variant_uts46Found
 				} else {
 					$domain = idn_to_utf8( $domain );


### PR DESCRIPTION
Fixes #1439 

Since ICU, which provides the `INTL_IDNA_VARIANT_UTS46` may not be kept up to date the same as PHP, a separate check here will prevent the undeclared constant warning.

The downside is `idn_to_utf8` function defaults to using `INTL_IDNA_VARIANT_2003` which would then throw a deprecated warning in PHP 7.2+. If PHP 7.4, it is planned that the default will be `INTL_IDNA_VARIANT_UTS46` which would likely return the original issue.

@westonruter What would you prefer? Checking for UTS46 and taking the deprecated in PHP 7.2 for sites running ancient ICU or check for the UTS46 variant along with the `idn_to_utf8` exists check? Or a third option?