### PR TITLE
Add source information for Embeds; discontinue extracting iframe from paragraphs

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -103,18 +103,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$new_node->appendChild( $placeholder_node );
 			}
 
-			$parent_node = $node->parentNode;
-			if ( 'p' !== strtolower( $parent_node->tagName ) ) {
-				$parent_node->replaceChild( $new_node, $node );
-			} else {
-				// AMP does not like iframes in <p> tags.
-				$parent_node->removeChild( $node );
-				$parent_node->parentNode->insertBefore( $new_node, $parent_node->nextSibling );
-
-				if ( AMP_DOM_Utils::is_node_empty( $parent_node ) ) {
-					$parent_node->parentNode->removeChild( $parent_node );
-				}
-			}
+			$node->parentNode->replaceChild( $new_node, $node );
 		}
 	}
 
@@ -182,6 +171,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Builds a DOMElement to use as a placeholder for an <iframe>.
 	 *
+	 * Important: The element returned must not be block-level (e.g. div) as the PHP DOM parser
+	 * will move it out from inside any containing paragraph. So this is why a span is used.
+	 *
 	 * @since 0.2
 	 *
 	 * @param string[] $parent_attributes {
@@ -193,7 +185,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return DOMElement|false
 	 */
 	private function build_placeholder( $parent_attributes ) {
-		$placeholder_node = AMP_DOM_Utils::create_node( $this->dom, 'div', array(
+		$placeholder_node = AMP_DOM_Utils::create_node( $this->dom, 'span', array(
 			'placeholder' => '',
 			'class'       => 'amp-wp-iframe-placeholder',
 		) );

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -976,6 +976,10 @@ class AMP_Invalid_URL_Post_Type {
 			}
 		}
 
+		if ( empty( $output ) && ! empty( $sources['embed'] ) ) {
+			$output[] = sprintf( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>%s</strong>', esc_html( 'Embed' ) );
+		}
+
 		if ( empty( $output ) && ! empty( $sources['hook'] ) ) {
 			$output[] = sprintf( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>%s</strong>', esc_html( $sources['hook'] ) );
 		}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -701,6 +701,8 @@ class AMP_Validation_Error_Taxonomy {
 					}
 					if ( isset( $source['type'], $source['name'] ) ) {
 						$invalid_sources[ $source['type'] ][] = $source['name'];
+					} elseif ( isset( $source['embed'] ) ) {
+						$invalid_sources['embed'] = true;
 					}
 				}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -475,7 +475,8 @@ class AMP_Validation_Manager {
 			add_filter( $wrapped_filter, array( __CLASS__, 'decorate_filter_source' ), PHP_INT_MAX );
 		}
 
-		add_filter( 'do_shortcode_tag', array( __CLASS__, 'decorate_shortcode_source' ), -1, 2 );
+		add_filter( 'do_shortcode_tag', array( __CLASS__, 'decorate_shortcode_source' ), PHP_INT_MAX, 2 );
+		add_filter( 'embed_oembed_html', array( __CLASS__, 'decorate_embed_source' ), PHP_INT_MAX, 3 );
 
 		$do_blocks_priority  = has_filter( 'the_content', 'do_blocks' );
 		$is_gutenberg_active = (
@@ -1235,6 +1236,28 @@ class AMP_Validation_Manager {
 			self::get_source_comment( $source, false ),
 		) );
 		return $output;
+	}
+
+	/**
+	 * Filters the output created by embeds.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $output Embed output.
+	 * @param string $url    URL.
+	 * @param array  $attr   Attributes.
+	 * @return string Output.
+	 */
+	public static function decorate_embed_source( $output, $url, $attr ) {
+		$source = array(
+			'embed' => $url,
+			'attr'  => $attr,
+		);
+		return implode( '', array(
+			self::get_source_comment( $source, true ),
+			trim( $output ),
+			self::get_source_comment( $source, false ),
+		) );
 	}
 
 	/**

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -87,15 +87,15 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			),
 			'iframe_in_p_tag' => array(
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>',
-				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
 			),
 			'multiple_iframes_in_p_tag' => array(
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
-				'<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
 			),
 			'multiple_iframes_and_contents_in_p_tag' => array(
 				'<p>contents<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
-				'<p>contents</p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'<p>contents<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
 			),
 			'iframe_src_with_commas_and_colons'         => array(
 				'<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&z=15&l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen=""></iframe>',
@@ -172,8 +172,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	}
 
 	public function test__args__placeholder() {
-		$source = '<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe>';
-		$expected = '<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"><div placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe>';
+		$source   = '<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>';
+		$expected = '<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe></p>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array(

--- a/tests/test-amp-script-sanitizer.php
+++ b/tests/test-amp-script-sanitizer.php
@@ -96,6 +96,6 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
 		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
 		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
-		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><div placeholder="" class="amp-wp-iframe-placeholder"></div></amp-iframe><!--/noscript-->', $content );
+		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe><!--/noscript-->', $content );
 	}
 }

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -253,7 +253,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertEmpty( AMP_Validation_Manager::$validation_error_status_overrides );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_content', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_excerpt', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
-		$this->assertEquals( -1, has_action( 'do_shortcode_tag', array( self::TESTED_CLASS, 'decorate_shortcode_source' ) ) );
+		$this->assertEquals( PHP_INT_MAX, has_action( 'do_shortcode_tag', array( self::TESTED_CLASS, 'decorate_shortcode_source' ) ) );
 
 		// Test overrides.
 		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( array( 'test' => 1 ) );


### PR DESCRIPTION
This implements https://github.com/Automattic/amp-wp/pull/1467#issuecomment-424493866.

Instead of showing invalid markup from oEmbeds as having the `the_content` source as per #1467, actually show that it is an “Embed”:

![image](https://user-images.githubusercontent.com/134745/46046816-56b4ef00-c0d7-11e8-96f8-d6bec00bf277.png)

Also reveal the embed source information in the source stack, including the embed URL and its attributes:

```json
    {
        "embed": "https://make.xwp.co/2018/09/24/amp-plugin-release-v1-0-beta4/",
        "attr": {
            "width": 840,
            "height": 1000
        }
    }
```

In order to accomplish the above, we needed to undo an old PR https://github.com/Automattic/amp-wp/pull/112 which extracted an `amp-iframe` from a contained `p`:

https://github.com/Automattic/amp-wp/blob/c5ebe1f38ff58d58ee1cbdb735cd97bb14a316fe/includes/sanitizers/class-amp-iframe-sanitizer.php#L110-L112

The reason for why this was needed is apparently because of the iframe placeholder. A `div` placeholder would get extracted from the `p` by the HTML parser. So an easy fix is to switch this to being a `span` instead.