### PR TITLE
Make the default layout responsive for the <amp-ooyala-player> block

### DIFF
--- a/blocks/amp-ooyala-player/index.js
+++ b/blocks/amp-ooyala-player/index.js
@@ -61,7 +61,7 @@ export default registerBlockType(
 			},
 			ampLayout: {
 				type: 'string',
-				default: 'fixed',
+				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'layout'


### PR DESCRIPTION
Thanks to @csossi for reporting this in #1581.

# Steps To Reproduce

1. Activate Twenty Seventeen
2. Create a new post with the block editor
3. Add an AMP Ooyala Player block
4. Set these values for it:
Video embed code (required): `Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ`
Player ID (required): `6440813504804d76ba35c8c787a4b33c`
Provider code for the account (required): `5zb2wxOlZcNCe_HVT3a6cawW298X`
Leave the defaults for the rest:
<img width="929" alt="ooyala-player" src="https://user-images.githubusercontent.com/4063887/47943800-8c5eac00-debd-11e8-8471-25dcb001d54a.png">

5. Publish the post, and go to the front-end
6. Expected: The `<amp-ooyala-player>` remains within its container
7. Actual: it overflows its container
<img width="999" alt="ooyala-overflows-container" src="https://user-images.githubusercontent.com/4063887/47943863-de9fcd00-debd-11e8-8e0f-386b0acaadc8.png">


* As Claudio pointed out, the default layout of fixed can cause it to overflow the container.
* The layout of  `responsive` seems to keep the width to the container size in Twenty Fifteen, Sixteen, and Seventeen.
* So this **changes the default layout** from `fixed` to `responsive`.
* Still, if the content area is floated, like in a mobile-first grid, a `fixed` layout might work better. Responsive layouts mean the element only has the width of its parent. But there's a `<select>` in the block editor to change this to something like `fixed` if needed.

Fixes #1581