### PR TITLE
Fix styling issue on Error Index page, where status icon is cut off

### DIFF
--- a/assets/css/amp-validation-error-taxonomy.css
+++ b/assets/css/amp-validation-error-taxonomy.css
@@ -146,6 +146,7 @@ details.single-error-detail[open] .single-error-detail-summary::after {
 	height: 20px;
 	width: 20px;
 	content: "";
+	min-width: 20px;
 }
 
 .status-text.sanitized::before {

--- a/assets/css/amp-validation-error-taxonomy.css
+++ b/assets/css/amp-validation-error-taxonomy.css
@@ -18,7 +18,7 @@ th.column-error_type {
 }
 
 th.column-status {
-	width: 10%;
+	width: 15%;
 }
 
 .fixed th.column-posts {


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter,
Could you please review this?

As @postphotos mentioned, on the **AMP Validation Error Index** page, the right part of this icon is cut off, like when the status is 'New Accepted'. 

So this make the column wider, to prevent this. 

This new styling only applies on this **AMP Validation Error Index** page. It's overridden by another rule on the single error URL page.

Before:
<img width="1011" alt="icon-cut-off" src="https://user-images.githubusercontent.com/4063887/45919519-eb67e480-be6c-11e8-8f43-df899007846f.png">

After (with this PR):
<img width="1007" alt="after-not-cut-off" src="https://user-images.githubusercontent.com/4063887/45919526-15210b80-be6d-11e8-883e-cf23d4cf7c8d.png">
