### PR TITLE
Improve column width in single URL validation page

### DIFF
--- a/assets/css/amp-validation-single-error-url.css
+++ b/assets/css/amp-validation-single-error-url.css
@@ -118,12 +118,21 @@ table.striped > tbody > tr.even {
 	margin-top: 0.5rem;
 }
 
+/* Give enough width to prevent the widest column status, 'New Accepted,' from forcing the <select> below the icon. */
 .wp-list-table th.column-status {
+	width: 150px;
+}
+
+.wp-list-table th.column-sources_with_invalid_output {
 	width: 20%;
 }
 
 .wp-list-table th.column-error {
-	width: 30%;
+	width: 25%;
+}
+
+.wp-list-table th.column-details {
+	width: 20%;
 }
 
 /** Add space between list table and the filter and search box above it. */

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -862,7 +862,7 @@ class AMP_Validated_URL_Post_Type {
 				) )
 			),
 			'sources_with_invalid_output' => __( 'Sources', 'amp' ),
-			'error_type'                  => __( 'Error Type', 'amp' ),
+			'error_type'                  => __( 'Type', 'amp' ),
 		);
 	}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1601,7 +1601,7 @@ class AMP_Validation_Error_Taxonomy {
 	public static function get_reader_friendly_error_type_text( $error_type ) {
 		switch ( $error_type ) {
 			case 'js_error':
-				return esc_html__( 'JavaScript', 'amp' );
+				return esc_html__( 'JS', 'amp' );
 
 			case 'html_element_error':
 				return esc_html__( 'HTML (Element)', 'amp' );

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -551,7 +551,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
 				'details'                     => 'Details<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Details&lt;/h3&gt;&lt;p&gt;The parent element of where the error occurred.&lt;/p&gt;"></div>',
 				'sources_with_invalid_output' => 'Sources',
-				'error_type'                  => 'Error Type',
+				'error_type'                  => 'Type',
 			),
 			AMP_Validated_URL_Post_Type::add_single_post_columns()
 		);

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -1060,7 +1060,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text()
 	 */
 	public function test_get_reader_friendly_error_type_text() {
-		$this->assertEquals( 'JavaScript', AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text( 'js_error' ) );
+		$this->assertEquals( 'JS', AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text( 'js_error' ) );
 		$this->assertEquals( 'HTML (Element)', AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text( 'html_element_error' ) );
 		$this->assertEquals( 'HTML (Attribute)', AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text( 'html_attribute_error' ) );
 		$this->assertEquals( 'CSS', AMP_Validation_Error_Taxonomy::get_reader_friendly_error_type_text( 'css_error' ) );


### PR DESCRIPTION
# Before
<img width="1179" alt="select-forced-next-line" src="https://user-images.githubusercontent.com/4063887/49206145-c44ef700-f376-11e8-82f3-aaa3ab63b0fc.png">

# After 
<img width="1182" alt="sources-column-icon-select" src="https://user-images.githubusercontent.com/4063887/49206156-ce70f580-f376-11e8-92dc-8766c31e03f5.png">

This makes the 'Status' and 'Sources' columns wider, and the 'Error' column narrower. Depending on the screen width, this 'Error' column could be really narrow.

Fixes #1654