### PR TITLE
Refactor conditional checks in is_amp_endpoint() and improve guidance when _doing_it_wrong()

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -603,7 +603,7 @@ function is_amp_endpoint() {
 		);
 	}
 
-	// note: is_embed() and is_feed() need $wp_query, so above checks must go first
+	// note: is_embed() and is_feed() need $wp_query, so above checks must go first.
 	if ( is_embed() || is_feed() ) {
 		return false;
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -603,7 +603,7 @@ function is_amp_endpoint() {
 		);
 	}
 
-	// note: is_embed() and is_feed() need $wp_query, so above checks must go first.
+	// Note: is_embed() and is_feed() need $wp_query, so above checks must go first.
 	if ( is_embed() || is_feed() ) {
 		return false;
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -566,7 +566,7 @@ function post_supports_amp( $post ) {
 function is_amp_endpoint() {
 	global $pagenow, $wp_query;
 
-	if ( is_admin() || is_embed() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ], true ) ) {
+	if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ], true ) ) {
 		return false;
 	}
 
@@ -601,6 +601,11 @@ function is_amp_endpoint() {
 			),
 			'1.1'
 		);
+	}
+
+	// note: is_embed() and is_feed() need $wp_query, so above checks must go first
+	if ( is_embed() || is_feed() ) {
+		return false;
 	}
 
 	/*

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -604,9 +604,25 @@ function is_amp_endpoint() {
 		return false;
 	}
 
-	// Short-circuit for embed or feed requests since they will never be AMP responses.
+	// Short-circuit queries that can never AMP responses (e.g. post embeds and feeds).
 	// Note that these conditionals only require the parse_query action to have been run. They don't depend on the wp action having been fired.
-	if ( $wp_query instanceof WP_Query && ( $wp_query->is_embed() || $wp_query->is_feed() ) ) {
+	if (
+		$wp_query instanceof WP_Query
+		&&
+		(
+			$wp_query->is_embed()
+			||
+			$wp_query->is_feed()
+			||
+			$wp_query->is_comment_feed()
+			||
+			$wp_query->is_trackback()
+			||
+			$wp_query->is_robots()
+			||
+			( method_exists( $wp_query, 'is_favicon' ) && $wp_query->is_favicon() )
+		)
+	) {
 		return false;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -573,8 +573,8 @@ function is_amp_endpoint() {
 
 	$warned        = false;
 	$error_message = sprintf(
-		/* translators: %1$s: is_amp_endpoint(), %2$s: the current action, %3$s: the wp action, %4$s: the parse_request action, %5$s: the WP_Query class, %6$s: the amp_skip_post() function */
-		__( '%1$s was called too early and so it will not work properly. WordPress is currently doing the "%2$s" action. Calling this function before the "%3$s" action means it will not have access to %4$s and the queried object to determine if it is an AMP response, thus neither the %5$s filter nor the AMP enabled toggle will be considered.', 'amp' ),
+		/* translators: %1$s: is_amp_endpoint(), %2$s: the current action, %3$s: the wp action, %4$s: the WP_Query class, %5$s: the amp_skip_post() function */
+		__( '%1$s was called too early and so it will not work properly. WordPress is currently doing the "%2$s" action. Calling this function before the "%3$s" action means it will not have access to %4$s and the queried object to determine if it is an AMP response, thus neither the "%5$s" filter nor the AMP enabled toggle will be considered.', 'amp' ),
 		__FUNCTION__ . '()',
 		current_action(),
 		'wp',

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -654,10 +654,10 @@ function is_amp_endpoint() {
 	if ( did_action( 'wp' ) && $wp_query instanceof WP_Query ) {
 		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$availability = AMP_Theme_Support::get_template_availability( $wp_query );
-			$supported    = $availability['supported'];
+			return $availability['supported'];
 		} else {
 			$queried_object = get_queried_object();
-			$supported      = $queried_object instanceof WP_Post && ( $wp_query->is_singular() || $wp_query->is_posts_page ) && post_supports_amp( $queried_object );
+			return $queried_object instanceof WP_Post && ( $wp_query->is_singular() || $wp_query->is_posts_page ) && post_supports_amp( $queried_object );
 		}
 	} else {
 		// If WP_Query was not available yet, then we will just assume the query is supported since at this point we do
@@ -667,10 +667,8 @@ function is_amp_endpoint() {
 		if ( ! $warned ) {
 			_doing_it_wrong( __FUNCTION__, esc_html( $error_message ), '1.0.2' );
 		}
-		$supported = amp_is_canonical() || $has_amp_query_var;
+		return amp_is_canonical() || $has_amp_query_var;
 	}
-
-	return $supported;
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -479,7 +479,7 @@ function amp_remove_endpoint( $url ) {
  * If there are known validation errors for the current URL then do not output anything.
  *
  * @since 1.0
- * @globla WP_Query $wp_query
+ * @global WP_Query $wp_query
  */
 function amp_add_amphtml_link() {
 	global $wp_query;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -584,7 +584,7 @@ function is_amp_endpoint() {
 
 	// Make sure the parse_request action has triggered before trying to read from the REST_REQUEST constant, which is set during rest_api_loaded().
 	if ( ! did_action( 'parse_request' ) ) {
-		_doing_it_wrong( __FUNCTION__, esc_html( $error_message ), '1.5.3' );
+		_doing_it_wrong( __FUNCTION__, esc_html( $error_message ), '1.6.0' );
 		$warned = true;
 	} elseif ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 		return false;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -628,6 +628,11 @@ function is_amp_endpoint() {
 		)
 	);
 
+	// If theme support is not present (if Standard or Transitional mode), then just consider the query var alone.
+	// If it turns out the URL actually does not support AMP, then AMP_Theme_Support::finish_init() will currently
+	// force the request to redirect to the non-AMP URL. This is somewhat of an accommodation for Reader mode sites
+	// calling is_amp_endpoint() early. So once transitioning to Standard or Transitional mode, then is_amp_endpoint()
+	// becomes more strict with the warnings it emits.
 	if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		return $has_amp_query_var;
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -593,18 +593,18 @@ function is_amp_endpoint() {
 	}
 
 	// Make sure that the parse_query action has triggered, as this is required to initially populate the global WP_Query.
-	if ( ! $warned && ! ( did_action( 'parse_query' ) || $wp_query instanceof WP_Query ) ) {
+	if ( ! $warned && ! ( $wp_query instanceof WP_Query || did_action( 'parse_query' ) ) ) {
 		_doing_it_wrong( __FUNCTION__, esc_html( $error_message ), '0.4.2' );
 		$warned = true;
 	}
 
-	// Always return false when requesting service worker.
+	// Always return false when requesting the service worker.
 	// Note this is no longer required because AMP_Theme_Support::prepare_response() will abort for non-HTML responses.
 	if ( class_exists( 'WP_Service_Workers' ) && $wp_query instanceof WP_Query && defined( 'WP_Service_Workers::QUERY_VAR' ) && $wp_query->get( WP_Service_Workers::QUERY_VAR ) ) {
 		return false;
 	}
 
-	// Short-circuit queries that can never AMP responses (e.g. post embeds and feeds).
+	// Short-circuit queries that can never have AMP responses (e.g. post embeds and feeds).
 	// Note that these conditionals only require the parse_query action to have been run. They don't depend on the wp action having been fired.
 	if (
 		$wp_query instanceof WP_Query
@@ -657,7 +657,7 @@ function is_amp_endpoint() {
 			$supported    = $availability['supported'];
 		} else {
 			$queried_object = get_queried_object();
-			$supported      = ( $wp_query->is_singular() || $wp_query->is_posts_page ) && $queried_object instanceof WP_Post && post_supports_amp( $queried_object );
+			$supported      = $queried_object instanceof WP_Post && ( $wp_query->is_singular() || $wp_query->is_posts_page ) && post_supports_amp( $queried_object );
 		}
 	} else {
 		// If WP_Query was not available yet, then we will just assume the query is supported since at this point we do

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -376,6 +376,7 @@ class AMP_Theme_Support {
 			add_filter( 'template_include', [ __CLASS__, 'serve_paired_browsing_experience' ] );
 		}
 
+		// @todo These two conditions can likely be combined into one.
 		$has_query_var  = (
 			isset( $_GET[ amp_get_slug() ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			||

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -376,26 +376,14 @@ class AMP_Theme_Support {
 			add_filter( 'template_include', [ __CLASS__, 'serve_paired_browsing_experience' ] );
 		}
 
-		// @todo These two conditions can likely be combined into one.
+		$is_reader_mode = self::READER_MODE_SLUG === self::get_support_mode();
 		$has_query_var  = (
 			isset( $_GET[ amp_get_slug() ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			||
 			false !== get_query_var( amp_get_slug(), false )
 		);
-		$is_reader_mode = self::READER_MODE_SLUG === self::get_support_mode();
-		if (
-			$is_reader_mode
-			&&
-			$has_query_var
-			&&
-			( ! is_singular() || ! post_supports_amp( get_post( get_queried_object_id() ) ) )
-		) {
-			// Reader mode only supports the singular template (for now) so redirect non-singular queries in reader mode to non-AMP version.
-			// Also ensure redirecting to non-AMP version when accessing a post which does not support AMP.
-			// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
-			wp_safe_redirect( amp_remove_endpoint( amp_get_current_url() ), current_user_can( 'manage_options' ) ? 302 : 301 );
-			return;
-		} elseif ( ! is_amp_endpoint() ) {
+
+		if ( ! is_amp_endpoint() ) {
 			/*
 			 * Redirect to AMP-less URL if AMP is not available for this URL and yet the query var is present.
 			 * Temporary redirect is used for admin users because implied transitional mode and template support can be
@@ -403,7 +391,7 @@ class AMP_Theme_Support {
 			 * without wrestling with the redirect cache.
 			 */
 			if ( $has_query_var ) {
-				self::redirect_non_amp_url( current_user_can( 'manage_options' ) ? 302 : 301, true );
+				self::redirect_non_amp_url( current_user_can( 'manage_options' ) ? 302 : 301 );
 			}
 
 			amp_add_frontend_actions();
@@ -445,10 +433,9 @@ class AMP_Theme_Support {
 	 *
 	 * @since 1.0
 	 *
-	 * @param bool $exit Whether to exit after redirecting.
-	 * @return bool Whether redirection was done. Naturally this is irrelevant if $exit is true.
+	 * @return bool Whether redirection should have been done.
 	 */
-	public static function ensure_proper_amp_location( $exit = true ) {
+	public static function ensure_proper_amp_location() {
 		$has_query_var = false !== get_query_var( amp_get_slug(), false ); // May come from URL param or endpoint slug.
 		$has_url_param = isset( $_GET[ amp_get_slug() ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -461,7 +448,7 @@ class AMP_Theme_Support {
 			 * to not be hampered by browser remembering permanent redirects and preventing test.
 			 */
 			if ( $has_query_var || $has_url_param ) {
-				return self::redirect_non_amp_url( current_user_can( 'manage_options' ) ? 302 : 301, $exit );
+				return self::redirect_non_amp_url( current_user_can( 'manage_options' ) ? 302 : 301 );
 			}
 		} elseif ( self::READER_MODE_SLUG === self::get_support_mode() && is_singular() ) {
 			// Prevent infinite URL space under /amp/ endpoint.
@@ -469,9 +456,10 @@ class AMP_Theme_Support {
 			$path_args = [];
 			wp_parse_str( $wp->matched_query, $path_args );
 			if ( isset( $path_args[ amp_get_slug() ] ) && '' !== $path_args[ amp_get_slug() ] ) {
-				wp_safe_redirect( amp_get_permalink( get_queried_object_id() ), 301 );
-				if ( $exit ) {
+				if ( wp_safe_redirect( amp_get_permalink( get_queried_object_id() ), 301 ) ) {
+					// @codeCoverageIgnoreStart
 					exit;
+					// @codeCoverageIgnoreEnd
 				}
 				return true;
 			}
@@ -486,13 +474,12 @@ class AMP_Theme_Support {
 			$new_url = add_query_arg( amp_get_slug(), '', amp_remove_endpoint( $old_url ) );
 			if ( $old_url !== $new_url ) {
 				// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
-				wp_safe_redirect( $new_url, current_user_can( 'manage_options' ) ? 302 : 301 );
-				// @codeCoverageIgnoreStart
-				if ( $exit ) {
+				if ( wp_safe_redirect( $new_url, current_user_can( 'manage_options' ) ? 302 : 301 ) ) {
+					// @codeCoverageIgnoreStart
 					exit;
+					// @codeCoverageIgnoreEnd
 				}
 				return true;
-				// @codeCoverageIgnoreEnd
 			}
 		}
 		return false;
@@ -507,24 +494,22 @@ class AMP_Theme_Support {
 	 * @since 1.0 Added $exit param.
 	 * @since 1.0 Renamed from redirect_canonical_amp().
 	 *
-	 * @param int  $status Status code (301 or 302).
-	 * @param bool $exit   Whether to exit after redirecting.
-	 * @return bool Whether redirection was done. Naturally this is irrelevant if $exit is true.
+	 * @param int $status Status code (301 or 302).
+	 * @return bool Whether redirection should have be done.
 	 */
-	public static function redirect_non_amp_url( $status = 302, $exit = true ) {
+	public static function redirect_non_amp_url( $status = 302 ) {
 		$current_url = amp_get_current_url();
 		$non_amp_url = amp_remove_endpoint( $current_url );
 		if ( $non_amp_url === $current_url ) {
 			return false;
 		}
 
-		wp_safe_redirect( $non_amp_url, $status );
-		// @codeCoverageIgnoreStart
-		if ( $exit ) {
+		if ( wp_safe_redirect( $non_amp_url, $status ) ) {
+			// @codeCoverageIgnoreStart
 			exit;
+			// @codeCoverageIgnoreEnd
 		}
 		return true;
-		// @codeCoverageIgnoreEnd
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -432,6 +432,7 @@ class AMP_Theme_Support {
 	 * Ensure that the current AMP location is correct.
 	 *
 	 * @since 1.0
+	 * @since 1.6 Removed $exit param.
 	 *
 	 * @return bool Whether redirection should have been done.
 	 */
@@ -493,6 +494,7 @@ class AMP_Theme_Support {
 	 * @since 0.7
 	 * @since 1.0 Added $exit param.
 	 * @since 1.0 Renamed from redirect_canonical_amp().
+	 * @since 1.6 Removed $exit param.
 	 *
 	 * @param int $status Status code (301 or 302).
 	 * @return bool Whether redirection should have be done.

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -588,8 +588,6 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * Test is_amp_endpoint() function when there is no WP_Query.
 	 *
 	 * @covers ::is_amp_endpoint()
-	 * @expectedIncorrectUsage is_feed
-	 * @expectedIncorrectUsage is_embed
 	 * @expectedIncorrectUsage is_amp_endpoint
 	 */
 	public function test_is_amp_endpoint_when_no_wp_query() {

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -58,8 +58,7 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		);
 
 		// Set global for WP<5.2 where get_the_content() doesn't take the $post parameter.
-		$GLOBALS['post'] = get_post( $post_id );
-		setup_postdata( $post_id );
+		$this->go_to( get_permalink( $post_id ) );
 
 		$before_is_amp_endpoint = is_amp_endpoint();
 

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -57,7 +57,6 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 			]
 		);
 
-		// Set global for WP<5.2 where get_the_content() doesn't take the $post parameter.
 		$this->go_to( get_permalink( $post_id ) );
 
 		$before_is_amp_endpoint = is_amp_endpoint();

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2592,7 +2592,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		return [
 			'admin_bar_included' => [
 				function () use ( $render_template ) {
-					$this->go_to( home_url() );
+					$this->go_to( amp_get_permalink( $this->factory()->post->create() ) );
 					show_admin_bar( true );
 					_wp_admin_bar_init();
 					switch_theme( 'twentyten' );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1340,6 +1340,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_wrap_widget_callbacks() {
 		global $wp_registered_widgets, $_wp_sidebars_widgets;
+		$this->go_to( amp_get_permalink( $this->factory()->post->create() ) );
 
 		$search_widget_id = 'search-2';
 		$this->assertArrayHasKey( $search_widget_id, $wp_registered_widgets );


### PR DESCRIPTION
Moved checking against is_embed() and is_feed() after
checking if parse_query has run and $wp_query has been filled, since
both these functions will fire _doing_it_wrong when $wp_query
is not yet set.

## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4525

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).

