### PR TITLE
Update the amp.php Plugin URI to the product site

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: AMP
  * Description: Add AMP support to your WordPress site.
- * Plugin URI: https://github.com/automattic/amp-wp
+ * Plugin URI: https://amp-wp.org
  * Author: WordPress.com VIP, XWP, Google, and contributors
  * Author URI: https://github.com/Automattic/amp-wp/graphs/contributors
  * Version: 1.0-RC4


### PR DESCRIPTION
* Changes this from the GitHub repo to https://amp-wp.org