### PR TITLE
Make amp_get_current_url() more robust

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -384,13 +384,32 @@ function amp_get_slug() {
  * @return string Current URL.
  */
 function amp_get_current_url() {
-	$url = preg_replace( '#(^https?://[^/]+)/.*#', '$1', home_url( '/' ) );
-	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$url = esc_url_raw( $url . wp_unslash( $_SERVER['REQUEST_URI'] ) );
-	} else {
-		$url .= '/';
+	$parsed_url = wp_parse_url( home_url() );
+	if ( empty( $parsed_url['scheme'] ) ) {
+		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}
-	return $url;
+	if ( ! isset( $parsed_url['host'] ) ) {
+		$parsed_url['host'] = wp_unslash( $_SERVER['HTTP_HOST'] );
+	}
+
+	$current_url = $parsed_url['scheme'] . '://';
+	if ( isset( $parsed_url['user'] ) ) {
+		$current_url .= $parsed_url['user'];
+		if ( isset( $parsed_url['pass'] ) ) {
+			$current_url .= ':' . $parsed_url['pass'];
+		}
+		$current_url .= '@';
+	}
+	$current_url .= $parsed_url['host'];
+	if ( isset( $parsed_url['port'] ) ) {
+		$current_url .= ':' . $parsed_url['port'];
+	}
+	$current_url .= '/';
+
+	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		$current_url .= ltrim( wp_unslash( $_SERVER['REQUEST_URI'] ), '/' );
+	}
+	return esc_url_raw( $current_url );
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -385,6 +385,9 @@ function amp_get_slug() {
  */
 function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );
+	if ( ! is_array( $parsed_url ) ) {
+		$parsed_url = [];
+	}
 	if ( empty( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -130,6 +130,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 			'ip_host'                     => function () {
 				$this->set_home_url_with_filter( 'http://127.0.0.1:1234' );
+				$this->go_to( '/' );
 				$this->assertEquals( 'http://127.0.0.1:1234/', amp_get_current_url() );
 			},
 

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -25,6 +25,21 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	const MOCK_SITE_ICON = 'https://example.com/new-site-icon.jpg';
 
 	/**
+	 * Backup of $_SERVER.
+	 *
+	 * @var array
+	 */
+	private $server_var_backup;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->server_var_backup = $_SERVER;
+	}
+
+	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
 	public function tearDown() {
@@ -34,6 +49,13 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$wp_scripts     = null;
 		$show_admin_bar = null;
 		$pagenow        = 'index.php'; // Since clean_up_global_scope() doesn't.
+		$_SERVER        = $this->server_var_backup;
+
+		global $wp_rewrite;
+		delete_option( 'permalink_structure' );
+		$wp_rewrite->use_trailing_slashes = true;
+		$wp_rewrite->init();
+		$wp_rewrite->flush_rules();
 
 		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
 			foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $block ) {
@@ -72,29 +94,103 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Get data for testing amp_get_current_url().
+	 *
+	 * @return array
+	 */
+	public function get_amp_get_current_url_test_data() {
+		$assertions = [
+			'path'                        => function () {
+				$_SERVER['REQUEST_URI'] = wp_slash( '/foo/' );
+				$this->assertEquals(
+					home_url( '/foo/' ),
+					amp_get_current_url()
+				);
+			},
+
+			'query'                       => function () {
+				$_SERVER['REQUEST_URI'] = wp_slash( '/bar/?baz=1' );
+				$this->assertEquals(
+					home_url( '/bar/?baz=1' ),
+					amp_get_current_url()
+				);
+			},
+
+			'permalink'                   => function () {
+				global $wp_rewrite;
+				update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+				$wp_rewrite->use_trailing_slashes = true;
+				$wp_rewrite->init();
+				$wp_rewrite->flush_rules();
+
+				$permalink = get_permalink( $this->factory()->post->create() );
+
+				$this->go_to( $permalink );
+				$this->assertEquals( $permalink, amp_get_current_url() );
+			},
+
+			'unset_request_uri'           => function () {
+				unset( $_SERVER['REQUEST_URI'] );
+				$this->assertEquals( home_url( '/' ), amp_get_current_url() );
+			},
+
+			'empty_request_uri'           => function () {
+				$_SERVER['REQUEST_URI'] = '';
+				$this->assertEquals( home_url( '/' ), amp_get_current_url() );
+			},
+
+			'no_slash_prefix_request_uri' => function () {
+				$_SERVER['REQUEST_URI'] = 'foo/';
+				$this->assertEquals( home_url( '/foo/' ), amp_get_current_url() );
+			},
+
+			'reconstructed_home_url'      => function () {
+				$_SERVER['HTTPS']       = 'on';
+				$_SERVER['REQUEST_URI'] = '/about/';
+				$_SERVER['HTTP_HOST']   = 'foo.example.org';
+				add_filter(
+					'home_url',
+					static function() {
+						return '/';
+					}
+				);
+				$this->assertEquals(
+					'https://foo.example.org/about/',
+					amp_get_current_url()
+				);
+			},
+
+			'home_url_with_trimmings'     => function () {
+				add_filter(
+					'home_url',
+					static function() {
+						return 'https://user:pass@example.museum:8080';
+					}
+				);
+				$_SERVER['REQUEST_URI'] = '/about/';
+				$this->assertEquals(
+					'https://user:pass@example.museum:8080/about/',
+					amp_get_current_url()
+				);
+			},
+		];
+		return array_map(
+			function ( $assertion ) {
+				return [ $assertion ];
+			},
+			$assertions
+		);
+	}
+
+	/**
 	 * Test amp_get_current_url().
 	 *
+	 * @param callable $assert Assert.
+	 * @dataProvider get_amp_get_current_url_test_data
 	 * @covers ::amp_get_current_url()
 	 */
-	public function test_amp_get_current_url() {
-		$request_uris = [
-			'/foo',
-			'/bar?baz',
-			null,
-		];
-
-		foreach ( $request_uris as $request_uri ) {
-			if ( $request_uri ) {
-				$_SERVER['REQUEST_URI'] = wp_slash( $request_uri );
-			} else {
-				unset( $_SERVER['REQUEST_URI'] );
-			}
-			$this->assertEquals(
-				home_url( $request_uri ?: '/' ),
-				amp_get_current_url(),
-				sprintf( 'Unexpected for URI: %s', wp_json_encode( $request_uri, 64 /* JSON_UNESCAPED_SLASHES */ ) )
-			);
-		}
+	public function test_amp_get_current_url( $assert ) {
+		call_user_func( $assert );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

See https://wordpress.org/support/topic/amphtml-missing-a-slash-after-site-url/

When a site is manipulating its `home_url` or `REQUEST_URI` in unexpected ways, the `amp_get_current_url()` function can return an erroneous URL. This PR attempts to make the function much more robust and resilient.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
