### PR TITLE
1532 - Added support for the older G block-list-apender for ghost page

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -360,7 +360,8 @@ div[data-type="amp/amp-story-page"] > div > div > .is-selected-parent > .editor-
 	top: 0;
 }
 
-.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point {
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point,
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .block-list-appender {
 	position: static;
 	margin-top: 38px;
 }
@@ -369,7 +370,10 @@ div[data-type="amp/amp-story-page"] > div > div > .is-selected-parent > .editor-
 	opacity: 1;
 }
 
-.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter .components-icon-button {
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .block-list-appender .components-button
+
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter .components-icon-button,
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .block-list-appender .components-button {
 	background-color: #FAFAFA;
 	background-image: url( '../images/add-page-inserter.svg' );
 	background-position: center center;
@@ -379,6 +383,8 @@ div[data-type="amp/amp-story-page"] > div > div > .is-selected-parent > .editor-
 	border-radius: 0;
 	height: 533px;
 	width: 338px;
+	margin: 0 auto;
+	outline: none;
 }
 
 .post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter .components-icon-button:hover,
@@ -386,7 +392,8 @@ div[data-type="amp/amp-story-page"] > div > div > .is-selected-parent > .editor-
 	box-shadow: inset 0 0 0 1px #e2e4e7,inset 0 0 0 2px #fff, 0 1px 1px rgba(25,30,35,.2);
 }
 
-.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter .components-icon-button svg {
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .editor-block-list__block[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter .components-icon-button svg,
+.post-type-amp_story .editor-writing-flow > div > div > .editor-block-list__layout > .block-list-appender .components-button svg {
 	display: none;
 }
 


### PR DESCRIPTION
Fixes #1532 for last week's Gutenberg version. Expands compatibility.