### PR TITLE
Prevent a notice from appearing in the Compatibility Tool meta box

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1599,7 +1599,15 @@ class AMP_Validated_URL_Post_Type {
 	public static function add_meta_boxes() {
 		remove_meta_box( 'submitdiv', self::POST_TYPE_SLUG, 'side' );
 		remove_meta_box( 'slugdiv', self::POST_TYPE_SLUG, 'normal' );
-		add_meta_box( self::STATUS_META_BOX, __( 'Status', 'amp' ), array( __CLASS__, 'print_status_meta_box' ), self::POST_TYPE_SLUG, 'side' );
+		add_meta_box(
+			self::STATUS_META_BOX,
+			__( 'Status', 'amp' ),
+			array( __CLASS__, 'print_status_meta_box' ),
+			self::POST_TYPE_SLUG,
+			'side',
+			'default',
+			array( '__back_compat_meta_box' => true )
+		);
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -1123,6 +1123,10 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 			),
 			$side_meta_box['callback']
 		);
+		$this->assertEquals(
+			array( '__back_compat_meta_box' => true ),
+			$side_meta_box['args']
+		);
 
 		$contexts = $wp_meta_boxes[ AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ]['side'];
 		foreach ( $contexts as $context ) {


### PR DESCRIPTION
It looks like this notice doesn't appear with WordPress `5.0-beta3` and Gutenberg `4.2.0`.

But it appeared on the single URL validation page, with earlier versions of both. I can't reproduce this (even with `WP_DEBUG` set to `true`):

<img width="1390" alt="meta-box" src="https://user-images.githubusercontent.com/4063887/48305369-ec250a80-e4ee-11e8-9b30-acf0279eea32.png">

Still, it might be good to ensure that in future versions of Core and Gutenberg, that notice doesn't appear.

This might not be the right flag. But this sets `__back_compat_meta_box` to `true`, to indicate that:

>...this meta box should only be loaded in the classic editor interface, and the block editor should not display it. ([source](https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/))

That document also notes:
>If you register your meta box with the __back_compat_meta_box set to true, then this warning will never be displayed with your meta box, now, or in future WordPress releases.

If this notice appeared in WP `5.0-beta3` and Gutenberg `4.2.0`, maybe another flag would be better.

This is based on this Make post that @westonruter mentioned:
See https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/