### PR TITLE
Short-circuit polldaddy shortcode when no poll or survey supplied

### DIFF
--- a/wpcom/class-amp-polldaddy-embed.php
+++ b/wpcom/class-amp-polldaddy-embed.php
@@ -36,17 +36,21 @@ class WPCOM_AMP_Polldaddy_Embed extends AMP_Base_Embed_Handler {
 	public function shortcode( $attr ) {
 		global $wp_embed;
 
-		$output = '';
-		$url    = 'https://polldaddy.com/';
+		$url = null;
 		if ( ! empty( $attr['poll'] ) ) {
-			$url .= 'poll/' . $attr['poll'] . '/';
+			$url = 'https://polldaddy.com/poll/' . $attr['poll'] . '/';
 		} elseif ( ! empty( $attr['survey'] ) ) {
-			$url .= 's/' . $attr['survey'] . '/';
+			$url = 'https://polldaddy.com/s/' . $attr['survey'] . '/';
+		}
+
+		// Short-circuit in the case of the ratings embed.
+		if ( ! $url ) {
+			return '';
 		}
 
 		if ( ! empty( $attr['title'] ) ) {
 			$output = $this->render_link( $url, $attr['title'] );
-		} elseif ( $url ) {
+		} else {
 			$output = $wp_embed->shortcode( $attr, $url );
 		}
 


### PR DESCRIPTION
Prevent showing a link when a rating embed is being output.

Aside: This logic should be moved to the ~Polldaddy~ Crowdsignal plugin and not be housed in the AMP plugin.

# Before

![image](https://user-images.githubusercontent.com/134745/48642197-064c6600-e991-11e8-81cf-a927abfd4f6d.png)

# After

![image](https://user-images.githubusercontent.com/134745/48642256-22e89e00-e991-11e8-81b0-c20ae6b9ed0f.png)

Fixes #1620.