### PR TITLE
Fix block and page-level validation notices 

### DIFF
--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -344,12 +344,13 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 		 * @return {Object} Validation errors grouped by block ID other ones.
 		 */
 		getBlocksValidationErrors: function getBlocksValidationErrors() {
-			var blockValidationErrorsByClientId, editorSelect, currentPost, blockOrder, validationErrors, otherValidationErrors;
+			var acceptedStatus, blockValidationErrorsByClientId, editorSelect, currentPost, blockOrder, validationErrors, otherValidationErrors;
+			acceptedStatus = 3; // eslint-disable-line no-magic-numbers
 			editorSelect = wp.data.select( 'core/editor' );
 			currentPost = editorSelect.getCurrentPost();
 			validationErrors = _.map(
 				_.filter( currentPost[ module.data.ampValidityRestField ].results, function( result ) {
-					return result.term_status !== 3; // If not accepted by the user.
+					return result.term_status !== acceptedStatus; // If not accepted by the user.
 				} ),
 				function( result ) {
 					return result.error;

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -349,7 +349,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			currentPost = editorSelect.getCurrentPost();
 			validationErrors = _.map(
 				_.filter( currentPost[ module.data.ampValidityRestField ].results, function( result ) {
-					return result.term_status !== 1; // If not accepted by the user.
+					return result.term_status !== 3; // If not accepted by the user.
 				} ),
 				function( result ) {
 					return result.error;

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -251,7 +251,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			noticeMessage += ' ';
 			// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Native mode.
 			if ( module.data.isSanitizationAutoAccepted ) {
-				if ( ! rejectedErrors.length ) {
+				if ( 0 === rejectedErrors.length ) {
 					noticeMessage += wp.i18n.__( 'However, your site is configured to automatically accept sanitization of the offending markup.', 'amp' );
 				} else {
 					noticeMessage += wp.i18n._n(
@@ -277,7 +277,11 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				];
 			}
 
-			wp.data.dispatch( 'core/notices' ).createNotice( 'warning', noticeMessage, noticeOptions );
+			// Display notice if there were validation errors.
+			if ( validationErrors.length > 0 ) {
+				wp.data.dispatch( 'core/notices' ).createNotice( 'warning', noticeMessage, noticeOptions );
+			}
+
 			module.validationWarningNoticeId = noticeOptions.id;
 		},
 

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -171,8 +171,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 					return (
 						0 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS */ === result.status ||
 						1 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS */ === result.status ||
-						2 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS */ === result.status || // eslint-disable-line no-magic-numbers
-						3 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS */ === result.status // eslint-disable-line no-magic-numbers
+						2 /* \AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS */ === result.status // eslint-disable-line no-magic-numbers
 					);
 				} ),
 				function( result ) {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -849,7 +849,7 @@ class AMP_Validation_Manager {
 			/*
 			 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
 			 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
-			 * In that case, this will still redirect to a non-AMP URL.
+			 * In that case, this will block serving AMP.
 			 * This could also apply if this is in 'Native' mode and the user has rejected a validation error.
 			 */
 			esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
@@ -1936,8 +1936,8 @@ class AMP_Validation_Manager {
 		);
 
 		$data = array(
-			'ampValidityRestField' => self::VALIDITY_REST_FIELD_NAME,
-			'isCanonical'          => amp_is_canonical(),
+			'ampValidityRestField'       => self::VALIDITY_REST_FIELD_NAME,
+			'isSanitizationAutoAccepted' => self::is_sanitization_auto_accepted(),
 		);
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -842,13 +842,14 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		if ( amp_is_canonical() || ( self::is_sanitization_auto_accepted() && ! $has_rejected_error ) ) {
+		if ( ( amp_is_canonical() || self::is_sanitization_auto_accepted() ) && ! $has_rejected_error ) {
 			esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 		} elseif ( self::is_sanitization_auto_accepted() && $has_rejected_error ) {
 			/*
 			 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
 			 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 			 * In that case, this will still redirect to a non-AMP URL.
+			 * This could also apply if this is in 'Native' mode and the user has rejected a validation error.
 			 */
 			esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 		} else {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -810,7 +810,8 @@ class AMP_Validation_Manager {
 		}
 
 		// Show all validation errors which have not been explicitly acknowledged as accepted.
-		$validation_errors = array();
+		$validation_errors  = array();
+		$has_rejected_error = false;
 		foreach ( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $invalid_url_post ) as $error ) {
 			$needs_moderation = (
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS === $error['status'] || // @todo Show differently since moderated?
@@ -819,6 +820,14 @@ class AMP_Validation_Manager {
 			);
 			if ( $needs_moderation ) {
 				$validation_errors[] = $error['data'];
+			}
+
+			if (
+				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS === $error['status']
+				||
+				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS === $error['status']
+			) {
+				$has_rejected_error = true;
 			}
 		}
 
@@ -832,11 +841,20 @@ class AMP_Validation_Manager {
 		// @todo Check if the error actually occurs in the_content, and if not, consider omitting the warning if the user does not have privileges to manage_options.
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
-		if ( amp_is_canonical() ) {
-			esc_html_e( 'Non-accepted validation errors prevent AMP from being served.', 'amp' );
+
+		if ( amp_is_canonical() || ( self::is_sanitization_auto_accepted() && ! $has_rejected_error ) ) {
+			esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
+		} elseif ( self::is_sanitization_auto_accepted() && $has_rejected_error ) {
+			/*
+			 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
+			 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
+			 * In that case, this will still redirect to a non-AMP URL.
+			 */
+			esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 		} else {
 			esc_html_e( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
 		}
+
 		echo sprintf(
 			' <a href="%s" target="_blank">%s</a>',
 			esc_url( get_edit_post_link( $invalid_url_post ) ),

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -842,7 +842,8 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		if ( ( amp_is_canonical() || self::is_sanitization_auto_accepted() ) && ! $has_rejected_error ) {
+		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Native mode.
+		if ( self::is_sanitization_auto_accepted() && ! $has_rejected_error ) {
 			esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 		} elseif ( self::is_sanitization_auto_accepted() && $has_rejected_error ) {
 			/*

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -843,16 +843,18 @@ class AMP_Validation_Manager {
 		echo ' ';
 
 		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Native mode.
-		if ( self::is_sanitization_auto_accepted() && ! $has_rejected_error ) {
-			esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
-		} elseif ( self::is_sanitization_auto_accepted() && $has_rejected_error ) {
-			/*
-			 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
-			 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
-			 * In that case, this will block serving AMP.
-			 * This could also apply if this is in 'Native' mode and the user has rejected a validation error.
-			 */
-			esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
+		if ( self::is_sanitization_auto_accepted() ) {
+			if ( ! $has_rejected_error ) {
+				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
+			} else {
+				/*
+				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
+				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
+				 * In that case, this will block serving AMP.
+				 * This could also apply if this is in 'Native' mode and the user has rejected a validation error.
+				 */
+				esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
+			}
 		} else {
 			esc_html_e( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
 		}

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -584,12 +584,12 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertContains( '<code>script</code>', $output );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 
-		// In 'Native' mode, there should be a notice that explains that this will accept the sanitization errors.
+		// In 'Native' mode, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		AMP_Validation_Manager::print_edit_form_validation_status( $post );
 		$output = ob_get_clean();
-		$this->assertContains( 'There is content which fails AMP validation. However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );
+		$this->assertContains( 'There is content which fails AMP validation. Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );
 
 		/*
 		 * When there are 'Rejected' or 'New Rejected' errors, there should be a message that explains that this will serve a non-AMP URL.


### PR DESCRIPTION
# Before
<img width="1148" alt="before-validation" src="https://user-images.githubusercontent.com/4063887/49256407-8e505800-f3f4-11e8-9ace-c76a6ded8dd6.png">

# After 
<img width="1384" alt="accepted-notice" src="https://user-images.githubusercontent.com/4063887/49255664-56e0ac00-f3f2-11e8-84b4-6102dd0be15b.png">

Fixes #1502.