### PR TITLE
Update the copy for the 'Details' tooltip

### DIFF
--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -830,7 +830,7 @@ class AMP_Invalid_URL_Post_Type {
 				esc_html__( 'Details', 'amp' ),
 				esc_attr( sprintf( '<h3>%s</h3><p>%s</p>',
 					esc_html__( 'Details', 'amp' ),
-					esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+					esc_html__( 'The parent element of where the error occurred.', 'amp' )
 				) )
 			),
 			'sources_with_invalid_output' => __( 'Sources', 'amp' ),

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -809,7 +809,7 @@ class AMP_Validation_Error_Taxonomy {
 					esc_html__( 'Details', 'amp' ),
 					esc_attr( sprintf( '<h3>%s</h3><p>%s</p>',
 						esc_html__( 'Details', 'amp' ),
-						esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+						esc_html__( 'The parent element of where the error occurred.', 'amp' )
 					) )
 				),
 				'error_type'       => esc_html__( 'Type', 'amp' ),

--- a/tests/validation/test-class-amp-invalid-url-post-type.php
+++ b/tests/validation/test-class-amp-invalid-url-post-type.php
@@ -549,7 +549,7 @@ class Test_AMP_Invalid_URL_Post_Type extends \WP_UnitTestCase {
 				'cb'                          => '<input type="checkbox" />',
 				'error'                       => 'Error',
 				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
-				'details'                     => 'Details<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Details&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
+				'details'                     => 'Details<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Details&lt;/h3&gt;&lt;p&gt;The parent element of where the error occurred.&lt;/p&gt;"></div>',
 				'sources_with_invalid_output' => 'Sources',
 				'error_type'                  => 'Error Type',
 			),


### PR DESCRIPTION
* Changes the 'Details' copy
* The previous text was a placeholder
* This will eventually be converted to a Gutenberg popover (#1479), but this change will apply to the `RC1` release


New 'Details' copy:
<img width="1090" alt="new-details-tooltip-copy" src="https://user-images.githubusercontent.com/4063887/46389860-3cac7b00-c69a-11e8-81be-2311825bfd7a.png">

Existing 'Status' copy:
<img width="1090" alt="status-tooltip-unchanged" src="https://user-images.githubusercontent.com/4063887/46389814-edfee100-c699-11e8-9dac-039b2cce9d45.png">

