### PR TITLE
Add 'More details' link to 'Status' tooltip

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -806,9 +806,14 @@ class AMP_Validated_URL_Post_Type {
 				AMP_Validation_Error_Taxonomy::ERROR_STATUS => sprintf(
 					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',
 					esc_html__( 'Status', 'amp' ),
-					esc_attr( sprintf( '<h3>%s</h3><p>%s</p>',
+					esc_attr( sprintf( '<h3>%s</h3><p>%s %s</p>',
 						__( 'Status', 'amp' ),
-						__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+						__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' ),
+						sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( __( 'https://amp-wp.org/documentation/how-the-plugin-works/amp-validation/', 'amp' ) ),
+							esc_html__( 'More details', 'amp' )
+						)
 					) )
 				),
 				AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => esc_html__( 'Invalid', 'amp' ),
@@ -848,9 +853,14 @@ class AMP_Validated_URL_Post_Type {
 			'status'                      => sprintf(
 				'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',
 				esc_html__( 'Status', 'amp' ),
-				esc_attr( sprintf( '<h3>%s</h3><p>%s</p>',
+				esc_attr( sprintf( '<h3>%s</h3><p>%s %s</p>',
 					esc_html__( 'Status', 'amp' ),
-					esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+					esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' ),
+					sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( __( 'https://amp-wp.org/documentation/how-the-plugin-works/amp-validation/', 'amp' ) ),
+						esc_html__( 'More details', 'amp' )
+					)
 				) )
 			),
 			'details'                     => sprintf(

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -801,9 +801,14 @@ class AMP_Validation_Error_Taxonomy {
 				'status'           => sprintf(
 					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',
 					esc_html__( 'Status', 'amp' ),
-					esc_attr( sprintf( '<h3>%s</h3><p>%s</p>',
+					esc_attr( sprintf( '<h3>%s</h3><p>%s %s</p>',
 						esc_html__( 'Status', 'amp' ),
-						esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' )
+						esc_html__( 'An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.', 'amp' ),
+						sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( __( 'https://amp-wp.org/documentation/how-the-plugin-works/amp-validation/', 'amp' ) ),
+							esc_html__( 'More details', 'amp' )
+						)
 					) )
 				),
 				'details'          => sprintf(

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -548,7 +548,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 			array(
 				'cb'                          => '<input type="checkbox" />',
 				'error'                       => 'Error',
-				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
+				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity. &lt;a href=&quot;https://amp-wp.org/documentation/how-the-plugin-works/amp-validation/&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;"></div>',
 				'details'                     => 'Details<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Details&lt;/h3&gt;&lt;p&gt;The parent element of where the error occurred.&lt;/p&gt;"></div>',
 				'sources_with_invalid_output' => 'Sources',
 				'error_type'                  => 'Error Type',

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -582,7 +582,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 			array_keys( array(
 				'cb'               => $cb,
 				'error'            => 'Error',
-				'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
+				'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity. <a href="https://amp-wp.org/documentation/how-the-plugin-works/amp-validation/">More details</a></p></div>',
 				'details'          => 'Details<div class="tooltip dashicons dashicons-editor-help"><h3>Details tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 				'error_type'       => 'Type',
 				'created_date_gmt' => 'Last Seen',


### PR DESCRIPTION
This adds a 'More details' link for the 'Status' tooltips on 3 of the 4 Compatibility Tool pages:
* AMP Validated URLs 
* Single URL page
* AMP Validation Error Taxonomy

<img width="1310" alt="new-link-more-details" src="https://user-images.githubusercontent.com/4063887/49213119-26b0f300-f389-11e8-8f5a-1ef74280be1c.png">




Closes #1400