### PR TITLE
Do not show fallback source as active theme if no validation errors

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -934,6 +934,12 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
+		// Show nothing if there are no valudation errors.
+		if ( 0 === count( array_filter( $error_summary ) ) ) {
+			esc_html_e( '--', 'amp' );
+			return;
+		}
+
 		$active_theme          = null;
 		$validated_environment = get_post_meta( $post_id, '_amp_validated_environment', true );
 		if ( isset( $validated_environment['theme'] ) ) {


### PR DESCRIPTION
There is a bug in `AMP_Validated_URL_Post_Type::render_sources_column()` where it will render the active theme with a `(?)` after it (via https://github.com/Automattic/amp-wp/commit/3be57670dcf0953573707cb13b924a3696720895) when it can't find the source for an error, since in that case it is normally in the theme template itself. However, this was incorrectly showing the active theme when there were no validation errors at all to display in the summary at all. So this fix short-circuits the source summary display in this case.

# Before

<img width="902" alt="screen shot 2018-11-07 at 9 28 47 am" src="https://user-images.githubusercontent.com/134745/48149082-1e750480-e270-11e8-9526-4507caa7f8b9.png">

# After

<img width="902" alt="screen shot 2018-11-07 at 9 29 45 am" src="https://user-images.githubusercontent.com/134745/48149087-23d24f00-e270-11e8-8893-cffae59ae3c2.png">
