### PR TITLE
Defer adding post type support until post types have been registered

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -150,7 +150,7 @@ function amp_init() {
 	AMP_HTTP::handle_xhr_request();
 	AMP_Theme_Support::init();
 	AMP_Validation_Manager::init();
-	AMP_Post_Type_Support::add_post_type_support();
+	add_action( 'init', array( 'AMP_Post_Type_Support', 'add_post_type_support' ), 1000 ); // After post types have been defined.
 
 	if ( defined( 'WP_CLI' ) ) {
 		WP_CLI::add_command( 'amp', new AMP_CLI() );


### PR DESCRIPTION
Post types are supposed to be registered at the `init` action, normally at priority 10. For example Jetpack's Testimonial and Portfolio post types. However, the call to register `amp` post type support:

https://github.com/Automattic/amp-wp/blob/84c1ab11811d0bb056e61b04d157c2d54a435434/amp.php#L153

Happens at `init` priority `0`:

https://github.com/Automattic/amp-wp/blob/84c1ab11811d0bb056e61b04d157c2d54a435434/amp.php#L127

This prevents custom post types from being included in the eligible post types for AMP support. 

The fix is just to defer the post type support addition to a later priority in the `init` action.