### PR TITLE
Update tests after block-library/style.css changes in Gutenberg 7.9

### DIFF
--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2612,7 +2612,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'wp_footer',
 						function() {
 							?>
-							<div class="is-style-outline"><button class="wp-block-button__link"></button></div>
+							<div class="wp-block-calendar"></div>
 							<div class="wp-block-foo"><figcaption></figcaption></div>
 							<img src="https://example.com/example.jpg" width="100" height="200">
 							<?php
@@ -2635,7 +2635,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$this->assertStringContains( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
 					$this->assertStringContains( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
 
-					$this->assertStringContains( '.is-style-outline .wp-block-button__link', $amphtml_source, 'Expected block-library/style.css' );
+					$this->assertStringContains( '.wp-block-calendar', $amphtml_source, 'Expected block-library/style.css' );
 					$this->assertStringContains( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
 					$this->assertStringContains( 'amp-img.amp-wp-enforced-sizes', $amphtml_source, 'Expected amp-default.css' );
 					$this->assertStringContains( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2612,7 +2612,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'wp_footer',
 						function() {
 							?>
-							<div class="wp-block-calendar"></div>
+							<figure class="wp-block-audio"><figcaption></figcaption></figure>
 							<div class="wp-block-foo"><figcaption></figcaption></div>
 							<img src="https://example.com/example.jpg" width="100" height="200">
 							<?php
@@ -2635,7 +2635,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$this->assertStringContains( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
 					$this->assertStringContains( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
 
-					$this->assertStringContains( '.wp-block-calendar', $amphtml_source, 'Expected block-library/style.css' );
+					$this->assertStringContains( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
 					$this->assertStringContains( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
 					$this->assertStringContains( 'amp-img.amp-wp-enforced-sizes', $amphtml_source, 'Expected amp-default.css' );
 					$this->assertStringContains( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );


### PR DESCRIPTION
## Summary

I noticed `\AMP_Style_Sanitizer_Test::test_prioritized_stylesheets()` started failing with Gutenberg [v7.9.0-rc.1](https://github.com/WordPress/gutenberg/releases/tag/v7.9.0-rc.1) checked out. This updates the examined selector for one that appears in both the previous version of Gutenberg and the next versions.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
