### PR TITLE
Gutenberg: Remove 'type' from attributes where 'source' is set.

### DIFF
--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -230,25 +230,21 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 				settings.attributes = {};
 			}
 			settings.attributes.ampFitText = {
-				type: 'boolean',
 				default: false
 			};
 			settings.attributes.minFont = {
-				type: 'number',
 				default: component.data.fontSizes.small,
 				source: 'attribute',
 				selector: 'amp-fit-text',
 				attribute: 'min-font-size'
 			};
 			settings.attributes.maxFont = {
-				type: 'number',
 				default: component.data.fontSizes.larger,
 				source: 'attribute',
 				selector: 'amp-fit-text',
 				attribute: 'max-font-size'
 			};
 			settings.attributes.height = {
-				type: 'number',
 				default: 50,
 				source: 'attribute',
 				selector: 'amp-fit-text',
@@ -502,13 +498,12 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 				el( TextControl, {
 					label: __( 'Height' ),
 					value: height,
-					type: 'number',
 					min: 1,
 					onChange: function( nextHeight ) {
 						props.setAttributes( { height: nextHeight } );
 					}
 				} ),
-				maxFont > height && el(
+				parseInt( maxFont ) > parseInt( height ) && el(
 					wp.components.Notice,
 					{
 						status: 'error',
@@ -525,13 +520,13 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 							if ( ! nextMinFont ) {
 								nextMinFont = component.data.fontSizes.small; // @todo Supplying fallbackFontSize should be done automatically by the component?
 							}
-							if ( nextMinFont <= maxFont ) {
+							if ( parseInt( nextMinFont ) <= parseInt( maxFont ) ) {
 								props.setAttributes( { minFont: nextMinFont } );
 							}
 						}
 					} )
 				),
-				minFont > maxFont && el(
+				parseInt( minFont ) > parseInt( maxFont ) && el(
 					wp.components.Notice,
 					{
 						status: 'error',

--- a/blocks/amp-brid-player/index.js
+++ b/blocks/amp-brid-player/index.js
@@ -36,37 +36,31 @@ export default registerBlockType(
 				type: 'boolean'
 			},
 			dataPartner: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-brid-player',
 				attribute: 'data-partner'
 			},
 			dataPlayer: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-brid-player',
 				attribute: 'data-player'
 			},
 			dataVideo: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-brid-player',
 				attribute: 'data-video'
 			},
 			dataPlaylist: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-brid-player',
 				attribute: 'data-playlist'
 			},
 			dataOutstream: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-brid-player',
 				attribute: 'data-outstream'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-brid-player',
@@ -77,7 +71,6 @@ export default registerBlockType(
 				default: 600
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-brid-player',

--- a/blocks/amp-ima-video/index.js
+++ b/blocks/amp-ima-video/index.js
@@ -40,39 +40,33 @@ export default registerBlockType(
 				attribute: 'data-delay-ad-request'
 			},
 			dataTag: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ima-video',
 				attribute: 'data-tag'
 			},
 			dataSrc: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ima-video',
 				attribute: 'data-src'
 			},
 			dataPoster: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ima-video',
 				attribute: 'data-poster'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-ima-video',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-ima-video',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-ima-video',

--- a/blocks/amp-jwplayer/index.js
+++ b/blocks/amp-jwplayer/index.js
@@ -32,39 +32,33 @@ export default registerBlockType(
 
 		attributes: {
 			dataPlayerId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-jwplayer',
 				attribute: 'data-player-id'
 			},
 			dataMediaId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-jwplayer',
 				attribute: 'data-media-id'
 			},
 			dataPlaylistId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-jwplayer',
 				attribute: 'data-playlist-id'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-jwplayer',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-jwplayer',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-jwplayer',

--- a/blocks/amp-mathml/index.js
+++ b/blocks/amp-mathml/index.js
@@ -26,7 +26,6 @@ export default registerBlockType(
 
 		attributes: {
 			dataFormula: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-mathml',
 				attribute: 'data-formula'

--- a/blocks/amp-o2-player/index.js
+++ b/blocks/amp-o2-player/index.js
@@ -34,49 +34,41 @@ export default registerBlockType(
 		// @todo Add other useful macro toggles, e.g. showing relevant content.
 		attributes: {
 			dataPid: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'data-pid'
 			},
 			dataVid: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'data-vid'
 			},
 			dataBcid: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'data-bcid'
 			},
 			dataBid: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'data-bid'
 			},
 			autoPlay: {
-				type: 'boolean',
 				default: false
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-o2-player',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-o2-player',

--- a/blocks/amp-ooyala-player/index.js
+++ b/blocks/amp-ooyala-player/index.js
@@ -35,46 +35,39 @@ export default registerBlockType(
 		// @todo Add data-config attribute?
 		attributes: {
 			dataEmbedCode: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'data-embedcode'
 			},
 			dataPlayerId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'data-playerid'
 			},
 			dataPcode: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'data-pcode'
 			},
 			dataPlayerVersion: {
-				type: 'string',
 				default: 'v3',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'data-playerversion'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-ooyala-player',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-ooyala-player',

--- a/blocks/amp-reach-player/index.js
+++ b/blocks/amp-reach-player/index.js
@@ -33,27 +33,23 @@ export default registerBlockType(
 
 		attributes: {
 			dataEmbedId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-reach-player',
 				attribute: 'data-embed-id'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'fixed-height',
 				source: 'attribute',
 				selector: 'amp-reach-player',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-reach-player',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-reach-player',

--- a/blocks/amp-springboard-player/index.js
+++ b/blocks/amp-springboard-player/index.js
@@ -33,59 +33,50 @@ export default registerBlockType(
 
 		attributes: {
 			dataSiteId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-site-id'
 			},
 			dataContentId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-content-id'
 			},
 			dataPlayerId: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-player-id'
 			},
 			dataDomain: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-domain'
 			},
 			dataMode: {
-				type: 'string',
 				default: 'video',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-mode'
 			},
 			dataItems: {
-				type: 'number',
 				default: 1,
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'data-items'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'responsive',
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				default: 600,
 				source: 'attribute',
 				selector: 'amp-springboard-player',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 400,
 				source: 'attribute',
 				selector: 'amp-springboard-player',

--- a/blocks/amp-timeago/index.js
+++ b/blocks/amp-timeago/index.js
@@ -45,32 +45,27 @@ export default registerBlockType(
 				type: 'string'
 			},
 			cutoff: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'cutoff'
 			},
 			dateTime: {
-				type: 'string',
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'datetime'
 			},
 			ampLayout: {
-				type: 'string',
 				default: 'fixed-height',
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'layout'
 			},
 			width: {
-				type: 'number',
 				source: 'attribute',
 				selector: 'amp-timeago',
 				attribute: 'width'
 			},
 			height: {
-				type: 'number',
 				default: 20,
 				source: 'attribute',
 				selector: 'amp-timeago',
@@ -90,7 +85,7 @@ export default registerBlockType(
 			const { align, cutoff } = attributes;
 			let timeAgo;
 			if ( attributes.dateTime ) {
-				if ( attributes.cutoff && attributes.cutoff < Math.abs( moment( attributes.dateTime ).diff( moment(), 'seconds' ) ) ) {
+				if ( attributes.cutoff && parseInt( attributes.cutoff ) < Math.abs( moment( attributes.dateTime ).diff( moment(), 'seconds' ) ) ) {
 					timeAgo = moment( attributes.dateTime ).format( 'dddd D MMMM HH:mm' );
 				} else {
 					timeAgo = timeago().format( attributes.dateTime );


### PR DESCRIPTION
Removes 'type' from attributes where 'source' is set, apparently that was deprecated in 4.1.0, removed in 4.2.0 and is now causes issues with blocks and extended features.

Note that `type` isn't mandatory for other cases either (if the source is not set at all).