### PR TITLE
Update changelog and bump version in amp.php to 1.0-RC3

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/automattic/amp-wp
  * Author: WordPress.com VIP, XWP, Google, and contributors
  * Author URI: https://github.com/Automattic/amp-wp/graphs/contributors
- * Version: 1.0-RC2
+ * Version: 1.0-RC3
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) || ! file_exists( __DIR__
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.0-RC2' );
+define( 'AMP__VERSION', '1.0-RC3' );
 
 /**
  * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).

--- a/amp.php
+++ b/amp.php
@@ -68,6 +68,34 @@ define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
 define( 'AMP__VERSION', '1.0-RC2' );
 
+/**
+ * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).
+ *
+ * @since 1.0
+ */
+function _amp_incorrect_plugin_slug_admin_notice() {
+	$actual_slug = basename( AMP__DIR__ );
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					/* translators: %1$s is the current directory name, and %2$s is the required directory name */
+					__( 'You appear to have installed the AMP plugin incorrectly. It is currently installed in the <code>%1$s</code> directory, but it needs to be placed in a directory named <code>%2$s</code>. Please rename the directory. This is important for WordPress plugin auto-updates.', 'amp' ),
+					$actual_slug,
+					'amp'
+				)
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+if ( 'amp' !== basename( AMP__DIR__ ) ) {
+	add_action( 'admin_notices', '_amp_incorrect_plugin_slug_admin_notice' );
+}
+
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();
 

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Gutenberg: Fix displaying validation warning and usage of PHP function. See [#1612](https://github.com/Automattic/amp-wp/pull/1612). Props miina.
 - Fix stretched images in Twenty Seventeen them and Gutenberg. See [#1321](https://github.com/Automattic/amp-wp/issues/1321), [#1281](https://github.com/Automattic/amp-wp/issues/1281), [#1237](https://github.com/Automattic/amp-wp/issues/1237). Props hellofromtonya.
 - Fix image dimension extractor so it does not disregard duplicate images. See [#1314](https://github.com/Automattic/amp-wp/issues/1314). Props lukas9393.
-- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](#https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
+- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
 - Remove redundant version from composer.json and add PHP version requirement. See [#1333](https://github.com/Automattic/amp-wp/issues/1333), [#1328](https://github.com/Automattic/amp-wp/issues/1328), [#1334](https://github.com/Automattic/amp-wp/issues/1334), [#1332](https://github.com/Automattic/amp-wp/issues/1332). Props swissspidy.
 - Add warning when AMP plugin is installed in incorrect directory. See [#1593](https://github.com/Automattic/amp-wp/pull/1593). Props westonruter.
 - Store validation errors in order of occurrence in document. See [#1335](https://github.com/Automattic/amp-wp/issues/1335). Props westonruter.
@@ -167,6 +167,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Normalize 'ver' query param in script/style validation errors to prevent recurrence after accepted. See [#1346](https://github.com/Automattic/amp-wp/issues/1346). Props westonruter.
 - Add bing-amp.com to the list of AMP Cache hosts. See [#1447](https://github.com/Automattic/amp-wp/pull/1447). Props westonruter.
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
+- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
 - Update spec from revision 720 to 734. See [#1475](https://github.com/Automattic/amp-wp/pull/1475). Props kienstra.
@@ -179,7 +180,6 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Fix handling responses to form submissions from an AMP Cache. See [#1382](https://github.com/Automattic/amp-wp/issues/1382), [#1356](https://github.com/Automattic/amp-wp/issues/1356).
 - Replace Gutenberg's deprecated isCleanNewPost selector. See [#1387](https://github.com/Automattic/amp-wp/issues/1387). Props miina.
 - Updates php-css-parser to include fix for parsing calc() with negative values. See [#1392](https://github.com/Automattic/amp-wp/issues/1392). Props westonruter.
-- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Add embed support for Twitter timelines via new amp-twitter attributes. See [#1396](https://github.com/Automattic/amp-wp/issues/1396). Props felixarntz.
 - Fix tooltip position. See [#1472](https://github.com/Automattic/amp-wp/pull/1472). Props jacobschweitzer.
 - Add error type filters on validation error and invalid URL screens. See [#1373](https://github.com/Automattic/amp-wp/issues/1373). Props kienstra.

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
 - Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
+- Update regex for tag selectors. See [#1534](https://github.com/Automattic/amp-wp/pull/1534). Props swissspidy, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
 - Update spec from revision 720 to 734. See [#1475](https://github.com/Automattic/amp-wp/pull/1475). Props kienstra.
 - Fix form sanitizer's handling of relative actions by making them absolute. See [#1352](https://github.com/Automattic/amp-wp/issues/1352), [#1349](https://github.com/Automattic/amp-wp/issues/1349). Props ricardobrg.

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - **Add support for allowing a site subset to be native AMP.** See [#1235](https://github.com/Automattic/amp-wp/pull/1235). Props westonruter.
 - Add an admin pointer for updated AMP settings screen for version 1.0. See [#1271](https://github.com/Automattic/amp-wp/pull/1271), [#1254](https://github.com/Automattic/amp-wp/issues/1254). Props kienstra.
 - Add support for three core themes (Twenty Fifteen, Twenty Sixteen, Twenty Seventeen) so that they can be used out of the box with AMP theme support added without needing to create a child theme. See [#1074](https://github.com/Automattic/amp-wp/pull/1074). Props westonruter, DavidCramer, kienstra.
+- Add AMP support for Twenty Nineteen. See [#1587](https://github.com/Automattic/amp-wp/pull/1587), [#1619](https://github.com/Automattic/amp-wp/pull/1619). Props westonruter.
 - Add AMP menu item to admin bar on frontend with indication of AMP validation status; accessing an AMP URL that has unaccepted validation errors will redirect to the non-AMP page and cause the AMP admin bar item to indicate the failure, along with a link to access the validation results. See [#1199](https://github.com/Automattic/amp-wp/pull/1199). Props westonruter.
 - Add dynamic handling of validation errors. See [#1093](https://github.com/Automattic/amp-wp/pull/1093), [#1063](https://github.com/Automattic/amp-wp/pull/1063), [#1087](https://github.com/Automattic/amp-wp/issues/1087). Props westonruter.
 - Add AMP validation of blocks. See [#1019](https://github.com/Automattic/amp-wp/pull/1019). Props westonruter.
@@ -147,18 +148,24 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Improve validation and presentation of analytics form. See [#1299](https://github.com/Automattic/amp-wp/pull/1299), [#1133](https://github.com/Automattic/amp-wp/issues/1133), [#1296](https://github.com/Automattic/amp-wp/pull/1296). Props westonruter, AdelDima.
 - Prevent validation of auto-drafts, including when merely accessing New Post screen. See [#1301](https://github.com/Automattic/amp-wp/pull/1301). Props westonruter.
 - Fix inability to move link element due to assigned parent. See [#1322](https://github.com/Automattic/amp-wp/issues/1322). Props westonruter.
+- Gutenberg: Remove 'type' from attributes where 'source' is set. See [#1622](https://github.com/Automattic/amp-wp/pull/1622). Props miina.
+- Gutenberg: Fix displaying validation warning and usage of PHP function. See [#1612](https://github.com/Automattic/amp-wp/pull/1612). Props miina.
 - Fix stretched images in Twenty Seventeen them and Gutenberg. See [#1321](https://github.com/Automattic/amp-wp/issues/1321), [#1281](https://github.com/Automattic/amp-wp/issues/1281), [#1237](https://github.com/Automattic/amp-wp/issues/1237). Props hellofromtonya.
 - Fix image dimension extractor so it does not disregard duplicate images. See [#1314](https://github.com/Automattic/amp-wp/issues/1314). Props lukas9393.
+- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](#https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
 - Remove redundant version from composer.json and add PHP version requirement. See [#1333](https://github.com/Automattic/amp-wp/issues/1333), [#1328](https://github.com/Automattic/amp-wp/issues/1328), [#1334](https://github.com/Automattic/amp-wp/issues/1334), [#1332](https://github.com/Automattic/amp-wp/issues/1332). Props swissspidy.
+- Add warning when AMP plugin is installed in incorrect directory. See [#1593](https://github.com/Automattic/amp-wp/pull/1593). Props westonruter.
 - Store validation errors in order of occurrence in document. See [#1335](https://github.com/Automattic/amp-wp/issues/1335). Props westonruter.
 - Add .editorconfig file. See [#1336](https://github.com/Automattic/amp-wp/issues/1336), [#51](https://github.com/Automattic/amp-wp/issues/51). Props swissspidy.
 - Update i18n to make use of updated WP-CLI command. See [#1329](https://github.com/Automattic/amp-wp/issues/1329), [#1327](https://github.com/Automattic/amp-wp/issues/1327), [#1341](https://github.com/Automattic/amp-wp/issues/1341), [#1345](https://github.com/Automattic/amp-wp/issues/1345), [#1393](https://github.com/Automattic/amp-wp/issues/1393). Props swissspidy, felixarntz, westonruter.
 - Use all eligible post types when `all_templates_supported` is selected. See [#1338](https://github.com/Automattic/amp-wp/issues/1338), [#1302](https://github.com/Automattic/amp-wp/issues/1302), [#1344](https://github.com/Automattic/amp-wp/issues/1344). Props hellofromtonya, westonruter.
+- Do not show fallback source as active theme if no validation errors. See [#1592](https://github.com/Automattic/amp-wp/pull/1592). Props westonruter.
 - Respect default AMP enabled status when creating a new post in Gutenberg. See [#1339](https://github.com/Automattic/amp-wp/issues/1339). Props hellofromtonya.
 - Fix incorrect attribution of theme as source for content validation errors. See [#1467](https://github.com/Automattic/amp-wp/pull/1467). Props westonruter.
 - Fix conversion of video to amp-video. See [#1477](https://github.com/Automattic/amp-wp/pull/1477). Props westonruter.
 - Add new icon, text, and style to splash notice. See [#1470](https://github.com/Automattic/amp-wp/pull/1470). Props jacobschweitzer.
 - Normalize 'ver' query param in script/style validation errors to prevent recurrence after accepted. See [#1346](https://github.com/Automattic/amp-wp/issues/1346). Props westonruter.
+- Add bing-amp.com to the list of AMP Cache hosts. See [#1447](https://github.com/Automattic/amp-wp/pull/1447). Props westonruter.
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
@@ -172,6 +179,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Fix handling responses to form submissions from an AMP Cache. See [#1382](https://github.com/Automattic/amp-wp/issues/1382), [#1356](https://github.com/Automattic/amp-wp/issues/1356).
 - Replace Gutenberg's deprecated isCleanNewPost selector. See [#1387](https://github.com/Automattic/amp-wp/issues/1387). Props miina.
 - Updates php-css-parser to include fix for parsing calc() with negative values. See [#1392](https://github.com/Automattic/amp-wp/issues/1392). Props westonruter.
+- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Add embed support for Twitter timelines via new amp-twitter attributes. See [#1396](https://github.com/Automattic/amp-wp/issues/1396). Props felixarntz.
 - Fix tooltip position. See [#1472](https://github.com/Automattic/amp-wp/pull/1472). Props jacobschweitzer.
 - Add error type filters on validation error and invalid URL screens. See [#1373](https://github.com/Automattic/amp-wp/issues/1373). Props kienstra.
@@ -186,6 +194,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Improve access to AMP admin screens for users who are not administrators. [#1437](https://github.com/Automattic/amp-wp/pull/1437). Props westonruter.
 - Display a welcome notice on the main 'AMP Settings' page. See [#1442](https://github.com/Automattic/amp-wp/pull/1442). Props kienstra.
 - Fix URL protocol validation and parsing attribute values with multiple URLs. See [#1411](https://github.com/Automattic/amp-wp/pull/1411), [#1410](https://github.com/Automattic/amp-wp/issues/1410). Props westonruter.
+- Prevent a notice from appearing in the Compatibility Tool meta box. See [#1605](https://github.com/Automattic/amp-wp/pull/1605). Props kienstra.
 - Restore ability to customize 'amp' query var when theme support added. [#1455](https://github.com/Automattic/amp-wp/pull/1455). Props westonruter.
 - Add slug constants for theme support and post type support. [#1456](https://github.com/Automattic/amp-wp/pull/1456). Props westonruter.
 - Fix ability to add AMP support for custom post types. See [#1441](https://github.com/Automattic/amp-wp/pull/1441). Props westonruter.

--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - **Add support for allowing a site subset to be native AMP.** See [#1235](https://github.com/Automattic/amp-wp/pull/1235). Props westonruter.
 - Add an admin pointer for updated AMP settings screen for version 1.0. See [#1271](https://github.com/Automattic/amp-wp/pull/1271), [#1254](https://github.com/Automattic/amp-wp/issues/1254). Props kienstra.
 - Add support for three core themes (Twenty Fifteen, Twenty Sixteen, Twenty Seventeen) so that they can be used out of the box with AMP theme support added without needing to create a child theme. See [#1074](https://github.com/Automattic/amp-wp/pull/1074). Props westonruter, DavidCramer, kienstra.
+- Add AMP support for Twenty Nineteen. See [#1587](https://github.com/Automattic/amp-wp/pull/1587), [#1619](https://github.com/Automattic/amp-wp/pull/1619). Props westonruter.
 - Add AMP menu item to admin bar on frontend with indication of AMP validation status; accessing an AMP URL that has unaccepted validation errors will redirect to the non-AMP page and cause the AMP admin bar item to indicate the failure, along with a link to access the validation results. See [#1199](https://github.com/Automattic/amp-wp/pull/1199). Props westonruter.
 - Add dynamic handling of validation errors. See [#1093](https://github.com/Automattic/amp-wp/pull/1093), [#1063](https://github.com/Automattic/amp-wp/pull/1063), [#1087](https://github.com/Automattic/amp-wp/issues/1087). Props westonruter.
 - Add AMP validation of blocks. See [#1019](https://github.com/Automattic/amp-wp/pull/1019). Props westonruter.
@@ -131,18 +132,24 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Improve validation and presentation of analytics form. See [#1299](https://github.com/Automattic/amp-wp/pull/1299), [#1133](https://github.com/Automattic/amp-wp/issues/1133), [#1296](https://github.com/Automattic/amp-wp/pull/1296). Props westonruter, AdelDima.
 - Prevent validation of auto-drafts, including when merely accessing New Post screen. See [#1301](https://github.com/Automattic/amp-wp/pull/1301). Props westonruter.
 - Fix inability to move link element due to assigned parent. See [#1322](https://github.com/Automattic/amp-wp/issues/1322). Props westonruter.
+- Gutenberg: Remove 'type' from attributes where 'source' is set. See [#1622](https://github.com/Automattic/amp-wp/pull/1622). Props miina.
+- Gutenberg: Fix displaying validation warning and usage of PHP function. See [#1612](https://github.com/Automattic/amp-wp/pull/1612). Props miina.
 - Fix stretched images in Twenty Seventeen them and Gutenberg. See [#1321](https://github.com/Automattic/amp-wp/issues/1321), [#1281](https://github.com/Automattic/amp-wp/issues/1281), [#1237](https://github.com/Automattic/amp-wp/issues/1237). Props hellofromtonya.
 - Fix image dimension extractor so it does not disregard duplicate images. See [#1314](https://github.com/Automattic/amp-wp/issues/1314). Props lukas9393.
+- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](#https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
 - Remove redundant version from composer.json and add PHP version requirement. See [#1333](https://github.com/Automattic/amp-wp/issues/1333), [#1328](https://github.com/Automattic/amp-wp/issues/1328), [#1334](https://github.com/Automattic/amp-wp/issues/1334), [#1332](https://github.com/Automattic/amp-wp/issues/1332). Props swissspidy.
+- Add warning when AMP plugin is installed in incorrect directory. See [#1593](https://github.com/Automattic/amp-wp/pull/1593). Props westonruter.
 - Store validation errors in order of occurrence in document. See [#1335](https://github.com/Automattic/amp-wp/issues/1335). Props westonruter.
 - Add .editorconfig file. See [#1336](https://github.com/Automattic/amp-wp/issues/1336), [#51](https://github.com/Automattic/amp-wp/issues/51). Props swissspidy.
 - Update i18n to make use of updated WP-CLI command. See [#1329](https://github.com/Automattic/amp-wp/issues/1329), [#1327](https://github.com/Automattic/amp-wp/issues/1327), [#1341](https://github.com/Automattic/amp-wp/issues/1341), [#1345](https://github.com/Automattic/amp-wp/issues/1345), [#1393](https://github.com/Automattic/amp-wp/issues/1393). Props swissspidy, felixarntz, westonruter.
 - Use all eligible post types when `all_templates_supported` is selected. See [#1338](https://github.com/Automattic/amp-wp/issues/1338), [#1302](https://github.com/Automattic/amp-wp/issues/1302), [#1344](https://github.com/Automattic/amp-wp/issues/1344). Props hellofromtonya, westonruter.
+- Do not show fallback source as active theme if no validation errors. See [#1592](https://github.com/Automattic/amp-wp/pull/1592). Props westonruter.
 - Respect default AMP enabled status when creating a new post in Gutenberg. See [#1339](https://github.com/Automattic/amp-wp/issues/1339). Props hellofromtonya.
 - Fix incorrect attribution of theme as source for content validation errors. See [#1467](https://github.com/Automattic/amp-wp/pull/1467). Props westonruter.
 - Fix conversion of video to amp-video. See [#1477](https://github.com/Automattic/amp-wp/pull/1477). Props westonruter.
 - Add new icon, text, and style to splash notice. See [#1470](https://github.com/Automattic/amp-wp/pull/1470). Props jacobschweitzer.
 - Normalize 'ver' query param in script/style validation errors to prevent recurrence after accepted. See [#1346](https://github.com/Automattic/amp-wp/issues/1346). Props westonruter.
+- Add bing-amp.com to the list of AMP Cache hosts. See [#1447](https://github.com/Automattic/amp-wp/pull/1447). Props westonruter.
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
@@ -156,6 +163,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Fix handling responses to form submissions from an AMP Cache. See [#1382](https://github.com/Automattic/amp-wp/issues/1382), [#1356](https://github.com/Automattic/amp-wp/issues/1356).
 - Replace Gutenberg's deprecated isCleanNewPost selector. See [#1387](https://github.com/Automattic/amp-wp/issues/1387). Props miina.
 - Updates php-css-parser to include fix for parsing calc() with negative values. See [#1392](https://github.com/Automattic/amp-wp/issues/1392). Props westonruter.
+- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Add embed support for Twitter timelines via new amp-twitter attributes. See [#1396](https://github.com/Automattic/amp-wp/issues/1396). Props felixarntz.
 - Fix tooltip position. See [#1472](https://github.com/Automattic/amp-wp/pull/1472). Props jacobschweitzer.
 - Add error type filters on validation error and invalid URL screens. See [#1373](https://github.com/Automattic/amp-wp/issues/1373). Props kienstra.
@@ -170,6 +178,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Improve access to AMP admin screens for users who are not administrators. [#1437](https://github.com/Automattic/amp-wp/pull/1437). Props westonruter.
 - Display a welcome notice on the main 'AMP Settings' page. See [#1442](https://github.com/Automattic/amp-wp/pull/1442). Props kienstra.
 - Fix URL protocol validation and parsing attribute values with multiple URLs. See [#1411](https://github.com/Automattic/amp-wp/pull/1411), [#1410](https://github.com/Automattic/amp-wp/issues/1410). Props westonruter.
+- Prevent a notice from appearing in the Compatibility Tool meta box. See [#1605](https://github.com/Automattic/amp-wp/pull/1605). Props kienstra.
 - Restore ability to customize 'amp' query var when theme support added. [#1455](https://github.com/Automattic/amp-wp/pull/1455). Props westonruter.
 - Add slug constants for theme support and post type support. [#1456](https://github.com/Automattic/amp-wp/pull/1456). Props westonruter.
 - Fix ability to add AMP support for custom post types. See [#1441](https://github.com/Automattic/amp-wp/pull/1441). Props westonruter.

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
 - Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
+- Update regex for tag selectors. See [#1534](https://github.com/Automattic/amp-wp/pull/1534). Props swissspidy, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
 - Update spec from revision 720 to 734. See [#1475](https://github.com/Automattic/amp-wp/pull/1475). Props kienstra.
 - Fix form sanitizer's handling of relative actions by making them absolute. See [#1352](https://github.com/Automattic/amp-wp/issues/1352), [#1349](https://github.com/Automattic/amp-wp/issues/1349). Props ricardobrg.

--- a/readme.txt
+++ b/readme.txt
@@ -136,7 +136,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Gutenberg: Fix displaying validation warning and usage of PHP function. See [#1612](https://github.com/Automattic/amp-wp/pull/1612). Props miina.
 - Fix stretched images in Twenty Seventeen them and Gutenberg. See [#1321](https://github.com/Automattic/amp-wp/issues/1321), [#1281](https://github.com/Automattic/amp-wp/issues/1281), [#1237](https://github.com/Automattic/amp-wp/issues/1237). Props hellofromtonya.
 - Fix image dimension extractor so it does not disregard duplicate images. See [#1314](https://github.com/Automattic/amp-wp/issues/1314). Props lukas9393.
-- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](#https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
+- Short-circuit polldaddy shortcode when no poll or survey supplied. See [#1621](https://github.com/Automattic/amp-wp/pull/1621). Props westonruter.
 - Remove redundant version from composer.json and add PHP version requirement. See [#1333](https://github.com/Automattic/amp-wp/issues/1333), [#1328](https://github.com/Automattic/amp-wp/issues/1328), [#1334](https://github.com/Automattic/amp-wp/issues/1334), [#1332](https://github.com/Automattic/amp-wp/issues/1332). Props swissspidy.
 - Add warning when AMP plugin is installed in incorrect directory. See [#1593](https://github.com/Automattic/amp-wp/pull/1593). Props westonruter.
 - Store validation errors in order of occurrence in document. See [#1335](https://github.com/Automattic/amp-wp/issues/1335). Props westonruter.
@@ -151,6 +151,7 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Normalize 'ver' query param in script/style validation errors to prevent recurrence after accepted. See [#1346](https://github.com/Automattic/amp-wp/issues/1346). Props westonruter.
 - Add bing-amp.com to the list of AMP Cache hosts. See [#1447](https://github.com/Automattic/amp-wp/pull/1447). Props westonruter.
 - Add missing tabindex attribute to lightbox images. See [#1350](https://github.com/Automattic/amp-wp/issues/1350). Props amedina.
+- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Detect ineffectual post-processor response cache due to high MISS rates and auto-disable. See [#1325](https://github.com/Automattic/amp-wp/issues/1325), [#1239](https://github.com/Automattic/amp-wp/issues/1239). Props hellofromtonya, westonruter.
 - Update the validator spec version to 720 and AMP v1534879991178; add support for reference points. See [#1315](https://github.com/Automattic/amp-wp/issues/1315), [#1386](https://github.com/Automattic/amp-wp/issues/1386), [#1330](https://github.com/Automattic/amp-wp/issues/1330). Props westonruter.
 - Update spec from revision 720 to 734. See [#1475](https://github.com/Automattic/amp-wp/pull/1475). Props kienstra.
@@ -163,7 +164,6 @@ To learn how to use the new features in this release, please see the wiki pages 
 - Fix handling responses to form submissions from an AMP Cache. See [#1382](https://github.com/Automattic/amp-wp/issues/1382), [#1356](https://github.com/Automattic/amp-wp/issues/1356).
 - Replace Gutenberg's deprecated isCleanNewPost selector. See [#1387](https://github.com/Automattic/amp-wp/issues/1387). Props miina.
 - Updates php-css-parser to include fix for parsing calc() with negative values. See [#1392](https://github.com/Automattic/amp-wp/issues/1392). Props westonruter.
-- Update AMP spec to 757 (v1811091519050). See [#1588](https://github.com/Automattic/amp-wp/pull/1588). Props westonruter, kienstra.
 - Add embed support for Twitter timelines via new amp-twitter attributes. See [#1396](https://github.com/Automattic/amp-wp/issues/1396). Props felixarntz.
 - Fix tooltip position. See [#1472](https://github.com/Automattic/amp-wp/pull/1472). Props jacobschweitzer.
 - Add error type filters on validation error and invalid URL screens. See [#1373](https://github.com/Automattic/amp-wp/issues/1373). Props kienstra.


### PR DESCRIPTION
* Adds all of the PRs [merged since](https://github.com/Automattic/amp-wp/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+merged%3A2018-11-05T03%3A17%3A43..2018-11-21T03%3A17%3A43Z+milestone%3Av1.0+) `1.0-RC2`
* Bumps the versions in `amp.php` to `1.0-RC3` 
* [Merges in](https://github.com/Automattic/amp-wp/pull/1628/commits/8e6d2ba30231709a9ddde0fcf559b229f7dae8b8) the `develop` branch