### PR TITLE
AMP validation - add pointer tooltips for status columns

### DIFF
--- a/assets/css/amp-validation-error-taxonomy.css
+++ b/assets/css/amp-validation-error-taxonomy.css
@@ -83,7 +83,7 @@ details[open] .details-attributes__summary::after, details.single-error-detail[o
 /* Error details toggle button */
 .manage-column.column-details, .manage-column.column-sources_with_invalid_output {
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-start;
 	align-items: center;
 }
 .manage-column.column-sources_with_invalid_output .error-details-toggle {
@@ -94,7 +94,7 @@ details[open] .details-attributes__summary::after, details.single-error-detail[o
 	display: flex;
 	flex-direction: column;
 	height: 14px;
-	margin-right: 10px;
+	margin-left: auto;
 	padding: 0;
 	background: none;
 	border: none;

--- a/assets/css/amp-validation-tooltips.css
+++ b/assets/css/amp-validation-tooltips.css
@@ -1,0 +1,11 @@
+.tooltip {
+    margin: 0 6px;
+}
+
+.tooltip * {
+    display: none;
+}
+
+.wp-pointer--tooltip {
+    transform: translateX(-52px);
+}

--- a/assets/css/amp-validation-tooltips.css
+++ b/assets/css/amp-validation-tooltips.css
@@ -1,11 +1,7 @@
-.tooltip {
+
+/* @todo This should be moved to admin-tables.css which is then enqueued on both screens. */
+.tooltip-button {
     margin: 0 6px;
-}
-
-.tooltip * {
-    display: none;
-}
-
-.wp-pointer--tooltip {
-    transform: translateX(-52px);
+    cursor: pointer;
+    color: #767676;
 }

--- a/assets/src/amp-validation-tooltips.js
+++ b/assets/src/amp-validation-tooltips.js
@@ -5,9 +5,9 @@ import domReady from '@wordpress/dom-ready';
 
 // WIP Pointer function
 function sourcesPointer() {
-	jQuery( '.tooltip' ).on( 'hover', function() {
+	jQuery( document ).on( 'click', '.tooltip-button', function() {
 		jQuery( this ).pointer( {
-			content: this.innerHTML,
+			content: jQuery( this ).next( '.tooltip' ).html(),
 			position: {
 				edge: 'top',
 				align: 'left'

--- a/assets/src/amp-validation-tooltips.js
+++ b/assets/src/amp-validation-tooltips.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+// WIP Pointer function
+function sourcesPointer() {
+	jQuery( '.tooltip' ).on( 'hover', function() {
+		jQuery( this ).pointer( {
+			content: this.innerHTML,
+			position: {
+				edge: 'top',
+				align: 'left'
+			},
+			pointerClass: 'wp-pointer wp-pointer--tooltip'
+		} ).pointer( 'open' );
+	} );
+}
+
+domReady( () => {
+	sourcesPointer();
+} );

--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -31,12 +31,20 @@ class AMP_Admin_Pointer {
 	const SCRIPT_SLUG = 'amp-admin-pointer';
 
 	/**
+	 * The slug of the tooltip script.
+	 * 
+	 * @var string
+	 */
+	const TOOLTIP_SLUG = 'amp-validation-tooltips';
+
+	/**
 	 * Initializes the class.
 	 *
 	 * @since 1.0
 	 */
 	public function init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_pointer' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_tooltips' ) );
 	}
 
 	/**
@@ -65,6 +73,28 @@ class AMP_Admin_Pointer {
 		wp_add_inline_script(
 			self::SCRIPT_SLUG,
 			sprintf( 'ampAdminPointer.load( %s );', wp_json_encode( $this->get_pointer_data() ) )
+		);
+	}
+
+	/**
+	 * Registers style and script for tooltips.
+	 * 
+	 * @since 1.0
+	 */
+	public function register_tooltips() {
+		wp_register_style(
+			self::TOOLTIP_SLUG,
+			amp_get_asset_url( 'css/' . self::TOOLTIP_SLUG . '.css' ),
+			array(),
+			AMP__VERSION
+		);
+
+		wp_register_script(
+			self::TOOLTIP_SLUG,
+			amp_get_asset_url( 'js/' . self::TOOLTIP_SLUG . '-compiled.js' ),
+			array( 'jquery', 'wp-pointer' ),
+			AMP__VERSION,
+			true
 		);
 	}
 

--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -32,7 +32,7 @@ class AMP_Admin_Pointer {
 
 	/**
 	 * The slug of the tooltip script.
-	 * 
+	 *
 	 * @var string
 	 */
 	const TOOLTIP_SLUG = 'amp-validation-tooltips';
@@ -78,7 +78,7 @@ class AMP_Admin_Pointer {
 
 	/**
 	 * Registers style and script for tooltips.
-	 * 
+	 *
 	 * @since 1.0
 	 */
 	public function register_tooltips() {

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -191,22 +191,20 @@ class AMP_Invalid_URL_Post_Type {
 		wp_enqueue_style(
 			'amp-validation-error-taxonomy',
 			amp_get_asset_url( 'css/amp-validation-error-taxonomy.css' ),
-			array( 'common' ),
+			array( 'common', 'amp-validation-tooltips' ),
 			AMP__VERSION
 		);
 		wp_enqueue_script(
 			'amp-validation-error-detail-toggle',
 			amp_get_asset_url( 'js/amp-validation-error-detail-toggle-compiled.js' ),
-			array(),
+			array( 'wp-dom-ready', 'amp-validation-tooltips' ),
 			AMP__VERSION,
 			true
 		);
 		wp_localize_script(
 			'amp-validation-error-detail-toggle',
 			'ampValidationI18n',
-			array(
-				'btnAriaLabel' => esc_attr__( 'Toggle all sources', 'amp' ),
-			)
+			array( 'btnAriaLabel' => esc_attr__( 'Toggle all sources', 'amp' ) )
 		);
 	}
 
@@ -702,7 +700,12 @@ class AMP_Invalid_URL_Post_Type {
 		$columns = array_merge(
 			$columns,
 			array(
-				AMP_Validation_Error_Taxonomy::ERROR_STATUS => sprintf( '%s<span class="dashicons dashicons-editor-help"></span>', esc_html__( 'Status', 'amp' ) ),  // @todo Create actual tooltip.
+				AMP_Validation_Error_Taxonomy::ERROR_STATUS => sprintf(
+					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
+					esc_html__( 'Status', 'amp' ),
+					__( 'Statuses tooltip title', 'amp' ),
+					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+				),
 				AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => esc_html__( 'Invalid', 'amp' ),
 				AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => esc_html__( 'Sources', 'amp' ),
 			)

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -197,7 +197,7 @@ class AMP_Invalid_URL_Post_Type {
 		wp_enqueue_script(
 			'amp-validation-error-detail-toggle',
 			amp_get_asset_url( 'js/amp-validation-error-detail-toggle-compiled.js' ),
-			array( 'wp-dom-ready', 'amp-validation-tooltips' ),
+			array( 'amp-validation-tooltips' ),
 			AMP__VERSION,
 			true
 		);
@@ -701,9 +701,9 @@ class AMP_Invalid_URL_Post_Type {
 			$columns,
 			array(
 				AMP_Validation_Error_Taxonomy::ERROR_STATUS => sprintf(
-					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
+					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden><h3>%s</h3><p>%s</p></div>',
 					esc_html__( 'Status', 'amp' ),
-					__( 'Statuses tooltip title', 'amp' ),
+					__( 'Status', 'amp' ),
 					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
 				),
 				AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => esc_html__( 'Invalid', 'amp' ),

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -635,7 +635,12 @@ class AMP_Validation_Error_Taxonomy {
 			return array(
 				'cb'               => $old_columns['cb'],
 				'error'            => __( 'Error', 'amp' ),
-				'status'           => __( 'Status', 'amp' ),
+				'status'           => sprintf(
+					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
+					__( 'Status', 'amp' ),
+					__( 'Statuses tooltip title', 'amp' ),
+					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+				),
 				'details'          => __( 'Details', 'amp' ),
 				'error_type'       => __( 'Type', 'amp' ),
 				'created_date_gmt' => __( 'Last Seen', 'amp' ),
@@ -657,14 +662,14 @@ class AMP_Validation_Error_Taxonomy {
 				wp_enqueue_style(
 					'amp-validation-error-taxonomy',
 					amp_get_asset_url( 'css/amp-validation-error-taxonomy.css' ),
-					array( 'common' ),
+					array( 'common', 'amp-validation-tooltips' ),
 					AMP__VERSION
 				);
 
 				wp_enqueue_script(
 					'amp-validation-error-detail-toggle',
 					amp_get_asset_url( 'js/amp-validation-error-detail-toggle-compiled.js' ),
-					array(),
+					array( 'wp-dom-ready', 'amp-validation-tooltips' ),
 					AMP__VERSION,
 					true
 				);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -646,7 +646,6 @@ class AMP_Validation_Error_Taxonomy {
 					__( 'Details', 'amp' ),
 					__( 'Details tooltip title', 'amp' ),
 					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
-
 				),
 				'error_type'       => __( 'Type', 'amp' ),
 				'created_date_gmt' => __( 'Last Seen', 'amp' ),

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -641,7 +641,13 @@ class AMP_Validation_Error_Taxonomy {
 					__( 'Statuses tooltip title', 'amp' ),
 					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
 				),
-				'details'          => __( 'Details', 'amp' ),
+				'details'          => sprintf(
+					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
+					__( 'Details', 'amp' ),
+					__( 'Details tooltip title', 'amp' ),
+					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+
+				),
 				'error_type'       => __( 'Type', 'amp' ),
 				'created_date_gmt' => __( 'Last Seen', 'amp' ),
 				'posts'            => __( 'Found URLs', 'amp' ),

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -634,22 +634,22 @@ class AMP_Validation_Error_Taxonomy {
 		add_filter( 'manage_edit-' . self::TAXONOMY_SLUG . '_columns', function( $old_columns ) {
 			return array(
 				'cb'               => $old_columns['cb'],
-				'error'            => __( 'Error', 'amp' ),
+				'error'            => esc_html__( 'Error', 'amp' ),
 				'status'           => sprintf(
-					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
-					__( 'Status', 'amp' ),
-					__( 'Statuses tooltip title', 'amp' ),
-					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden><h3>%s</h3><p>%s</p></div>',
+					esc_html__( 'Status', 'amp' ),
+					esc_html__( 'Status', 'amp' ),
+					esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
 				),
 				'details'          => sprintf(
-					'%s<div class="tooltip dashicons dashicons-editor-help"><h3>%s</h3><p>%s</p></div>',
-					__( 'Details', 'amp' ),
-					__( 'Details tooltip title', 'amp' ),
-					__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden><h3>%s</h3><p>%s</p></div>',
+					esc_html__( 'Details', 'amp' ),
+					esc_html__( 'Details', 'amp' ),
+					esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
 				),
-				'error_type'       => __( 'Type', 'amp' ),
-				'created_date_gmt' => __( 'Last Seen', 'amp' ),
-				'posts'            => __( 'Found URLs', 'amp' ),
+				'error_type'       => esc_html__( 'Type', 'amp' ),
+				'created_date_gmt' => esc_html__( 'Last Seen', 'amp' ),
+				'posts'            => esc_html__( 'Found URLs', 'amp' ),
 			);
 		} );
 

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -524,15 +524,15 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			'cb' => '<input type="checkbox">',
 		);
 		$this->assertEquals(
-			array_merge(
+			array_keys( array_merge(
 				$initial_columns,
 				array(
-					AMP_Validation_Error_Taxonomy::ERROR_STATUS => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
-					AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => 'Sources',
+					AMP_Validation_Error_Taxonomy::ERROR_STATUS => 'Status',
 					AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => 'Invalid',
+					AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => 'Sources',
 				)
-			),
-			AMP_Invalid_URL_Post_Type::add_post_columns( $initial_columns )
+			) ),
+			array_keys( AMP_Invalid_URL_Post_Type::add_post_columns( $initial_columns ) )
 		);
 	}
 

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -527,7 +527,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			array_merge(
 				$initial_columns,
 				array(
-					AMP_Validation_Error_Taxonomy::ERROR_STATUS => 'Status<span class="dashicons dashicons-editor-help"></span>',
+					AMP_Validation_Error_Taxonomy::ERROR_STATUS => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 					AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => 'Sources',
 					AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => 'Invalid',
 				)
@@ -544,7 +544,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	public function get_custom_columns() {
 		$source = array(
 			'type' => 'plugin',
-			'name' => 'amp',
+			'name' => 'AMP',
 		);
 		$errors = array(
 			array(

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -376,16 +376,16 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		$cb              = '<input type="checkbox" />';
 		$initial_columns = array( 'cb' => $cb );
 		$this->assertEquals(
-			array(
+			array_keys( array(
 				'cb'               => $cb,
 				'error'            => 'Error',
 				'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 				'details'          => 'Details<div class="tooltip dashicons dashicons-editor-help"><h3>Details tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
+				'error_type'       => 'Type',
 				'created_date_gmt' => 'Last Seen',
 				'posts'            => 'Found URLs',
-				'error_type'       => 'Type',
-			),
-			apply_filters( 'manage_edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_columns', $initial_columns ) // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			) ),
+			array_keys( apply_filters( 'manage_edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_columns', $initial_columns ) ) // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		);
 
 		// Assert that the 'query_vars' callback adds these query vars.

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -379,7 +379,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 			array(
 				'cb'               => $cb,
 				'error'            => 'Error',
-				'status'           => 'Status',
+				'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 				'details'          => 'Details',
 				'created_date_gmt' => 'Last Seen',
 				'posts'            => 'Found URLs',

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -380,7 +380,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 				'cb'               => $cb,
 				'error'            => 'Error',
 				'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
-				'details'          => 'Details',
+				'details'          => 'Details<div class="tooltip dashicons dashicons-editor-help"><h3>Details tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 				'created_date_gmt' => 'Last Seen',
 				'posts'            => 'Found URLs',
 				'error_type'       => 'Type',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ module.exports = {
 		filename: '[name].js'
 	},
 	externals: {
-		'@wordpress/dom-ready': 'wp.domReady',
 		'amp-validation-i18n': 'ampValidationI18n'
 	},
 	devtool: 'cheap-eval-source-map',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,13 +6,15 @@ module.exports = {
 	entry: {
 		'./assets/js/amp-blocks-compiled': './blocks/index.js',
 		'./assets/js/amp-block-editor-toggle-compiled': './assets/src/amp-block-editor-toggle.js',
-		'./assets/js/amp-validation-error-detail-toggle-compiled': './assets/src/amp-validation-error-detail-toggle.js'
+		'./assets/js/amp-validation-error-detail-toggle-compiled': './assets/src/amp-validation-error-detail-toggle.js',
+		'./assets/js/amp-validation-tooltips-compiled': './assets/src/amp-validation-tooltips'
 	},
 	output: {
 		path: path.resolve( __dirname ),
 		filename: '[name].js'
 	},
 	externals: {
+		'@wordpress/dom-ready': 'wp.domReady',
 		'amp-validation-i18n': 'ampValidationI18n'
 	},
 	devtool: 'cheap-eval-source-map',


### PR DESCRIPTION
This partially resolves #1400 by adding a tooltip to the headings of "Status" columns on AMP validation screens. It's not fully resolved because (1) we'll need to put in the final text, and (2) the styling and positioning of the tooltips could potentially use a little fine-tuning. Further, the tooltips could easily be created with the `Tooltip` component from the `@wordpress/components` package where Gutenberg-derived assets are available --  but I didn't go this route now because that tooltip looks much different from the one that had been decided on for this task.

Edit: Added the tooltip to the "Details" column as well. There's a little bit of conflicting information on this in the tickets/comps. It can easily be removed.