### PR TITLE
Look in entire document for Schema.org metadata not just head

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1175,6 +1175,8 @@ class AMP_Theme_Support {
 		 * @var DOMElement $link
 		 */
 
+		$xpath = new DOMXPath( $dom );
+
 		// Make sure the HEAD element is in the doc.
 		$head = $dom->getElementsByTagName( 'head' )->item( 0 );
 		if ( ! $head ) {
@@ -1182,14 +1184,9 @@ class AMP_Theme_Support {
 			$dom->documentElement->insertBefore( $head, $dom->documentElement->firstChild );
 		}
 
-		// Ensure there is a schema.org script.
-		$schema_org_meta_script = null;
-		foreach ( $head->getElementsByTagName( 'script' ) as $script ) {
-			if ( 'application/ld+json' === $script->getAttribute( 'type' ) && false !== strpos( $script->nodeValue, 'schema.org' ) ) {
-				$schema_org_meta_script = $script;
-				break;
-			}
-		}
+		// Ensure there is a schema.org script in the document.
+		// @todo Consider applying the amp_schemaorg_metadata filter on the contents when a script is already present.
+		$schema_org_meta_script = $xpath->query( '//script[ @type = "application/ld+json" ][ contains( ./text(), "schema.org" ) ]' )->item( 0 );
 		if ( ! $schema_org_meta_script ) {
 			$script = $dom->createElement( 'script' );
 			$script->setAttribute( 'type', 'application/ld+json' );


### PR DESCRIPTION
The JSON-LD `script` elements can appear anywhere in a document, not just the `head`. This fixes the detection to account for that so that when another plugin outputs Schema.org metadata, the AMP plugin won't output a duplicate.

Fixes #1659 