### PR TITLE
Set status for HTTPS status Site Health test to critical if `is_ssl()` returns false

### DIFF
--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -452,13 +452,12 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 	 * @return array Modified test result.
 	 */
 	public function modify_test_result( $test_result ) {
-		// Set the `https_status` test status to critical if `is_ssl()` returns false, along with adding to the
+		// Set the `https_status` test status to critical if its current status is recommended, along with adding to the
 		// description for why its required for AMP.
 		if (
 			isset( $test_result['test'], $test_result['status'], $test_result['description'] )
 			&& 'https_status' === $test_result['test']
 			&& 'recommended' === $test_result['status']
-			&& ! is_ssl()
 		) {
 			$test_result['status']       = 'critical';
 			$test_result['description'] .= '<p>' . __( 'Additionally, AMP requires HTTPS for most components to work properly, including iframes and videos.', 'amp' ) . '</p>';

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -66,6 +66,7 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 	public function register() {
 		add_filter( 'site_status_tests', [ $this, 'add_tests' ] );
 		add_filter( 'debug_information', [ $this, 'add_debug_information' ] );
+		add_filter( 'site_status_test_result', [ $this, 'modify_test_result' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
 		add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
 	}
@@ -441,6 +442,25 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 				],
 			]
 		);
+	}
+
+	/**
+	 * @param array $test_result Site Health test result.
+	 *
+	 * @return array Modified test result.
+	 */
+	public function modify_test_result( $test_result ) {
+		if (
+			isset( $test_result['test'], $test_result['status'], $test_result['description'] )
+			&& 'https_status' === $test_result['test']
+			&& 'recommended' === $test_result['status']
+			&& ! is_ssl()
+		) {
+			$test_result['status']       = 'critical';
+			$test_result['description'] .= '<p>' . __( 'Additionally, AMP requires HTTPS for most components to work properly, including iframes and videos.', 'amp' ) . '</p>';
+		}
+
+		return $test_result;
 	}
 
 	/**

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -445,11 +445,15 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 	}
 
 	/**
+	 * Modify test results.
+	 *
 	 * @param array $test_result Site Health test result.
 	 *
 	 * @return array Modified test result.
 	 */
 	public function modify_test_result( $test_result ) {
+		// Set the `https_status` test status to critical if `is_ssl()` returns false, along with adding to the
+		// description for why its required for AMP.
 		if (
 			isset( $test_result['test'], $test_result['status'], $test_result['description'] )
 			&& 'https_status' === $test_result['test']

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -259,19 +259,6 @@ class Test_Site_Health extends WP_UnitTestCase {
 			'recommended_https_status_result'          => [
 				[
 					'test'        => 'https_status',
-					'status'      => 'recommended',
-					'description' => '',
-				],
-			],
-
-			'no_https_recommended_https_status_result' => [
-				[
-					'test'        => 'https_status',
-					'status'      => 'recommended',
-					'description' => '',
-				],
-				[
-					'test'        => 'https_status',
 					'status'      => 'critical',
 					'description' => '<p>Additionally, AMP requires HTTPS for most components to work properly, including iframes and videos.</p>',
 				],
@@ -289,8 +276,12 @@ class Test_Site_Health extends WP_UnitTestCase {
 	 * @param array $test_data Data from Site Health test.
 	 * @param array $expected  Expected modified test result.
 	 */
-	public function test_modify_test_result( $test_data, $expected ) {
+	public function test_modify_test_result( $test_data, $expected = null ) {
 		$test_result = $this->instance->modify_test_result( $test_data );
+
+		if ( ! $expected ) {
+			$expected = $test_data;
+		}
 
 		$this->assertEquals( $expected, $test_result );
 	}

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -246,17 +246,17 @@ class Test_Site_Health extends WP_UnitTestCase {
 	 */
 	public function get_test_result() {
 		return [
-			'empty_result'                             => [
+			'empty_result'                    => [
 				[],
 			],
-			'good_https_status_result'                 => [
+			'good_https_status_result'        => [
 				[
 					'test'        => 'https_status',
 					'status'      => 'good',
 					'description' => '',
 				],
 			],
-			'recommended_https_status_result'          => [
+			'recommended_https_status_result' => [
 				[
 					'test'        => 'https_status',
 					'status'      => 'critical',

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -259,6 +259,11 @@ class Test_Site_Health extends WP_UnitTestCase {
 			'recommended_https_status_result' => [
 				[
 					'test'        => 'https_status',
+					'status'      => 'recommended',
+					'description' => '',
+				],
+				[
+					'test'        => 'https_status',
 					'status'      => 'critical',
 					'description' => '<p>Additionally, AMP requires HTTPS for most components to work properly, including iframes and videos.</p>',
 				],

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -27,29 +27,6 @@ class Test_Site_Health extends WP_UnitTestCase {
 	public $instance;
 
 	/**
-	 * The original value of `$_SERVER['HTTPS']` before being modified by tests.
-	 *
-	 * @var string
-	 */
-	private static $original_server_https;
-
-	/**
-	 * Runs the routine before setting up all tests.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		self::$original_server_https = $_SERVER['HTTPS'];
-	}
-
-	/**
-	 * Runs the routine after all tests have been run.
-	 */
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
-		$_SERVER['HTTPS'] = self::$original_server_https;
-	}
-
-	/**
 	 * Sets up each test.
 	 *
 	 * @inheritDoc
@@ -270,19 +247,9 @@ class Test_Site_Health extends WP_UnitTestCase {
 	public function get_test_result() {
 		return [
 			'empty_result'                             => [
-				static function() {
-					return [];
-				},
 				[],
 			],
 			'good_https_status_result'                 => [
-				static function () {
-					return [
-						'test'        => 'https_status',
-						'status'      => 'good',
-						'description' => '',
-					];
-				},
 				[
 					'test'        => 'https_status',
 					'status'      => 'good',
@@ -290,14 +257,6 @@ class Test_Site_Health extends WP_UnitTestCase {
 				],
 			],
 			'recommended_https_status_result'          => [
-				static function () {
-					$_SERVER['HTTPS'] = 'on';
-					return [
-						'test'        => 'https_status',
-						'status'      => 'recommended',
-						'description' => '',
-					];
-				},
 				[
 					'test'        => 'https_status',
 					'status'      => 'recommended',
@@ -306,14 +265,11 @@ class Test_Site_Health extends WP_UnitTestCase {
 			],
 
 			'no_https_recommended_https_status_result' => [
-				static function () {
-					$_SERVER['HTTPS'] = 'off';
-					return [
-						'test'        => 'https_status',
-						'status'      => 'recommended',
-						'description' => '',
-					];
-				},
+				[
+					'test'        => 'https_status',
+					'status'      => 'recommended',
+					'description' => '',
+				],
 				[
 					'test'        => 'https_status',
 					'status'      => 'critical',
@@ -330,11 +286,11 @@ class Test_Site_Health extends WP_UnitTestCase {
 	 *
 	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::modify_test_result()
 	 *
-	 * @param callable $callback Function that returns the test data.
-	 * @param array    $expected Expected modified test data.
+	 * @param array $test_data Data from Site Health test.
+	 * @param array $expected  Expected modified test result.
 	 */
-	public function test_modify_test_result( $callback, $expected ) {
-		$test_result = $this->instance->modify_test_result( $callback() );
+	public function test_modify_test_result( $test_data, $expected ) {
+		$test_result = $this->instance->modify_test_result( $test_data );
 
 		$this->assertEquals( $expected, $test_result );
 	}


### PR DESCRIPTION
## Summary

Sets the status for the `https_status` Site Health test to `critical` if `is_ssl()` returns `false`. Also, the description of the test result is modified to indicate the AMP requirement for HTTPS.

<!-- Please reference the issue this PR addresses. -->
Fixes #4608

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
