### PR TITLE
Update amphtml validator spec to v2005150002001

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1043;
+	private static $spec_file_revision = 1045;
 	private static $minimum_validator_revision_required = 455;
 
 	private static $descendant_tag_lists = array(
@@ -3884,6 +3884,11 @@ class AMP_Allowed_Tags_Generated {
 		'amp-jwplayer' => array(
 			array(
 				'attr_spec_list' => array(
+					'autoplay' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'data-media-id' => array(
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
@@ -3893,6 +3898,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'data-playlist-id' => array(
 						'value_regex_casei' => '[0-9a-z]{8}',
+					),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
 					),
 				),
 				'tag_spec' => array(
@@ -3913,6 +3923,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-jwplayer',
 					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-jwplayer',
 				),
 			),
 		),


### PR DESCRIPTION
Previously #4701.

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [ ] ~Update spec generator as needed based on spec format changes.~
- [ ] ~Modify validating sanitizer based on changes to spec, if needed.~
- [ ] ~Add tests for key changes.~

# Changelog

* Add `autoplay` and `dock` to `amp-jwplayer`.

# Details

```bash
(
    PREV_VERSION=2005050322002;
    THIS_VERSION=2005150002001; 
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details>
<summary>2005050322002...2005150002001</summary>

```diff
diff --git a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
index 600dd84eb..a87bb3739 100644
--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
@@ -30,6 +30,10 @@ tags: {  # <amp-jwplayer>
   html_format: AMP
   tag_name: "AMP-JWPLAYER"
   requires_extension: "amp-jwplayer"
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
   attrs: {
     name: "data-media-id"
     mandatory_oneof: "['data-media-id', 'data-playlist-id']"
@@ -45,6 +49,10 @@ tags: {  # <amp-jwplayer>
     mandatory_oneof: "['data-media-id', 'data-playlist-id']"
     value_regex_casei: "[0-9a-z]{8}"
   }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -53,4 +61,5 @@ tags: {  # <amp-jwplayer>
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
+  spec_url: "https://amp.dev/documentation/components/amp-jwplayer"
 }
diff --git a/validator/validator-css.protoascii b/validator/validator-css.protoascii
index 8de8067ba..4526ac62f 100644
--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -217,6 +217,7 @@ declaration_list {
   declaration: { name: "text-decoration" }
   declaration: { name: "text-decoration-color" }
   declaration: { name: "text-decoration-line" }
+  declaration: { name: "text-decoration-skip-ink" }
   declaration: { name: "text-decoration-style" }
   declaration: { name: "text-fill-color" }
   declaration: { name: "text-indent" }
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index db8f115ba..4adc1df00 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 455
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1043
+spec_file_revision: 1045
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
```

</details>