### PR TITLE
Add warning when AMP plugin is installed in incorrect directory

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -68,6 +68,34 @@ define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
 define( 'AMP__VERSION', '1.0-RC2' );
 
+/**
+ * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).
+ *
+ * @since 1.0
+ */
+function _amp_incorrect_plugin_slug_admin_notice() {
+	$actual_slug = basename( AMP__DIR__ );
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					/* translators: %1$s is the current directory name, and %2$s is the required directory name */
+					__( 'You appear to have installed the AMP plugin incorrectly. It is currently installed in the <code>%1$s</code> directory, but it needs to be placed in a directory named <code>%2$s</code>. Please rename the directory. This is important for WordPress plugin auto-updates.', 'amp' ),
+					$actual_slug,
+					'amp'
+				)
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+if ( 'amp' !== basename( AMP__DIR__ ) ) {
+	add_action( 'admin_notices', '_amp_incorrect_plugin_slug_admin_notice' );
+}
+
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();
 


### PR DESCRIPTION
This adds a warning admin notice when the plugin is installed in a directory other than `amp` (e.g. when accidentally cloning as `amp-wp` from GitHub).

<img width="924" alt="screen shot 2018-11-07 at 9 51 58 am" src="https://user-images.githubusercontent.com/134745/48150366-516cc780-e273-11e8-8f97-cf9673782fee.png">
