### PR TITLE
 Fix object-fit:cover style of Twenty Nineteen featured image

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -539,6 +539,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public static function add_twentynineteen_masthead_styles() {
 		add_action( 'wp_enqueue_scripts', function() {
+			ob_start();
 			?>
 			<style>
 			.site-header.featured-image .site-featured-image .post-thumbnail amp-img > img {

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1282,7 +1282,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::enqueue_block_validation()
 	 */
 	public function test_enqueue_block_validation() {
-		if ( ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+		if ( ! function_exists( 'wp_get_jed_locale_data' ) && ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 			$this->markTestSkipped( 'Gutenberg not available.' );
 		}
 


### PR DESCRIPTION
The solution here mirrors what was done for the header image in Twenty Seventeen (in #1074).

See fix deployed to https://paired-ampconfdemo.pantheonsite.io/2018/11/16/bison/?amp

# Before

<img width="1221" alt="screen shot 2018-11-15 at 10 25 32 pm" src="https://user-images.githubusercontent.com/134745/48601833-05cab580-e926-11e8-84a0-eb966d2f4965.png">

# After

<img width="1173" alt="screen shot 2018-11-15 at 10 25 46 pm" src="https://user-images.githubusercontent.com/134745/48601861-1ed36680-e926-11e8-9cab-c1446c1821c4.png">

See #1604.