### PR TITLE
Amend AMP style elements with sourceURL comment for DevTools

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1760,6 +1760,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$stylesheet_sets = array(
 			'custom'    => array(
+				'source_map_comment'  => "\n\n/*# sourceURL=amp-custom.css */",
 				'total_size'          => 0,
 				'cdata_spec'          => $this->style_custom_cdata_spec,
 				'pending_stylesheets' => array(),
@@ -1767,6 +1768,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'remove_unused_rules' => $this->args['remove_unused_rules'],
 			),
 			'keyframes' => array(
+				'source_map_comment'  => "\n\n/*# sourceURL=amp-keyframes.css */",
 				'total_size'          => 0,
 				'cdata_spec'          => $this->style_keyframes_cdata_spec,
 				'pending_stylesheets' => array(),
@@ -1834,6 +1836,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			$css  = implode( '', $stylesheet_sets['custom']['imports'] ); // For native dirty AMP.
 			$css .= implode( '', $stylesheet_sets['custom']['final_stylesheets'] );
+			$css .= $stylesheet_sets['custom']['source_map_comment'];
 
 			/*
 			 * Let the style[amp-custom] be populated with the concatenated CSS.
@@ -1920,9 +1923,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				) );
 			} else {
+				$css  = implode( '', $stylesheet_sets['keyframes']['final_stylesheets'] );
+				$css .= $stylesheet_sets['keyframes']['source_map_comment'];
+
 				$style_element = $this->dom->createElement( 'style' );
 				$style_element->setAttribute( 'amp-keyframes', '' );
-				$style_element->appendChild( $this->dom->createTextNode( implode( '', $stylesheet_sets['keyframes']['final_stylesheets'] ) ) );
+				$style_element->appendChild( $this->dom->createTextNode( $css ) );
 				$body->appendChild( $style_element );
 			}
 		}
@@ -2002,7 +2008,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Finalized stylesheet set.
 	 */
 	private function finalize_stylesheet_set( $stylesheet_set ) {
-		$is_too_much_css   = $stylesheet_set['total_size'] > $stylesheet_set['cdata_spec']['max_bytes'];
+		$max_bytes         = $stylesheet_set['cdata_spec']['max_bytes'] - strlen( $stylesheet_set['source_map_comment'] );
+		$is_too_much_css   = $stylesheet_set['total_size'] > $max_bytes;
 		$should_tree_shake = (
 			'always' === $stylesheet_set['remove_unused_rules'] || (
 				$is_too_much_css
@@ -2081,7 +2088,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Report validation error if size is now too big.
-			if ( $final_size + $sheet_size > $stylesheet_set['cdata_spec']['max_bytes'] ) {
+			if ( $final_size + $sheet_size > $max_bytes ) {
 				$validation_error = array(
 					'code' => 'excessive_css',
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -424,6 +424,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$this->assertContains( $expected_stylesheet, $sanitized_html );
 		}
 
+		$this->assertContains( "\n\n/*# sourceURL=amp-custom.css */", $sanitized_html );
 		$this->assertEquals( $expected_errors, $error_codes );
 	}
 
@@ -997,6 +998,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_keyframe_sanitizer( $source, $expected = null, $expected_errors = array() ) {
 		$expected    = isset( $expected ) ? $expected : $source;
+		$expected    = preg_replace( '#(?=</style>)#', "\n\n/*# sourceURL=amp-keyframes.css */", $expected );
 		$dom         = AMP_DOM_Utils::get_dom_from_content( $source );
 		$error_codes = array();
 		$sanitizer   = new AMP_Style_Sanitizer( $dom, array(


### PR DESCRIPTION
When stylesheets include a `sourceURL` comment at the end then they will be listed in DevTools as sources which can by analyzed for CSS code coverage:

![image](https://user-images.githubusercontent.com/134745/47885683-7f758600-ddf3-11e8-9b5e-e1078dcee861.png)

This change is important because it allows developers to identify which CSS rules specifically need to be removed. As discussed in #1583, the CSS tree shaker in the plugin is not able to be very sophisticated in how deeply it shakes the tree because it must be done at runtime.

So this relates to #1583, but it re-uses DevTools to do the code coverage instead of having to re-implement the functionality on the PHP side. This is not a replacement, however, because the code coverage does not indicate the specific stylesheet sources for where the unused CSS rules are coming from.

Thanks to @paulirish for the tip.