### PR TITLE
Base64-encode Sizer SVG files

### DIFF
--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -646,7 +646,13 @@ final class ServerSideRendering implements Transformer
         $height_int = (int) $height->getNumeral();
         $width_int  = (int) $width->getNumeral();
 
-        $sizer_img->setAttribute(Attribute::SRC, "data:image/svg+xml;charset=utf-8,<svg height=&quot;{$height_int}&quot; width=&quot;{$width_int}&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>");
+        $sizer_img->setAttribute(
+            Attribute::SRC,
+            sprintf(
+                'data:image/svg+xml;base64,%s',
+                base64_encode("<svg height='{$height_int}' width='{$width_int}' xmlns='http://www.w3.org/2000/svg' version='1.1'/>")
+            )
+        );
 
         $sizer->appendChild($sizer_img);
 

--- a/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
+++ b/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
@@ -272,13 +272,13 @@ final class ServerSideRenderingTest extends TestCase
             // @todo Remove floor when ampproject/amphtml#27528 is resolved.
             'decimal dimensions intrinsic closer to floor' => [
                 $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic"></amp-img>'),
-                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
+                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9JzEwMCcgd2lkdGg9JzIwMCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB2ZXJzaW9uPScxLjEnLz4="></i-amphtml-sizer></amp-img>'),
             ],
 
             // @todo Remove floor when ampproject/amphtml#27528 is resolved.
             'decimal dimensions intrinsic closer to ceiling' => [
                 $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic"></amp-img>'),
-                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
+                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9JzEwMCcgd2lkdGg9JzIwMCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB2ZXJzaW9uPScxLjEnLz4="></i-amphtml-sizer></amp-img>'),
             ],
 
             'media attribute without amp-custom' => [


### PR DESCRIPTION
## Summary

use base64-encoding for generating sizer SVG images in the `ServerSideRendering` transformer.

This makes the sizer elements more robust against HTML minification.

Fixes #4491

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
