### PR TITLE
Use title case for Paired Browsing link in edit post screen

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1928,7 +1928,7 @@ class AMP_Validated_URL_Post_Type {
 							printf(
 								' | <a href="%s">%s</a>',
 								esc_url( AMP_Theme_Support::get_paired_browsing_url( self::get_url_from_post( $post ) ) ),
-								esc_html__( 'Paired browsing', 'amp' )
+								esc_html__( 'Paired Browsing', 'amp' )
 							);
 						}
 						?>


### PR DESCRIPTION
## Summary

Improve consistency with the other links in the publish metabox.

Before:

![image](https://user-images.githubusercontent.com/134745/78618736-3ae3ea80-7830-11ea-8aca-86dae6571030.png)

After:

![image](https://user-images.githubusercontent.com/134745/78618792-5c44d680-7830-11ea-8dc5-78da876cdbde.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
