### PR TITLE
Restore ability to customize 'amp' query var when theme support added

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -8,26 +8,15 @@
 /**
  * Get the slug used in AMP for the query var, endpoint, and post type support.
  *
- * This function always returns 'amp' when 'amp' theme support is present. Otherwise,
- * the return value can be overridden by previously defining a AMP_QUERY_VAR
+ * The return value can be overridden by previously defining a AMP_QUERY_VAR
  * constant or by adding a 'amp_query_var' filter, but *warning* this ability
  * may be deprecated in the future. Normally the slug should be just 'amp'.
  *
  * @since 0.7
- * @since 1.0 The return value is always 'amp' when 'amp' theme support is present, and the 'amp_query_var' filter no longer applies.
  *
  * @return string Slug used for query var, endpoint, and post type support.
  */
 function amp_get_slug() {
-	if ( current_theme_supports( 'amp' ) ) {
-		if ( ! defined( 'AMP_QUERY_VAR' ) ) {
-			define( 'AMP_QUERY_VAR', 'amp' );
-		} elseif ( 'amp' !== AMP_QUERY_VAR ) {
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'The AMP_QUERY_VAR constant should only be defined as "amp" when "amp" theme support is present.', 'amp' ), '1.0' );
-		}
-		return 'amp';
-	}
-
 	if ( defined( 'AMP_QUERY_VAR' ) ) {
 		return AMP_QUERY_VAR;
 	}
@@ -38,7 +27,6 @@ function amp_get_slug() {
 	 * Warning: This filter may become deprecated.
 	 *
 	 * @since 0.3.2
-	 * @since 1.0 This filter does not apply when 'amp' theme support is present.
 	 *
 	 * @param string $query_var The AMP query variable.
 	 */
@@ -73,10 +61,8 @@ function amp_get_current_url() {
  * Retrieves the full AMP-specific permalink for the given post ID.
  *
  * @since 0.1
- * @since 1.0 The query var 'amp' is always used exclusively when 'amp' theme support is present; the 'amp_pre_get_permalink' and 'amp_get_permalink' filters do not apply.
  *
  * @param int $post_id Post ID.
- *
  * @return string AMP permalink.
  */
 function amp_get_permalink( $post_id ) {
@@ -85,7 +71,7 @@ function amp_get_permalink( $post_id ) {
 	if ( current_theme_supports( 'amp' ) ) {
 		$permalink = get_permalink( $post_id );
 		if ( ! amp_is_canonical() ) {
-			$permalink = add_query_arg( 'amp', '', $permalink );
+			$permalink = add_query_arg( amp_get_slug(), '', $permalink );
 		}
 		return $permalink;
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -451,6 +451,8 @@ class AMP_Options_Manager {
 			}
 			$theme_support['paired'] = 'paired' === $template_mode;
 			add_theme_support( 'amp', $theme_support );
+		} else {
+			remove_theme_support( 'amp' ); // So that the amp_get_permalink() will work for classic URL.
 		}
 
 		$url = amp_admin_get_preview_permalink();


### PR DESCRIPTION
In https://github.com/Automattic/amp-wp/issues/1148 (PR https://github.com/Automattic/amp-wp/pull/1194) it was proposed that the ability to customize the `amp` query var should be eliminated. This was to facilitate themes and plugins to be able to look at the query var early before the `parse_query` action to determine if it is going to be an AMP response. However, this had to be undone in https://github.com/Automattic/amp-wp/pull/1235 because it is not possible to know whether AMP should be available before `parse_query` because we need the query vars and queried object in order to determine whether the given request is among the supported post types, supported templates, or if AMP has been disabled for the entire post itself. So the reason for this code is now obsolete.

However, there is also a bug that this code introduced. For example, consider a plugin that customizes the slug to `lite`:

```php
add_filter( 'amp_query_var', function() {
	return 'lite';
} );
```

On such a site in classic mode, the URL to a post would be https://example.com/2018/09/14/foo/lite/

If, however, a AMP were switched over to the new paired mode at present, then the query var is forcibly made `amp` and the above URL would no longer return an AMP version at all but rather the non-AMP version (since the endpoint then would be ignored). No redirect from `/lite/` to `?amp` would be done. This could be problematic for indexes that have cached the URLs to the AMP version but the AMP version is lost from the URL.

So this PR removes the unnecessary code and also fixes the above bug.