### PR TITLE
Add slug constants for theme support and post type support

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -207,7 +207,7 @@ function amp_force_query_var_value( $query_vars ) {
 function amp_maybe_add_actions() {
 
 	// Short-circuit when theme supports AMP, as everything is handled by AMP_Theme_Support.
-	if ( current_theme_supports( 'amp' ) ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		return;
 	}
 
@@ -283,26 +283,26 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
 /**
  * Whether this is in 'canonical mode'.
  *
- * Themes can register support for this with `add_theme_support( 'amp' )`:
+ * Themes can register support for this with `add_theme_support( AMP_Theme_Support::SLUG )`:
  *
- *      add_theme_support( 'amp' );
+ *      add_theme_support( AMP_Theme_Support::SLUG );
  *
  * This will serve templates in native AMP, allowing you to use AMP components in your theme templates.
  * If you want to make available in paired mode, where templates are served in AMP or non-AMP documents, do:
  *
- *      add_theme_support( 'amp', array(
+ *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'paired' => true,
  *      ) );
  *
  * Paired mode is also implied if you define a template_dir:
  *
- *      add_theme_support( 'amp', array(
+ *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'template_dir' => 'amp',
  *      ) );
  *
  * If you want to have AMP-specific templates in addition to serving native AMP, do:
  *
- *      add_theme_support( 'amp', array(
+ *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'paired'       => false,
  *          'template_dir' => 'amp',
  *      ) );
@@ -310,7 +310,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  * If you want to force AMP to always be served on a given template, you can use the templates_supported arg,
  * for example to always serve the Category template in AMP:
  *
- *      add_theme_support( 'amp', array(
+ *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'templates_supported' => array(
  *              'is_category' => true,
  *          ),
@@ -318,7 +318,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *
  * Or if you want to force AMP to be used on all templates:
  *
- *      add_theme_support( 'amp', array(
+ *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'templates_supported' => 'all',
  *      ) );
  *
@@ -326,7 +326,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
  */
 function amp_is_canonical() {
-	if ( ! current_theme_supports( 'amp' ) ) {
+	if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		return false;
 	}
 
@@ -457,7 +457,7 @@ function amp_render_post( $post ) {
  * Uses the priority of 12 for the 'after_setup_theme' action.
  * Many themes run `add_theme_support()` on the 'after_setup_theme' hook, at the default priority of 10.
  * And that function's documentation suggests adding it to that action.
- * So this enables themes to `add_theme_support( 'amp' )`.
+ * So this enables themes to `add_theme_support( AMP_Theme_Support::SLUG )`.
  * And `amp_init_customizer()` will be able to recognize theme support by calling `amp_is_canonical()`.
  *
  * @since 0.4
@@ -481,7 +481,7 @@ add_action( 'plugins_loaded', '_amp_bootstrap_customizer', 9 ); // Should be hoo
 function amp_redirect_old_slug_to_new_url( $link ) {
 
 	if ( is_amp_endpoint() && ! amp_is_canonical() ) {
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$link = add_query_arg( amp_get_slug(), '', $link );
 		} else {
 			$link = trailingslashit( trailingslashit( $link ) . amp_get_slug() );

--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -184,7 +184,7 @@ class AMP_Template_Customizer {
 			true
 		);
 
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$availability = AMP_Theme_Support::get_template_availability();
 			$available    = $availability['supported'];
 		} elseif ( is_singular() || $wp_query->is_posts_page ) {

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -151,7 +151,7 @@ class AMP_Editor_Blocks {
 		wp_add_inline_script(
 			'amp-editor-blocks',
 			sprintf( 'ampEditorBlocks.boot( %s );', wp_json_encode( array(
-				'hasThemeSupport' => current_theme_supports( 'amp' ),
+				'hasThemeSupport' => current_theme_supports( AMP_Theme_Support::SLUG ),
 			) ) )
 		);
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -153,7 +153,7 @@ class AMP_Post_Meta_Box {
 			AMP__VERSION
 		);
 
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$availability   = AMP_Theme_Support::get_template_availability( $post );
 			$support_errors = $availability['errors'];
 		} else {
@@ -265,7 +265,7 @@ class AMP_Post_Meta_Box {
 		 * Checking for template availability will include a check for get_support_errors. Otherwise, if theme support is not present
 		 * then we just check get_support_errors.
 		 */
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$availability = AMP_Theme_Support::get_template_availability( $post );
 			$status       = $availability['supported'] ? self::ENABLED_STATUS : self::DISABLED_STATUS;
 			$errors       = array_diff( $availability['errors'], array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -60,7 +60,7 @@ function amp_admin_get_preview_permalink() {
 	}
 
 	// If theme support is present, then bail if the singular template is not supported.
-	if ( current_theme_supports( 'amp' ) ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		$supported_templates = AMP_Theme_Support::get_supportable_templates();
 		if ( empty( $supported_templates['is_singular']['supported'] ) ) {
 			return null;
@@ -90,7 +90,7 @@ function amp_admin_get_preview_permalink() {
  */
 function amp_add_customizer_link() {
 	/** This filter is documented in includes/settings/class-amp-customizer-design-settings.php */
-	if ( ! apply_filters( 'amp_customizer_is_enabled', true ) || current_theme_supports( 'amp' ) ) {
+	if ( ! apply_filters( 'amp_customizer_is_enabled', true ) || current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		return;
 	}
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -49,7 +49,7 @@ function amp_admin_get_preview_permalink() {
 	$post_type = (string) apply_filters( 'amp_customizer_post_type', 'post' );
 
 	// Make sure the desired post type is actually supported, and if so, prefer it.
-	$supported_post_types = get_post_types_by_support( amp_get_slug() );
+	$supported_post_types = get_post_types_by_support( AMP_Post_Type_Support::SLUG );
 	if ( in_array( $post_type, $supported_post_types, true ) ) {
 		$supported_post_types = array_unique( array_merge( array( $post_type ), $supported_post_types ) );
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -68,7 +68,7 @@ function amp_get_current_url() {
 function amp_get_permalink( $post_id ) {
 
 	// When theme support is present, the plain query var should always be used.
-	if ( current_theme_supports( 'amp' ) ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		$permalink = get_permalink( $post_id );
 		if ( ! amp_is_canonical() ) {
 			$permalink = add_query_arg( amp_get_slug(), '', $permalink );
@@ -177,7 +177,7 @@ function amp_add_amphtml_link() {
 	$current_url = amp_get_current_url();
 
 	$amp_url = null;
-	if ( current_theme_supports( 'amp' ) ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		if ( AMP_Theme_Support::is_paired_available() ) {
 			$amp_url = add_query_arg( amp_get_slug(), '', $current_url );
 		}
@@ -195,7 +195,7 @@ function amp_add_amphtml_link() {
 	}
 
 	// Check to see if there are known unaccepted validation errors for this URL.
-	if ( current_theme_supports( 'amp' ) ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		$validation_errors = AMP_Invalid_URL_Post_Type::get_invalid_url_validation_errors( $current_url, array( 'ignore_accepted' => true ) );
 		$error_count       = count( $validation_errors );
 		if ( $error_count > 0 ) {
@@ -264,7 +264,7 @@ function is_amp_endpoint() {
 		false !== get_query_var( amp_get_slug(), false )
 	);
 
-	if ( ! current_theme_supports( 'amp' ) ) {
+	if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		return $has_amp_query_var;
 	}
 
@@ -563,7 +563,7 @@ function amp_print_analytics( $analytics ) {
  * @return array Embed handlers.
  */
 function amp_get_content_embed_handlers( $post = null ) {
-	if ( current_theme_supports( 'amp' ) && $post ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) && $post ) {
 		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
 		$post = null;
 	}
@@ -614,7 +614,7 @@ function amp_get_content_embed_handlers( $post = null ) {
  * @return array Embed handlers.
  */
 function amp_get_content_sanitizers( $post = null ) {
-	if ( current_theme_supports( 'amp' ) && $post ) {
+	if ( current_theme_supports( AMP_Theme_Support::SLUG ) && $post ) {
 		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
 		$post = null;
 	}
@@ -646,7 +646,7 @@ function amp_get_content_sanitizers( $post = null ) {
 				'add_placeholder' => true,
 			),
 			'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
-				'carousel_required' => ! current_theme_supports( 'amp' ), // For back-compat.
+				'carousel_required' => ! current_theme_supports( AMP_Theme_Support::SLUG ), // For back-compat.
 			),
 			'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
 			'AMP_Script_Sanitizer'            => array(),

--- a/includes/class-amp-cli.php
+++ b/includes/class-amp-cli.php
@@ -169,14 +169,14 @@ class AMP_CLI {
 			self::$force_crawl_urls = true;
 		}
 
-		if ( ! current_theme_supports( 'amp' ) ) {
+		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			if ( self::$force_crawl_urls ) {
 				/*
 				 * There is no theme support added programmatically or via options.
 				 * So make sure that theme support is present so that AMP_Validation_Manager::validate_url()
 				 * will use a canonical URL as the basis for obtaining validation results.
 				 */
-				add_theme_support( 'amp' );
+				add_theme_support( AMP_Theme_Support::SLUG );
 			} else {
 				WP_CLI::error(
 					sprintf(

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -402,7 +402,7 @@ class AMP_HTTP {
 	public static function filter_comment_post_redirect( $url, $comment ) {
 		$theme_support = AMP_Theme_Support::get_theme_support_args();
 
-		// Cause a page refresh if amp-live-list is not implemented for comments via add_theme_support( 'amp', array( 'comments_live_list' => true ) ).
+		// Cause a page refresh if amp-live-list is not implemented for comments via add_theme_support( AMP_Theme_Support::SLUG, array( 'comments_live_list' => true ) ).
 		if ( empty( $theme_support['comments_live_list'] ) ) {
 			/*
 			 * Add the comment ID to the URL to force AMP to refresh the page.

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -46,7 +46,7 @@ class AMP_Post_Type_Support {
 	 * @since 0.6
 	 */
 	public static function add_post_type_support() {
-		if ( current_theme_supports( 'amp' ) && AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) && AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
 			$post_types = self::get_eligible_post_types();
 		} else {
 			$post_types = AMP_Options_Manager::get_option( 'supported_post_types', array() );
@@ -102,7 +102,7 @@ class AMP_Post_Type_Support {
 			 * support is present (in which case AMP_Theme_Support::get_template_availability() determines availability).
 			 */
 			$enabled = (
-				current_theme_supports( 'amp' )
+				current_theme_supports( AMP_Theme_Support::SLUG )
 				||
 				(
 					! (bool) get_page_template_slug( $post )

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -12,6 +12,13 @@
 class AMP_Post_Type_Support {
 
 	/**
+	 * Post type support slug.
+	 *
+	 * @var string
+	 */
+	const SLUG = 'amp';
+
+	/**
 	 * Get post types that plugin supports out of the box (which cannot be disabled).
 	 *
 	 * @deprecated
@@ -52,7 +59,7 @@ class AMP_Post_Type_Support {
 			$post_types = AMP_Options_Manager::get_option( 'supported_post_types', array() );
 		}
 		foreach ( $post_types as $post_type ) {
-			add_post_type_support( $post_type, amp_get_slug() );
+			add_post_type_support( $post_type, self::SLUG );
 		}
 	}
 
@@ -70,7 +77,7 @@ class AMP_Post_Type_Support {
 		}
 		$errors = array();
 
-		if ( ! post_type_supports( $post->post_type, amp_get_slug() ) ) {
+		if ( ! post_type_supports( $post->post_type, self::SLUG ) ) {
 			$errors[] = 'post-type-support';
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -13,6 +13,13 @@
 class AMP_Theme_Support {
 
 	/**
+	 * Theme support slug.
+	 *
+	 * @var string
+	 */
+	const SLUG = 'amp';
+
+	/**
 	 * Replaced with the necessary scripts depending on components used in output.
 	 *
 	 * @var string
@@ -124,7 +131,7 @@ class AMP_Theme_Support {
 	 */
 	public static function init() {
 		self::read_theme_support();
-		if ( ! current_theme_supports( 'amp' ) ) {
+		if ( ! current_theme_supports( self::SLUG ) ) {
 			return;
 		}
 
@@ -164,7 +171,7 @@ class AMP_Theme_Support {
 	 */
 	public static function read_theme_support() {
 		$theme_support_option = AMP_Options_Manager::get_option( 'theme_support' );
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( self::SLUG ) ) {
 			$args = self::get_theme_support_args();
 
 			// Validate theme support usage.
@@ -184,12 +191,12 @@ class AMP_Theme_Support {
 			}
 			self::$support_added_via_option = false;
 		} elseif ( 'disabled' !== $theme_support_option ) {
-			add_theme_support( 'amp', array(
+			add_theme_support( self::SLUG, array(
 				'paired' => ( 'paired' === $theme_support_option ),
 			) );
 			self::$support_added_via_option = true;
 		} elseif ( AMP_Validation_Manager::is_theme_support_forced() ) {
-			add_theme_support( 'amp' );
+			add_theme_support( self::SLUG );
 		}
 	}
 
@@ -203,10 +210,10 @@ class AMP_Theme_Support {
 	 * @return array|false Theme support args, or false if theme support is not present.
 	 */
 	public static function get_theme_support_args() {
-		if ( ! current_theme_supports( 'amp' ) ) {
+		if ( ! current_theme_supports( self::SLUG ) ) {
 			return false;
 		}
-		$support = get_theme_support( 'amp' );
+		$support = get_theme_support( self::SLUG );
 		if ( true === $support ) {
 			return array(
 				'paired' => false,
@@ -342,7 +349,7 @@ class AMP_Theme_Support {
 	 * @return bool Whether available.
 	 */
 	public static function is_paired_available() {
-		if ( ! current_theme_supports( 'amp' ) ) {
+		if ( ! current_theme_supports( self::SLUG ) ) {
 			return false;
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -445,14 +445,14 @@ class AMP_Options_Manager {
 		// Ensure theme support flags are set properly according to the new mode so that proper AMP URL can be generated.
 		$has_theme_support = ( 'native' === $template_mode || 'paired' === $template_mode );
 		if ( $has_theme_support ) {
-			$theme_support = current_theme_supports( 'amp' );
+			$theme_support = current_theme_supports( AMP_Theme_Support::SLUG );
 			if ( ! is_array( $theme_support ) ) {
 				$theme_support = array();
 			}
 			$theme_support['paired'] = 'paired' === $template_mode;
-			add_theme_support( 'amp', $theme_support );
+			add_theme_support( AMP_Theme_Support::SLUG, $theme_support );
 		} else {
-			remove_theme_support( 'amp' ); // So that the amp_get_permalink() will work for classic URL.
+			remove_theme_support( AMP_Theme_Support::SLUG ); // So that the amp_get_permalink() will work for classic URL.
 		}
 
 		$url = amp_admin_get_preview_permalink();

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -244,7 +244,7 @@ class AMP_Options_Manager {
 				continue;
 			}
 
-			$post_type_supported = post_type_supports( $post_type->name, amp_get_slug() );
+			$post_type_supported = post_type_supports( $post_type->name, AMP_Post_Type_Support::SLUG );
 			$is_support_elected  = in_array( $post_type->name, $supported_types, true );
 
 			$error = null;
@@ -438,7 +438,7 @@ class AMP_Options_Manager {
 
 		// Make sure post type support has been added for sake of amp_admin_get_preview_permalink().
 		foreach ( AMP_Post_Type_Support::get_eligible_post_types() as $post_type ) {
-			remove_post_type_support( $post_type, amp_get_slug() );
+			remove_post_type_support( $post_type, AMP_Post_Type_Support::SLUG );
 		}
 		AMP_Post_Type_Support::add_post_type_support();
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -143,7 +143,7 @@ class AMP_Options_Menu {
 		$native_description = __( 'Reuses active theme\'s templates to display AMP responses but does not use separate URLs for AMP. Your canonical URLs are AMP. AMP-specific blocks are available for inserting into content. Any AMP validation errors are automatically sanitized.', 'amp' );
 		$builtin_support    = in_array( get_template(), array( 'twentyfifteen', 'twentysixteen', 'twentyseventeen' ), true );
 		?>
-		<?php if ( current_theme_supports( 'amp' ) && ! AMP_Theme_Support::is_support_added_via_option() ) : ?>
+		<?php if ( current_theme_supports( AMP_Theme_Support::SLUG ) && ! AMP_Theme_Support::is_support_added_via_option() ) : ?>
 			<div class="notice notice-info notice-alt inline">
 				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
 			</div>
@@ -191,7 +191,7 @@ class AMP_Options_Menu {
 					<dd>
 						<?php esc_html_e( 'Display AMP responses in classic (legacy) post templates in a basic design that does not match your theme\'s templates.', 'amp' ); ?>
 
-						<?php if ( ! current_theme_supports( 'amp' ) && wp_count_posts( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG )->publish > 0 ) : ?>
+						<?php if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && wp_count_posts( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG )->publish > 0 ) : ?>
 							<div class="notice notice-info inline notice-alt">
 								<p>
 									<?php
@@ -441,7 +441,7 @@ class AMP_Options_Menu {
 					templateModeInputs = $( 'input[type=radio][name="amp-options[theme_support]"]' );
 					themeSupportDisabledInput = $( '#theme_support_disabled' );
 					allTemplatesSupportedInput = $( '#all_templates_supported' );
-					supportForced = <?php echo wp_json_encode( current_theme_supports( 'amp' ) && ! AMP_Theme_Support::is_support_added_via_option() ); ?>;
+					supportForced = <?php echo wp_json_encode( current_theme_supports( AMP_Theme_Support::SLUG ) && ! AMP_Theme_Support::is_support_added_via_option() ); ?>;
 
 					function isThemeSupportDisabled() {
 						return ! supportForced && themeSupportDisabledInput.prop( 'checked' );

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -403,7 +403,7 @@ class AMP_Options_Menu {
 						id="<?php echo esc_attr( $element_id ); ?>"
 						name="<?php echo esc_attr( $element_name ); ?>"
 						value="<?php echo esc_attr( $post_type->name ); ?>"
-						<?php checked( post_type_supports( $post_type->name, amp_get_slug() ) ); ?>
+						<?php checked( post_type_supports( $post_type->name, AMP_Post_Type_Support::SLUG ) ); ?>
 						>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $post_type->label ); ?>

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -130,7 +130,7 @@ class AMP_Invalid_URL_Post_Type {
 	 */
 	public static function should_show_in_menu() {
 		global $pagenow;
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			return true;
 		}
 		return ( 'edit.php' === $pagenow && ( isset( $_GET['post_type'] ) && self::POST_TYPE_SLUG === $_GET['post_type'] ) ); // WPCS: CSRF OK.
@@ -1141,7 +1141,7 @@ class AMP_Invalid_URL_Post_Type {
 			// Display admin notice according to the AMP mode.
 			if ( amp_is_canonical() ) {
 				$template_mode = 'native';
-			} elseif ( current_theme_supports( 'amp' ) ) {
+			} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 				$template_mode = 'paired';
 			} else {
 				$template_mode = 'classic';

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -279,7 +279,7 @@ class AMP_Validation_Error_Taxonomy {
 	 */
 	public static function should_show_in_menu() {
 		global $pagenow;
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			return true;
 		}
 		return ( 'edit-tags.php' === $pagenow && ( isset( $_GET['taxonomy'] ) && self::TAXONOMY_SLUG === $_GET['taxonomy'] ) ); // WPCS: CSRF OK.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -159,7 +159,7 @@ class AMP_Validation_Manager {
 		AMP_Validation_Error_Taxonomy::register();
 
 		// Short-circuit if AMP is not supported as only the post types should be available.
-		if ( ! current_theme_supports( 'amp' ) ) {
+		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			return;
 		}
 

--- a/tests/test-amp-analytics-options.php
+++ b/tests/test-amp-analytics-options.php
@@ -232,7 +232,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'type', $analytics[ $key ] );
 		$this->assertEquals( 'googleanalytics', $analytics[ $key ]['type'] );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		add_filter( 'amp_analytics_entries', function( $analytics ) use ( $key ) {
 			$analytics[ $key ]['type'] = 'test';
 			return $analytics;

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -21,7 +21,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
 	public function tearDown() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		global $wp_scripts, $pagenow;
 		$wp_scripts = null;
 		$pagenow    = 'index.php'; // Since clean_up_global_scope() doesn't.
@@ -81,7 +81,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \amp_get_permalink()
 	 */
 	public function test_amp_get_permalink_without_pretty_permalinks() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		delete_option( 'permalink_structure' );
 		flush_rewrite_rules();
 
@@ -117,7 +117,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		remove_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ) );
 
 		// Now check with theme support added (in paired mode).
-		add_theme_support( 'amp', array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
@@ -176,7 +176,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		remove_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10 );
 
 		// Now check with theme support added (in paired mode).
-		add_theme_support( 'amp', array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_page ) );
@@ -197,7 +197,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_get_permalink_with_theme_support() {
 		global $wp_rewrite;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 		$wp_rewrite->use_trailing_slashes = true;
@@ -207,7 +207,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		$this->assertEquals( get_permalink( $post_id ), amp_get_permalink( $post_id ) );
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => 'amp',
 		) );
 	}
@@ -294,7 +294,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$assert_amphtml_link_present();
 
 		// Make sure that the link is not provided when there are validation errors associated with the URL.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => './',
 		) );
 		AMP_Theme_Support::init();
@@ -328,15 +328,15 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertFalse( is_amp_endpoint() );
 
 		// Paired theme support.
-		add_theme_support( 'amp', array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
 		$_GET['amp'] = '';
 		$this->assertTrue( is_amp_endpoint() );
 		unset( $_GET['amp'] );
 		$this->assertFalse( is_amp_endpoint() );
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 
 		// Native theme support.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( is_amp_endpoint() );
 
 		// Special core pages.
@@ -451,7 +451,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		add_filter( 'amp_content_embed_handlers', array( $this, 'capture_filter_call' ), 10, 2 );
 
 		$this->last_filter_call = null;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$handlers = amp_get_content_embed_handlers();
 		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
 		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
@@ -459,7 +459,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertNull( $this->last_filter_call['args'][1] );
 
 		$this->last_filter_call = null;
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$handlers = amp_get_content_embed_handlers( $post );
 		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
 		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
@@ -475,7 +475,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	public function test_amp_get_content_embed_handlers_deprecated_param() {
 		$post = $this->factory()->post->create_and_get();
 		$this->setExpectedDeprecated( 'amp_get_content_embed_handlers' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		amp_get_content_embed_handlers( $post );
 	}
 
@@ -489,7 +489,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		add_filter( 'amp_content_sanitizers', array( $this, 'capture_filter_call' ), 10, 2 );
 
 		$this->last_filter_call = null;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$handlers = amp_get_content_sanitizers();
 		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
 		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
@@ -499,7 +499,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( 'AMP_Tag_And_Attribute_Sanitizer', end( $handler_classes ) );
 
 		$this->last_filter_call = null;
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$handlers = amp_get_content_sanitizers( $post );
 		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
 		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
@@ -525,7 +525,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	public function test_amp_get_content_sanitizers_deprecated_param() {
 		$post = $this->factory()->post->create_and_get();
 		$this->setExpectedDeprecated( 'amp_get_content_sanitizers' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		amp_get_content_sanitizers( $post );
 	}
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -535,7 +535,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \post_supports_amp()
 	 */
 	public function test_post_supports_amp() {
-		add_post_type_support( 'page', amp_get_slug() );
+		add_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
 
 		// Test disabled by default for page for posts and show on front.
 		update_option( 'show_on_front', 'page' );
@@ -556,7 +556,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertFalse( post_supports_amp( $post ) );
 
 		// Reset.
-		remove_post_type_support( 'page', amp_get_slug() );
+		remove_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
 	}
 
 	/**

--- a/tests/test-amp-render-post.php
+++ b/tests/test-amp-render-post.php
@@ -57,7 +57,7 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->assertTrue( $this->was_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
 		$this->assertFalse( $after_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( is_amp_endpoint() );
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1338,7 +1338,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers \AMP_DOM_Utils::get_content_from_dom_node()
 	 */
 	public function test_unicode_stylesheet() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -15,7 +15,7 @@ class Test_AMP extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**
@@ -24,29 +24,29 @@ class Test_AMP extends WP_UnitTestCase {
 	 * @covers \amp_is_canonical()
 	 */
 	public function test_amp_is_canonical() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( amp_is_canonical() );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => 'amp-templates',
 		) );
 		$this->assertFalse( amp_is_canonical() );
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired'       => false,
 			'template_dir' => 'amp-templates',
 		) );
 		$this->assertTrue( amp_is_canonical() );
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired' => true,
 		) );
 		$this->assertFalse( amp_is_canonical() );
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'custom_prop' => 'something',
 		) );
 		$this->assertTrue( amp_is_canonical() );

--- a/tests/test-class-amp-cli.php
+++ b/tests/test-class-amp-cli.php
@@ -117,11 +117,11 @@ class Test_AMP_CLI extends \WP_UnitTestCase {
 		AMP_CLI::$force_crawl_urls = false;
 
 		// In Native AMP, the IDs should include all of the newly-created posts.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 
 		// In Paired Mode, the IDs should also include all of the newly-created posts.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired' => true,
 		) );
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -331,7 +331,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	 */
 	public function test_intercept_post_request_redirect() {
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$url = home_url( '', 'https' ) . ':443/?test=true#test';
 
 		add_filter( 'wp_doing_ajax', '__return_true' );
@@ -467,7 +467,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			return '__return_null';
 		} );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$post    = $this->factory()->post->create_and_get();
 		$comment = $this->factory()->comment->create_and_get( array(
 			'comment_post_ID' => $post->ID,
@@ -482,7 +482,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		);
 
 		// Test with comments_live_list.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'comments_live_list' => true,
 		) );
 		add_filter( 'amp_comment_posted_message', function( $message, WP_Comment $filter_comment ) {

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -127,7 +127,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$checkbox_enabled  = '<input id="amp-status-enabled" type="radio" name="amp_status" value="enabled"  checked=\'checked\'>';
 
 		// This is not in AMP 'canonical mode' but rather classic paired mode.
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();
@@ -135,7 +135,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertContains( $checkbox_enabled, $output );
 
 		// This is in AMP native mode with a template that can be rendered.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();
@@ -190,7 +190,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		);
 
 		// In Native AMP, there also shouldn't be errors.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals(
 			$expected_status_and_errors,
 			$this->instance->get_status_and_errors( $post )

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -122,7 +122,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory()->user->create( array(
 			'role' => 'administrator',
 		) ) );
-		add_post_type_support( 'post', amp_get_slug() );
+		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		$amp_status_markup = '<div class="misc-pub-section misc-amp-status"';
 		$checkbox_enabled  = '<input id="amp-status-enabled" type="radio" name="amp_status" value="enabled"  checked=\'checked\'>';
 
@@ -143,13 +143,13 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertContains( $checkbox_enabled, $output );
 
 		// Post type no longer supports AMP, so no status input.
-		remove_post_type_support( 'post', amp_get_slug() );
+		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		ob_start();
 		$this->instance->render_status( $post );
 		$output = ob_get_clean();
 		$this->assertContains( 'post type does not support it', $output );
 		$this->assertNotContains( $checkbox_enabled, $output );
-		add_post_type_support( 'post', amp_get_slug() );
+		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
@@ -161,7 +161,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertNotContains( $checkbox_enabled, $output );
 
 		// User doesn't have the capability to display the metabox.
-		add_post_type_support( 'post', amp_get_slug() );
+		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		wp_set_current_user( $this->factory()->user->create( array(
 			'role' => 'subscriber',
 		) ) );
@@ -197,7 +197,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		);
 
 		// If post type doesn't support AMP, this method should return AMP as being disabled.
-		remove_post_type_support( 'post', amp_get_slug() );
+		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		$this->assertEquals(
 			array(
 				'status' => 'disabled',
@@ -205,7 +205,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 			),
 			$this->instance->get_status_and_errors( $post )
 		);
-		add_post_type_support( 'post', amp_get_slug() );
+		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 
 		// There's no template to render this post, so this method should also return AMP as disabled.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -223,7 +223,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	public function test_check_supported_post_type_update_errors() {
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // clear any errors before starting.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		register_post_type( 'foo', array(
 			'public' => true,
 			'label'  => 'Foo',

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -242,7 +242,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		foreach ( get_post_types() as $post_type ) {
 			if ( 'foo' !== $post_type ) {
-				remove_post_type_support( $post_type, amp_get_slug() );
+				remove_post_type_support( $post_type, AMP_Post_Type_Support::SLUG );
 			}
 		}
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
@@ -250,7 +250,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEmpty( get_settings_errors() );
 
 		// Test when 'all_templates_supported' is not selected, and theme support is also disabled.
-		add_post_type_support( 'post', amp_get_slug() );
+		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
@@ -261,8 +261,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEquals( 'foo_deactivation_error', $settings_errors[0]['code'] );
 
 		// Activation error.
-		remove_post_type_support( 'post', amp_get_slug() );
-		remove_post_type_support( 'foo', amp_get_slug() );
+		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
+		remove_post_type_support( 'foo', AMP_Post_Type_Support::SLUG );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
 		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
@@ -274,7 +274,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		// Deactivation error.
 		AMP_Options_Manager::update_option( 'supported_post_types', array() );
-		add_post_type_support( 'foo', amp_get_slug() );
+		add_post_type_support( 'foo', AMP_Post_Type_Support::SLUG );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$errors = get_settings_errors();
 		$this->assertCount( 1, $errors );

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -54,7 +54,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::add_post_type_support()
 	 */
 	public function test_add_post_type_support() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		register_post_type( 'book', array(
 			'label'  => 'Book',
 			'public' => true,
@@ -77,7 +77,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::get_support_errors()
 	 */
 	public function test_get_support_error() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		register_post_type( 'book', array(
 			'label'  => 'Book',
 			'public' => true,

--- a/tests/test-class-amp-post-type-support.php
+++ b/tests/test-class-amp-post-type-support.php
@@ -66,9 +66,9 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post', 'poem' ) );
 
 		AMP_Post_Type_Support::add_post_type_support();
-		$this->assertTrue( post_type_supports( 'post', amp_get_slug() ) );
-		$this->assertTrue( post_type_supports( 'poem', amp_get_slug() ) );
-		$this->assertFalse( post_type_supports( 'book', amp_get_slug() ) );
+		$this->assertTrue( post_type_supports( 'post', AMP_Post_Type_Support::SLUG ) );
+		$this->assertTrue( post_type_supports( 'poem', AMP_Post_Type_Support::SLUG ) );
+		$this->assertFalse( post_type_supports( 'book', AMP_Post_Type_Support::SLUG ) );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		// Post type support.
 		$book_id = $this->factory()->post->create( array( 'post_type' => 'book' ) );
 		$this->assertEquals( array( 'post-type-support' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
-		add_post_type_support( 'book', amp_get_slug() );
+		add_post_type_support( 'book', AMP_Post_Type_Support::SLUG );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
 		// Password-protected.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -27,7 +27,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		parent::setUp();
 		AMP_Validation_Manager::reset_validation_results();
 		unset( $GLOBALS['current_screen'] );
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$wp_scripts = null;
 		parent::tearDown();
 		AMP_Validation_Manager::reset_validation_results();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		remove_theme_support( 'custom-header' );
 		$_REQUEST                = array(); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
 		$_SERVER['QUERY_STRING'] = '';
@@ -65,7 +65,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'widgets_init', array( self::TESTED_CLASS, 'register_widgets' ) ) );
 		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'finish_init' ) ) );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		$this->assertEquals( 10, has_action( 'widgets_init', array( self::TESTED_CLASS, 'register_widgets' ) ) );
 		$this->assertEquals( PHP_INT_MAX, has_action( 'wp', array( self::TESTED_CLASS, 'finish_init' ) ) );
@@ -83,9 +83,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'paired'            => false,
 			'invalid_param_key' => array(),
 		);
-		add_theme_support( 'amp', $args );
+		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Theme_Support::read_theme_support();
-		$this->assertTrue( current_theme_supports( 'amp' ) );
+		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
 	}
 
@@ -96,13 +96,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers \AMP_Theme_Support::read_theme_support()
 	 */
 	public function test_read_theme_support_bad_available_callback() {
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'available_callback' => function() {
 				return (bool) wp_rand( 0, 1 );
 			},
 		) );
 		AMP_Theme_Support::read_theme_support();
-		$this->assertTrue( current_theme_supports( 'amp' ) );
+		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 	}
 
 	/**
@@ -121,29 +121,29 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'paired'              => true,
 			'comments_live_list'  => true,
 		);
-		add_theme_support( 'amp', $args );
+		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals( $args, AMP_Theme_Support::get_theme_support_args() );
 		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
-		$this->assertTrue( current_theme_supports( 'amp' ) );
+		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 
-		add_theme_support( 'amp' );
-		$this->assertTrue( current_theme_supports( 'amp' ) );
+		add_theme_support( AMP_Theme_Support::SLUG );
+		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 		$this->assertFalse( AMP_Theme_Support::is_support_added_via_option() );
 		$this->assertEquals( array( 'paired' => false ), AMP_Theme_Support::get_theme_support_args() );
 
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'theme_support', 'native' ); // Will be ignored since theme support flag set.
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( AMP_Theme_Support::is_support_added_via_option() );
-		$this->assertTrue( current_theme_supports( 'amp' ) );
+		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
 		$_GET[ AMP_Validation_Manager::VALIDATE_QUERY_VAR ] = AMP_Validation_Manager::get_amp_validate_nonce();
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( AMP_Theme_Support::is_support_added_via_option() );
-		$this->assertTrue( get_theme_support( 'amp' ) );
+		$this->assertTrue( get_theme_support( AMP_Theme_Support::SLUG ) );
 	}
 
 	/**
@@ -153,7 +153,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_finish_init() {
 		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test' ) );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired'       => true,
 			'template_dir' => 'amp',
 		) );
@@ -174,7 +174,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Test canonical, so amphtml link is not added and init finalizes.
 		remove_action( 'wp_head', 'amp_add_amphtml_link' );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired'       => false,
 			'template_dir' => 'amp',
 		) );
@@ -192,7 +192,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::ensure_proper_amp_location()
 	 */
 	public function test_ensure_proper_amp_location_canonical() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$e = null;
 
 		// Already canonical.
@@ -230,7 +230,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::ensure_proper_amp_location()
 	 */
 	public function test_ensure_proper_amp_location_paired() {
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => './',
 		) );
 		$e = null;
@@ -296,17 +296,17 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Establish initial state.
 		$post_id = $this->factory()->post->create( array( 'post_title' => 'Test' ) );
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
 		$this->assertTrue( is_singular() );
 
 		// Paired support is not available if theme support is not present or canonical.
 		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
 
 		// Paired mode is available once template_dir is supplied.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => 'amp-templates',
 		) );
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
@@ -321,7 +321,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_filter( 'amp_skip_post', '__return_true' );
 
 		// Check that mode=paired works.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired' => true,
 		) );
 		add_filter( 'amp_supportable_templates', function( $supportable_templates ) {
@@ -384,7 +384,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_validate_non_amp_theme() {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 
@@ -434,7 +434,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertNull( $availability['template'] );
 
 		// Test no theme support.
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$this->go_to( get_permalink( $this->factory()->post->create() ) );
 		$availability = AMP_Theme_Support::get_template_availability();
 		$this->assertEquals( array( 'no_theme_support' ), $availability['errors'] );
@@ -451,7 +451,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_get_template_availability_with_available_callback() {
 		$this->go_to( get_permalink( $this->factory()->post->create() ) );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'available_callback' => '__return_true',
 		) );
 		AMP_Theme_Support::init();
@@ -466,7 +466,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			)
 		);
 
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'available_callback' => '__return_false',
 		) );
 		AMP_Theme_Support::init();
@@ -495,7 +495,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test successful match of singular template.
 		$this->assertTrue( is_singular() );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$availability = AMP_Theme_Support::get_template_availability();
 		$this->assertEmpty( $availability['errors'] );
 		$this->assertTrue( $availability['supported'] );
@@ -664,7 +664,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Test supporting templates by theme support args: all.
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'templates_supported' => 'all',
 		) );
 		AMP_Theme_Support::init();
@@ -676,7 +676,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Test supporting templates by theme support args: selective templates.
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'templates_supported' => array(
 				'is_date'   => true,
 				'is_author' => false,
@@ -794,7 +794,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertTrue( is_singular() );
 
 		// Test native AMP.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
 		ob_start();
 		AMP_Theme_Support::amend_comment_form();
@@ -804,7 +804,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<div submit-error>', $output );
 
 		// Test paired AMP.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => 'amp-templates',
 		) );
 		$this->assertFalse( amp_is_canonical() );
@@ -823,7 +823,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_filter_amp_template_hierarchy() {
 		$template_dir = 'amp-templates';
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'template_dir' => $template_dir,
 		) );
 		$templates          = array(
@@ -1061,7 +1061,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			}
 		}
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 
@@ -1080,7 +1080,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_finish_output_buffering() {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 
@@ -1128,7 +1128,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_filter_customize_partial_render() {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 
@@ -1360,7 +1360,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$wp_scripts = null;
 		$wp_styles  = null;
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 		$wp_widget_factory = new WP_Widget_Factory();
@@ -1465,7 +1465,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_prepare_response_bad_html() {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 
@@ -1490,7 +1490,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_prepare_response_to_add_html5_doctype_and_amp_attribute() {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 		ob_start();
@@ -1515,7 +1515,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_filter( 'amp_validation_error_sanitized', '__return_false', 100 );
 
 		$this->go_to( home_url( '/?amp' ) );
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired' => true,
 		) );
 		add_filter( 'amp_content_sanitizers', function( $sanitizers ) {

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -560,12 +560,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 'is_special', $availability['template'] );
 		$this->assertFalse( $availability['immutable'] );
 
-		remove_post_type_support( 'page', 'amp' );
+		remove_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
 		$availability = AMP_Theme_Support::get_template_availability( $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) ) );
 		$this->assertFalse( $availability['supported'] );
 		$this->assertEquals( array( 'post-type-support' ), $availability['errors'] );
 		$this->assertEquals( 'is_page', $availability['template'] );
-		add_post_type_support( 'page', 'amp' );
+		add_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
 		$availability = AMP_Theme_Support::get_template_availability( $this->factory()->post->create_and_get( array( 'post_type' => 'page' ) ) );
 		$this->assertTrue( $availability['supported'] );
 

--- a/tests/test-class-amp-widget-archives.php
+++ b/tests/test-class-amp-widget-archives.php
@@ -26,7 +26,7 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		wp_maybe_load_widgets();
 		AMP_Theme_Support::init();
 		$this->widget = new AMP_Widget_Archives();
@@ -39,7 +39,7 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**

--- a/tests/test-class-amp-widget-categories.php
+++ b/tests/test-class-amp-widget-categories.php
@@ -26,7 +26,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		wp_maybe_load_widgets();
 		AMP_Theme_Support::init();
 		$this->widget = new AMP_Widget_Categories();
@@ -39,7 +39,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**

--- a/tests/test-class-amp-widget-media-video.php
+++ b/tests/test-class-amp-widget-media-video.php
@@ -34,7 +34,7 @@ class Test_AMP_Widget_Media_Video extends WP_UnitTestCase {
 		parent::setUp();
 		wp_maybe_load_widgets();
 		$this->widget = new $class();
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Test_AMP_Widget_Media_Video extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**

--- a/tests/test-class-amp-widget-text.php
+++ b/tests/test-class-amp-widget-text.php
@@ -34,7 +34,7 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 		parent::setUp();
 		wp_maybe_load_widgets();
 		$this->widget = new $class();
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -32,7 +32,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Invalid_URL_Post_Type::add_admin_hooks()
 	 */
 	public function test_register() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( is_admin() );
 
 		AMP_Invalid_URL_Post_Type::register();
@@ -61,10 +61,10 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_should_show_in_menu() {
 		global $pagenow;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( AMP_Invalid_URL_Post_Type::should_show_in_menu() );
 
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( AMP_Invalid_URL_Post_Type::should_show_in_menu() );
 
 		$pagenow           = 'edit.php'; // WPCS: override ok.
@@ -172,7 +172,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_get_invalid_url_validation_errors() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create();
 		$this->assertEmpty( AMP_Invalid_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ) ) );
@@ -232,7 +232,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Invalid_URL_Post_Type::get_invalid_url_post()
 	 */
 	public function test_get_invalid_url_post() {
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 		$this->assertEquals( null, AMP_Invalid_URL_Post_Type::get_invalid_url_post( get_permalink( $post ) ) );
@@ -279,7 +279,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Invalid_URL_Post_Type::get_url_from_post()
 	 */
 	public function test_get_url_from_post() {
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 
@@ -299,7 +299,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 			AMP_Invalid_URL_Post_Type::get_url_from_post( $invalid_post_id )
 		);
 
-		add_theme_support( 'amp', array( 'paired' => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
 		$this->assertEquals(
 			get_permalink( $post ),
 			AMP_Invalid_URL_Post_Type::get_url_from_post( $invalid_post_id )
@@ -319,7 +319,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_store_validation_errors() {
 		global $post;
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 
@@ -644,7 +644,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	public function test_handle_bulk_action() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Validation_Manager::init();
 
 		$invalid_post_id = AMP_Invalid_URL_Post_Type::store_validation_errors(
@@ -719,7 +719,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Invalid_URL_Post_Type::print_admin_notice()
 	 */
 	public function test_print_admin_notice() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
 		ob_start();
@@ -770,7 +770,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_handle_validate_request() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		AMP_Validation_Manager::init();
 
@@ -1493,7 +1493,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_filter_post_row_actions() {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
 		$validated_url   = home_url( '/' );

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -31,7 +31,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		$_REQUEST = array();
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
 		remove_all_filters( 'amp_validation_error_sanitized' );
 		remove_all_filters( 'terms_clauses' );
@@ -46,7 +46,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 */
 	public function test_register() {
 		global $wp_taxonomies;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 
 		AMP_Validation_Error_Taxonomy::register();
 		$taxonomy_object = $wp_taxonomies[ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ];
@@ -89,10 +89,10 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 */
 	public function test_should_show_in_menu() {
 		global $pagenow;
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
 
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
 
 		$pagenow          = 'edit-tags.php'; // WPCS: override ok.
@@ -288,7 +288,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		);
 
 		// New accepted, since canonical.
-		add_theme_support( 'amp', array(
+		add_theme_support( AMP_Theme_Support::SLUG, array(
 			'paired' => false,
 		) );
 		$this->assertTrue( amp_is_canonical() );
@@ -543,7 +543,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::add_admin_hooks()
 	 */
 	public function test_add_admin_hooks() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Error_Taxonomy::register();
 
 		// add_group_terms_clauses_filter() needs the screen to be set.

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -97,7 +97,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		$GLOBALS['wp_registered_widgets'] = $this->original_wp_registered_widgets; // WPCS: override ok.
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		$_REQUEST = array();
 		unset( $GLOBALS['current_screen'] );
 		AMP_Validation_Manager::$should_locate_sources = false;
@@ -113,7 +113,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::init()
 	 */
 	public function test_init() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
 		$this->assertTrue( post_type_exists( AMP_Invalid_URL_Post_Type::POST_TYPE_SLUG ) );
@@ -160,23 +160,23 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::is_sanitization_auto_accepted()
 	 */
 	public function test_is_sanitization_auto_accepted() {
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 	}
@@ -200,7 +200,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 
 		// No admin bar item when no template available.
 		$this->go_to( home_url() );
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$this->assertTrue( AMP_Validation_Manager::has_cap() );
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
@@ -212,7 +212,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 
 		// Admin bar item available in native mode.
-		add_theme_support( 'amp', array( 'paired' => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -222,7 +222,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 
 		// Admin bar item available in paired mode.
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -233,7 +233,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 
 		// Admin bar item available in paired mode with validation errors.
 		$_GET[ AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR ] = 3;
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -347,7 +347,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assert_rest_api_field_present( $post_types_non_canonical );
 
 		// Test in a Native AMP (canonical) context.
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::add_rest_api_fields();
 		$post_types_canonical = get_post_types_by_support( 'editor' );
 		$this->assert_rest_api_field_present( $post_types_canonical );
@@ -545,7 +545,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::print_edit_form_validation_status()
 	 */
 	public function test_print_edit_form_validation_status() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 
 		AMP_Invalid_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
@@ -1132,7 +1132,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		foreach ( $filtered_sanitizers as $sanitizer => $args ) {
 			$this->assertEquals( $expected_callback, $args['validation_error_callback'] );
 		}
-		remove_theme_support( 'amp' );
+		remove_theme_support( AMP_Theme_Support::SLUG );
 	}
 
 	/**
@@ -1182,7 +1182,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::validate_url()
 	 */
 	public function test_validate_url() {
-		add_theme_support( 'amp' );
+		add_theme_support( AMP_Theme_Support::SLUG );
 
 		$validation_errors = array(
 			array(


### PR DESCRIPTION
Instead of using a string literal `'amp'` everywhere to add/remove/get the theme support, it seems preferable to have this in a constant like `AMP_Theme_Support::SLUG` instead.

Likewise, when adding post type support it seems preferable that there be a constant like `AMP_Post_Type_Support::SLUG` as opposed to re-using `amp_get_slug()` whose value is variable.