### PR TITLE
Remove deprecated PHPStan autoload_files option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "extra": {
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b703c50fcadc75ea79c37c2f88a0bec7",
+    "content-hash": "be1aab0c1b2b2e620c2db83d99cc3dcd",
     "packages": [
         {
             "name": "ampproject/common",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "lib/common",
-                "reference": "799ee515d198b4b778d1aa56b2e2502da6d6db92"
+                "reference": "9ada7ae0569dc2d0544867c74d3a18e1408ec916"
             },
             "require": {
                 "ext-dom": "*",
@@ -71,7 +71,7 @@
                     "@analyze"
                 ],
                 "analyze": [
-                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi"
+                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi"
                 ],
                 "unit": [
                     "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
@@ -92,7 +92,7 @@
             "dist": {
                 "type": "path",
                 "url": "lib/optimizer",
-                "reference": "9c751f93bbdbdfde6d995bd1f4c825fd11dbbb35"
+                "reference": "f9c39e52ece00ea8fb3bd6a1d60d662847f2715e"
             },
             "require": {
                 "ampproject/common": "^1",
@@ -156,7 +156,7 @@
                     "@analyze"
                 ],
                 "analyze": [
-                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi"
+                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan version; phpstan analyze --ansi; fi"
                 ],
                 "unit": [
                     "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
@@ -590,16 +590,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.4.0",
+            "version": "v5.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "baab62405f6a6ac9b25ed3fe6df371d090f9bc0c"
+                "reference": "38b0963698ca5858658a5b09198062411f22932a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/baab62405f6a6ac9b25ed3fe6df371d090f9bc0c",
-                "reference": "baab62405f6a6ac9b25ed3fe6df371d090f9bc0c",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/38b0963698ca5858658a5b09198062411f22932a",
+                "reference": "38b0963698ca5858658a5b09198062411f22932a",
                 "shasum": ""
             },
             "replace": {
@@ -626,7 +626,7 @@
                 "static analysis",
                 "wordpress"
             ],
-            "time": "2020-03-31T21:58:11+00:00"
+            "time": "2020-06-11T14:56:54+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "885e8b1e0bc2096989fd20938342e407e8045186"
+                "reference": "499fb201e495ef0064da064f520c845d3638fe24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/885e8b1e0bc2096989fd20938342e407e8045186",
-                "reference": "885e8b1e0bc2096989fd20938342e407e8045186",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/499fb201e495ef0064da064f520c845d3638fe24",
+                "reference": "499fb201e495ef0064da064f520c845d3638fe24",
                 "shasum": ""
             },
             "conflict": {
@@ -808,13 +808,14 @@
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
                 "amphp/artax": "<1.0.6|>=2,<2.0.6",
                 "amphp/http": "<1.0.1",
+                "amphp/http-client": ">=4,<4.4",
                 "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
                 "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
-                "bolt/bolt": "<3.6.10",
+                "bolt/bolt": "<3.7.1",
                 "brightlocal/phpwhois": "<=4.2.5",
                 "buddypress/buddypress": "<5.1.2",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
@@ -840,10 +841,10 @@
                 "doctrine/mongodb-odm": ">=1,<1.0.2",
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
-                "dolibarr/dolibarr": "<=10.0.6",
+                "dolibarr/dolibarr": "<11.0.4",
                 "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=7,<7.69|>=8,<8.7.12|>=8.8,<8.8.4",
-                "drupal/drupal": ">=7,<7.69|>=8,<8.7.12|>=8.8,<8.8.4",
+                "drupal/core": ">=7,<7.70|>=8,<8.7.14|>=8.8,<8.8.6",
+                "drupal/drupal": ">=7,<7.70|>=8,<8.7.14|>=8.8,<8.8.6",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
@@ -853,8 +854,9 @@
                 "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
                 "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2",
+                "ezsystems/ezplatform-kernel": ">=1,<1.0.2.1",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
-                "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.1|>=6,<6.7.9.1|>=6.8,<6.13.6.2|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.6.2",
+                "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.2|>=6,<6.7.9.1|>=6.8,<6.13.6.3|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.7.1",
                 "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.1|>=2011,<2017.12.7.2|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.4.2",
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
                 "ezyang/htmlpurifier": "<4.1.1",
@@ -892,6 +894,7 @@
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/october": ">=1.0.319,<1.0.466",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "openid/php-openid": "<2.3",
@@ -903,7 +906,8 @@
                 "paypal/merchant-sdk-php": "<3.12",
                 "pear/archive_tar": "<1.4.4",
                 "phpfastcache/phpfastcache": ">=5,<5.0.13",
-                "phpmailer/phpmailer": ">=5,<5.2.27|>=6,<6.0.6",
+                "phpmailer/phpmailer": "<6.1.6",
+                "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<4.9.2",
                 "phpoffice/phpexcel": "<1.8.2",
                 "phpoffice/phpspreadsheet": "<1.8",
@@ -918,6 +922,7 @@
                 "propel/propel": ">=2-alpha.1,<=2-alpha.7",
                 "propel/propel1": ">=1,<=1.7.1",
                 "pusher/pusher-php-server": "<2.2.1",
+                "rainlab/debugbar-plugin": "<3.1",
                 "robrichards/xmlseclibs": "<3.0.4",
                 "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
                 "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
@@ -1066,7 +1071,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-16T00:00:31+00:00"
+            "time": "2020-06-17T06:37:54+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/includes/class-amp-comment-walker.php
+++ b/includes/class-amp-comment-walker.php
@@ -81,10 +81,11 @@ class AMP_Comment_Walker extends Walker_Comment {
 	 * @param int          $max_depth The maximum hierarchical depth.
 	 * @param int          $page_num The specific page number, beginning with 1.
 	 * @param int          $per_page Per page counter.
+	 * @param mixed        ...$args  Optional additional arguments.
 	 *
 	 * @return string XHTML of the specified page of elements.
 	 */
-	public function paged_walk( $elements, $max_depth, $page_num, $per_page ) {
+	public function paged_walk( $elements, $max_depth, $page_num, $per_page, ...$args ) {
 		if ( empty( $elements ) || $max_depth < -1 ) {
 			return '';
 		}

--- a/lib/common/composer.json
+++ b/lib/common/composer.json
@@ -58,7 +58,7 @@
       "@cs",
       "@analyze"
     ],
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi",
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi",
     "unit": "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
   }
 }

--- a/lib/common/composer.json
+++ b/lib/common/composer.json
@@ -32,7 +32,7 @@
     },
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -8,7 +8,3 @@ parameters:
 		- src/
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
-		-
-			message: '#^If condition is always false\.$#'
-			path: 'src/Dom/Document.php'
-			# See https://github.com/phpstan/phpstan/issues/3291

--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -5,9 +5,7 @@ parameters:
 	level: 4
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
-		- %currentWorkingDirectory%/src/
-	autoload_files:
-		- %currentWorkingDirectory%/vendor/autoload.php
+		- src/
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
 		-

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -71,7 +71,7 @@
       "@cs",
       "@analyze"
     ],
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi",
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan version; phpstan analyze --ansi; fi",
     "unit": "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi",
     "update-test-specs":  "rm -rf tests/spec && bin/sync-amp-toolbox-test-suite.php"
   }

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -71,7 +71,7 @@
       "@cs",
       "@analyze"
     ],
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan version; phpstan analyze --ansi; fi",
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi",
     "unit": "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi",
     "update-test-specs":  "rm -rf tests/spec && bin/sync-amp-toolbox-test-suite.php"
   }

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -33,7 +33,7 @@
     },
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,3 +25,7 @@ parameters:
 	ignoreErrors:
 		# Uses func_get_args()
 		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+		# Missing declaration in PHPStan/PHPStorm stubs
+		# See https://github.com/phpstan/phpstan/issues/3492
+		# and https://github.com/JetBrains/phpstorm-stubs/pull/845
+		- '#^Access to an undefined property DOMNamedNodeMap::\$length.$#'


### PR DESCRIPTION
## Summary

This PR makes the following changes:
- Removes the `autoload_files` option from `lib/common`
- Removes the exception that is not needed anymore due to being fixed upstream via https://github.com/phpstan/phpstan-src/pull/203
- Adds PHPStan version output to the test scripts to check the version in CI output.
- Fixes issues across the codebase that the latest version of PHPStan found.
- Adds an exception for an issue that is yet to be fixed upstream: https://github.com/phpstan/phpstan/issues/3492 => https://github.com/JetBrains/phpstorm-stubs/pull/845

~Currently blocked by upstream bugs:~
~https://github.com/phpstan/phpstan/issues/3477~
~https://github.com/phpstan/phpstan/issues/3478~
(fixed in upstream, and current PR pulls latest `master` from PHPStan while we wait for a release)

Fixes #4865

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
