### PR TITLE
Prevent printing styles for Site Health on every admin page

### DIFF
--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -29,7 +29,7 @@ final class SiteHealth {
 		add_filter( 'site_status_tests', [ $this, 'add_tests' ] );
 		add_filter( 'debug_information', [ $this, 'add_debug_information' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
-		add_action( 'admin_print_styles', [ $this, 'add_styles' ] );
+		add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
 
 		( new ReenableCssTransientCachingAjaxAction() )->register();
 	}

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -55,6 +55,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'site_status_tests', [ $this->instance, 'add_tests' ] ) );
 		$this->assertEquals( 10, has_action( 'debug_information', [ $this->instance, 'add_debug_information' ] ) );
 		$this->assertEquals( 10, has_action( 'site_status_test_php_modules', [ $this->instance, 'add_extensions' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_print_styles-site-health.php', [ $this->instance, 'add_styles' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4643.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
