### PR TITLE
Fix incorrect attribution of theme as source for content validation errors

### DIFF
--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -976,6 +976,10 @@ class AMP_Invalid_URL_Post_Type {
 			}
 		}
 
+		if ( empty( $output ) && ! empty( $sources['hook'] ) ) {
+			$output[] = sprintf( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>%s</strong>', esc_html( $sources['hook'] ) );
+		}
+
 		if ( empty( $sources ) && $active_theme ) {
 			$theme_obj = wp_get_theme( $active_theme );
 			if ( ! $theme_obj->errors() ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -694,6 +694,14 @@ class AMP_Validation_Error_Taxonomy {
 			}
 
 			if ( ! empty( $validation_error['sources'] ) ) {
+				$hook = null;
+				foreach ( $validation_error['sources'] as $source ) {
+					if ( isset( $source['hook'] ) ) {
+						$invalid_sources['hook'] = $source['hook'];
+						break;
+					}
+				}
+
 				$source = array_shift( $validation_error['sources'] );
 
 				if ( isset( $source['type'], $source['name'] ) ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -698,14 +698,15 @@ class AMP_Validation_Error_Taxonomy {
 				foreach ( $validation_error['sources'] as $source ) {
 					if ( isset( $source['hook'] ) ) {
 						$invalid_sources['hook'] = $source['hook'];
-						break;
+					}
+					if ( isset( $source['type'], $source['name'] ) ) {
+						$invalid_sources[ $source['type'] ][] = $source['name'];
 					}
 				}
 
-				$source = array_shift( $validation_error['sources'] );
-
-				if ( isset( $source['type'], $source['name'] ) ) {
-					$invalid_sources[ $source['type'] ][] = $source['name'];
+				// Remove core if there is a plugin or theme.
+				if ( isset( $invalid_sources['core'] ) && ( isset( $invalid_sources['theme'] ) || isset( $invalid_sources['plugin'] ) ) ) {
+					unset( $invalid_sources['core'] );
 				}
 			}
 		}


### PR DESCRIPTION
Given `post_content` such as:

```html
See post on Make XWP:

https://make.xwp.co/2018/09/24/amp-plugin-release-v1-0-beta4/

This is something: <button onclick="ok">food</button>
```

The Invalid URL screen currently displays sources as the following (the New Rejected errors are from the content here):

![image](https://user-images.githubusercontent.com/134745/46041102-e7370380-c0c6-11e8-8ba3-94165b0b8968.png)

Note how they are incorrectly being attributed to “Twenty Sixteen (?)”. This was due to a change I made in https://github.com/Automattic/amp-wp/pull/1449/commits/3be57670dcf0953573707cb13b924a3696720895 from #1449. But it is clearly not right. The four validation errors should all be contributed to _the content_, not guessing the theme. 

This PR fixes that problem by listing the outermost hook running in the source stack, if available, and if no other source was obtained. So the result is this:

![image](https://user-images.githubusercontent.com/134745/46041518-d470fe80-c0c7-11e8-965b-8b5e7b943250.png)

Note how each source now indicates `the_content` as the source. 