### PR TITLE
Gutenberg: Fix displaying validation warning and usage of PHP function

### DIFF
--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -258,7 +258,20 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				)
 			] );
 
-			module.validationWarningNoticeId = wp.data.dispatch( 'core/editor' ).createWarningNotice( noticeElement, { spokenMessage: noticeMessage } ).notice.id;
+			var options = {
+				id: 'amp-errors-notice'
+			};
+			if ( ampValidity.review_link ) {
+				options.actions = [
+					{
+						label: wp.i18n.__( 'Review issues', 'amp' ),
+						url: ampValidity.review_link,
+					}
+				];
+			}
+
+			wp.data.dispatch( 'core/notices' ).createNotice( 'warning', noticeMessage, options );
+			module.validationWarningNoticeId = options.id;
 		},
 
 		/**
@@ -303,7 +316,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 */
 		resetWarningNotice: function resetWarningNotice() {
 			if ( module.validationWarningNoticeId ) {
-				wp.data.dispatch( 'core/editor' ).removeNotice( module.validationWarningNoticeId );
+				wp.data.dispatch( 'core/notices' ).removeNotice( module.validationWarningNoticeId );
 				module.validationWarningNoticeId = null;
 			}
 		},

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -145,7 +145,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 * @return {void}
 		 */
 		handleValidationErrorsStateChange: function handleValidationErrorsStateChange() {
-			var currentPost, validationErrors, blockValidationErrors, noticeElement, noticeMessage, blockErrorCount, ampValidity;
+			var currentPost, validationErrors, blockValidationErrors, noticeOptions, noticeMessage, blockErrorCount, ampValidity;
 
 			if ( ! module.isAMPEnabled() ) {
 				if ( ! module.lastStates.noticesAreReset ) {
@@ -249,29 +249,20 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				noticeMessage += wp.i18n.__( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
 			}
 
-			noticeElement = wp.element.createElement( 'p', {}, [
-				noticeMessage + ' ',
-				ampValidity.review_link && wp.element.createElement(
-					'a',
-					{ key: 'review_link', href: ampValidity.review_link, target: '_blank' },
-					wp.i18n.__( 'Review issues', 'amp' )
-				)
-			] );
-
-			var options = {
+			noticeOptions = {
 				id: 'amp-errors-notice'
 			};
 			if ( ampValidity.review_link ) {
-				options.actions = [
+				noticeOptions.actions = [
 					{
 						label: wp.i18n.__( 'Review issues', 'amp' ),
-						url: ampValidity.review_link,
+						url: ampValidity.review_link
 					}
 				];
 			}
 
-			wp.data.dispatch( 'core/notices' ).createNotice( 'warning', noticeMessage, options );
-			module.validationWarningNoticeId = options.id;
+			wp.data.dispatch( 'core/notices' ).createNotice( 'warning', noticeMessage, noticeOptions );
+			module.validationWarningNoticeId = noticeOptions.id;
 		},
 
 		/**

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -155,9 +155,10 @@ class AMP_Editor_Blocks {
 			) ) )
 		);
 
+		$locale_data = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
 		wp_add_inline_script(
 			'wp-i18n',
-			'wp.i18n.setLocaleData( ' . wp_json_encode( gutenberg_get_jed_locale_data( 'amp' ) ) . ', "amp" );',
+			'wp.i18n.setLocaleData( ' . wp_json_encode( $locale_data ) . ', "amp" );',
 			'after'
 		);
 	}

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -176,7 +176,6 @@ class AMP_Post_Meta_Box {
 
 	/**
 	 * Enqueues block assets.
-	 * The name of gutenberg_get_jed_locale_data() may change, as the Gutenberg Core merge approaches.
 	 *
 	 * @since 1.0
 	 */
@@ -203,9 +202,7 @@ class AMP_Post_Meta_Box {
 			'errorMessages' => $error_messages,
 		);
 
-		if ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
-			$script_data['i18n'] = gutenberg_get_jed_locale_data( 'amp' );
-		}
+		$script_data['i18n'] = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
 
 		wp_add_inline_script(
 			self::BLOCK_ASSET_HANDLE,

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1916,7 +1916,7 @@ class AMP_Validation_Manager {
 		);
 
 		$data = wp_json_encode( array(
-			'i18n'                 => gutenberg_get_jed_locale_data( 'amp' ),
+			'i18n'                 => function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' ),
 			'ampValidityRestField' => self::VALIDITY_REST_FIELD_NAME,
 			'isCanonical'          => amp_is_canonical(),
 		) );

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -77,7 +77,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 * @see AMP_Post_Meta_Box::enqueue_block_assets()
 	 */
 	public function test_enqueue_block_assets() {
-		if ( ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+		if ( ! function_exists( 'wp_get_jed_locale_data' ) && ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 			$this->markTestSkipped( 'Gutenberg is not available' );
 		}
 


### PR DESCRIPTION
Makes use of `core/notices`. Updates creating a warning notice.

See #1604.