### PR TITLE
Enable SSR by default, remove use of WP_DEBUG as a signal.

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2163,7 +2163,7 @@ class AMP_Theme_Support {
 
 		$enable_ssr = array_key_exists( ConfigurationArgument::ENABLE_SSR, $args )
 			? $args[ ConfigurationArgument::ENABLE_SSR ]
-			: ! ( defined( 'WP_DEBUG' ) && WP_DEBUG );
+			: true;
 
 		/**
 		 * Filter whether the AMP Optimizer should use server-side rendering or not.


### PR DESCRIPTION
## Summary

Enable SSR by default, remove use of WP_DEBUG as a signal.

Any tests that need to be updated or added for this?

Fixes https://github.com/ampproject/amp-wp/issues/4667

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
