### PR TITLE
Fix detection for whether AMP is available to allow new accepted errors

### DIFF
--- a/includes/class-amp-cli.php
+++ b/includes/class-amp-cli.php
@@ -649,7 +649,11 @@ class AMP_CLI {
 			$validation_errors,
 			function( $error ) {
 				$validation_status = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error );
-				return AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS !== $validation_status['term_status'];
+				return (
+					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS !== $validation_status['term_status']
+					&&
+					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS !== $validation_status['term_status']
+				);
 			}
 		) );
 

--- a/includes/validation/class-amp-invalid-url-post-type.php
+++ b/includes/validation/class-amp-invalid-url-post-type.php
@@ -370,7 +370,7 @@ class AMP_Invalid_URL_Post_Type {
 			}
 
 			$sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $stored_validation_error['data'] );
-			if ( $args['ignore_accepted'] && AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS === $sanitization['status'] ) {
+			if ( $args['ignore_accepted'] && ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS === $sanitization['status'] || AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS === $sanitization['status'] ) ) {
 				continue;
 			}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -304,7 +304,7 @@ class AMP_Validation_Manager {
 				if ( $amp_invalid_url_post ) {
 					$error_count = 0;
 					foreach ( AMP_Invalid_URL_Post_Type::get_invalid_url_validation_errors( $amp_invalid_url_post ) as $error ) {
-						if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS !== $error['term_status'] ) {
+						if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS === $error['term_status'] || AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS === $error['term_status'] ) {
 							$error_count++;
 						}
 					}
@@ -322,7 +322,7 @@ class AMP_Validation_Manager {
 
 		if ( is_amp_endpoint() ) {
 			$icon = '&#x2705;'; // WHITE HEAVY CHECK MARK. This will get overridden in AMP_Validation_Manager::finalize_validation() if there are unaccepted errors.
-		} elseif ( $error_count > 0 && ! self::is_sanitization_auto_accepted() ) {
+		} elseif ( $error_count > 0 ) {
 			$icon = '&#x274C;'; // CROSS MARK.
 		} else {
 			$icon = '&#x1F517;'; // LINK SYMBOL.
@@ -362,7 +362,7 @@ class AMP_Validation_Manager {
 		$first_item_is_validate = (
 			amp_is_canonical()
 			||
-			( ! is_amp_endpoint() && $error_count > 0 && ! self::is_sanitization_auto_accepted() )
+			( ! is_amp_endpoint() && $error_count > 0 )
 		);
 		if ( $first_item_is_validate ) {
 			$title          = __( 'Validate AMP', 'amp' );


### PR DESCRIPTION
In paired mode, I noticed when there were new-accepted validation errors (but no rejected ones) there was no `amphtml` link provided, with instead a comment:

```html
<!--
There are 19 validation errors that are blocking the amphtml version from being available.
-->
```

Likewise, with auto-accepting sanitization disabled, I would also see the admin bar as indicating AMP is not available when it actually is:

![image](https://user-images.githubusercontent.com/134745/46432497-474f2a80-c703-11e8-9bbe-fc479976688b.png)

This PR fixes those issues by ensuring that ack-accepted and new-accepted aren't being accounted for together, including elimination of obsolete `is_sanitization_auto_accepted` checks.

This is a regression from #1429.