### PR TITLE
Fix CSS parsing by stripping BOM

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1046,6 +1046,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$options
 		);
 
+		// Strip the dreaded UTF-8 byte order mark (BOM, \uFEFF). This should ideally get handled by PHP-CSS-Parser <https://github.com/sabberworm/PHP-CSS-Parser/issues/150>.
+		$stylesheet_string = preg_replace( '/^\xEF\xBB\xBF/', '', $stylesheet_string );
+
 		$stylesheet         = array();
 		$parsed_stylesheet  = $this->parse_stylesheet( $stylesheet_string, $options );
 		$validation_results = $parsed_stylesheet['validation_results'];
@@ -1838,9 +1841,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$css .= implode( '', $stylesheet_sets['custom']['final_stylesheets'] );
 			$css .= $stylesheet_sets['custom']['source_map_comment'];
 
-			// Remove the Byte Order Mark if it exists, as it can prevent styles from rendering.
-			$css = preg_replace( '/\x{FEFF}/u', '', $css );
-
 			/*
 			 * Let the style[amp-custom] be populated with the concatenated CSS.
 			 * !important: Updating the contents of this style element by setting textContent is not
@@ -2066,8 +2066,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 									empty( $parsed_selector['tags'] )
 									||
 									0 === count( array_diff( $parsed_selector['tags'], $this->get_used_tag_names() ) )
-									||
-									0 === count( array_diff( $parsed_selector['tags'], $stylesheet_set['cdata_spec']['css_spec']['allowed_at_rules'] ) )
 								)
 							)
 						);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1839,7 +1839,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$css .= $stylesheet_sets['custom']['source_map_comment'];
 
 			// Remove the Byte Order Mark if it exists, as it can prevent styles from rendering.
-			$css = preg_replace('/\x{FEFF}/u', '', $css );
+			$css = preg_replace( '/\x{FEFF}/u', '', $css );
 
 			/*
 			 * Let the style[amp-custom] be populated with the concatenated CSS.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2063,6 +2063,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 									empty( $parsed_selector['tags'] )
 									||
 									0 === count( array_diff( $parsed_selector['tags'], $this->get_used_tag_names() ) )
+									||
+									0 === count( array_diff( $parsed_selector['tags'], $stylesheet_set['cdata_spec']['css_spec']['allowed_at_rules'] ) )
 								)
 							)
 						);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1838,6 +1838,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$css .= implode( '', $stylesheet_sets['custom']['final_stylesheets'] );
 			$css .= $stylesheet_sets['custom']['source_map_comment'];
 
+			// Remove the Byte Order Mark if it exists, as it can prevent styles from rendering.
+			$css = preg_replace('/\x{FEFF}/u', '', $css );
+
 			/*
 			 * Let the style[amp-custom] be populated with the concatenated CSS.
 			 * !important: Updating the contents of this style element by setting textContent is not


### PR DESCRIPTION
# Steps to reproduce
1. Activate the [Essence Pro](https://my.studiopress.com/themes/essence/) Genesis theme (or use the `wp_enqueue_style()` snippet below in another theme)
2. View the source of the front page
3. Expected: the [ionicons stylesheet](https://unpkg.com/ionicons@4.1.2/dist/css/ionicons.min.css?ver=1.0.2) should have more that `0` bytes in the `<style amp-custom>`:
<img width="1266" alt="ionicons-expected" src="https://user-images.githubusercontent.com/4063887/48347711-ab3f0a00-e644-11e8-8154-02ba77c5be2e.png">
4. Actual: the stylesheet has 0 bytes...it seems that it's stripped in tree-shaking:
<img width="1257" alt="ionicons-actual" src="https://user-images.githubusercontent.com/4063887/48347769-dfb2c600-e644-11e8-9d96-6f9acc307c1f.png">


This [stylesheet](https://unpkg.com/ionicons@4.1.2/dist/css/ionicons.min.css?ver=1.0.2) is enqueued in the Essence Pro theme's `functions.php`:

```php
wp_enqueue_style(
	'ionicons',
	'//unpkg.com/ionicons@4.1.2/dist/css/ionicons.min.css',
	array(),
	CHILD_THEME_VERSION
);
```

This PR outputs the `ionicons` `@font-face`, as shown in the 'Expected' screenshot. Still, this approach probably needs more thought.

This issue doesn't look to exist on other Genesis themes that use an `ionicons` stylesheet. They use a different URL for the stylesheet, and it seems to appear fine.