### PR TITLE
Revert decimal image size hotfix

### DIFF
--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -639,14 +639,7 @@ final class ServerSideRendering implements Transformer
         $sizer_img->setAttribute(Attribute::CLASS_, Amp::INTRINSIC_SIZER_ELEMENT);
         $sizer_img->setAttribute(Attribute::ROLE, Role::PRESENTATION);
 
-        // Temporarily cast decimal dimensions to integers. Can be reverted when/if the AMP Validator allows decimals.
-        // Note that the floor value is used because two elements with width=99.5 in a container 199px-wide will not fit
-        // on the same line if rounding is used.
-        // @todo Revisit after <https://github.com/ampproject/amphtml/issues/27528>.
-        $height_int = (int) $height->getNumeral();
-        $width_int  = (int) $width->getNumeral();
-
-        $sizer_img->setAttribute(Attribute::SRC, "data:image/svg+xml;charset=utf-8,<svg height=&quot;{$height_int}&quot; width=&quot;{$width_int}&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>");
+        $sizer_img->setAttribute(Attribute::SRC, "data:image/svg+xml;charset=utf-8,<svg height=&quot;{$height->getNumeral()}&quot; width=&quot;{$width->getNumeral()}&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>");
 
         $sizer->appendChild($sizer_img);
 

--- a/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
+++ b/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
@@ -269,18 +269,6 @@ final class ServerSideRenderingTest extends TestCase
                 ],
             ],
 
-            // @todo Remove floor when ampproject/amphtml#27528 is resolved.
-            'decimal dimensions intrinsic closer to floor' => [
-                $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic"></amp-img>'),
-                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
-            ],
-
-            // @todo Remove floor when ampproject/amphtml#27528 is resolved.
-            'decimal dimensions intrinsic closer to ceiling' => [
-                $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic"></amp-img>'),
-                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
-            ],
-
             'media attribute without amp-custom' => [
                 $input('<amp-img height="355" layout="fixed" media="(min-width: 650px)" src="wide.jpg" width="466"></amp-img>'),
                 $expectWithoutBoilerplate(


### PR DESCRIPTION
## Summary

Revert the hotfix for the issue with decimal image sizes described at #4493.

Fixes #4863

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
