### PR TITLE
Bump 1.1-alpha

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/automattic/amp-wp
  * Author: WordPress.com VIP, XWP, Google, and contributors
  * Author URI: https://github.com/Automattic/amp-wp/graphs/contributors
- * Version: 1.0-beta4
+ * Version: 1.1-alpha
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -49,7 +49,7 @@ if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) || ! file_exists( __DIR__
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.0-beta4' );
+define( 'AMP__VERSION', '1.1-alpha' );
 
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,9 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 
 ## Changelog ##
 
+### 1.1 (unreleased) ###
+...
+
 ### 1.0 (unreleased) ###
 To learn how to use the new features in this release, please see the wiki pages for [Adding Theme Support](https://github.com/Automattic/amp-wp/wiki/Adding-Theme-Support) and [Implementing Interactivity](https://github.com/Automattic/amp-wp/wiki/Implementing-Interactivity).
 

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,10 @@ Follow along with or [contribute](https://github.com/Automattic/amp-wp/blob/deve
 
 == Changelog ==
 
+= 1.1 (unreleased) =
+
+...
+
 = 1.0 (unreleased) =
 
 To learn how to use the new features in this release, please see the wiki pages for [Adding Theme Support](https://github.com/Automattic/amp-wp/wiki/Adding-Theme-Support) and [Implementing Interactivity](https://github.com/Automattic/amp-wp/wiki/Implementing-Interactivity).


### PR DESCRIPTION
A [`1.0` branch](https://github.com/Automattic/amp-wp/tree/1.0) has been created which is where we'll tie up any final loose ends for the 1.0-RC1 release and 1.0 final, followed by any patch fix releases.