### PR TITLE
Fix generation of validation error when element has multiple invalid attributes

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -441,9 +441,11 @@ abstract class AMP_Base_Sanitizer {
 				$error['type'] = 'script' === $node->nodeName ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE;
 			}
 
-			$error['node_attributes'] = array();
-			foreach ( $node->attributes as $attribute ) {
-				$error['node_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
+			if ( ! isset( $error['node_attributes'] ) ) {
+				$error['node_attributes'] = array();
+				foreach ( $node->attributes as $attribute ) {
+					$error['node_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
+				}
 			}
 
 			// Capture script contents.
@@ -465,10 +467,12 @@ abstract class AMP_Base_Sanitizer {
 				// If this is an attribute that begins with on, like onclick, it should be a js_error.
 				$error['type'] = preg_match( '/^on\w+/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE;
 			}
-			$error['element_attributes'] = array();
-			if ( $node->parentNode && $node->parentNode->hasAttributes() ) {
-				foreach ( $node->parentNode->attributes as $attribute ) {
-					$error['element_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
+			if ( ! isset( $error['element_attributes'] ) ) {
+				$error['element_attributes'] = array();
+				if ( $node->parentNode && $node->parentNode->hasAttributes() ) {
+					foreach ( $node->parentNode->attributes as $attribute ) {
+						$error['element_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
+					}
 				}
 			}
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -519,8 +519,20 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Remove all invalid attributes.
-		foreach ( $disallowed_attributes as $disallowed_attribute ) {
-			$this->remove_invalid_attribute( $node, $disallowed_attribute );
+		if ( ! empty( $disallowed_attributes ) ) {
+			/*
+			 * Capture all element attributes up front so that differing validation errors result when
+			 * one invalid attribute is accepted but the others are still rejected.
+			 */
+			$validation_error = array(
+				'element_attributes' => array(),
+			);
+			foreach ( $node->attributes as $attribute ) {
+				$validation_error['element_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
+			}
+			foreach ( $disallowed_attributes as $disallowed_attribute ) {
+				$this->remove_invalid_attribute( $node, $disallowed_attribute, $validation_error );
+			}
 		}
 
 		// Add required AMP component scripts if the element is still in the document.


### PR DESCRIPTION
Consider HTML that has an element with multiple invalid attributes:

```html
<amp-iframe
	class="wp-embedded-content amp-wp-enforced-sizes amp-wp-5e9b0a2"
	sandbox="allow-scripts"
	security="restricted"
	src="https://src.wordpress-develop.test/2018/09/24/lorem-ipsum-2/embed/#?secret=ELp4qNLN1k"
	data-secret="ELp4qNLN1k"
	width="600"
	height="338"
	title="“Lorem Ipsum” — WordPress Develop's"
	frameborder="0"
	marginwidth="0"
	marginheight="0"
	scrolling="no"
	layout="intrinsic"
>
</amp-iframe>
```

This is the HTML generated when adding a post embed. The underlying `iframe` element has three attributes that are invalid AMP:

* `security`
* `marginwidth`
* `marginheight`

So three validation errors are generated. If you bulk accept the three validation errors, and the page is then re-validated, behold only one the first validation error shows as being accepted. Why? It's because in this case the `security` attribute is removed and so when the subsequent validation errors are generated, they no longer contain the `security` attribute among their `element_attributes` and so they are considered to be completely different validation errors. If you then bulk-accept all again, then only the validation error for the `marginwidth` validation error becomes accepted, whereas `marginheight` is not. So you then have to accept a third time. You can also see this reflected in the Error Index:

![image](https://user-images.githubusercontent.com/134745/45979864-48969e00-c005-11e8-963c-0ff8d6d590b6.png)

The fix is to simply make sure that we obtain all `element_attributes` for the validation error before we start iterating over the invalid attributes to remove them.

This is specifically an issue when auto-accepting of validation errors is not enabled, that is in paired mode.