### PR TITLE
Catch exceptions thrown during sanitization

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1849,7 +1849,10 @@ class AMP_Theme_Support {
 			newrelic_disable_autorum();
 		}
 
-		ob_start( [ __CLASS__, 'finish_output_buffering' ] );
+		if ( ! ob_start( [ __CLASS__, 'finish_output_buffering' ] ) ) {
+			wp_die( esc_html__( 'AMP plugin unable to start output buffering.', 'amp' ) );
+		}
+
 		self::$is_output_buffering = true;
 	}
 


### PR DESCRIPTION
## Summary

Work in progress PR to debug support topic issue: https://wordpress.org/support/topic/1-5-3-update-issues/

If an exception is thrown during the style sanitizer, for example, instead of rendering a broken AMP page the result is then a plain text response like so:

```
Failed to generate AMP version of this page.

Exception (code: 0) thrown when calling sanitize_document: bad

Stack trace:
#0 /app/public/content/plugins/amp/includes/templates/class-amp-content-sanitizer.php(121) AMP_Style_Sanitizer->sanitize()
#1 /app/public/content/plugins/amp/includes/class-amp-theme-support.php(2010) AMP_Content_Sanitizer::sanitize_document()
#2 /app/public/content/plugins/amp/includes/class-amp-theme-support.php(1880) AMP_Theme_Support::prepare_response()
#3 AMP_Theme_Support::finish_output_buffering()
#4 /app/public/core-dev/src/wp-includes/functions.php(4622) ob_end_flush
#5 /app/public/core-dev/src/wp-includes/class-wp-hook.php(287) wp_ob_end_flush_all
#6 /app/public/core-dev/src/wp-includes/class-wp-hook.php(311) WP_Hook->apply_filters()
#7 /app/public/core-dev/src/wp-includes/plugin.php(478) WP_Hook->do_action()
#8 /app/public/core-dev/src/wp-includes/load.php(960) do_action
#9 shutdown_action_hook

Original response is as follows:
...
```

The original HTML document being passed to `prepare_response` is then appended.

The exception details and stack trace are only shown if `WP_DEBUG` is enabled.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
