### PR TITLE
Merge PR #1634's branch into 1.0, not develop

### DIFF
--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -138,6 +138,10 @@ class AMP_Editor_Blocks {
 				array( 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
 				AMP__VERSION
 			);
+
+			if ( function_exists( 'wp_set_script_translations' ) ) {
+				wp_set_script_translations( 'amp-editor-blocks-build', 'amp' );
+			}
 		}
 
 		wp_enqueue_script(
@@ -155,12 +159,9 @@ class AMP_Editor_Blocks {
 			) ) )
 		);
 
-		$locale_data = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
-		wp_add_inline_script(
-			'wp-i18n',
-			'wp.i18n.setLocaleData( ' . wp_json_encode( $locale_data ) . ', "amp" );',
-			'after'
-		);
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( 'amp-editor-blocks', 'amp' );
+		}
 	}
 
 	/**

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -135,7 +135,7 @@ class AMP_Editor_Blocks {
 			wp_enqueue_script(
 				'amp-editor-blocks-build',
 				amp_get_asset_url( 'js/amp-blocks-compiled.js' ),
-				array( 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
+				array( 'wp-editor', 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
 				AMP__VERSION
 			);
 

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -161,6 +161,13 @@ class AMP_Editor_Blocks {
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( 'amp-editor-blocks', 'amp' );
+		} elseif ( function_exists( 'wp_get_jed_locale_data' ) || function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+			$locale_data = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
+			wp_add_inline_script(
+				'wp-i18n',
+				'wp.i18n.setLocaleData( ' . wp_json_encode( $locale_data ) . ', "amp" );',
+				'after'
+			);
 		}
 	}
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -204,6 +204,10 @@ class AMP_Post_Meta_Box {
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( self::BLOCK_ASSET_HANDLE, 'amp' );
+		} elseif ( function_exists( 'wp_get_jed_locale_data' ) ) {
+			$script_data['i18n'] = wp_get_jed_locale_data( 'amp' );
+		} elseif ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+			$script_data['i18n'] = gutenberg_get_jed_locale_data( 'amp' );
 		}
 
 		wp_add_inline_script(

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -202,7 +202,9 @@ class AMP_Post_Meta_Box {
 			'errorMessages' => $error_messages,
 		);
 
-		$script_data['i18n'] = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( self::BLOCK_ASSET_HANDLE, 'amp' );
+		}
 
 		wp_add_inline_script(
 			self::BLOCK_ASSET_HANDLE,

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1915,14 +1915,17 @@ class AMP_Validation_Manager {
 			true
 		);
 
-		if ( function_exists( 'wp_set_script_translations' ) ) {
-			wp_set_script_translations( $slug, 'amp' );
-		}
-
-		$data = wp_json_encode( array(
+		$data = array(
 			'ampValidityRestField' => self::VALIDITY_REST_FIELD_NAME,
 			'isCanonical'          => amp_is_canonical(),
-		) );
-		wp_add_inline_script( $slug, sprintf( 'ampBlockValidation.boot( %s );', $data ) );
+		);
+
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( $slug, 'amp' );
+		} elseif ( function_exists( 'wp_get_jed_locale_data' ) || function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+			$data['i18n'] = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
+		}
+
+		wp_add_inline_script( $slug, sprintf( 'ampBlockValidation.boot( %s );', wp_json_encode( $data ) ) );
 	}
 }

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1915,8 +1915,11 @@ class AMP_Validation_Manager {
 			true
 		);
 
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( $slug, 'amp' );
+		}
+
 		$data = wp_json_encode( array(
-			'i18n'                 => function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' ),
 			'ampValidityRestField' => self::VALIDITY_REST_FIELD_NAME,
 			'isCanonical'          => amp_is_canonical(),
 		) );

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -77,7 +77,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 * @see AMP_Post_Meta_Box::enqueue_block_assets()
 	 */
 	public function test_enqueue_block_assets() {
-		if ( ! function_exists( 'wp_get_jed_locale_data' ) && ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+		if ( ! function_exists( 'the_gutenberg_project' ) ) {
 			$this->markTestSkipped( 'Gutenberg is not available' );
 		}
 

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -77,8 +77,8 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 * @see AMP_Post_Meta_Box::enqueue_block_assets()
 	 */
 	public function test_enqueue_block_assets() {
-		if ( ! function_exists( 'the_gutenberg_project' ) ) {
-			$this->markTestSkipped( 'Gutenberg is not available' );
+		if ( ! function_exists( 'register_block_type' ) ) {
+			$this->markTestSkipped( 'The block editor is not available' );
 		}
 
 		// If a post type doesn't have AMP enabled, the script shouldn't be enqueued.

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1292,10 +1292,15 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->set_capability();
 		AMP_Validation_Manager::enqueue_block_validation();
 
-		$script        = wp_scripts()->registered[ $slug ];
-		$inline_script = $script->extra['after'][1];
+		$script                = wp_scripts()->registered[ $slug ];
+		$inline_script         = $script->extra['after'][1];
+		$expected_dependencies = array( 'underscore', AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE );
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			$expected_dependencies[] = 'wp-i18n';
+		}
+
 		$this->assertContains( 'js/amp-block-validation.js', $script->src );
-		$this->assertEqualSets( array( 'underscore', AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ), $script->deps );
+		$this->assertEqualSets( $expected_dependencies, $script->deps );
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, wp_scripts()->queue, true ) );
 		$this->assertContains( 'ampBlockValidation.boot', $inline_script );

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1300,7 +1300,6 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertTrue( in_array( $slug, wp_scripts()->queue, true ) );
 		$this->assertContains( 'ampBlockValidation.boot', $inline_script );
 		$this->assertContains( AMP_Validation_Manager::VALIDITY_REST_FIELD_NAME, $inline_script );
-		$this->assertContains( '"domain":"amp"', $inline_script );
 	}
 
 	/**

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1282,7 +1282,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::enqueue_block_validation()
 	 */
 	public function test_enqueue_block_validation() {
-		if ( ! function_exists( 'wp_get_jed_locale_data' ) && ! function_exists( 'gutenberg_get_jed_locale_data' ) ) {
+		if ( ! function_exists( 'the_gutenberg_project' ) ) {
 			$this->markTestSkipped( 'Gutenberg not available.' );
 		}
 

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -1282,8 +1282,8 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::enqueue_block_validation()
 	 */
 	public function test_enqueue_block_validation() {
-		if ( ! function_exists( 'the_gutenberg_project' ) ) {
-			$this->markTestSkipped( 'Gutenberg not available.' );
+		if ( ! function_exists( 'register_block_type' ) ) {
+			$this->markTestSkipped( 'The block editor is not available.' );
 		}
 
 		global $post;


### PR DESCRIPTION
I had wrongly opened PR #1634 to the `develop` branch, not `1.0`.

But that PR is needed for the `1.0-RC3` release.

The `develop` branch could also use that PR, as we normally merge the release branch into `develop` after a release.