### PR TITLE
Classic templates: Prevent escaping HTML for category and tag lists

### DIFF
--- a/templates/meta-taxonomy.php
+++ b/templates/meta-taxonomy.php
@@ -3,7 +3,7 @@
 	<div class="amp-wp-meta amp-wp-tax-category">
 		<?php
 		/* translators: %s: list of categories. */
-		echo esc_html( sprintf( __( 'Categories: %s', 'amp' ), $categories ) );
+		printf( esc_html__( 'Categories: %s', 'amp' ), $categories ); // WPCS: XSS OK.
 		?>
 	</div>
 <?php endif; ?>
@@ -19,7 +19,7 @@ $tags = get_the_tag_list(
 	<div class="amp-wp-meta amp-wp-tax-tag">
 		<?php
 		/* translators: %s: list of tags. */
-		echo esc_html( sprintf( __( 'Tags: %s', 'amp' ), $tags ) );
+		printf( esc_html__( 'Tags: %s', 'amp' ), $tags ); // WPCS: XSS OK.
 		?>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
Fixes regression introduced by me in #1329 via https://github.com/Automattic/amp-wp/pull/1329/commits/d9230899e5442c0cc1a0005dc24018eba8bdcb4a:

> <img width="841" alt="screen shot 2018-09-22 at 6 06 43 pm" src="https://user-images.githubusercontent.com/134745/45923156-d3a35700-be92-11e8-9673-4d2899c487e0.png">

With this PR:

> <img width="845" alt="screen shot 2018-09-22 at 6 07 26 pm" src="https://user-images.githubusercontent.com/134745/45923157-d605b100-be92-11e8-8dad-9a25f1e292da.png">

Issue has been present since 1.0-beta3.