### PR TITLE
Fix output buffer fatal error due to not properly handling class method output callbacks

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -463,11 +463,18 @@ class AMP_Options_Manager {
 			if ( is_wp_error( $validation ) ) {
 				$review_messages[] = esc_html( sprintf(
 					/* translators: %1$s is the error message, %2$s is the error code */
-					__( 'However, there was an error when checking the AMP validity for your site: %1$s (code: %2$s) ', 'amp' ),
+					__( 'However, there was an error when checking the AMP validity for your site.', 'amp' ),
 					$validation->get_error_message(),
 					$validation->get_error_code()
 				) );
 
+				$error_message = $validation->get_error_message();
+				if ( $error_message ) {
+					$review_messages[] = $error_message;
+				} else {
+					/* translators: %s is the error code */
+					$review_messages[] = esc_html( sprintf( __( 'Error code: %s.', 'amp' ), $validation->get_error_code() ) );
+				}
 				$notice_type = 'error';
 			} elseif ( is_array( $validation ) ) {
 				$new_errors      = 0;

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -1090,23 +1090,9 @@ class AMP_Invalid_URL_Post_Type {
 		if ( isset( $_GET['amp_validate_error'] ) ) { // WPCS: CSRF OK.
 			$error_codes = array_unique( array_map( 'sanitize_key', (array) $_GET['amp_validate_error'] ) ); // WPCS: CSRF OK.
 			foreach ( $error_codes as $error_code ) {
-				switch ( $error_code ) {
-					case 'http_request_failed':
-						$message = __( 'Failed to fetch URL(s) to validate. This may be due to a request timeout.', 'amp' );
-						break;
-					case '404':
-						$message = __( 'The fetched URL(s) was not found. It may have been deleted. If so, you can trash this.', 'amp' );
-						break;
-					case '500':
-						$message = __( 'An internal server error occurred when fetching the URL.', 'amp' );
-						break;
-					default:
-						/* translators: %s is error code */
-						$message = sprintf( __( 'Unable to validate the URL(s); error code is %s.', 'amp' ), $error_code ); // Note that $error_code has been sanitized with sanitize_key(); will be escaped below as well.
-				}
 				printf(
 					'<div class="notice is-dismissible error"><p>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
-					esc_html( $message ),
+					esc_html( AMP_Validation_Manager::get_validate_url_error_message( $error_code ) ),
 					esc_html__( 'Dismiss this notice.', 'amp' )
 				);
 			}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1789,18 +1789,50 @@ class AMP_Validation_Manager {
 		);
 
 		$response = wp_remote_retrieve_body( $r );
+		if ( strlen( trim( $response ) ) === 0 ) {
+			$error_code = 'white_screen_of_death';
+			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
+		}
 		if ( ! preg_match( '#</body>.*?<!--\s*AMP_VALIDATION\s*:\s*(\{.*?\})\s*-->#s', $response, $matches ) ) {
-			return new WP_Error( 'response_comment_absent' );
+			$error_code = 'response_comment_absent';
+			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
 		}
 		$validation = json_decode( $matches[1], true );
 		if ( json_last_error() || ! isset( $validation['results'] ) || ! is_array( $validation['results'] ) ) {
-			return new WP_Error( 'malformed_json_validation_errors' );
+			$error_code = 'malformed_json_validation_errors';
+			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
 		}
 
 		return array_merge(
 			$validation,
 			compact( 'url' )
 		);
+	}
+
+	/**
+	 * Get error message for a validate URL failure.
+	 *
+	 * @param string $error_code Error code.
+	 * @return string Error message.
+	 */
+	public static function get_validate_url_error_message( $error_code ) {
+		switch ( $error_code ) {
+			case 'http_request_failed':
+				return __( 'Failed to fetch URL(s) to validate. This may be due to a request timeout.', 'amp' );
+			case 'white_screen_of_death':
+				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a fatal error. Please check your server\'s PHP error logs.', 'amp' );
+			case '404':
+				return __( 'The fetched URL(s) was not found. It may have been deleted. If so, you can trash this.', 'amp' );
+			case '500':
+				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' );
+			case 'response_comment_absent':
+				return __( 'URL validation failed to due to the absence of the expected JSON-containing AMP_VALIDATION comment after the body.', 'amp' );
+			case 'malformed_json_validation_errors':
+				return __( 'URL validation failed to due to unexpected JSON in the AMP_VALIDATION comment after the body.', 'amp' );
+			default:
+				/* translators: %s is error code */
+				return sprintf( __( 'Unable to validate the URL(s); error code is %s.', 'amp' ), $error_code ); // Note that $error_code has been sanitized with sanitize_key(); will be escaped below as well.
+		};
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1387,7 +1387,13 @@ class AMP_Validation_Manager {
 		}
 		$backtrace = debug_backtrace( $arg ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Only way to find out if we are in a buffering display handler.
 		foreach ( $backtrace as $call_stack ) {
-			$called_functions[] = '{closure}' === $call_stack['function'] ? 'Closure::__invoke' : $call_stack['function'];
+			if ( '{closure}' === $call_stack['function'] ) {
+				$called_functions[] = 'Closure::__invoke';
+			} elseif ( isset( $call_stack['class'] ) ) {
+				$called_functions[] = sprintf( '%s::%s', $call_stack['class'], $call_stack['function'] );
+			} else {
+				$called_functions[] = $call_stack['function'];
+			}
 		}
 		return 0 === count( array_intersect( ob_list_handlers(), $called_functions ) );
 	}

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -516,7 +516,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			'fields'    => 'ids',
 		) );
 		$this->assertCount( 0, $invalid_url_posts );
-		$this->assertContains( 'response_comment_absent', $new_error['message'] );
 		$this->assertEquals( 'error', $new_error['type'] );
 	}
 

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1201,7 +1201,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		add_filter( 'pre_http_request', $filter );
 		$r = AMP_Validation_Manager::validate_url( home_url( '/' ) );
 		$this->assertInstanceOf( 'WP_Error', $r );
-		$this->assertEquals( 'response_comment_absent', $r->get_error_code() );
+		$this->assertEquals( 'white_screen_of_death', $r->get_error_code() );
 		remove_filter( 'pre_http_request', $filter );
 
 		// Test success.


### PR DESCRIPTION
When activating the `all-in-one-seo-pack` plugin, an error shows up in the error log when validating a URL:

> PHP Fatal error:  ob_start(): Cannot use output buffering in output buffering display handlers

The underlying code in the plugin that causes the problem is the adding of the `All_in_One_SEO_Pack ::output_callback_for_title()` method as an output buffer callback in:

https://github.com/semperfiwebdesign/all-in-one-seo-pack/blob/982cbb6a6ba183cf538d86b858273505a417720f/aioseop_class.php#L3496

The AMP plugin is supposed to prevent this error from happening via the `AMP_Validation_Manager::can_output_buffer()` method. It turns out there was a flaw in the logic being used to convert a function on the call stack into the format expected by `ob_list_handlers()`. In particular, it was not handling the case where an output callback was a class method. The issue is fixed by properly detecting when a call stack entry is for a class method.

This pull request also improves error message shown when a `validate_url` call fails. Instead of showing an error code like `response_comment_absent` it will now show a full message explaining what is going on. This change also adds WSOD (whitescreen of death detection) as a more specific error case for when the JSON comment is absent:

![image](https://user-images.githubusercontent.com/134745/45921967-4b628900-be75-11e8-919f-8d4378218670.png)
