### PR TITLE
Restore unification of multi-page post content in Reader mode

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -342,8 +342,14 @@ class AMP_Post_Template {
 	 * Build post content.
 	 */
 	private function build_post_content() {
-		/** This filter is documented in wp-includes/post-template.php */
-		$content = apply_filters( 'the_content', get_the_content( null, false, $this->post ) );
+		if ( post_password_required( $this->post ) ) {
+			$content = get_the_password_form( $this->post );
+		} else {
+			// Note: This is intentionally not using get_the_content() because the legacy behavior of posts in Reader
+			// mode is to display multi-page posts as a single page without any pagination links.
+			/** This filter is documented in wp-includes/post-template.php */
+			$content = apply_filters( 'the_content', $this->post->post_content );
+		}
 
 		$this->add_data_by_key( 'post_amp_content', $content );
 	}

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -347,7 +347,7 @@ class AMP_Post_Template {
 		} else {
 			/**
 			 * This filter is documented in wp-includes/post-template.php.
-			 * 
+			 *
 			 * Note: This is intentionally not using get_the_content() because the legacy behavior of posts in
 			 * Reader mode is to display multi-page posts as a single page without any pagination links.
 			 */

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -345,9 +345,12 @@ class AMP_Post_Template {
 		if ( post_password_required( $this->post ) ) {
 			$content = get_the_password_form( $this->post );
 		} else {
-			// Note: This is intentionally not using get_the_content() because the legacy behavior of posts in Reader
-			// mode is to display multi-page posts as a single page without any pagination links.
-			/** This filter is documented in wp-includes/post-template.php */
+			/**
+			 * This filter is documented in wp-includes/post-template.php.
+			 * 
+			 * Note: This is intentionally not using get_the_content() because the legacy behavior of posts in
+			 * Reader mode is to display multi-page posts as a single page without any pagination links.
+			 */
 			$content = apply_filters( 'the_content', $this->post->post_content );
 		}
 


### PR DESCRIPTION
## Summary

Originally reported on a [support forum topic](https://wordpress.org/support/topic/pagination-error-22/):

<blockquote>Since the last update to your AMP plugin (which we’ve been using with the Zox News WordPress theme for over a year), we’ve encountered this issue. We use <code>&lt;!--nextpage--&gt;</code> to paginate our big features on desktop/mobile (like <a href="https://www.slantmagazine.com/features/the-100-best-westerns-of-all-time/" rel="nofollow ugc">this one</a>). Your plugin has always ignored this code and presented those features as one big page. Now, though, our AMP pages are killing all content after it hits the <code>&lt;!--nextpage--&gt;</code> directive, meaning that our readers aren’t seeing our full content. Click <a href="https://www.slantmagazine.com/features/the-100-best-westerns-of-all-time/amp/" rel="nofollow ugc">here</a> to see how the AMP version of the list above is ending at number 91. We want to avoid having to un-paginate our features in order to correct this issue. Thanks.</blockquote>

The regression was introduced in #3781 via this change: https://github.com/ampproject/amp-wp/pull/3781/files#r405130526

The switch to `get_the_content()` caused pagination to be introduced which was not present before, when `post_content` was directly passed into `the_content` filters.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
