### PR TITLE
Suppress display of fatal errors during validate request

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -601,12 +601,12 @@ class AMP_Validation_Manager {
 			self::add_validation_error_sourcing();
 			self::$is_validate_request = true;
 
-			$display_errors = ini_get( 'display_errors' );
+			$display_errors = (string) ini_get( 'display_errors' );
 
-			if ( ! empty( $display_errors ) || 'stderr' !== $display_errors ) {
+			if ( '1' === $display_errors ) {
 				// Suppress the display of fatal errors that may arise during validation so that they will not be counted
 				// as actual validation errors.
-				ini_set( 'display_errors', false );
+				ini_set( 'display_errors', 0 ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Blacklisted
 			}
 		} else {
 			self::$is_validate_request = false;

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -601,9 +601,7 @@ class AMP_Validation_Manager {
 			self::add_validation_error_sourcing();
 			self::$is_validate_request = true;
 
-			$display_errors = (string) ini_get( 'display_errors' );
-
-			if ( '1' === $display_errors ) {
+			if ( '1' === (string) ini_get( 'display_errors' ) ) {
 				// Suppress the display of fatal errors that may arise during validation so that they will not be counted
 				// as actual validation errors.
 				ini_set( 'display_errors', 0 ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Blacklisted

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -600,6 +600,14 @@ class AMP_Validation_Manager {
 		if ( true === $should_validate_response ) {
 			self::add_validation_error_sourcing();
 			self::$is_validate_request = true;
+
+			$display_errors = ini_get( 'display_errors' );
+
+			if ( ! empty( $display_errors ) || 'stderr' !== $display_errors ) {
+				// Suppress the display of fatal errors that may arise during validation so that they will not be counted
+				// as actual validation errors.
+				ini_set( 'display_errors', false );
+			}
 		} else {
 			self::$is_validate_request = false;
 


### PR DESCRIPTION
## Summary

This PR suppresses the display of any fatal errors that may arise during validation. When these errors are displayed, they may be flagged as validation errors and can can give a false count of the actual state of validation errors for the page. 

Fixes #4747.

## Demo

With this [gist plugin](https://gist.github.com/pierlon/cb3dc7e78ae99ba48e377d8256de5cb5) activated:

- Additional validation errors should be reported when fatal errors are displayed:
![](https://user-images.githubusercontent.com/16200219/82392320-184e0f80-9a33-11ea-89ed-10668c77751a.png)

- Only relevant errors are reported when the display of fatal errors are suppressed:
![](https://user-images.githubusercontent.com/16200219/82392314-12f0c500-9a33-11ea-826b-af2679361338.png)

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
