### PR TITLE
Use SVG variant of `yes-alt` Dashicon

### DIFF
--- a/assets/css/src/amp-icons.css
+++ b/assets/css/src/amp-icons.css
@@ -18,10 +18,12 @@ body .amp-icon {
  * See https://make.wordpress.org/design/handbook/design-guide/foundations/colors/#auxiliary-hues
  */
 .amp-icon.amp-valid::before {
-	content: "\f12a";
+	width: 20px;
+	height: 20px;
+	display: inline-block;
 
-	/* Accent Green */
-	color: #46b450 !important;
+	/* The SVG variant of the `yes-alt` Dashicon is used as the icon glyph is not available in WP < 5.1 */
+	content: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><rect x="0" fill="none" width="20" height="20"/><g><path fill="%2346b450" d="M10 2c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm-.615 12.66h-1.34l-3.24-4.54 1.34-1.25 2.57 2.4 5.14-5.93 1.34.94-5.81 8.38z"/></g></svg>');
 }
 
 .amp-icon.amp-invalid::before {


### PR DESCRIPTION
## Summary

This PR replaces the use of the Dashicon glyph for `yes-alt` with its SVG variant. This allows for the same icon to be rendered irregardless of the WordPress version being used.

Fixes regression introduced in #4382.

<!-- Please reference the issue this PR addresses. -->
Fixes #4940.
Fixes #3726.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
