### PR TITLE
Restrict doing plugin upgrade routine when not in admin

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -124,7 +124,7 @@ function amp_init() {
 	 */
 	$options     = get_option( AMP_Options_Manager::OPTION_NAME, [] );
 	$old_version = isset( $options['version'] ) ? $options['version'] : '0.0';
-	if ( AMP__VERSION !== $old_version ) {
+	if ( AMP__VERSION !== $old_version && is_admin() && current_user_can( 'manage_options' ) ) {
 		/**
 		 * Triggers when after amp_init when the plugin version has updated.
 		 *


### PR DESCRIPTION
## Summary

The changes here in effect restrict the upgrade routine to happen at `admin_init`. This was discussed in depth at #4177. This implements https://github.com/ampproject/amp-wp/issues/3284#issuecomment-601461737:

> The DB upgrade routines don't happen on the frontend either, as you recall the upgrade DB message is only presented once trying to access the admin.

Fixes #3284

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
