### PR TITLE
Split dev and prod builds into two different jobs

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
-          path: builds
+          path: builds/dev
 
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -149,7 +149,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
-          path: builds
+          path: builds/prod
 
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -160,11 +160,17 @@ jobs:
       - dev-zip
       - prod-zip
     steps:
-      - name: Download artifacts
+      - name: Download dev build
         uses: actions/download-artifact@v2
         with:
-          name: amp-${{ needs.release-zip.outputs.branch-name }}-${{ needs.release-zip.outputs.git-sha-8 }}
-          path: builds
+          name: amp-${{ needs.dev-zip.outputs.branch-name }}-${{ needs.dev-zip.outputs.git-sha-8 }}
+          path: builds/dev
+
+      - name: Download prod build
+        uses: actions/download-artifact@v2
+        with:
+          name: amp-${{ needs.prod-zip.outputs.branch-name }}-${{ needs.prod-zip.outputs.git-sha-8 }}
+          path: builds/prod
 
       - name: Setup Google Cloud SDK
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -178,8 +178,11 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT_ID }}
           service_account_key: ${{ secrets.GCS_APPLICATION_CREDENTIALS }}
 
-      - name: Upload artifacts to bucket
-        run: gsutil cp -r builds/* gs://ampwp_github_artifacts/${{ github.ref }}
+      - name: Upload dev build to bucket
+        run: gsutil cp -r builds/dev/amp.zip gs://ampwp_github_artifacts/${{ github.ref }}/dev/amp.zip
+
+      - name: Upload prod build to bucket
+        run: gsutil cp -r builds/prod/amp.zip gs://ampwp_github_artifacts/${{ github.ref }}/prod/amp.zip
 
 #-----------------------------------------------------------------------------------------------------------------------
 

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -10,8 +10,9 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
-  release-zip:
-    name: Build plugin ZIPs and upload them as GHA artifact
+
+  dev-zip:
+    name: Build dev build ZIP and upload as GHA artifact
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
@@ -58,12 +59,78 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Create destination directories
-        run: mkdir -p builds/{dev,prod}
+        run: mkdir -p builds/dev
 
       - name: Build develop version
         run: |
           npm run build:dev
           mv amp.zip builds/dev/amp.zip
+
+      - name: Retrieve branch name
+        id: retrieve-branch-name
+        run: echo "::set-output name=branch_name::$(REF=${GITHUB_HEAD_REF:-$GITHUB_REF} && echo ${REF#refs/heads/} | sed 's/\//-/g')"
+
+      - name: Retrieve git SHA-8 string
+        id: retrieve-git-sha-8
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
+      - name: Upload build as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
+          path: builds
+
+#-----------------------------------------------------------------------------------------------------------------------
+
+  prod-zip:
+    name: Build prod build ZIP and upload as GHA artifact
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}
+      git-sha-8: ${{ steps.retrieve-git-sha-8.outputs.sha8 }}
+
+    steps:
+      - name: Check out source files
+        uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Configure Composer cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        # Scripts are not ignored as they are needed to apply patches for the
+        # `sabberworm/php-css-parser` dependency.
+        run: composer install --prefer-dist --optimize-autoloader
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Configure npm cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Node dependencies
+        # Prevent malicious scripts from being run with `--ignore-scripts`
+        run: npm install --ignore-scripts
+
+      - name: Create destination directories
+        run: mkdir -p builds/prod
 
       - name: Build production version
         run: |
@@ -78,16 +145,20 @@ jobs:
         id: retrieve-git-sha-8
         run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-      - name: Upload artifacts
+      - name: Upload build as artifact
         uses: actions/upload-artifact@v2
         with:
           name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
           path: builds
 
+#-----------------------------------------------------------------------------------------------------------------------
+
   upload-to-gcs:
     name: Upload plugin ZIPs to Google Cloud Storage
     runs-on: ubuntu-latest
-    needs: release-zip
+    needs:
+      - dev-zip
+      - prod-zip
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v2
@@ -103,6 +174,8 @@ jobs:
 
       - name: Upload artifacts to bucket
         run: gsutil cp -r builds/* gs://ampwp_github_artifacts/${{ github.ref }}
+
+#-----------------------------------------------------------------------------------------------------------------------
 
   comment-on-pr:
     name: Comment on PR with links to plugin ZIPs

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload build as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
+          name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}-dev
           path: builds/dev
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -148,7 +148,7 @@ jobs:
       - name: Upload build as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}
+          name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}-prod
           path: builds/prod
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -163,13 +163,13 @@ jobs:
       - name: Download dev build
         uses: actions/download-artifact@v2
         with:
-          name: amp-${{ needs.dev-zip.outputs.branch-name }}-${{ needs.dev-zip.outputs.git-sha-8 }}
+          name: amp-${{ needs.dev-zip.outputs.branch-name }}-${{ needs.dev-zip.outputs.git-sha-8 }}-dev
           path: builds/dev
 
       - name: Download prod build
         uses: actions/download-artifact@v2
         with:
-          name: amp-${{ needs.prod-zip.outputs.branch-name }}-${{ needs.prod-zip.outputs.git-sha-8 }}
+          name: amp-${{ needs.prod-zip.outputs.branch-name }}-${{ needs.prod-zip.outputs.git-sha-8 }}-prod
           path: builds/prod
 
       - name: Setup Google Cloud SDK


### PR DESCRIPTION
## Summary

This PR splits the `release-zip` job into two separate jobs: `dev-zip` & `prod-zip`. This way, the main work of running `npm run build` is done in parallel for the two builds and saves time for the subsequent jobs.

Fixes #4830

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
