### PR TITLE
Prevent empty term status from being interpreted as new-rejected during bulk change

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -360,6 +360,11 @@ class AMP_Validation_Error_Taxonomy {
 	public static function sanitize_term_status( $status, $options = array() ) {
 		$multiple = ! empty( $options['multiple'] );
 
+		// Catch case where an empty string is supplied. Prevent casting to 0.
+		if ( ! is_numeric( $status ) && empty( $status ) ) {
+			return $multiple ? array() : null;
+		}
+
 		if ( is_string( $status ) ) {
 			$statuses = wp_parse_id_list( $status );
 		} else {
@@ -940,6 +945,8 @@ class AMP_Validation_Error_Taxonomy {
 				array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => $groups ),
 				$url
 			);
+		} else {
+			$url = remove_query_arg( self::VALIDATION_ERROR_STATUS_QUERY_VAR, $url );
 		}
 
 		return $url;

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -176,11 +176,16 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::sanitize_term_status()
 	 */
 	public function test_sanitize_term_status() {
+		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( '' ) );
+		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( false ) );
+		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( null ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( '0' ) );
+		$this->assertSame( array(), AMP_Validation_Error_Taxonomy::sanitize_term_status( '', array( 'multiple' => true ) ) );
 		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( '100' ) );
-		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS ) );
-		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS ) );
-		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS ) );
-		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, array( 'multiple' => false ) ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, array( 'multiple' => false ) ) );
 
 		$this->assertEquals(
 			array(


### PR DESCRIPTION
Fixes problem where bulk-rejecting/accepting validation errors redirects you to a screen where no validation errors are shown, unexpectedly.