### PR TITLE
Fix failing tests

### DIFF
--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -41,7 +41,7 @@ class AMP_Gallery_Embed_Handler_Test extends WP_UnitTestCase {
 	 */
 	public function get_conversion_data() {
 		$amp_carousel_caption = '<span class="amp-wp-gallery-caption"><span>' . self::CAPTION_TEXT . '</span></span>';
-		$loading_attribute    = version_compare( get_bloginfo( 'version' ), '5.4', '>' ) ? 'loading="lazy"' : '';
+		$loading_attribute    = version_compare( get_bloginfo( 'version' ), '5.5', '>' ) ? 'loading="lazy"' : '';
 
 		return [
 			'shortcode_with_invalid_id'               => [

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -135,7 +135,7 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	}
 
 	public function get_conversion_data() {
-		$loading_attribute = version_compare( get_bloginfo( 'version' ), '5.4', '>' ) ? 'loading="lazy" ' : '';
+		$loading_attribute = version_compare( get_bloginfo( 'version' ), '5.5', '>' ) ? 'loading="lazy" ' : '';
 
 		return [
 			'no_embed'                         => [

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1611,7 +1611,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 				[
 					'type'     => 'core',
 					'name'     => 'wp-includes',
-					'function' => version_compare( get_bloginfo( 'version' ), '5.4', '>' ) ? 'wp_filter_content_tags' : 'wp_make_content_images_responsive',
+					'function' => version_compare( get_bloginfo( 'version' ), '5.5', '>' ) ? 'wp_filter_content_tags' : 'wp_make_content_images_responsive',
 				],
 				[
 					'type'     => 'core',


### PR DESCRIPTION
## Summary

<!-- 
Please reference the issue this PR addresses. If one doesn't exist, please 
create one and put in its description what you would have otherwise put here 
in the PR description. Do not use "Fixes" or "Closes" as the issue needs to 
remain open for QA/UAT purposes until the release is published. 
-->

Fixes the error and failures occurring while testing against latest release of WordPress (v5.4.1). Since lazy loading has been deferred to WP 5.5 some of our tests that accommodate that are now failing. 

Fixes #4641.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
