### PR TITLE
Add requirements to plugin file header

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -9,6 +9,8 @@
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
+ * Requires at least: 4.9
+ * Requires PHP: 5.6
  *
  * @package AMP
  */


### PR DESCRIPTION
## Summary

We already have the plugin requirements encoded in the `readme.txt`, but to make sure WordPress enforces them properly, we also add them to the plugin file header metadata.

Fixes #4520

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).