### PR TITLE
Change the heading of the single URL page

### DIFF
--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1921,7 +1921,7 @@ class AMP_Invalid_URL_Post_Type {
 
 	/**
 	 * Gets the heading for the single URL page at /wp-admin/post.php.
-	 * This will be in the format of 'Errors For <page title>'.
+	 * This will be in the format of 'Errors for: <page title>'.
 	 *
 	 * @return string|null The page heading, or null.
 	 */
@@ -1953,7 +1953,7 @@ class AMP_Invalid_URL_Post_Type {
 		}
 
 		/* translators: %s is the name of the page with the the validation error(s) */
-		return esc_html( sprintf( __( 'Errors For %s', 'amp' ), $name ) );
+		return esc_html( sprintf( __( 'Errors for: %s', 'amp' ), $name ) );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -1097,7 +1097,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 		$after_script  = wp_scripts()->registered[ AMP_Invalid_URL_Post_Type::EDIT_POST_SCRIPT_HANDLE ]->extra['after'];
 		$inline_script = end( $after_script );
 		$this->assertContains(
-			sprintf( 'Errors For %s', $post->post_title ),
+			sprintf( 'Errors for: %s', $post->post_title ),
 			$inline_script
 		);
 		$this->assertContains( 'Show all', $inline_script );
@@ -1451,7 +1451,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			)
 		);
 		$this->assertEquals(
-			sprintf( 'Errors For %s', $post->post_title ),
+			sprintf( 'Errors for: %s', $post->post_title ),
 			AMP_Invalid_URL_Post_Type::get_single_url_page_heading()
 		);
 
@@ -1466,7 +1466,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			)
 		);
 		$this->assertEquals(
-			sprintf( 'Errors For %s', $term->name ),
+			sprintf( 'Errors for: %s', $term->name ),
 			AMP_Invalid_URL_Post_Type::get_single_url_page_heading()
 		);
 
@@ -1481,7 +1481,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			)
 		);
 		$this->assertEquals(
-			sprintf( 'Errors For %s', $user->display_name ),
+			sprintf( 'Errors for: %s', $user->display_name ),
 			AMP_Invalid_URL_Post_Type::get_single_url_page_heading()
 		);
 	}


### PR DESCRIPTION
Before, it was 'Errors For `<name of post>`':
<img width="1106" alt="before-error" src="https://user-images.githubusercontent.com/4063887/45909262-3505f000-bdd7-11e8-9e15-a74ec5e9592b.png">


Now, it is 'Errors for: `<name of post>'`:

<img width="729" alt="errors-test-embeds" src="https://user-images.githubusercontent.com/4063887/45909228-0a1b9c00-bdd7-11e8-940c-3ae05e66e603.png">
