### PR TITLE
Prevent the admin pointer from staying below the viewport

### DIFF
--- a/assets/js/amp-admin-pointer.js
+++ b/assets/js/amp-admin-pointer.js
@@ -27,16 +27,6 @@ var ampAdminPointer = ( function( $ ) { // eslint-disable-line no-unused-vars
 							pointer: data.pointer.pointer_id,
 							action: 'dismiss-wp-pointer'
 						} );
-					},
-
-					/**
-					 * Adds styling to the pointer, to ensure it appears alongside the AMP menu.
-					 *
-					 * @param {Object} event The pointer event.
-					 * @param {Object} t Pointer element and state.
-					 */
-					show: function( event, t ) {
-						t.pointer.css( 'position', 'fixed' );
 					}
 				}
 			);


### PR DESCRIPTION
# Steps to reproduce
1. Add several admin menu items above the AMP plugin's menu item:
<img width="863" alt="extra-test-menu-items" src="https://user-images.githubusercontent.com/4063887/49415900-b960e180-f73d-11e8-8e48-61772367ee0b.png">

This snippet might help:
```php
/**
 * Adds 10 test menu items above and below the AMP menu.
 */
add_action( 'admin_menu', function() {
	$upper_menu_name = __( 'Test menu a', 'amp-scratchpad' );
	$lower_menu_name = __( 'Test menu b', 'amp-scratchpad' );

	for ( $i = 0; $i < 10; $i++ ) {
		add_menu_page( $upper_menu_name, $upper_menu_name, 'edit_posts', $upper_menu_name, '', '', $i );
		add_menu_page( $lower_menu_name, $lower_menu_name, 'edit_posts', $lower_menu_name, '', '', 100 + $i );
	}
} );
```

2. Expected: AMP admin pointer is visible on scrolling down to the AMP menu

3. Actual: the admin pointer is not visible:
<img width="808" alt="admin-pointer-scrolling-down" src="https://user-images.githubusercontent.com/4063887/49416048-46a43600-f73e-11e8-99b0-78b206f36cc9.png">

This PR simply removes the `position: fixed` rule that caused the pointer to be hidden. But that has a side effect.

The `position: fixed` style caused the admin pointer to always point to the AMP menu item. But now it doesn't.

It looks like that's also the case with the privacy admin pointer from WordPress `4.9.6`. Notice how the privacy admin pointer doesn't always point to the Tools.

# Privacy Admin Pointer
![admin-pointer-10](https://user-images.githubusercontent.com/4063887/49415575-d3e68b00-f73c-11e8-89b2-bc78e1d77e8a.gif)

# AMP Plugin Admin Pointer With This PR
![admin-pointer-privacy](https://user-images.githubusercontent.com/4063887/49415570-cfba6d80-f73c-11e8-86be-51a39ee6fa14.gif)

