### PR TITLE
Add PHP 8 as a build job on Travis; bump some jobs up to PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# Using trusty instead of precise because we don't need PHP 5.2 or 5.3 anymore.
-dist: trusty
+dist: xenial
 
 addons:
   apt:
@@ -169,9 +168,7 @@ jobs:
     - name: Libraries that are meant to be externalized (7.4)
       php: "7.4"
       before_script:
-        - |
-          phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
-          echo "extension = zip.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        - phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
       install:
         - composer --working-dir=lib/common install
         - composer --working-dir=lib/optimizer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ jobs:
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
     # PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)
     - env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 RUN_PHPUNIT_COVERAGE=1
-    # PHP unit tests (7.4, WordPress trunk)
+    # PHP unit tests (8.0, WordPress trunk)
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
-      php: 7.4snapshot
+      php: nightly
   include:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)
@@ -134,12 +134,8 @@ jobs:
       php: "5.6"
       env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_SUITE=external-http
 
-    - name: PHP unit tests (7.3, WordPress trunk)
-      php: "7.3"
-      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
-
-    - name: PHP unit tests (7.4, WordPress trunk)
-      php: "7.4snapshot"
+    - name: PHP unit tests (8.0, WordPress trunk)
+      php: "nightly"
       env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
 
     - name: PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: php
 
 dist: xenial
 
+services:
+  - mysql
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
   include:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)
-      php: "7.3"
+      php: "7.4"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpsyntax
       before_script:
         - phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
@@ -82,7 +82,7 @@ jobs:
 
     - stage: analyze
       name: Static analysis (PHP)
-      php: "7.3"
+      php: "7.4"
       install:
         - composer install
       script:
@@ -90,14 +90,14 @@ jobs:
 
     - stage: test
       name: JavaScript unit tests
-      php: "7.3"
+      php: "7.4"
       env: WP_VERSION=latest DEV_LIB_SKIP=phpcs,eslint,xmllint,phpsyntax,phpunit
       script:
         - source "$DEV_LIB_PATH/travis.script.sh"
         - npm run test:js -- --ci --cacheDirectory="$HOME/.jest-cache"
 
     - name: E2E tests
-      php: "7.3"
+      php: "7.4"
       env: WP_VERSION=latest DEV_LIB_SKIP=phpcs,eslint,xmllint,phpsyntax,phpunit
       install:
         - nvm install
@@ -110,9 +110,13 @@ jobs:
         - npm run test:e2e:ci
         - npm run env:stop
 
-    - name: PHP unit tests w/ external-http (7.3, WordPress latest)
-      php: "7.3"
+    - name: PHP unit tests w/ external-http (7.4, WordPress latest)
+      php: "7.4"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1 PHPUNIT_EXTRA_SUITE=external-http
+
+    - name: PHP unit tests (7.3, WordPress latest)
+      php: "7.3"
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"
@@ -138,9 +142,9 @@ jobs:
       php: "nightly"
       env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
 
-    - name: PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)
+    - name: PHP and JavaScript unit tests (7.4, WordPress trunk, with code coverage)
       if: branch = develop AND type = push
-      php: "7.3"
+      php: "7.4"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 RUN_PHPUNIT_COVERAGE=1
       before_script:
         - echo "Running unit tests with code coverage..."
@@ -162,8 +166,12 @@ jobs:
         - composer --working-dir=lib/common test
         - composer --working-dir=lib/optimizer test
 
-    - name: Libraries that are meant to be externalized (7.3)
-      php: "7.3"
+    - name: Libraries that are meant to be externalized (7.4)
+      php: "7.4"
+      before_script:
+        - |
+          phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
+          echo "extension = zip.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
       install:
         - composer --working-dir=lib/common install
         - composer --working-dir=lib/optimizer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,8 +170,7 @@ jobs:
 
     - name: Libraries that are meant to be externalized (7.4)
       php: "7.4"
-      before_script:
-        - phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
+
       install:
         - composer --working-dir=lib/common install
         - composer --working-dir=lib/optimizer install

--- a/lib/optimizer/src/TransformationEngine.php
+++ b/lib/optimizer/src/TransformationEngine.php
@@ -116,7 +116,7 @@ final class TransformationEngine
 
             // The use of `ReflectionParameter::getClass()` is deprecated in PHP 8, and is superseded
             // by `ReflectionParameter::getType()`. See https://github.com/php/php-src/pull/5209.
-            if (version_compare('7.1', PHP_VERSION, '<')) {
+            if (PHP_VERSION_ID >= 70100)) {
                 if ($parameter->getType()) {
                     /** @var \ReflectionNamedType $returnType */
                     $returnType = $parameter->getType();

--- a/lib/optimizer/src/TransformationEngine.php
+++ b/lib/optimizer/src/TransformationEngine.php
@@ -112,7 +112,16 @@ final class TransformationEngine
 
         $dependencies = [];
         foreach ($constructor->getParameters() as $parameter) {
-            $dependencyType = $parameter->getClass();
+            // The use of `ReflectionParameter::getClass()` is deprecated in PHP 8, and is superseded
+            // by `ReflectionParameter::getType()`. See https://github.com/php/php-src/pull/5209.
+            if ( version_compare( '7.0', PHP_VERSION, '<' ) ) {
+                if ( $parameter->getType() ) {
+                    $dependencyName = $parameter->getType()->getName();
+                    $dependencyType = new ReflectionClass( $dependencyName );
+                }
+            } else {
+                $dependencyType = $parameter->getClass();
+            }
 
             if ($dependencyType === null) {
                 // No type provided, so we pass `null` in the hopes that the argument is optional.

--- a/lib/optimizer/src/TransformationEngine.php
+++ b/lib/optimizer/src/TransformationEngine.php
@@ -112,12 +112,15 @@ final class TransformationEngine
 
         $dependencies = [];
         foreach ($constructor->getParameters() as $parameter) {
+            $dependencyType = null;
+
             // The use of `ReflectionParameter::getClass()` is deprecated in PHP 8, and is superseded
             // by `ReflectionParameter::getType()`. See https://github.com/php/php-src/pull/5209.
-            if ( version_compare( '7.0', PHP_VERSION, '<' ) ) {
-                if ( $parameter->getType() ) {
-                    $dependencyName = $parameter->getType()->getName();
-                    $dependencyType = new ReflectionClass( $dependencyName );
+            if (version_compare('7.1', PHP_VERSION, '<')) {
+                if ($parameter->getType()) {
+                    /** @var \ReflectionNamedType $returnType */
+                    $returnType = $parameter->getType();
+                    $dependencyType = new ReflectionClass($returnType->getName());
                 }
             } else {
                 $dependencyType = $parameter->getClass();

--- a/lib/optimizer/src/TransformationEngine.php
+++ b/lib/optimizer/src/TransformationEngine.php
@@ -116,7 +116,7 @@ final class TransformationEngine
 
             // The use of `ReflectionParameter::getClass()` is deprecated in PHP 8, and is superseded
             // by `ReflectionParameter::getType()`. See https://github.com/php/php-src/pull/5209.
-            if (PHP_VERSION_ID >= 70100)) {
+            if (PHP_VERSION_ID >= 70100) {
                 if ($parameter->getType()) {
                     /** @var \ReflectionNamedType $returnType */
                     $returnType = $parameter->getType();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,7 +25,3 @@ parameters:
 	ignoreErrors:
 		# Uses func_get_args()
 		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
-		# Missing declaration in PHPStan/PHPStorm stubs
-		# See https://github.com/phpstan/phpstan/issues/3492
-		# and https://github.com/JetBrains/phpstorm-stubs/pull/845
-		- '#^Access to an undefined property DOMNamedNodeMap::\$length.$#'

--- a/tests/php/src/PrivateAccess.php
+++ b/tests/php/src/PrivateAccess.php
@@ -73,10 +73,10 @@ trait PrivateAccess {
 	 * @throws ReflectionException If the object could not be reflected upon.
 	 */
 	private function get_private_property( $object, $property_name ) {
-		$class = new ReflectionClass( $object );
+		$class    = new ReflectionClass( $object );
 		$property = $class->getProperty( $property_name );
 
-		if ( $property->isStatic() ){
+		if ( $property->isStatic() ) {
 			return $class->getStaticPropertyValue( $property_name );
 		}
 

--- a/tests/php/src/PrivateAccess.php
+++ b/tests/php/src/PrivateAccess.php
@@ -73,7 +73,14 @@ trait PrivateAccess {
 	 * @throws ReflectionException If the object could not be reflected upon.
 	 */
 	private function get_private_property( $object, $property_name ) {
-		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
+		$class = new ReflectionClass( $object );
+		$property = $class->getProperty( $property_name );
+
+		if ( $property->isStatic() ){
+			return $class->getStaticPropertyValue( $property_name );
+		}
+
+		// Note: `ReflectionProperty::getValue()` requires the argument to be an object in PHP 8`.
 		$property->setAccessible( true );
 		return $property->getValue( $object );
 	}

--- a/tests/php/src/PrivateAccess.php
+++ b/tests/php/src/PrivateAccess.php
@@ -76,13 +76,11 @@ trait PrivateAccess {
 		$class    = new ReflectionClass( $object );
 		$property = $class->getProperty( $property_name );
 
-		if ( $property->isStatic() ) {
-			return $class->getStaticPropertyValue( $property_name );
-		}
-
-		// Note: `ReflectionProperty::getValue()` requires the argument to be an object in PHP 8`.
 		$property->setAccessible( true );
-		return $property->getValue( $object );
+
+		// Note: In PHP 8, `ReflectionProperty::getValue()` now requires that an object be supplied if it's a
+		// non-static property.
+		return $property->isStatic() ? $property->getValue() : $property->getValue( $object );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Upgrades CI to Ubuntu Xenial 16.04 (some required PHP extensions we're not available on `trusty`)
- Bumps the stages `lint`, `analyze`, and some `test` jobs from PHP 7.3 to 7.4
- Adds a test job to run against PHP 8.0.0-dev (which is allowed to fail)
- Reports the PHP 7.4 test job if it fails

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
