### PR TITLE
For the 'Preview AMP' button, replace tooltip with title attribute

### DIFF
--- a/assets/src/block-editor/components/amp-preview.js
+++ b/assets/src/block-editor/components/amp-preview.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { Component, createRef, renderToString } from '@wordpress/element';
-import { Button, Icon, Tooltip } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -236,25 +236,23 @@ class AMPPreview extends Component {
 
 		return (
 			isEnabled && ! errorMessages.length && ! isStandardMode && (
-				<Tooltip text={ __( 'Preview AMP', 'amp' ) } >
-					<Button
-						className="amp-editor-post-preview"
-						href={ href }
-						label={ __( 'Preview AMP', 'amp' ) }
-						isSecondary
-						disabled={ ! isSaveable }
-						onClick={ this.openPreviewWindow }
-						ref={ this.buttonRef }
-					>
-						{ ampFilledIcon( { viewBox: '0 0 62 62', width: 18, height: 18 } ) }
-						<span className="screen-reader-text">
-							{
-								/* translators: accessibility text */
-								__( '(opens in a new tab)', 'amp' )
-							}
-						</span>
-					</Button>
-				</Tooltip>
+				<Button
+					className="amp-editor-post-preview"
+					href={ href }
+					title={ __( 'Preview AMP', 'amp' ) }
+					isSecondary
+					disabled={ ! isSaveable }
+					onClick={ this.openPreviewWindow }
+					ref={ this.buttonRef }
+				>
+					{ ampFilledIcon( { viewBox: '0 0 62 62', width: 18, height: 18 } ) }
+					<span className="screen-reader-text">
+						{
+							/* translators: accessibility text */
+							__( '(opens in a new tab)', 'amp' )
+						}
+					</span>
+				</Button>
 			)
 		);
 	}


### PR DESCRIPTION
## Summary
This fixes an issue where the tooltip was cut off:


![tooltip-here](https://user-images.githubusercontent.com/4063887/79400746-afafd680-7f4c-11ea-9042-a39ee2d9e2c3.png)

Now, the `<Button>` has a `title` attribute, instead of being wrapped in a `<Tooltip>`:

![rep-title-attr](https://user-images.githubusercontent.com/4063887/79531101-eeba5680-8036-11ea-8366-6411078bb0ad.png)

<!-- Please reference the issue this PR addresses. -->
Fixes #4590

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests) 
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
