### PR TITLE
Address an issue in the Gutenberg notice when a block has an error

### DIFF
--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -171,7 +171,8 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 					return (
 						0 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS */ === result.status ||
 						1 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS */ === result.status ||
-						2 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS */ === result.status // eslint-disable-line no-magic-numbers
+						2 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS */ === result.status || // eslint-disable-line no-magic-numbers
+						3 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS */ === result.status // eslint-disable-line no-magic-numbers
 					);
 				} ),
 				function( result ) {


### PR DESCRIPTION
@amedina noticed this issue in block validation.

**Steps to reproduce**
(please correct these if needed)
1. Select Paired mode, with 'Automatically accept sanitization' unchecked
2. Create a post in Gutenberg with intentionally invalid AMP
3. Expected: the notice at the top should include 'And 1 is directly due to content here.' (or some other number)
4. Actual: the notice says 'But it is not directly due to content here'
<img width="1120" alt="before-validation-error" src="https://user-images.githubusercontent.com/4063887/46396118-14ca1100-c6b4-11e8-823d-dd0671f57dbf.png">

With this PR applied, the notice looks to be as expected. Thanks to @westonruter for pointing out where to fix this:

<img width="1145" alt="after-block-validation" src="https://user-images.githubusercontent.com/4063887/46396181-43e08280-c6b4-11e8-99f2-a9e4e639059a.png">
