### PR TITLE
Raise PHPStan level to 4 in lib/common

### DIFF
--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
 	# @see https://github.com/phpstan/phpstan-src/blob/master/conf/bleedingEdge.neon
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 3
+	level: 4
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- %currentWorkingDirectory%/src/

--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -10,3 +10,7 @@ parameters:
 		- %currentWorkingDirectory%/vendor/autoload.php
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
+		-
+			message: '#^If condition is always false\.$#'
+			path: 'src/Dom/Document.php'
+			# See https://github.com/phpstan/phpstan/issues/3291

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1420,7 +1420,7 @@ final class Document extends DOMDocument
         /**
          * Main tag to keep.
          *
-         * @var DOMElement $mainTag
+         * @var DOMElement|null $mainTag
          */
         $mainTag = $tags->item(0);
 

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -847,26 +847,26 @@ final class Document extends DOMDocument
      */
     private function maybeReplaceNoscriptElements($html)
     {
-        if (! version_compare(LIBXML_DOTTED_VERSION, '2.8', '<')) {
-            return $html;
+        if (version_compare(LIBXML_DOTTED_VERSION, '2.8', '<')) {
+            $html = preg_replace_callback(
+                '#^.+?(?=<body)#is',
+                function ($headMatches) {
+                    return preg_replace_callback(
+                        '#<noscript[^>]*>.*?</noscript>#si',
+                        function ($noscriptMatches) {
+                            $placeholder = sprintf('<!--noscript:%s-->', (string)$this->rand());
+
+                            $this->noscriptPlaceholderComments[$placeholder] = $noscriptMatches[0];
+                            return $placeholder;
+                        },
+                        $headMatches[0]
+                    );
+                },
+                $html
+            );
         }
 
-        return preg_replace_callback(
-            '#^.+?(?=<body)#is',
-            function ($headMatches) {
-                return preg_replace_callback(
-                    '#<noscript[^>]*>.*?</noscript>#si',
-                    function ($noscriptMatches) {
-                        $placeholder = sprintf('<!--noscript:%s-->', (string)$this->rand());
-
-                        $this->noscriptPlaceholderComments[$placeholder] = $noscriptMatches[0];
-                        return $placeholder;
-                    },
-                    $headMatches[0]
-                );
-            },
-            $html
-        );
+        return $html;
     }
 
     /**

--- a/lib/common/src/Exception/FailedToGetFromRemoteUrl.php
+++ b/lib/common/src/Exception/FailedToGetFromRemoteUrl.php
@@ -18,7 +18,7 @@ final class FailedToGetFromRemoteUrl extends RuntimeException implements FailedR
      *
      * This is not always set.
      *
-     * @var int
+     * @var int|null
      */
     private $statusCode;
 

--- a/lib/common/src/RuntimeVersion.php
+++ b/lib/common/src/RuntimeVersion.php
@@ -78,7 +78,7 @@ final class RuntimeVersion
         $response = $this->remoteRequest->get(self::RUNTIME_METADATA_ENDPOINT);
         $statusCode = $response->getStatusCode();
 
-        if (200 < $statusCode || $statusCode >= 300) {
+        if ($statusCode < 200 || $statusCode >= 300) {
             return '0';
         }
 


### PR DESCRIPTION
## Summary
This PR fixes the following issues that PHPStan detected at level 4:

- [Document.php:850](https://github.com/ampproject/amp-wp/tree/9a8928b00d272cb6457bad3df2b9a70ec4c8174b/lib/common/src/Dom/Document.php#L850) - **Negated boolean expression is always true.** => false positive, see https://github.com/phpstan/phpstan/issues/3291, ignored via https://github.com/ampproject/amp-wp/pull/4686/commits/ba20769f3e6b3ddd7cb066e9d529426da2ccd3cc
- [Document.php:854](https://github.com/ampproject/amp-wp/tree/9a8928b00d272cb6457bad3df2b9a70ec4c8174b/lib/common/src/Dom/Document.php#L854) - **Unreachable statement - code above always terminates.** => side effect from false positive above
- [Document.php:1427](https://github.com/ampproject/amp-wp/tree/9a8928b00d272cb6457bad3df2b9a70ec4c8174b/lib/common/src/Dom/Document.php#L1427) - **Strict comparison using === between null and DOMElement will always evaluate to false.** => missing typehint, added via https://github.com/ampproject/amp-wp/pull/4686/commits/82f7b02ca1f5b73a23508cfaa0bffe20a460e619
- [FailedToGetFromRemoteUrl.php:76](https://github.com/ampproject/amp-wp/tree/9a8928b00d272cb6457bad3df2b9a70ec4c8174b/lib/common/src/Exception/FailedToGetFromRemoteUrl.php#L76) - **Property AmpProject\Exception\FailedToGetFromRemoteUrl::$statusCode (int) in isset() is not nullable.** => missing typehint, added via https://github.com/ampproject/amp-wp/pull/4686/commits/8481781ecaca6f91acb1b57a9350bb94914e9cff
- [RuntimeVersion.php:81](https://github.com/ampproject/amp-wp/tree/9a8928b00d272cb6457bad3df2b9a70ec4c8174b/lib/common/src/RuntimeVersion.php#L81) - **Comparison operation ">=" between int<min, 200> and 300 is always false.** => actual bug, fixed via https://github.com/ampproject/amp-wp/pull/4686/commits/0cda75a8081b76fb9464216b287192909ddb651c

Fixes #4379

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
