### PR TITLE
Replace deprecated PHPStan autoload_files option

### DIFF
--- a/lib/optimizer/phpstan.neon.dist
+++ b/lib/optimizer/phpstan.neon.dist
@@ -5,6 +5,4 @@ parameters:
 	level: 4
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
-		- %currentWorkingDirectory%/src/
-	autoload_files:
-		- %currentWorkingDirectory%/vendor/autoload.php
+		- src/


### PR DESCRIPTION
## Summary

This PR removes the deprecated `autoload_files` option. No further changes were needed for the `ampproject/optimizer` library.

Fixes #4865

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
