### PR TITLE
Add native/paired/classic mode to AMP generator meta

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -311,6 +311,15 @@ function amp_get_boilerplate_code() {
 }
 
 /**
+ * Add generator metadata.
+ *
+ * @since 6.0
+ */
+function amp_add_generator_metadata() {
+	printf( '<meta name="generator" content="%s" />', esc_attr( 'AMP Plugin v' . AMP__VERSION ) );
+}
+
+/**
  * Register default scripts for AMP components.
  *
  * @param WP_Scripts $wp_scripts Scripts.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -314,9 +314,17 @@ function amp_get_boilerplate_code() {
  * Add generator metadata.
  *
  * @since 6.0
+ * @since 1.0 Add template mode.
  */
 function amp_add_generator_metadata() {
-	printf( '<meta name="generator" content="%s" />', esc_attr( 'AMP Plugin v' . AMP__VERSION ) );
+	if ( amp_is_canonical() ) {
+		$mode = 'native';
+	} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		$mode = 'paired';
+	} else {
+		$mode = 'classic';
+	}
+	printf( '<meta name="generator" content="%s">', esc_attr( sprintf( 'AMP Plugin v%s; mode=%s', AMP__VERSION, $mode ) ) );
 }
 
 /**

--- a/includes/amp-post-template-actions.php
+++ b/includes/amp-post-template-actions.php
@@ -137,12 +137,3 @@ function amp_post_template_add_analytics_data() {
 	$analytics = amp_add_custom_analytics();
 	amp_print_analytics( $analytics );
 }
-
-/**
- * Add generator metadata.
- *
- * @since 6.0
- */
-function amp_add_generator_metadata() {
-	printf( '<meta name="generator" content="%s" />', esc_attr( 'AMP Plugin v' . AMP__VERSION ) );
-}

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -389,6 +389,34 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amp_add_generator_metadata.
+	 *
+	 * @covers \amp_add_generator_metadata()
+	 */
+	public function test_amp_add_generator_metadata() {
+		remove_theme_support( AMP_Theme_Support::SLUG );
+		ob_start();
+		amp_add_generator_metadata();
+		$output = ob_get_clean();
+		$this->assertContains( 'mode=classic', $output );
+		$this->assertContains( 'v' . AMP__VERSION, $output );
+
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		ob_start();
+		amp_add_generator_metadata();
+		$output = ob_get_clean();
+		$this->assertContains( 'mode=paired', $output );
+		$this->assertContains( 'v' . AMP__VERSION, $output );
+
+		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
+		ob_start();
+		amp_add_generator_metadata();
+		$output = ob_get_clean();
+		$this->assertContains( 'mode=native', $output );
+		$this->assertContains( 'v' . AMP__VERSION, $output );
+	}
+
+	/**
 	 * Test script registering.
 	 *
 	 * @covers \amp_register_default_scripts()


### PR DESCRIPTION
In order to track the success of the new AMP theme support (in native and paired modes) over the classic mode, it is important to capture whether the new paired or native modes are in use. This PR adds a `mode` param to the meta generator tag:

```html
<meta name="generator" content="AMP Plugin v1.0-beta4; mode=native">
```
```html
<meta name="generator" content="AMP Plugin v1.0-beta4; mode=paired">
```
```html
<meta name="generator" content="AMP Plugin v1.0-beta4; mode=classic">
```