### PR TITLE
Update PHP-CSS-Parser and include tree shaker effectiveness in style[amp-custom] manifest comment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.3.6 || ^7.0",
-        "sabberworm/php-css-parser": "dev-add/at-rule-before-after"
+        "sabberworm/php-css-parser": "dev-master"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "539e80946c38e5b05a8aef89a8c50a09",
+    "content-hash": "33d4c9d9bf48285e6557d79a6b4b7601",
     "packages": [
         {
             "name": "sabberworm/php-css-parser",
-            "version": "dev-add/at-rule-before-after",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/PHP-CSS-Parser.git",
-                "reference": "53b0c2ba0895bd7c54e0e80b69d74a8237bad8a5"
+                "reference": "22311fa3d67217c5fcd0b839670be39a768eda7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/53b0c2ba0895bd7c54e0e80b69d74a8237bad8a5",
-                "reference": "53b0c2ba0895bd7c54e0e80b69d74a8237bad8a5",
+                "url": "https://api.github.com/repos/xwp/PHP-CSS-Parser/zipball/22311fa3d67217c5fcd0b839670be39a768eda7b",
+                "reference": "22311fa3d67217c5fcd0b839670be39a768eda7b",
                 "shasum": ""
             },
             "require": {
@@ -48,9 +48,9 @@
                 "stylesheet"
             ],
             "support": {
-                "source": "https://github.com/xwp/PHP-CSS-Parser/tree/add/at-rule-before-after"
+                "source": "https://github.com/xwp/PHP-CSS-Parser/tree/master"
             },
-            "time": "2018-09-13 21:49:15"
+            "time": "2018-11-25 04:50:29"
         }
     ],
     "packages-dev": [
@@ -124,16 +124,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "wimg/php-compatibility",


### PR DESCRIPTION
Amends #1423.

Update `composer.json` to refer to `master` branch after merge of https://github.com/xwp/PHP-CSS-Parser/pull/1

Also include percentages for CSS tree shaking effectiveness, including sum total of all CSS attempted to be added to the page:

```
The style[amp-custom] element is populated with:
     0 B: style[amp-custom=]
     0 B: style
   466 B (10%): link#dashicons-css[rel=stylesheet][id=dashicons-css][href=https://src.wordpress-develop.test/wp-includes/css/dashicons.css?ver=4.9.9-alpha-43554-src][type=text/css][media=all]
 17547 B (96%): link#admin-bar-css[rel=stylesheet][id=admin-bar-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/admin-bar.css?ver=1.0-RC3][type=text/css][media=all]
    99 B (46%): style#admin-bar-inline-css[id=admin-bar-inline-css][type=text/css]
     0 B: link#wp-block-library-theme-css[rel=stylesheet][id=wp-block-library-theme-css][href=https://src.wordpress-develop.test/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=1542650930][type=text/css][media=all]
     0 B: link#wp-block-library-css[rel=stylesheet][id=wp-block-library-css][href=https://src.wordpress-develop.test/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1542650930][type=text/css][media=all]
 30305 B (61%): link#twentynineteen-style-css[rel=stylesheet][id=twentynineteen-style-css][href=https://src.wordpress-develop.test/wp-content/themes/twentynineteen/style.css?ver=4.9.9-alpha-43554-src][type=text/css][media=all]
     0 B: style#twentynineteen-style-inline-css[id=twentynineteen-style-inline-css][type=text/css]
  1201 B (81%): link#twentynineteen-print-style-css[rel=stylesheet][id=twentynineteen-print-style-css][href=https://src.wordpress-develop.test/wp-content/themes/twentynineteen/print.css?ver=1.0][type=text/css][media=print]
   253 B (40%): link#jetpack-widget-social-icons-styles-css[rel=stylesheet][id=jetpack-widget-social-icons-styles-css][href=https://src.wordpress-develop.test/wp-content/plugins/jetpack/modules/widgets/social-icons/social-icons.css?ver=20170506][type=text/css][media=all]
    64 B (62%): link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.0-RC3][type=text/css][media=all]
Total included size: 49,935 bytes (59% of 83,304 total after tree shaking)

The following stylesheets are too large to be included in style[amp-custom]:
   122 B: style[type=text/css]
    39 B: style[type=text/css][media=print]
   225 B: style[type=text/css][media=screen]
  1501 B (91%): style[type=text/css]
   308 B (3%): link#mediaelement-css[rel=stylesheet][id=mediaelement-css][href=https://src.wordpress-develop.test/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.6-78496d1][type=text/css][media=all]
  1430 B (58%): link#wp-mediaelement-css[rel=stylesheet][id=wp-mediaelement-css][href=https://src.wordpress-develop.test/wp-includes/js/mediaelement/wp-mediaelement.css?ver=4.9.9-alpha-43554-src][type=text/css][media=all]
   175 B (90%): link#amp-playlist-shortcode-css[rel=stylesheet][id=amp-playlist-shortcode-css][href=https://src.wordpress-develop.test/wp-content/plugins/amp/assets/css/amp-playlist-shortcode.css?ver=1.0-RC3][type=text/css][media=all]
    74 B: figure.wp-caption alignnone amp-wp-d9900c6[class=wp-caption alignnone amp-wp-d9900c6]
   107 B: amp-iframe.wp-embedded-content amp-wp-enforced-sizes amp-wp-5e9b0a2[class=wp-embedded-content amp-wp-enforced-sizes amp-wp-5e9b0a2][sandbox=allow-scripts][security=restricted][src=https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/embed/#?secret=hV1M7xOhnz][data-secret=hV1M7xOhnz][width=600][height=338][title=“What’s new in Gutenberg? (11th December)” — Make WordPress Core][frameborder=0][marginwidth=0][marginheight=0][scrolling=no][layout=intrinsic]
    77 B: amp-iframe.amp-wp-enforced-sizes amp-wp-a2937b9[type=text/html][width=640][height=550][frameborder=0][allowfullscreen=][src=https://read.amazon.com/kp/card?preview=inline&linkCode=kpd&ref_=k4w_oembed_7YfCt01hVbfUFo&asin=B00DPM7TIG&tag=kpembed-20][sandbox=allow-scripts allow-same-origin][layout=intrinsic][class=amp-wp-enforced-sizes amp-wp-a2937b9]
    77 B: amp-iframe.amp-wp-enforced-sizes amp-wp-a2937b9[type=text/html][width=640][height=550][frameborder=0][allowfullscreen=][src=https://read.amazon.co.uk/kp/card?preview=inline&linkCode=kpd&ref_=k4w_oembed_z4FVjcj03Aj1yK&asin=B00G1TOJ7Y&tag=kpembed-20][sandbox=allow-scripts allow-same-origin][layout=intrinsic][class=amp-wp-enforced-sizes amp-wp-a2937b9]
    77 B: amp-iframe.amp-wp-enforced-sizes amp-wp-a2937b9[type=text/html][width=640][height=550][frameborder=0][allowfullscreen=][src=https://read.amazon.cn/kp/card?preview=inline&linkCode=kpd&ref_=k4w_oembed_AYDuePX8wScU8x&asin=B00DPM7TIG&tag=kpembed-20][sandbox=allow-scripts allow-same-origin][layout=intrinsic][class=amp-wp-enforced-sizes amp-wp-a2937b9]
   121 B: div.amp-wp-f0bace6[class=amp-wp-f0bace6]
    75 B: div#meetup_oembed.amp-wp-ca6c424[id=meetup_oembed][class=amp-wp-ca6c424]
    95 B: div.amp-wp-85dd052[class=amp-wp-85dd052]
   110 B: p.amp-wp-c197624[class=amp-wp-c197624]
    94 B: span.amp-wp-ddb6a1c[class=amp-wp-ddb6a1c]
    79 B: p.amp-wp-f44f203[class=amp-wp-f44f203]
    80 B: p.amp-wp-8ee72cf[class=amp-wp-8ee72cf]
   134 B: amp-iframe.amp-wp-enforced-sizes amp-wp-e90104b[src=https://www.slideshare.net/slideshow/embed_code/key/u6WNbsR5worSzC][width=427][height=356][frameborder=0][marginwidth=0][marginheight=0][scrolling=no][allowfullscreen=][sandbox=allow-scripts allow-same-origin][layout=intrinsic][class=amp-wp-enforced-sizes amp-wp-e90104b]
    80 B: div.amp-wp-980cd45[class=amp-wp-980cd45]
   113 B: amp-iframe#talk_frame_48643.amp-wp-enforced-sizes amp-wp-703d6dc[allowfullscreen=][allowtransparency=][frameborder=0][height=543][id=talk_frame_48643][mozallowfullscreen=true][src=https://speakerdeck.com/player/4648d440a3230130452522b217532879][webkitallowfullscreen=true][width=640][sandbox=allow-scripts allow-same-origin][layout=intrinsic][class=amp-wp-enforced-sizes amp-wp-703d6dc]
   107 B: amp-iframe.wp-embedded-content amp-wp-enforced-sizes amp-wp-5e9b0a2[class=wp-embedded-content amp-wp-enforced-sizes amp-wp-5e9b0a2][sandbox=allow-scripts][security=restricted][src=https://wordpress.org/plugins/amp/embed/#?secret=vDcIalQKTk][data-secret=vDcIalQKTk][width=600][height=338][title=“AMP for WordPress” — Plugin Directory][frameborder=0][marginwidth=0][marginheight=0][scrolling=no][layout=intrinsic]
    74 B: figure.wp-caption alignnone amp-wp-00fd489[class=wp-caption alignnone amp-wp-00fd489]
    89 B: amp-img.image wp-image-580 foo bar attachment-full size-full amp-wp-enforced-sizes amp-wp-36746cb[width=652][height=96][src=https://src.wordpress-develop.test/wp-content/uploads/2018/02/Grouplogo-1.png][class=image wp-image-580 foo bar attachment-full size-full amp-wp-enforced-sizes amp-wp-36746cb][alt=Example alt value][title=example image title][srcset=https://src.wordpress-develop.test/wp-content/uploads/2018/02/Grouplogo-1.png 652w, https://src.wordpress-develop.test/wp-content/uploads/2018/02/Grouplogo-1-300x44.png 300w][sizes=(max-width: 652px) 100vw, 652px][layout=intrinsic]
    75 B: div.amp-wp-cb45893[class=amp-wp-cb45893]
Total excluded size: 5,538 bytes (39% of 14,100 total after tree shaking)

Total combined size: 55,473 bytes (56% of 97,404 total after tree shaking)
```