### PR TITLE
Omit non-standard type attribute during <amp-iframe> normalization

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -221,7 +221,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type int $frameborder <iframe> `frameborder` attribute - Filter to '0' or '1'; default to '0'
 	 *      @type bool $allowfullscreen <iframe> `allowfullscreen` attribute - Convert 'false' to empty string ''
 	 *      @type bool $allowtransparency <iframe> `allowtransparency` attribute - Convert 'false' to empty string ''
-	 *      @type string $type <iframe> `type` attribute - Pass along if found
+	 *      @type string $type <iframe> `type` attribute - Pass along if value is not `text/html`
 	 * }
 	 * @return array Returns HTML attributes; normalizes src, dimensions, frameborder, sandbox, allowtransparency and allowfullscreen
 	 */
@@ -307,9 +307,12 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 				case 'type':
 					/*
-					 * Though type is non-standard attribute in <iframe> tag, some embeds (i.e Amazon Kindle Embed) uses
-					 * it, therefore we need to omit this.
+					 * Omit the `type` attribute if its value is `text/html`. Popular embed providers such as YouTube
+					 * and Amazon use this non-standard attribute.
 					 */
+					if ( 'text/html' !== strtolower( $value ) ) {
+						$out[ $name ] = $value;
+					}
 					break;
 
 				default:

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -221,6 +221,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type int $frameborder <iframe> `frameborder` attribute - Filter to '0' or '1'; default to '0'
 	 *      @type bool $allowfullscreen <iframe> `allowfullscreen` attribute - Convert 'false' to empty string ''
 	 *      @type bool $allowtransparency <iframe> `allowtransparency` attribute - Convert 'false' to empty string ''
+	 *      @type string $type <iframe> `type` attribute - Pass along if found
 	 * }
 	 * @return array Returns HTML attributes; normalizes src, dimensions, frameborder, sandbox, allowtransparency and allowfullscreen
 	 */
@@ -302,6 +303,13 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 				case 'data-amp-overflow-text':
 					// No need to copy.
+					break;
+
+				case 'type':
+					/*
+					 * Though type is non-standard attribute in <iframe> tag, some embeds (i.e Amazon Kindle Embed) uses
+					 * it, therefore we need to omit this.
+					 */
 					break;
 
 				default:

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -307,8 +307,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 				case 'type':
 					/*
-					 * Omit the `type` attribute if its value is `text/html`. Popular embed providers such as YouTube
-					 * and Amazon use this non-standard attribute.
+					 * Omit the `type` attribute if its value is `text/html`. Popular embed providers such as Amazon
+					 * Kindle use this non-standard attribute, which is apparently a vestige from usage on <object>.
 					 */
 					if ( 'text/html' !== strtolower( $value ) ) {
 						$out[ $name ] = $value;

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -476,6 +476,16 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					</amp-iframe>',
 			],
 
+			'iframe_with_type_html_attr' => [
+				'<iframe type="text/html" src="https://example.com" width="320" height="640"></iframe>',
+				'
+					<amp-iframe src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>',
+			],
+
 			'iframe_with_marginheight_and_marginwidth_attrs' => [
 				'<iframe marginwidth="0" marginheight="0" src="https://example.com" width="320" height="640"></iframe>',
 				'


### PR DESCRIPTION
## Summary

- Omit non-standard `type` attribute  during `<amp-iframe>` normalization

Fixes #4758

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
