### PR TITLE
Remove the `wp-has-aspect-ratio` class from block embeds

### DIFF
--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -47,22 +47,20 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			// Remove classes pertaining to aspect ratios as the embed's responsiveness will be handled by AMP's layout system.
-			if ( in_array( 'wp-has-aspect-ratio', $classes, true ) ) {
-				$classes = array_diff( $classes, [ 'wp-has-aspect-ratio' ] );
-			}
-
 			$responsive_width  = null;
 			$responsive_height = null;
 
-			$classes = preg_replace_callback(
-				'/wp-embed-aspect-(?P<width>\d+)-(?P<height>\d+)/',
-				static function ( $matches ) use ( &$responsive_width, &$responsive_height ) {
-					$responsive_width  = $matches['width'];
-					$responsive_height = $matches['height'];
-					return '';
-				},
-				$classes
+			// Remove classes related to aspect ratios as the embed's responsiveness will be handled by AMP's layout system.
+			$classes = array_filter(
+				$classes,
+				static function ( $class ) use ( &$responsive_width, &$responsive_height ) {
+					if ( preg_match( '/^wp-embed-aspect-(?P<width>\d+)-(?P<height>\d+)$/', $class, $matches ) ) {
+						$responsive_width  = $matches['width'];
+						$responsive_height = $matches['height'];
+						return false;
+					}
+					return 'wp-has-aspect-ratio' !== $class;
+				}
 			);
 
 			$node->setAttribute( 'class', implode( ' ', array_filter( $classes ) ) );

--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -41,26 +41,31 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 
 			// We are only looking for <figure> elements which have wp-block-embed as class.
-			$class = (string) $node->getAttribute( 'class' );
-			if ( false === strpos( $class, 'wp-block-embed' ) ) {
+			$classes = preg_split( '/\s+/', trim( $node->getAttribute( 'class' ) ) );
+
+			if ( ! in_array( 'wp-block-embed', $classes, true ) ) {
 				continue;
 			}
 
-			// Remove classes like wp-embed-aspect-16-9 since responsive layout is handled by AMP's layout system.
+			// Remove classes pertaining to aspect ratios as the embed's responsiveness will be handled by AMP's layout system.
+			if ( in_array( 'wp-has-aspect-ratio', $classes, true ) ) {
+				$classes = array_diff( $classes, [ 'wp-has-aspect-ratio' ] );
+			}
+
 			$responsive_width  = null;
 			$responsive_height = null;
-			$node->setAttribute(
-				'class',
-				preg_replace_callback(
-					'/(?<=^|\s)wp-embed-aspect-(?P<width>\d+)-(?P<height>\d+)(?=\s|$)/',
-					function ( $matches ) use ( &$responsive_width, &$responsive_height ) {
-						$responsive_width  = $matches['width'];
-						$responsive_height = $matches['height'];
-						return '';
-					},
-					$class
-				)
+
+			$classes = preg_replace_callback(
+				'/wp-embed-aspect-(?P<width>\d+)-(?P<height>\d+)/',
+				static function ( $matches ) use ( &$responsive_width, &$responsive_height ) {
+					$responsive_width  = $matches['width'];
+					$responsive_height = $matches['height'];
+					return '';
+				},
+				$classes
 			);
+
+			$node->setAttribute( 'class', implode( ' ', array_filter( $classes ) ) );
 
 			// We're looking for <figure> elements that have one child node only.
 			if ( 1 !== count( $node->childNodes ) ) {

--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -63,7 +63,7 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			);
 
-			$node->setAttribute( 'class', implode( ' ', array_filter( $classes ) ) );
+			$node->setAttribute( 'class', implode( ' ', $classes ) );
 
 			// We're looking for <figure> elements that have one child node only.
 			if ( 1 !== count( $node->childNodes ) ) {

--- a/tests/php/test-class-amp-block-sanitizer.php
+++ b/tests/php/test-class-amp-block-sanitizer.php
@@ -24,7 +24,7 @@ class AMP_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'more_than_one_child'  => [
 				'<figure class="wp-block-embed wp-embed-aspect-16-9 wp-has-aspect-ratio"><amp-facebook></amp-facebook><amp-facebook></amp-facebook></figure>',
-				'<figure class="wp-block-embed  wp-has-aspect-ratio"><amp-facebook></amp-facebook><amp-facebook></amp-facebook></figure>',
+				'<figure class="wp-block-embed"><amp-facebook></amp-facebook><amp-facebook></amp-facebook></figure>',
 			],
 
 			'no_wp_block_embed'    => [
@@ -44,7 +44,7 @@ class AMP_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'responsive_layout'    => [
 				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="640" layout="responsive"></amp-soundcloud></div></figure>',
-				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud  wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="3" width="4" layout="responsive"></amp-soundcloud></div></figure>',
+				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="3" width="4" layout="responsive"></amp-soundcloud></div></figure>',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

As of Gutenberg 8.2, when the `wp-has-aspect-ratio` class is set on an embed block, it adds a large gap to the top of the embed. This breaks the visual parity of the AMP page when compared to its non-AMP counterpart. For example:

![](https://user-images.githubusercontent.com/16200219/83850389-5f5d2580-a700-11ea-98dc-cd57c13eeda3.png)

The `wp-has-aspect-ratio` class is not needed in the AMP context because the responsive layout of the embed will be handled natively. When the class is removed, visual parity is restored:

![image](https://user-images.githubusercontent.com/16200219/83850687-cbd82480-a700-11ea-8ab2-5898b4740d72.png)

<!-- Please reference the issue this PR addresses. -->
Fixes #4810

Related: #1683

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
