### PR TITLE
Ensure font stylesheets are requested in CORS mode in both AMP and non-AMP documents

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -102,6 +102,9 @@ add_action( 'wp_default_scripts', 'amp_register_default_scripts' );
 // Ensure async and custom-element/custom-template attributes are present on script tags.
 add_filter( 'script_loader_tag', 'amp_filter_script_loader_tag', PHP_INT_MAX, 2 );
 
+// Ensure crossorigin=anonymous is added to font links.
+add_filter( 'style_loader_tag', 'amp_filter_font_style_loader_tag_with_crossorigin_anonymous', 10, 4 );
+
 /**
  * Set up AMP.
  *

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -492,6 +492,48 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
 }
 
 /**
+ * Opt-in to CORS Mode for the font stylesheets.
+ *
+ * This ensures that a service worker caching the external stylesheet will not inflate the storage quota.
+ * This must be done in AMP and non-AMP alike because in paired mode the service worker could cache the
+ * font stylesheets in a non-AMP document without CORS (crossorigin="anonymous") in which case the
+ * service worker could then fail to serve the cached font resources in an AMP document with the warning:
+ *
+ * > The FetchEvent resulted in a network error response: an "opaque" response was used for a request whose type is not no-cors
+ *
+ * @since 1.0
+ * @link https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
+ * @link https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses
+ * @todo This should be proposed for WordPress core.
+ *
+ * @param string $tag    Link tag HTML.
+ * @param string $handle Dependency handle.
+ * @param string $href   Link URL.
+ * @return string Link tag HTML.
+ */
+function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $handle, $href ) {
+	static $allowed_font_src_regex = null;
+	unset( $handle );
+	if ( ! $allowed_font_src_regex ) {
+		$spec_name = 'link rel=stylesheet for fonts'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'link' ) as $spec_rule ) {
+			if ( isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) && $spec_name === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
+				$allowed_font_src_regex = '@^(' . $spec_rule[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['href']['value_regex'] . ')$@';
+				break;
+			}
+		}
+	}
+
+	$href = preg_replace( '#^(http:)?(?=//)#', 'https:', $href );
+
+	if ( preg_match( $allowed_font_src_regex, $href ) && false === strpos( $tag, 'crossorigin=' ) ) {
+		$tag = preg_replace( '/(?<=<link\s)/', 'crossorigin="anonymous" ', $tag );
+	}
+
+	return $tag;
+}
+
+/**
  * Retrieve analytics data added in backend.
  *
  * @since 0.7

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -492,12 +492,13 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
 }
 
 /**
- * Opt-in to CORS Mode for the font stylesheets.
+ * Explicitly opt-in to CORS mode by adding the crossorigin attribute to font stylesheet links.
  *
- * This ensures that a service worker caching the external stylesheet will not inflate the storage quota.
- * This must be done in AMP and non-AMP alike because in paired mode the service worker could cache the
- * font stylesheets in a non-AMP document without CORS (crossorigin="anonymous") in which case the
- * service worker could then fail to serve the cached font resources in an AMP document with the warning:
+ * This explicitly triggers a CORS request, and gets back a non-opaque response, ensuring that a service
+ * worker caching the external stylesheet will not inflate the storage quota. This must be done in AMP
+ * and non-AMP alike because in paired mode the service worker could cache the font stylesheets in a
+ * non-AMP document without CORS (crossorigin="anonymous") in which case the service worker could then
+ * fail to serve the cached font resources in an AMP document with the warning:
  *
  * > The FetchEvent resulted in a network error response: an "opaque" response was used for a request whose type is not no-cors
  *

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -638,18 +638,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			/*
-			 * Opt-in to CORS Mode for the stylesheet. This ensures that a service worker caching the external
-			 * stylesheet will not inflate the storage quota.
-			 *
-			 * See:
-			 * - https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
-			 * - https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses
-			 */
-			if ( ! $element->hasAttribute( 'crossorigin' ) ) {
-				$element->setAttribute( 'crossorigin', 'anonymous' );
-			}
-
-			/*
 			 * Make sure rel=preconnect link is present for Google Fonts stylesheet.
 			 * Note that core themes normally do this already, per <https://core.trac.wordpress.org/ticket/37171>.
 			 * But not always, per <https://core.trac.wordpress.org/ticket/44668>.

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1201,12 +1201,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that font URLs get validated.
 	 *
+	 * @covers \amp_filter_font_style_loader_tag_with_crossorigin_anonymous()
 	 * @dataProvider get_font_urls
 	 * @param string $url         Font URL.
 	 * @param array  $error_codes Error codes.
 	 */
 	public function test_font_urls( $url, $error_codes ) {
-		$dom = AMP_DOM_Utils::get_dom( sprintf( '<html><head><link rel="stylesheet" href="%s"></head></html>', $url ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$tag = sprintf( '<link rel="stylesheet" href="%s">', esc_url( $url ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$tag = amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, 'font', $url );
+
+		$dom = AMP_DOM_Utils::get_dom( sprintf( '<html><head>%s</head></html>', $tag ) );
 
 		$validation_errors = array();
 
@@ -1237,11 +1241,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test addition of crossorigin attribute to external stylesheet links.
 	 *
 	 * @covers AMP_Style_Sanitizer::process_link_element()
+	 * @covers \amp_filter_font_style_loader_tag_with_crossorigin_anonymous()
 	 */
 	public function test_cors_enabled_stylesheet_url() {
 
 		// Test supplying crossorigin attribute.
-		$document  = AMP_DOM_Utils::get_dom( '<html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"></head></html>' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$url       = 'https://fonts.googleapis.com/css?family=Tangerine';
+		$link      = amp_filter_font_style_loader_tag_with_crossorigin_anonymous( "<link rel='stylesheet' href='$url'>", 'font', $url ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$document  = AMP_DOM_Utils::get_dom( "<html><head>$link</head></html>" );
 		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
 		$sanitizer->sanitize();
 		$link = $document->getElementsByTagName( 'link' )->item( 0 );
@@ -1249,7 +1256,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'anonymous', $link->getAttribute( 'crossorigin' ) );
 
 		// Test that existing crossorigin attribute is not overridden.
-		$document  = AMP_DOM_Utils::get_dom( '<html><head><link rel="stylesheet" crossorigin="use-credentials" href="https://fonts.googleapis.com/css?family=Tangerine"></head></html>' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$link      = amp_filter_font_style_loader_tag_with_crossorigin_anonymous( "<link crossorigin='use-credentials' rel='stylesheet' href='$url'>", 'font', $url ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$document  = AMP_DOM_Utils::get_dom( "<html><head>$link</head></html>" ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
 		$sanitizer->sanitize();
 		$link = $document->getElementsByTagName( 'link' )->item( 0 );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1192,7 +1192,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'<link rel="icon" href="http://example.org/favicon.png" sizes="192x192">',
 
 			'#<style amp-custom>.*?body\s*{\s*background:\s*black;?\s*}.*?</style>#s',
-			'<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine" crossorigin="anonymous">',
+			'<link crossorigin="anonymous" rel="stylesheet" id="my-font-css" href="https://fonts.googleapis.com/css?family=Tangerine" type="text/css" media="all">',
 			'<style amp-boilerplate>',
 			'<noscript><style amp-boilerplate>',
 			'<script type="application/ld+json">{"@context"',
@@ -1370,13 +1370,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		add_action( 'wp_enqueue_scripts', function() {
 			wp_enqueue_script( 'amp-list' );
+			wp_enqueue_style( 'my-font', 'https://fonts.googleapis.com/css?family=Tangerine', array(), null ); // phpcs:ignore
 		} );
 		add_action( 'wp_print_scripts', function() {
 			echo '<!-- wp_print_scripts -->';
-		} );
-
-		add_action( 'wp_print_styles', function() {
-			echo '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine">';
 		} );
 
 		add_filter( 'script_loader_tag', function( $tag, $handle ) {


### PR DESCRIPTION
The AMP plugin is currently using the post-processor to add `crossorigin=anonymous` to font stylesheet links. This is not being done, however, in the non-AMP responses. This is a problem because when a service worker is caching the font stylesheet responses with CORS but then tries to serve it in response to a stylesheet being requested without CORS, then the fetch fails entirely with:

> The FetchEvent resulted in a network error response: an "opaque" response was used for a request whose type is not no-cors

So we need to make sure that such font URLs _always_ get served with CORS (`crossorigin="anonymous"`) when in AMP and not-AMP alike to prevent this problem from happening.

Another benefit of CORS is that it ensures that a service worker caching the external stylesheet will not inflate the storage quota. See: 
* https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
* https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses

This PR is cherry-picking https://github.com/Automattic/amp-wp/pull/1261/commits/02fd0a7b04e29651e0f63d4a5b09ae22210a54e2 from #1261. We'll not ship the PWA plugin integration for 1.0, but this fix needs to be deployed first.