### PR TITLE
[amp-stories sub-task] Hide disallowed blocks from Inserter

### DIFF
--- a/assets/js/amp-story-editor-blocks.js
+++ b/assets/js/amp-story-editor-blocks.js
@@ -180,8 +180,21 @@ var ampStoryEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 	 * @return {Object} Properties.
 	 */
 	component.setBlockParent = function( props ) {
-		if ( component.data.gridBlocks.includes( props.name ) || 'amp/amp-story-cta-layer' === props.name ) {
-			let parent = [ props.name ];
+		// Note that `parent` setting gets priority over `allowedBlocks`.
+		if ( component.data.allowedBlocks.includes( props.name ) ) {
+			// Allow CTA as the parent for all the blocks.
+			let parent = [
+				'amp/amp-story-cta-layer'
+			];
+
+			// In case of other allowed blocks except for button also add other grid layers as parents.
+			if ( 'core/button' !== props.name ) {
+				parent = parent.concat( [
+					'amp/amp-story-grid-layer-horizontal',
+					'amp/amp-story-grid-layer-vertical',
+					'amp/amp-story-grid-layer-thirds'
+				] );
+			}
 			if ( props.parent ) {
 				parent = parent.concat( props.parent );
 			}
@@ -189,6 +202,13 @@ var ampStoryEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 				{},
 				props,
 				{ parent: parent }
+			);
+		} else if ( -1 === props.name.indexOf( 'amp/amp-story-' ) ) {
+			// Do not allow inserting any of the blocks if they're not AMP Story blocks.
+			return Object.assign(
+				{},
+				props,
+				{ parent: [ '' ] }
 			);
 		}
 		return props;


### PR DESCRIPTION
Fixes #1541.
Fixes #1559.

- Only display Page on the root level inserter;
- Stop displaying Layers in the Inserters within Layer;