### PR TITLE
[amp-stories sub-task] Hide CTA on the first page in block explorer

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -390,6 +390,11 @@ div[data-amp-type="grid"] .block-library-image__resizer {
 	opacity: 0.5;
 }
 
+/* Hide CTA button when inserting on the first page */
+.amp-story-page-first .editor-block-types-list .editor-block-list-item-amp-amp-story-cta-layer {
+	display: none;
+}
+
 /*
  * 6.1 Ghosted page inserter
  * Change the last inserter into a ghosted page.


### PR DESCRIPTION
I was able to hide the CTA button when using the add layer button in the block navigator as there I had the context on whether it was the first page ... I can't hide his parent which has a generic class though:
https://dsh.re/bb4d3d

When adding a layer from the page itself the inserter gets outside of the pages context, so I don't know on whether it's the first page or not, hence in this case, I wasn't able to hide the CTA button.. and clicking it will trigger the same - you can't add a CTA to the first page notice.
https://dsh.re/accc0

Fixes #1532 - specifically the potential hiding of the CTA button in the proper context.