### PR TITLE
Register services with the service container immediately after loading

### DIFF
--- a/src/Infrastructure/ServiceBasedPlugin.php
+++ b/src/Infrastructure/ServiceBasedPlugin.php
@@ -27,7 +27,8 @@ abstract class ServiceBasedPlugin implements Plugin {
 	const INJECTOR_ID = 'injector';
 
 	// WordPress action to trigger the service registration on.
-	const REGISTRATION_ACTION = 'plugins_loaded';
+	// Use false to register as soon as the code is loaded.
+	const REGISTRATION_ACTION = false;
 
 	// Prefixes to use.
 	const HOOK_PREFIX    = '';
@@ -123,10 +124,14 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @throws InvalidService If a service is not valid.
 	 */
 	public function register() {
-		\add_action(
-			static::REGISTRATION_ACTION,
-			[ $this, 'register_services' ]
-		);
+		if ( false !== static::REGISTRATION_ACTION ) {
+			\add_action(
+				static::REGISTRATION_ACTION,
+				[ $this, 'register_services' ]
+			);
+		} else {
+			$this->register_services();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Instead of registering the services with the service container at a certain action, just register them right away.

This is needed because of the way the "sourcing" of the validation manager works. Registering the services right away avoids the validation manager requesting the plugin registry when the services haven't been populated yet.
Fixes #4906

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
