### PR TITLE
Update dependency sirbrillig/phpcs-variable-analysis to v2.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php-stubs/wordpress-stubs": "^5.3.2",
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "roave/security-advisories": "dev-master",
-    "sirbrillig/phpcs-variable-analysis": "2.8.1",
+    "sirbrillig/phpcs-variable-analysis": "2.8.2",
     "wp-coding-standards/wpcs": "2.3.0",
     "xwp/wp-dev-lib": "1.6.4"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be1aab0c1b2b2e620c2db83d99cc3dcd",
+    "content-hash": "33d3a5cac78dd8988336e5878feb0874",
     "packages": [
         {
             "name": "ampproject/common",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "lib/common",
-                "reference": "9ada7ae0569dc2d0544867c74d3a18e1408ec916"
+                "reference": "762d6a1043c22ba50aa761c859aab5e7897cbf54"
             },
             "require": {
                 "ext-dom": "*",
@@ -38,7 +38,7 @@
                 },
                 "downloads": {
                     "phpstan": {
-                        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+                        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
                         "path": "vendor/bin/phpstan",
                         "type": "phar"
                     }
@@ -82,8 +82,7 @@
             ],
             "description": "PHP library with common base functionality for AMP integrations.",
             "transport-options": {
-                "symlink": true,
-                "relative": true
+                "symlink": true
             }
         },
         {
@@ -92,7 +91,7 @@
             "dist": {
                 "type": "path",
                 "url": "lib/optimizer",
-                "reference": "f9c39e52ece00ea8fb3bd6a1d60d662847f2715e"
+                "reference": "7078af13ce8b25e00cc4405382b0d24b6a180ca2"
             },
             "require": {
                 "ampproject/common": "^1",
@@ -119,7 +118,7 @@
                 },
                 "downloads": {
                     "phpstan": {
-                        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+                        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
                         "path": "vendor/bin/phpstan",
                         "type": "phar"
                     }
@@ -156,7 +155,7 @@
                     "@analyze"
                 ],
                 "analyze": [
-                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan version; phpstan analyze --ansi; fi"
+                    "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi"
                 ],
                 "unit": [
                     "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
@@ -170,8 +169,7 @@
             ],
             "description": "PHP library for optimizing AMP pages.",
             "transport-options": {
-                "symlink": true,
-                "relative": true
+                "symlink": true
             }
         },
         {
@@ -794,12 +792,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "499fb201e495ef0064da064f520c845d3638fe24"
+                "reference": "6d2e5ab854782830911ddd33b7d4649b9f18c10f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/499fb201e495ef0064da064f520c845d3638fe24",
-                "reference": "499fb201e495ef0064da064f520c845d3638fe24",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6d2e5ab854782830911ddd33b7d4649b9f18c10f",
+                "reference": "6d2e5ab854782830911ddd33b7d4649b9f18c10f",
                 "shasum": ""
             },
             "conflict": {
@@ -843,8 +841,8 @@
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
                 "dolibarr/dolibarr": "<11.0.4",
                 "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=7,<7.70|>=8,<8.7.14|>=8.8,<8.8.6",
-                "drupal/drupal": ">=7,<7.70|>=8,<8.7.14|>=8.8,<8.8.6",
+                "drupal/core": ">=7,<7.72|>=8,<8.8.8|>=8.9,<8.9.1|>=9,<9.0.1",
+                "drupal/drupal": ">=7,<7.72|>=8,<8.8.8|>=8.9,<8.9.1|>=9,<9.0.1",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
@@ -1071,20 +1069,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-17T06:37:54+00:00"
+            "time": "2020-06-19T13:23:43+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.8.1",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "5be26b4d719acaf7a433d1cad469159cbf034f2a"
+                "reference": "4a60e8bc9eebdb054a8a4ad41e4518d43d458c47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/5be26b4d719acaf7a433d1cad469159cbf034f2a",
-                "reference": "5be26b4d719acaf7a433d1cad469159cbf034f2a",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/4a60e8bc9eebdb054a8a4ad41e4518d43d458c47",
+                "reference": "4a60e8bc9eebdb054a8a4ad41e4518d43d458c47",
                 "shasum": ""
             },
             "require": {
@@ -1093,9 +1091,9 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
-                "limedeck/phpunit-detailed-printer": "^3.1",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
                 "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^5.0 || ^6.5",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
                 "sirbrillig/phpcs-import-detection": "^1.1"
             },
             "type": "phpcodesniffer-standard",
@@ -1119,7 +1117,7 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2020-02-11T22:18:48+00:00"
+            "time": "2020-05-25T17:00:12+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -50,7 +50,7 @@ function amp_post_template_add_canonical( $amp_template ) {
  */
 function amp_post_template_add_fonts( $amp_template ) {
 	$font_urls = $amp_template->get( 'font_urls', [] );
-	foreach ( $font_urls as $slug => $url ) {
+	foreach ( $font_urls as $url ) {
 		printf( '<link rel="stylesheet" href="%s">', esc_url( esc_url( $url ) ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}
 }

--- a/includes/embeds/class-amp-dailymotion-embed-handler.php
+++ b/includes/embeds/class-amp-dailymotion-embed-handler.php
@@ -66,10 +66,9 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param array  $matches URL pattern matches.
 	 * @param array  $attr    Shortcode attributes.
 	 * @param string $url     URL.
-	 * @param string $rawattr Unmodified shortcode attributes.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed( $matches, $attr, $url, $rawattr ) {
+	public function oembed( $matches, $attr, $url ) {
 		$video_id = $this->get_video_id_from_url( $url );
 		return $this->render(
 			[

--- a/includes/embeds/class-amp-vimeo-embed-handler.php
+++ b/includes/embeds/class-amp-vimeo-embed-handler.php
@@ -78,10 +78,9 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param array  $matches URL pattern matches.
 	 * @param array  $attr    Shortcode attribues.
 	 * @param string $url     URL.
-	 * @param string $rawattr Unmodified shortcode attributes.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed( $matches, $attr, $url, $rawattr ) {
+	public function oembed( $matches, $attr, $url ) {
 		$video_id = $this->get_video_id_from_url( $url );
 
 		return $this->render(

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -245,7 +245,7 @@ class AMP_Options_Manager {
 
 		// Validate analytics.
 		if ( isset( $new_options[ Option::ANALYTICS ] ) && $new_options[ Option::ANALYTICS ] !== $options[ Option::ANALYTICS ] ) {
-			foreach ( $new_options[ Option::ANALYTICS ] as $id => $data ) {
+			foreach ( $new_options[ Option::ANALYTICS ] as $data ) {
 
 				// Check save/delete pre-conditions and proceed if correct.
 				if ( empty( $data['type'] ) || empty( $data['config'] ) ) {

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -169,7 +169,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			// Add placeholder.
 			if ( $placeholder_node || true === $this->args['add_placeholder'] ) {
 				if ( ! $placeholder_node ) {
-					$placeholder_node = $this->build_placeholder( $normalized_attributes ); // @todo Can a better placeholder default be devised?
+					$placeholder_node = $this->build_placeholder(); // @todo Can a better placeholder default be devised?
 				}
 				$new_node->appendChild( $placeholder_node );
 			}
@@ -363,16 +363,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 0.2
 	 *
-	 * @param string[] $parent_attributes {
-	 *      Attributes.
-	 *
-	 *      @type string $placeholder AMP HTML <amp-iframe> `placeholder` attribute; default to 'amp-wp-iframe-placeholder'
-	 *      @type string $class AMP HTML <amp-iframe> `class` attribute; default to 'amp-wp-iframe-placeholder'
-	 * }
 	 * @return DOMElement|false
 	 */
-	private function build_placeholder( $parent_attributes ) {
-		$placeholder_node = AMP_DOM_Utils::create_node(
+	private function build_placeholder() {
+		return AMP_DOM_Utils::create_node(
 			$this->dom,
 			'span',
 			[
@@ -380,8 +374,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				'class'       => 'amp-wp-iframe-placeholder',
 			]
 		);
-
-		return $placeholder_node;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2888,7 +2888,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function get_validate_response_data() {
 		$stylesheets = [];
-		foreach ( $this->pending_stylesheets as $j => $pending_stylesheet ) {
+		foreach ( $this->pending_stylesheets as $pending_stylesheet ) {
 			$attributes = [];
 			foreach ( $pending_stylesheet['element']->attributes as $attribute ) {
 				$attributes[ $attribute->nodeName ] = $attribute->nodeValue;

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1943,7 +1943,7 @@ class AMP_Validation_Manager {
 	 * @return array $sanitizers The filtered AMP sanitizers.
 	 */
 	public static function filter_sanitizer_args( $sanitizers ) {
-		foreach ( $sanitizers as $sanitizer => &$args ) {
+		foreach ( $sanitizers as &$args ) {
 			$args['validation_error_callback'] = __CLASS__ . '::add_validation_error';
 		}
 

--- a/src/Transformer/AmpSchemaOrgMetadata.php
+++ b/src/Transformer/AmpSchemaOrgMetadata.php
@@ -51,7 +51,7 @@ final class AmpSchemaOrgMetadata implements Transformer {
 	 * @param ErrorCollection $errors   Collection of errors that are collected during transformation.
 	 * @return void
 	 */
-	public function transform( Document $document, ErrorCollection $errors ) {
+	public function transform( Document $document, ErrorCollection $errors ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// @todo How should we handle an existing schema.org script?
 		$schema_org_meta_script = $document->xpath->query( self::SCHEMA_ORG_XPATH )->item( 0 );
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2104,7 +2104,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		$expected_callback   = self::TESTED_CLASS . '::add_validation_error';
 		$filtered_sanitizers = AMP_Validation_Manager::filter_sanitizer_args( $sanitizers );
-		foreach ( $filtered_sanitizers as $sanitizer => $args ) {
+		foreach ( $filtered_sanitizers as $args ) {
 			$this->assertEquals( $expected_callback, $args['validation_error_callback'] );
 		}
 		remove_theme_support( AMP_Theme_Support::SLUG );


### PR DESCRIPTION
## Summary

Updates PHP dependency `sirbrillig/phpcs-variable-analysis` to v2.8.2 and fixes several reported lint errors.

<!-- Please reference the issue this PR addresses. -->
Closes #4803.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
