### PR TITLE
Ensure that validation query vars persist through redirects

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2077,7 +2077,7 @@ class AMP_Validation_Manager {
 				break;
 			}
 
-			$validation_url = $location_header;
+			$validation_url = add_query_arg( $added_query_vars, $location_header );
 		}
 
 		if ( is_wp_error( $r ) ) {


### PR DESCRIPTION
## Summary

Given a plugin that performs a redirect, such as the contrived example which redirects any AMP page to automatically get `redirected=1` added as an additional query var:

```php
add_action(
	'template_redirect',
	function () {
		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() && ! isset( $_GET['redirected'] ) ) {
			$url = wp_unslash( $_SERVER['REQUEST_URI'] );
			$url = add_query_arg( 'redirected', '1', $url );
			$url = remove_query_arg( [ 'amp_validate', 'amp_cache_bust' ], $url );
			wp_redirect( $url );
			exit;
		}
	}
);
```

At the moment for a site in Transitional mode, going to a non-AMP page at `/about/` and clicking Validate in the admin bar results in:

![image](https://user-images.githubusercontent.com/134745/78635001-143aa980-785a-11ea-8cdc-da16ba5b4244.png)

The issue is that the `amp_validate` query var was not persisting across redirects, so this PR fixes that problem so that this is now the result when attempting to validate `/about/` on a Transitional mode site:

![image](https://user-images.githubusercontent.com/134745/78635082-3af8e000-785a-11ea-94e2-7594261be898.png)

This issue came up specifically where WPML was attempting to redirect the homepage to `/en/` in this support topic: https://wordpress.org/support/topic/url-validation-failed-due-to-unexpected-json-in-amp-validation-response/#post-12637035

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
