### PR TITLE
Add default values for AMP Timeago block

### DIFF
--- a/blocks/amp-timeago/index.js
+++ b/blocks/amp-timeago/index.js
@@ -58,6 +58,7 @@ export default registerBlockType(
 			},
 			ampLayout: {
 				type: 'string',
+				default: 'fixed-height',
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'layout'
@@ -70,6 +71,7 @@ export default registerBlockType(
 			},
 			height: {
 				type: 'number',
+				default: 20,
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'height'
@@ -99,7 +101,7 @@ export default registerBlockType(
 			}
 
 			const ampLayoutOptions = [
-				{ value: '', label: __( 'Responsive', 'amp' ) }, // Default for amp-timeago.
+				{ value: '', label: __( 'Responsive', 'amp' ) },
 				{ value: 'fixed', label: __( 'Fixed', 'amp' ) },
 				{ value: 'fixed-height', label: __( 'Fixed height', 'amp' ) }
 			];


### PR DESCRIPTION
Thanks to @csossi for reporting this in #1580. 

Creating an AMP Timeago block with the default values causes a validation error in the Chrome extension because it doesn't have the required `height` value:

<img width="775" alt="height-value-required" src="https://user-images.githubusercontent.com/4063887/47945467-cc2a9100-dec7-11e8-83b8-2f28dbae53e1.png">

So this sets a default value of `20` for the height. This is the value in [this example](https://www.ampproject.org/ko/docs/reference/components/amp-timeago#behavior).

It also sets the default layout to `fixed-height`. This is the only layout available that doesn't require a `width` (there's no default width in the editor):

<img width="971" alt="new-default-values" src="https://user-images.githubusercontent.com/4063887/47945498-085df180-dec8-11e8-9b02-99d65117118d.png">

Fixes #1580 