### PR TITLE
Use latest Gutenberg version for tests

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -8,9 +8,26 @@ DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
 CHECK_SCOPE=all
 
 function after_wp_install {
-	if [[ "$WP_VERSION" != "4.9" ]]; then
-		echo -n "Installing Gutenberg 7.1.0..."
-		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/tags/7.1.0/
+	case "$WP_VERSION" in
+	"4.9")
+		gb_version=""
+		;;
+	"5.0" | "5.1")
+		gb_version="6.9.0"
+	  ;;
+	"5.2")
+		gb_version="7.6.1"
+		;;
+	*)
+		# WP 5.3 onwards can use the latest version of Gutenberg.
+		gb_version="trunk"
+	esac
+
+	if [[ "$gb_version" != "" ]]; then
+		echo -n "Installing Gutenberg ${gb_version}..."
+
+		url_path=$([ $gb_version == "trunk" ] && echo "trunk" || echo "tags/${gb_version}")
+		gutenberg_plugin_svn_url="https://plugins.svn.wordpress.org/gutenberg/${url_path}/"
 		svn export -q "$gutenberg_plugin_svn_url" "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
 		echo "done"
 	fi

--- a/tests/php/src/Unit/PluginSuppressionTest.php
+++ b/tests/php/src/Unit/PluginSuppressionTest.php
@@ -37,7 +37,6 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		$this->reset_widgets();

--- a/tests/php/src/Unit/PluginSuppressionTest.php
+++ b/tests/php/src/Unit/PluginSuppressionTest.php
@@ -16,6 +16,7 @@ use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AMP_Validated_URL_Post_Type;
 use AMP_Validation_Manager;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 use Exception;
 use WP_Block_Type_Registry;
 use WP_UnitTestCase;
@@ -26,6 +27,9 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	use PrivateAccess;
 	use AssertContainsCompatibility;
 	use ThemesApiRequestMocking;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	private $attempted_validate_request_urls = [];
 
@@ -34,12 +38,12 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
+
 		$this->reset_widgets();
 		add_filter(
 			'pre_http_request',
 			function( $r, $args, $url ) {
-				unset( $args );
-
 				if ( false === strpos( $url, 'amp_validate=' ) ) {
 					return $r;
 				}

--- a/tests/php/src/WithoutBlockPreRendering.php
+++ b/tests/php/src/WithoutBlockPreRendering.php
@@ -26,9 +26,9 @@ trait WithoutBlockPreRendering {
 				global $post;
 
 				if (
-				null === $post &&
-				defined( 'GUTENBERG_VERSION' ) &&
-				version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
+					null === $post &&
+					defined( 'GUTENBERG_VERSION' ) &&
+					version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
 				) {
 					// Add a marker to indicate that this is not a block to be pre-rendered.
 					$parsed_block['remove_post_data'] = true;

--- a/tests/php/src/WithoutBlockPreRendering.php
+++ b/tests/php/src/WithoutBlockPreRendering.php
@@ -20,33 +20,41 @@ trait WithoutBlockPreRendering {
 	public function setUp() { //phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		parent::setUp();
 
-		add_filter( 'render_block_data', static function( $parsed_block ) {
-			global $post;
+		add_filter(
+			'render_block_data',
+			static function( $parsed_block ) {
+				global $post;
 
-			if (
+				if (
 				null === $post &&
 				defined( 'GUTENBERG_VERSION' ) &&
 				version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
-			) {
-				// Add a marker to indicate that this is not a block to be pre-rendered.
-				$parsed_block['remove_post_data'] = true;
-				// Create a dummy post so that there is a post available for the pre-rendering to utilize.
-				$post = self::factory()->post->create_and_get();
+				) {
+					// Add a marker to indicate that this is not a block to be pre-rendered.
+					$parsed_block['remove_post_data'] = true;
+					// Create a dummy post so that there is a post available for the pre-rendering to utilize.
+					$post = self::factory()->post->create_and_get();
+				}
+
+				return $parsed_block;
 			}
+		);
 
-			return $parsed_block;
-		} );
+		add_filter(
+			'render_block_context',
+			static function( $context, $parsed_block ) {
+				global $post;
 
-		add_filter( 'render_block_context', static function( $context, $parsed_block ) {
-			global $post;
+				// Remove the dummy post from the global scope and unset post related data from the context.
+				if ( isset( $parsed_block['remove_post_data'] ) ) {
+					$post = null;
+					unset( $context['postId'], $context['postType'], $parsed_block['remove_post_data'] );
+				}
 
-			// Remove the dummy post from the global scope and unset post related data from the context.
-			if ( isset( $parsed_block['remove_post_data'] ) ) {
-				$post = null;
-				unset( $context['postId'], $context['postType'], $parsed_block['remove_post_data'] );
-			}
-
-			return $context;
-		}, 10, 2 );
+				return $context;
+			},
+			10,
+			2
+		);
 	}
 }

--- a/tests/php/src/WithoutBlockPreRendering.php
+++ b/tests/php/src/WithoutBlockPreRendering.php
@@ -8,7 +8,7 @@
 namespace AmpProject\AmpWP\Tests;
 
 /**
- * Helper trait to remove block pre-rendering for tests.
+ * Helper trait to skip block pre-rendering for tests that are not block related.
  *
  * @package AmpProject\AmpWP
  */
@@ -18,11 +18,35 @@ trait WithoutBlockPreRendering {
 	 * Set up.
 	 */
 	public function setUp() { //phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		if (
-			defined( 'GUTENBERG_VERSION' ) &&
-			version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
-		) {
-			remove_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9 );
-		}
+		parent::setUp();
+
+		add_filter( 'render_block_data', static function( $parsed_block ) {
+			global $post;
+
+			if (
+				null === $post &&
+				defined( 'GUTENBERG_VERSION' ) &&
+				version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
+			) {
+				// Add a marker to indicate that this is not a block to be pre-rendered.
+				$parsed_block['remove_post_data'] = true;
+				// Create a dummy post so that there is a post available for the pre-rendering to utilize.
+				$post = self::factory()->post->create_and_get();
+			}
+
+			return $parsed_block;
+		} );
+
+		add_filter( 'render_block_context', static function( $context, $parsed_block ) {
+			global $post;
+
+			// Remove the dummy post from the global scope and unset post related data from the context.
+			if ( isset( $parsed_block['remove_post_data'] ) ) {
+				$post = null;
+				unset( $context['postId'], $context['postType'], $parsed_block['remove_post_data'] );
+			}
+
+			return $context;
+		}, 10, 2 );
 	}
 }

--- a/tests/php/src/WithoutBlockPreRendering.php
+++ b/tests/php/src/WithoutBlockPreRendering.php
@@ -17,7 +17,7 @@ trait WithoutBlockPreRendering {
 	/**
 	 * Set up.
 	 */
-	public function setUp() {
+	public function setUp() { //phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		if (
 			defined( 'GUTENBERG_VERSION' ) &&
 			version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )

--- a/tests/php/src/WithoutBlockPreRendering.php
+++ b/tests/php/src/WithoutBlockPreRendering.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Trait WithoutBlockPreRendering.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\Tests;
+
+/**
+ * Helper trait to remove block pre-rendering for tests.
+ *
+ * @package AmpProject\AmpWP
+ */
+trait WithoutBlockPreRendering {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		if (
+			defined( 'GUTENBERG_VERSION' ) &&
+			version_compare( '8.1.0', GUTENBERG_VERSION, '<=' )
+		) {
+			remove_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9 );
+		}
+	}
+}

--- a/tests/php/test-amp-crowdsignal-embed-handler.php
+++ b/tests/php/test-amp-crowdsignal-embed-handler.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Crowdsignal_Embed_Handler_Test
  *
  * @covers AMP_Crowdsignal_Embed_Handler
  */
 class AMP_Crowdsignal_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	/**
 	 * Get conversion data.

--- a/tests/php/test-amp-dailymotion-embed-handler.php
+++ b/tests/php/test-amp-dailymotion-embed-handler.php
@@ -1,6 +1,10 @@
 <?php
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 class AMP_DailyMotion_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	public function get_conversion_data() {
 		return [

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -24,7 +24,6 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\MarkupComparison;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 
 /**
  * Test AMP_Facebook_Embed_Handler_Test
@@ -14,11 +15,17 @@ use AmpProject\AmpWP\Tests\MarkupComparison;
  */
 class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 
+	use MarkupComparison;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
+
 	/**
 	 * Set up.
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
@@ -62,8 +69,6 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 			'http_response' => null,
 		];
 	}
-
-	use MarkupComparison;
 
 	/**
 	 * Get scripts data.

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -5,10 +5,14 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Gallery_Embed_Handler_Test
  */
 class AMP_Gallery_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	/**
 	 * Tear down.

--- a/tests/php/test-amp-instagram-embed-handler.php
+++ b/tests/php/test-amp-instagram-embed-handler.php
@@ -1,6 +1,10 @@
 <?php
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	public function get_conversion_data() {
 		return [

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -1,6 +1,10 @@
 <?php
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 class AMP_Pinterest_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	public function get_conversion_data() {
 		return [

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -29,7 +29,6 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -5,12 +5,18 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Scribd_Embed_Handler_Test
  *
  * @covers AMP_Scribd_Embed_Handler
  */
 class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Scribd document URL.
@@ -21,22 +27,10 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @global WP_Post $post
 	 */
 	public function setUp() {
-		global $post;
 		parent::setUp();
-
-		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior to 4.9, the WP_Embed::shortcode()
-		 * method would short-circuit when this is the case:
-		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
-		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$post = self::factory()->post->create_and_get();
-		}
+		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}

--- a/tests/php/test-amp-soundcloud-embed-handler.php
+++ b/tests/php/test-amp-soundcloud-embed-handler.php
@@ -52,7 +52,6 @@ class AMP_SoundCloud_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-amp-soundcloud-embed-handler.php
+++ b/tests/php/test-amp-soundcloud-embed-handler.php
@@ -5,12 +5,18 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_SoundCloud_Embed_Handler_Test
  *
  * @covers AMP_SoundCloud_Embed_Handler
  */
 class AMP_SoundCloud_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Track URL.
@@ -44,22 +50,10 @@ class AMP_SoundCloud_Embed_Handler_Test extends WP_UnitTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @global WP_Post $post
 	 */
 	public function setUp() {
-		global $post;
 		parent::setUp();
-
-		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
-		 * method would short-circuit when this is the case:
-		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
-		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$post = $this->factory()->post->create_and_get();
-		}
+		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2707,9 +2707,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
 		// Temporarily fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
 		$theme_features = [
-				'editor-color-palette',
-				'editor-gradient-presets',
-				'editor-font-sizes',
+			'editor-color-palette',
+			'editor-gradient-presets',
+			'editor-font-sizes',
 		];
 		foreach ( $theme_features as $theme_feature ) {
 			if ( ! current_theme_supports( $theme_feature ) ) {

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2703,6 +2703,20 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Requires WordPress 5.0.' );
 		}
 		global $wp_theme_directories; // Note that get_theme_roots() does not work, for some reason.
+
+		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
+		// Temporary fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
+		if ( ! (
+			current_theme_supports( 'editor-color-palette' ) &&
+			current_theme_supports( 'editor-gradient-presets' ) &&
+			current_theme_supports( 'editor-font-sizes' )
+		) ) {
+			$args = [];
+			add_theme_support( 'editor-color-palette', $args );
+			add_theme_support( 'editor-gradient-presets', $args );
+			add_theme_support( 'editor-font-sizes', $args );
+		}
+
 		$theme_exists = false;
 		foreach ( $wp_theme_directories as $theme_root ) {
 			$theme_exists = wp_get_theme( 'twentyten', $theme_root )->exists();

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2705,16 +2705,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		global $wp_theme_directories; // Note that get_theme_roots() does not work, for some reason.
 
 		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
-		// Temporary fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
-		if ( ! (
-			current_theme_supports( 'editor-color-palette' ) &&
-			current_theme_supports( 'editor-gradient-presets' ) &&
-			current_theme_supports( 'editor-font-sizes' )
-		) ) {
-			$args = [];
-			add_theme_support( 'editor-color-palette', $args );
-			add_theme_support( 'editor-gradient-presets', $args );
-			add_theme_support( 'editor-font-sizes', $args );
+		// Temporarily fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
+		$theme_features = [
+				'editor-color-palette',
+				'editor-gradient-presets',
+				'editor-font-sizes',
+		];
+		foreach ( $theme_features as $theme_feature ) {
+			if ( ! current_theme_supports( $theme_feature ) ) {
+				add_theme_support( $theme_feature, [] );
+			}
 		}
 
 		$theme_exists = false;

--- a/tests/php/test-amp-twitter-embed-handler.php
+++ b/tests/php/test-amp-twitter-embed-handler.php
@@ -5,12 +5,18 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Twitter_Embed_Handler_Test
  *
  * @covers AMP_Twitter_Embed_Handler
  */
 class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * oEmbed response for the tweet ID 987437752164737025.
@@ -31,6 +37,8 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
+
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}
 

--- a/tests/php/test-amp-twitter-embed-handler.php
+++ b/tests/php/test-amp-twitter-embed-handler.php
@@ -36,7 +36,6 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up each test.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-amp-vimeo-embed-handler.php
+++ b/tests/php/test-amp-vimeo-embed-handler.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Vimeo_Embed_Handler_Test
  *
  * @covers AMP_Vimeo_Embed_Handler
  */
 class AMP_Vimeo_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	/**
 	 * Get conversion data.

--- a/tests/php/test-amp-vine-embed-handler.php
+++ b/tests/php/test-amp-vine-embed-handler.php
@@ -1,6 +1,10 @@
 <?php
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 class AMP_Vine_Embed_Handler_Test extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering;
 
 	public function get_conversion_data() {
 		return [

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -32,7 +32,6 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
 			$this->markTestSkipped( 'Missing required render_block filter.' );
 		}
-		parent::setUp();
 		$this->prevent_block_pre_render();
 	}
 

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -7,6 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 
 /**
  * Tests for AMP_Core_Block_Handler.
@@ -17,6 +18,9 @@ use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Set up.
@@ -29,6 +33,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Missing required render_block filter.' );
 		}
 		parent::setUp();
+		$this->prevent_block_pre_render();
 	}
 
 	/**

--- a/tests/php/test-class-amp-gfycat-embed-handler.php
+++ b/tests/php/test-class-amp-gfycat-embed-handler.php
@@ -22,7 +22,6 @@ class AMP_Gfycat_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.

--- a/tests/php/test-class-amp-gfycat-embed-handler.php
+++ b/tests/php/test-class-amp-gfycat-embed-handler.php
@@ -5,6 +5,8 @@
  * @package AMP.
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Gfycat_Embed_Handler_Test
  *
@@ -12,14 +14,16 @@
  */
 class AMP_Gfycat_Embed_Handler_Test extends WP_UnitTestCase {
 
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
+
 	/**
 	 * Set up.
-	 *
-	 * @global WP_Post $post
 	 */
 	public function setUp() {
-		global $post;
 		parent::setUp();
+		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.
 		add_filter(
@@ -37,16 +41,6 @@ class AMP_Gfycat_Embed_Handler_Test extends WP_UnitTestCase {
 			10,
 			2
 		);
-
-		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
-		 * method would short-circuit when this is the case:
-		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
-		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$post = self::factory()->post->create_and_get();
-		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-hulu-embed-handler.php
+++ b/tests/php/test-class-amp-hulu-embed-handler.php
@@ -5,6 +5,8 @@
  * @package AMP.
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Hulu_Embed_Handler_Test
  *
@@ -12,14 +14,16 @@
  */
 class AMP_Hulu_Embed_Handler_Test extends WP_UnitTestCase {
 
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
+
 	/**
 	 * Set up.
-	 *
-	 * @global WP_Post $post
 	 */
 	public function setUp() {
-		global $post;
 		parent::setUp();
+		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.
 		add_filter(
@@ -43,16 +47,6 @@ class AMP_Hulu_Embed_Handler_Test extends WP_UnitTestCase {
 			10,
 			3
 		);
-
-		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
-		 * method would short-circuit when this is the case:
-		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
-		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$post = self::factory()->post->create_and_get();
-		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-hulu-embed-handler.php
+++ b/tests/php/test-class-amp-hulu-embed-handler.php
@@ -22,7 +22,6 @@ class AMP_Hulu_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.

--- a/tests/php/test-class-amp-imgur-embed-handler.php
+++ b/tests/php/test-class-amp-imgur-embed-handler.php
@@ -5,19 +5,23 @@
  * @package AMP.
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class AMP_Imgur_Embed_Handler_Test
  */
 class AMP_Imgur_Embed_Handler_Test extends WP_UnitTestCase {
 
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
+
 	/**
 	 * Set up.
-	 *
-	 * @global WP_Post $post
 	 */
 	public function setUp() {
-		global $post;
 		parent::setUp();
+		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.
 		add_filter(
@@ -46,16 +50,6 @@ class AMP_Imgur_Embed_Handler_Test extends WP_UnitTestCase {
 			10,
 			3
 		);
-
-		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
-		 * method would short-circuit when this is the case:
-		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
-		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
-		 */
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$post = self::factory()->post->create_and_get();
-		}
 	}
 
 	/**
@@ -64,13 +58,9 @@ class AMP_Imgur_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
-			$width  = 600;
-			$height = 480;
-		} else {
-			$width  = 500;
-			$height = 750;
-		}
+		$width  = 500;
+		$height = 750;
+
 		return [
 			'no_embed'        => [
 				'<p>Hello world.</p>',

--- a/tests/php/test-class-amp-imgur-embed-handler.php
+++ b/tests/php/test-class-amp-imgur-embed-handler.php
@@ -20,7 +20,6 @@ class AMP_Imgur_Embed_Handler_Test extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -7,6 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 
 /**
  * Tests for AMP_Playlist_Embed_Handler.
@@ -17,6 +18,9 @@ use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Instance of the tested class.
@@ -44,6 +48,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
 		$this->instance = new AMP_Playlist_Embed_Handler();
 	}
 

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -47,7 +47,6 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * Set up test.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 		$this->instance = new AMP_Playlist_Embed_Handler();
 	}

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -20,7 +20,6 @@ class Test_AMP_TikTok_Embed_Handler extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -5,16 +5,23 @@
  * @package AMP.
  */
 
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
+
 /**
  * Class Test_AMP_TikTok_Embed_Handler
  */
 class Test_AMP_TikTok_Embed_Handler extends WP_UnitTestCase {
+
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Set up.
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
 
 		// Mock the HTTP request.
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-class-amp-wordpress-tv-embed-handler.php
+++ b/tests/php/test-class-amp-wordpress-tv-embed-handler.php
@@ -26,7 +26,6 @@ class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
 	 * Set up.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-class-amp-wordpress-tv-embed-handler.php
+++ b/tests/php/test-class-amp-wordpress-tv-embed-handler.php
@@ -7,6 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 
 /**
  * Tests for AMP_WordPress_TV_Embed_Handler.
@@ -17,12 +18,17 @@ use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * Set up.
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
+
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}
 

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -8,6 +8,7 @@
 
 use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\PrivateAccess;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 
 /**
  * Tests for AMP_YouTube_Embed_Handler.
@@ -18,6 +19,9 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
 	use PrivateAccess;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	protected $youtube_video_id = 'kfVsfOSbJY0';
 
@@ -41,6 +45,8 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->prevent_block_pre_render();
+
 		$this->handler = new AMP_YouTube_Embed_Handler();
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -44,7 +44,6 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	 * Set up each test.
 	 */
 	public function setUp() {
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		$this->handler = new AMP_YouTube_Embed_Handler();

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -102,7 +102,6 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		unset( $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] );
-		parent::setUp();
 		$this->prevent_block_pre_render();
 
 		$dom_document = new Document( '1.0', 'utf-8' );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1188,6 +1188,19 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @param callable $assert   Function to assert the expected sources.
 	 */
 	public function test_locate_sources_e2e( $callback, $xpath, $assert ) {
+		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
+		// Temporary fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
+		if ( ! (
+				current_theme_supports( 'editor-color-palette' ) &&
+				current_theme_supports( 'editor-gradient-presets' ) &&
+				current_theme_supports( 'editor-font-sizes' )
+		) ) {
+			$args = [];
+			add_theme_support( 'editor-color-palette', $args );
+			add_theme_support( 'editor-gradient-presets', $args );
+			add_theme_support( 'editor-font-sizes', $args );
+		}
+
 		add_theme_support( 'amp' );
 		AMP_Validation_Manager::add_validation_error_sourcing();
 		$callback();

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\HandleValidation;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 use AmpProject\AmpWP\Tests\AssertRestApiField;
+use AmpProject\AmpWP\Tests\WithoutBlockPreRendering;
 use AmpProject\Dom\Document;
 
 /**
@@ -26,6 +27,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	use HandleValidation;
 	use PrivateAccess;
 	use AssertRestApiField;
+	use WithoutBlockPreRendering {
+		setUp as public prevent_block_pre_render;
+	}
 
 	/**
 	 * The name of the tested class.
@@ -99,6 +103,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function setUp() {
 		unset( $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] );
 		parent::setUp();
+		$this->prevent_block_pre_render();
+
 		$dom_document = new Document( '1.0', 'utf-8' );
 		$this->node   = $dom_document->createElement( self::TAG_NAME );
 		$dom_document->appendChild( $this->node );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1188,16 +1188,16 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_locate_sources_e2e( $callback, $xpath, $assert ) {
 		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
-		// Temporary fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
-		if ( ! (
-				current_theme_supports( 'editor-color-palette' ) &&
-				current_theme_supports( 'editor-gradient-presets' ) &&
-				current_theme_supports( 'editor-font-sizes' )
-		) ) {
-			$args = [];
-			add_theme_support( 'editor-color-palette', $args );
-			add_theme_support( 'editor-gradient-presets', $args );
-			add_theme_support( 'editor-font-sizes', $args );
+		// Temporarily fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
+		$theme_features = [
+				'editor-color-palette',
+				'editor-gradient-presets',
+				'editor-font-sizes',
+		];
+		foreach ( $theme_features as $theme_feature ) {
+			if ( ! current_theme_supports( $theme_feature ) ) {
+				add_theme_support( $theme_feature, [] );
+			}
 		}
 
 		add_theme_support( 'amp' );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1190,9 +1190,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
 		// Temporarily fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
 		$theme_features = [
-				'editor-color-palette',
-				'editor-gradient-presets',
-				'editor-font-sizes',
+			'editor-color-palette',
+			'editor-gradient-presets',
+			'editor-font-sizes',
 		];
 		foreach ( $theme_features as $theme_feature ) {
 			if ( ! current_theme_supports( $theme_feature ) ) {


### PR DESCRIPTION
## Summary

This PR downloads the latest compatible Gutenberg plugin for the WordPress version being tested agaisnt, and also fixes some tests that throw errors when Gutenber v8.1.0 (and later) is installed.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
