### PR TITLE
Turn off Developer Tools when user preference is disabled

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1287,7 +1287,7 @@ function amp_is_dev_mode() {
 			// For the few sites that forcibly show the admin bar even when the user is logged out, only enable dev
 			// mode if the user is actually logged in. This prevents the dev mode from being served to crawlers
 			// when they index the AMP version. The theme support check disables dev mode in Reader mode.
-			( is_admin_bar_showing() && is_user_logged_in() && current_theme_supports( 'amp' ) )
+			( is_admin_bar_showing() && is_user_logged_in() )
 			||
 			is_customize_preview()
 		)

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -19,6 +19,13 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
+
+	add_action( 'admin_bar_init', [ 'AMP_Theme_Support', 'init_admin_bar' ] );
+	add_action( 'amp_post_template_footer', 'wp_admin_bar_render' );
+
+	// Printing scripts here is done primarily for the benefit of the admin bar. Note that wp_enqueue_scripts() is not called.
+	add_action( 'amp_post_template_head', 'wp_print_head_scripts' );
+	add_action( 'amp_post_template_footer', 'wp_print_footer_scripts' );
 }
 
 /**
@@ -65,6 +72,8 @@ function amp_post_template_add_block_styles() {
 	if ( function_exists( 'wp_common_block_scripts_and_styles' ) ) {
 		wp_common_block_scripts_and_styles();
 	}
+
+	// Note that this will also print the admin-bar styles since WP_Admin_Bar::initialize() has been called.
 	wp_styles()->do_items();
 }
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -6,10 +6,12 @@
  */
 
 use AmpProject\Amp;
+use AmpProject\AmpWP\Admin\DevToolsUserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVars;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
 use AmpProject\AmpWP\ConfigurationArgument;
+use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Transformer;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
@@ -155,6 +157,17 @@ class AMP_Theme_Support {
 	 * @var null|string
 	 */
 	protected static $support_added_via_theme;
+
+	/**
+	 * Get dev tools user access service.
+	 *
+	 * @return DevToolsUserAccess
+	 */
+	private static function get_dev_tools_user_access() {
+		/** @var DevToolsUserAccess $service */
+		$service = Services::get( 'dev_tools.user_access' );
+		return $service;
+	}
 
 	/**
 	 * Initialize.
@@ -317,9 +330,6 @@ class AMP_Theme_Support {
 				]
 			);
 			self::$support_added_via_option = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
-		} elseif ( true === AMP_Validation_Manager::should_validate_response() ) { // @todo Eventually reader mode should allow for validate requests.
-			self::$support_added_via_option = self::STANDARD_MODE_SLUG;
-			add_theme_support( self::SLUG );
 		}
 	}
 
@@ -419,10 +429,8 @@ class AMP_Theme_Support {
 
 		self::add_hooks();
 		self::$sanitizer_classes = amp_get_content_sanitizers();
-		if ( ! $is_reader_mode ) {
-			self::$sanitizer_classes = AMP_Validation_Manager::filter_sanitizer_args( self::$sanitizer_classes );
-		}
-		self::$embed_handlers = self::register_content_embed_handlers();
+		self::$sanitizer_classes = AMP_Validation_Manager::filter_sanitizer_args( self::$sanitizer_classes );
+		self::$embed_handlers    = self::register_content_embed_handlers();
 		self::$sanitizer_classes['AMP_Embed_Sanitizer']['embed_handlers'] = self::$embed_handlers;
 
 		foreach ( self::$sanitizer_classes as $sanitizer_class => $args ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -6,12 +6,10 @@
  */
 
 use AmpProject\Amp;
-use AmpProject\AmpWP\Admin\DevToolsUserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVars;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
 use AmpProject\AmpWP\ConfigurationArgument;
-use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Transformer;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
@@ -157,17 +155,6 @@ class AMP_Theme_Support {
 	 * @var null|string
 	 */
 	protected static $support_added_via_theme;
-
-	/**
-	 * Get dev tools user access service.
-	 *
-	 * @return DevToolsUserAccess
-	 */
-	private static function get_dev_tools_user_access() {
-		/** @var DevToolsUserAccess $service */
-		$service = Services::get( 'dev_tools.user_access' );
-		return $service;
-	}
 
 	/**
 	 * Initialize.

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -601,8 +601,7 @@ class AMP_Options_Manager {
 		AMP_Post_Type_Support::add_post_type_support();
 
 		// Ensure theme support flags are set properly according to the new mode so that proper AMP URL can be generated.
-		$has_theme_support = ( AMP_Theme_Support::STANDARD_MODE_SLUG === $template_mode || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode );
-		if ( $has_theme_support ) {
+		if ( AMP_Theme_Support::STANDARD_MODE_SLUG === $template_mode || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode ) {
 			$theme_support = current_theme_supports( AMP_Theme_Support::SLUG );
 			if ( ! is_array( $theme_support ) ) {
 				$theme_support = [];
@@ -617,7 +616,7 @@ class AMP_Options_Manager {
 
 		$notice_type     = 'updated';
 		$review_messages = [];
-		if ( $url && $has_theme_support ) {
+		if ( $url ) {
 			$validation = AMP_Validation_Manager::validate_url_and_store( $url );
 
 			if ( is_wp_error( $validation ) ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -196,39 +196,6 @@ class AMP_Options_Menu {
 				</dt>
 				<dd>
 					<?php echo wp_kses_post( $reader_description ); ?>
-
-					<?php if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && wp_count_posts( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->publish > 0 ) : ?>
-						<div class="notice notice-info inline notice-alt">
-							<p>
-								<?php
-								echo wp_kses_post(
-									sprintf(
-										/* translators: %1: link to invalid URLs. 2: link to validation errors. */
-										__( 'View current site compatibility results for standard and transitional modes: %1$s and %2$s.', 'amp' ),
-										sprintf(
-											'<a href="%s">%s</a>',
-											esc_url( add_query_arg( 'post_type', AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, admin_url( 'edit.php' ) ) ),
-											esc_html( get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->labels->name )
-										),
-										sprintf(
-											'<a href="%s">%s</a>',
-											esc_url(
-												add_query_arg(
-													[
-														'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-														'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-													],
-													admin_url( 'edit-tags.php' )
-												)
-											),
-											esc_html( get_taxonomy( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG )->labels->name )
-										)
-									)
-								);
-								?>
-							</p>
-						</div>
-					<?php endif; ?>
 				</dd>
 			</dl>
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -116,8 +116,7 @@ class AMP_Validated_URL_Post_Type {
 
 		// Show in the admin menu if dev tools are enabled for the user or if the user is on any dev tools screen.
 		$show_in_menu = (
-			// @todo Remove the current_theme_supports() flag.
-			( current_theme_supports( 'amp' ) && $dev_tools_user_access->is_user_enabled() )
+			$dev_tools_user_access->is_user_enabled()
 			||
 			( isset( $_GET['post_type'] ) && self::POST_TYPE_SLUG === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			||

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -172,7 +172,7 @@ class AMP_Validated_URL_Post_Type {
 		if ( $show_in_menu && ! current_user_can( 'manage_options' ) ) {
 			add_action(
 				'admin_menu',
-				function () {
+				static function () {
 					global $menu;
 					foreach ( $menu as &$menu_item ) {
 						if ( 'edit.php?post_type=' . self::POST_TYPE_SLUG === $menu_item[2] ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -436,14 +436,16 @@ class AMP_Validated_URL_Post_Type {
 
 	/**
 	 * Add count of how many validation error posts there are to the admin menu.
+	 *
+	 * @global array $submenu
 	 */
 	public static function add_admin_menu_new_invalid_url_count() {
 		global $submenu;
 
-		$post_type_admin_url = 'edit.php?post_type=' . self::POST_TYPE_SLUG;
-		$submenu_key         = current_user_can( 'manage_options' ) ? AMP_Options_Manager::OPTION_NAME : $post_type_admin_url;
+		$post_type_menu_slug = 'edit.php?post_type=' . self::POST_TYPE_SLUG;
+		$parent_menu_slug    = current_user_can( 'manage_options' ) ? AMP_Options_Manager::OPTION_NAME : $post_type_menu_slug;
 
-		if ( ! isset( $submenu[ $submenu_key ] ) ) {
+		if ( ! isset( $submenu[ $parent_menu_slug ] ) ) {
 			return;
 		}
 
@@ -462,8 +464,8 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
-		foreach ( $submenu[ $submenu_key ] as &$submenu_item ) {
-			if ( $post_type_admin_url === $submenu_item[2] ) {
+		foreach ( $submenu[ $parent_menu_slug ] as &$submenu_item ) {
+			if ( $post_type_menu_slug === $submenu_item[2] ) {
 				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="new-validation-error-urls-count">' . esc_html( number_format_i18n( $new_validation_error_urls ) ) . '</span></span>';
 				break;
 			}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -231,8 +231,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		// Show in the admin menu if dev tools are enabled for the user or if the user is on any dev tools screen.
 		$show_in_menu = (
-			// @todo Remove the current_theme_supports() flag.
-			( current_theme_supports( 'amp' ) && $dev_tools_user_access->is_user_enabled() )
+			$dev_tools_user_access->is_user_enabled()
 			||
 			( isset( $_GET['post_type'] ) && AMP_Validated_URL_Post_Type::POST_TYPE_SLUG === $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			||

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -787,12 +787,6 @@ class AMP_Validation_Error_Taxonomy {
 		add_action( 'load-post.php', [ __CLASS__, 'add_order_clauses_from_description_json' ] );
 		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), [ __CLASS__, 'render_taxonomy_filters' ] );
 		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), [ __CLASS__, 'render_link_to_invalid_urls_screen' ] );
-		add_action(
-			'load-edit-tags.php',
-			static function() {
-				add_filter( 'user_has_cap', [ __CLASS__, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ], 10, 3 );
-			}
-		);
 		add_filter( 'terms_clauses', [ __CLASS__, 'filter_terms_clauses_for_description_search' ], 10, 3 );
 		add_action( 'admin_notices', [ __CLASS__, 'add_admin_notices' ] );
 		add_filter( self::TAXONOMY_SLUG . '_row_actions', [ __CLASS__, 'filter_tag_row_actions' ], PHP_INT_MAX, 2 );
@@ -1541,27 +1535,6 @@ class AMP_Validation_Error_Taxonomy {
 			wp_nonce_field( self::VALIDATION_ERROR_CLEAR_EMPTY_ACTION, self::VALIDATION_ERROR_CLEAR_EMPTY_ACTION . '_nonce', false );
 			submit_button( __( 'Clear Empty', 'amp' ), '', self::VALIDATION_ERROR_CLEAR_EMPTY_ACTION, false );
 		}
-	}
-
-	/**
-	 * Prevent user from being able to delete validation errors in order to disable the checkbox on the post list table.
-	 *
-	 * Yes, this is not ideal.
-	 *
-	 * @param array $allcaps All caps.
-	 * @param array $caps    Requested caps.
-	 * @param array $args    Cap args.
-	 * @return array All caps.
-	 */
-	public static function filter_user_has_cap_for_hiding_term_list_table_checkbox( $allcaps, $caps, $args ) {
-		if ( isset( $args[0] ) && 'delete_term' === $args[0] ) {
-			$term  = get_term( $args[2] );
-			$error = json_decode( $term->description, true );
-			if ( ! is_array( $error ) ) {
-				return $allcaps;
-			}
-		}
-		return $allcaps;
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -230,7 +230,7 @@ class AMP_Validation_Manager {
 	 * @return void
 	 */
 	public static function init() {
-		add_filter( 'map_meta_cap', [ __CLASS__, 'map_meta_cap' ], 9, 2 );
+		add_filter( 'map_meta_cap', [ __CLASS__, 'map_meta_cap' ], 100, 2 );
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -245,7 +245,7 @@ class AMP_Validation_Manager {
 		add_action( 'rest_api_init', [ __CLASS__, 'add_rest_api_fields' ] );
 
 		// Add actions for checking theme support is present to determine plugin compatibility and show validation links in the admin bar.
-		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		if ( current_theme_supports( AMP_Theme_Support::SLUG ) && self::get_dev_tools_user_access()->is_user_enabled() ) {
 			// Actions and filters involved in validation.
 			add_action(
 				'activate_plugin',

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -366,11 +366,15 @@ class AMP_Validation_Manager {
 			return;
 		}
 
+		$is_amp_endpoint = is_amp_endpoint();
+
 		$current_url = amp_get_current_url();
 		$non_amp_url = amp_remove_endpoint( $current_url );
-		if ( amp_is_canonical() ) {
-			$non_amp_url = add_query_arg( QueryVars::NOAMP, QueryVars::NOAMP_AVAILABLE, $non_amp_url );
-		}
+		$non_amp_url = add_query_arg(
+			QueryVars::NOAMP,
+			amp_is_canonical() ? QueryVars::NOAMP_AVAILABLE : QueryVars::NOAMP_MOBILE,
+			$non_amp_url
+		);
 
 		$amp_url = remove_query_arg(
 			array_merge( wp_removable_query_args(), [ QueryVars::NOAMP ] ),
@@ -383,7 +387,7 @@ class AMP_Validation_Manager {
 		$validate_url = AMP_Validated_URL_Post_Type::get_recheck_url( AMP_Validated_URL_Post_Type::get_invalid_url_post( $amp_url ) ?: $amp_url );
 
 		// Construct the parent admin bar item.
-		if ( is_amp_endpoint() ) {
+		if ( $is_amp_endpoint ) {
 			$icon = Icon::valid(); // This will get overridden in AMP_Validation_Manager::finalize_validation() if there are unaccepted errors.
 			$href = $validate_url;
 		} else {
@@ -420,18 +424,18 @@ class AMP_Validation_Manager {
 		$link_item = [
 			'parent' => 'amp',
 			'id'     => 'amp-view',
-			'href'   => esc_url( is_amp_endpoint() ? $non_amp_url : $amp_url ),
+			'href'   => esc_url( $is_amp_endpoint ? $non_amp_url : $amp_url ),
 		];
 		if ( amp_is_canonical() ) {
 			$link_item['title'] = esc_html__( 'View with AMP disabled', 'amp' );
 		} else {
-			$link_item['title'] = esc_html( is_amp_endpoint() ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) );
+			$link_item['title'] = esc_html( $is_amp_endpoint ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) );
 		}
 
 		// Add top-level menu item. Note that this will correctly merge/amend any existing AMP nav menu item added in amp_add_admin_bar_view_link().
 		$wp_admin_bar->add_node( $parent );
 
-		if ( is_amp_endpoint() ) {
+		if ( $is_amp_endpoint ) {
 			$wp_admin_bar->add_node( $validate_item );
 			$wp_admin_bar->add_node( $link_item );
 		} else {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -243,7 +243,7 @@ class AMP_Validation_Manager {
 		// Actions and filters involved in validation.
 		add_action(
 			'activate_plugin',
-			function() {
+			static function() {
 				if ( ! has_action( 'shutdown', [ __CLASS__, 'validate_after_plugin_activation' ] ) && self::get_dev_tools_user_access()->is_user_enabled() ) {
 					add_action( 'shutdown', [ __CLASS__, 'validate_after_plugin_activation' ] ); // Shutdown so all plugins will have been activated.
 				}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1891,7 +1891,7 @@ class AMP_Validation_Manager {
 
 		// Otherwise, since it is in a paired mode, only allow showing the dirty AMP page if the user is authorized.
 		// If not, normally the result is redirection to the non-AMP version.
-		return self::has_cap() || is_customize_preview(); // @todo do self::get_dev_tools_user_access()->is_user_enabled() instead of has_cap?
+		return self::has_cap() || is_customize_preview();
 	}
 
 	/**

--- a/src/Admin/DevToolsUserAccess.php
+++ b/src/Admin/DevToolsUserAccess.php
@@ -9,9 +9,9 @@
 
 namespace AmpProject\AmpWP\Admin;
 
-use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AMP_Validation_Manager;
 use WP_Error;
 use WP_User;
 
@@ -36,6 +36,60 @@ final class DevToolsUserAccess implements Service, Registerable {
 	 */
 	public function register() {
 		add_action( 'rest_api_init', [ $this, 'register_rest_field' ] );
+		add_action( 'personal_options', [ $this, 'print_personal_options' ] );
+		add_action( 'personal_options_update', [ $this, 'update_user_setting' ] );
+		add_action( 'edit_user_profile_update', [ $this, 'update_user_setting' ] );
+	}
+
+	/**
+	 * Determine whether developer tools are enabled for the a user and whether they can access them.
+	 *
+	 * @param null|WP_User|int $user User. Defaults to the current user.
+	 * @return bool Whether developer tools are enabled for the user.
+	 */
+	public function is_user_enabled( $user = null ) {
+		if ( null === $user ) {
+			$user = wp_get_current_user();
+		} elseif ( ! $user instanceof WP_User ) {
+			$user = new WP_User( $user );
+		}
+
+		if ( ! AMP_Validation_Manager::has_cap( $user ) ) {
+			return false;
+		}
+
+		return $this->get_user_enabled( $user );
+	}
+
+	/**
+	 * Get user enabled (regardless of whether they have the required capability).
+	 *
+	 * @param int|WP_User $user User.
+	 * @return bool Whether dev tools is enabled.
+	 */
+	public function get_user_enabled( $user ) {
+		if ( ! $user instanceof WP_User ) {
+			$user = new WP_User( $user );
+		}
+		$value = $user->get( self::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
+		if ( '' === $value ) {
+			$value = true; // @todo Allow to be filtered so that the default status can be changed.
+		}
+		return rest_sanitize_boolean( $value );
+	}
+
+	/**
+	 * Set user enabled.
+	 *
+	 * @param int|WP_User $user    User.
+	 * @param bool        $enabled Whether enabled.
+	 * @return bool Whether update was successful.
+	 */
+	public function set_user_enabled( $user, $enabled ) {
+		if ( $user instanceof WP_User ) {
+			$user = $user->ID;
+		}
+		return (bool) update_user_meta( (int) $user, self::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( (bool) $enabled ) );
 	}
 
 	/**
@@ -57,20 +111,51 @@ final class DevToolsUserAccess implements Service, Registerable {
 	}
 
 	/**
+	 * Add the developer tools checkbox to the user edit screen.
+	 *
+	 * @param WP_User $profile_user Current user being edited.
+	 */
+	public function print_personal_options( $profile_user ) {
+		if ( ! AMP_Validation_Manager::has_cap( $profile_user ) ) {
+			return;
+		}
+		?>
+		<tr>
+			<th scope="row"><?php esc_html_e( 'AMP Developer Tools', 'amp' ); ?></th>
+			<td>
+				<label for="amp_dev_tools_enabled">
+					<input name="<?php echo esc_attr( self::USER_FIELD_DEVELOPER_TOOLS_ENABLED ); ?>" type="checkbox" id="amp_dev_tools_enabled" value="true" <?php checked( $this->is_user_enabled( $profile_user ) ); ?> />
+					<?php esc_html_e( 'Enable AMP developer tools to surface validation errors when editing posts and viewing the site.', 'amp' ); ?>
+				</label>
+
+				<p class="description"><?php esc_html_e( 'This presumes you have some experience coding with HTML, CSS, JS, and PHP.', 'amp' ); ?></p>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * Update the user setting from the edit user screen).
+	 *
+	 * @param int $user_id User being edited.
+	 * @return bool Whether update was successful.
+	 */
+	public function update_user_setting( $user_id ) {
+		if ( ! current_user_can( 'edit_user', $user_id ) || ! AMP_Validation_Manager::has_cap( $user_id ) ) {
+			return false;
+		}
+		$enabled = isset( $_POST[ self::USER_FIELD_DEVELOPER_TOOLS_ENABLED ] ) && rest_sanitize_boolean( wp_unslash( $_POST[ self::USER_FIELD_DEVELOPER_TOOLS_ENABLED ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return $this->set_user_enabled( $user_id, $enabled );
+	}
+
+	/**
 	 * Provides the user's dev tools enabled setting.
 	 *
 	 * @param array $user Array of user data prepared for REST.
 	 * @return null|boolean Whether tools are enabled for the user, or null if the option has not been set.
 	 */
 	public function rest_get_dev_tools_enabled( $user ) {
-		$meta_value = get_user_meta( $user['id'], self::USER_FIELD_DEVELOPER_TOOLS_ENABLED, true );
-
-		if ( '' !== $meta_value ) {
-			return rest_sanitize_boolean( $meta_value );
-		}
-
-		// If the field is not yet set, don't make a default selection in the setup wizard.
-		return null;
+		return $this->is_user_enabled( $user['id'] );
 	}
 
 	/**
@@ -78,10 +163,10 @@ final class DevToolsUserAccess implements Service, Registerable {
 	 *
 	 * @param bool    $new_value New setting for whether dev tools are enabled for the user.
 	 * @param WP_User $user      The WP user to update.
-	 * @return int|bool|WP_Error The result of update_user_meta, or WP_Error if the current user lacks permission.
+	 * @return bool|WP_Error The result of update_user_meta, or WP_Error if the current user lacks permission.
 	 */
 	public function rest_update_dev_tools_enabled( $new_value, WP_User $user ) {
-		if ( ! current_user_can( 'manage_options' ) || ! current_user_can( 'edit_user', $user->ID ) ) {
+		if ( ! AMP_Validation_Manager::has_cap( $user ) || ! current_user_can( 'edit_user', $user->ID ) ) {
 			return new WP_Error(
 				'amp_rest_cannot_edit_user',
 				__( 'Sorry, the current user is not allowed to make this change.', 'amp' ),
@@ -89,6 +174,6 @@ final class DevToolsUserAccess implements Service, Registerable {
 			);
 		}
 
-		return update_user_meta( $user->ID, self::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( (bool) $new_value ) );
+		return $this->set_user_enabled( $user->ID, $new_value );
 	}
 }

--- a/src/Admin/DevToolsUserAccess.php
+++ b/src/Admin/DevToolsUserAccess.php
@@ -116,7 +116,7 @@ final class DevToolsUserAccess implements Service, Registerable {
 	 * @param WP_User $profile_user Current user being edited.
 	 */
 	public function print_personal_options( $profile_user ) {
-		if ( ! AMP_Validation_Manager::has_cap( $profile_user ) ) {
+		if ( ! current_user_can( 'edit_user', $profile_user->ID ) || ! AMP_Validation_Manager::has_cap( $profile_user ) ) {
 			return;
 		}
 		?>

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -44,7 +44,6 @@ final class MobileRedirection implements Service, Registerable {
 		add_filter( 'amp_default_options', [ $this, 'filter_default_options' ] );
 		add_action( 'amp_options_menu_items', [ $this, 'add_settings_field' ], 10 );
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
-		// @todo Add noamp=mobile to amp-view link in admin bar.
 
 		if ( AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
 			add_action( 'wp', [ $this, 'redirect' ] );

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -44,6 +44,7 @@ final class MobileRedirection implements Service, Registerable {
 		add_filter( 'amp_default_options', [ $this, 'filter_default_options' ] );
 		add_action( 'amp_options_menu_items', [ $this, 'add_settings_field' ], 10 );
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
+		// @todo Add noamp=mobile to amp-view link in admin bar.
 
 		if ( AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
 			add_action( 'wp', [ $this, 'redirect' ] );

--- a/tests/php/src/Unit/PluginSuppressionTest.php
+++ b/tests/php/src/Unit/PluginSuppressionTest.php
@@ -511,7 +511,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 */
 	private function update_suppressed_plugins_option( $plugins ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		}
 		if ( ! isset( $GLOBALS['wp_registered_settings'][ AMP_Options_Manager::OPTION_NAME ] ) ) {
 			AMP_Options_Manager::register_settings(); // Adds validate_options as filter.

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -142,7 +142,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				$wp_rewrite->init();
 				$wp_rewrite->flush_rules();
 
-				$permalink = get_permalink( $this->factory()->post->create() );
+				$permalink = get_permalink( self::factory()->post->create() );
 
 				$this->go_to( $permalink );
 				$this->assertEquals( $permalink, amp_get_current_url() );
@@ -423,7 +423,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				];
 			},
 			'is_post'         => function() {
-				$post_id = $this->factory()->post->create();
+				$post_id = self::factory()->post->create();
 				return [
 					get_permalink( $post_id ),
 					amp_get_permalink( $post_id ),
@@ -521,7 +521,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				];
 			},
 			'is_post'         => function() {
-				$post_id = $this->factory()->post->create();
+				$post_id = self::factory()->post->create();
 				return [
 					get_permalink( $post_id ),
 					amp_get_permalink( $post_id ),

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -561,9 +561,9 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return int|WP_Error The new attachment ID, or WP_Error.
 	 */
 	public function get_new_attachment_id() {
-		return $this->factory()->attachment->create_object(
+		return self::factory()->attachment->create_object(
 			'example-image.jpeg',
-			$this->factory()->post->create(),
+			self::factory()->post->create(),
 			[
 				'post_mime_type' => 'image/jpeg',
 				'post_type'      => 'attachment',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2632,7 +2632,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		return [
 			'admin_bar_included' => [
 				function () use ( $render_template ) {
-					$this->go_to( amp_get_permalink( $this->factory()->post->create() ) );
+					$this->go_to( amp_get_permalink( self::factory()->post->create() ) );
 					show_admin_bar( true );
 					_wp_admin_bar_init();
 					switch_theme( 'twentyten' );

--- a/tests/php/test-class-amp-cli-validation-command.php
+++ b/tests/php/test-class-amp-cli-validation-command.php
@@ -50,11 +50,11 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$this->assertEquals( $number_original_urls, $this->call_private_method( $this->validation, 'count_urls_to_validate' ) );
 		$this->validation->limit_type_validate_count = 100;
 
-		$category         = $this->factory()->term->create( [ 'taxonomy' => 'category' ] );
+		$category         = self::factory()->term->create( [ 'taxonomy' => 'category' ] );
 		$number_new_posts = $this->validation->limit_type_validate_count / 2;
 		$post_ids         = [];
 		for ( $i = 0; $i < $number_new_posts; $i++ ) {
-			$post_ids[] = $this->factory()->post->create(
+			$post_ids[] = self::factory()->post->create(
 				[
 					'tax_input' => [ 'category' => $category ],
 				]
@@ -73,7 +73,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$taxonomy                   = 'category';
 		$terms_for_current_taxonomy = [];
 		for ( $i = 0; $i < $number_of_new_terms; $i++ ) {
-			$terms_for_current_taxonomy[] = $this->factory()->term->create(
+			$terms_for_current_taxonomy[] = self::factory()->term->create(
 				[
 					'taxonomy' => $taxonomy,
 				]
@@ -99,7 +99,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$number_of_posts = 20;
 		$ids             = [];
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
-			$ids[] = $this->factory()->post->create();
+			$ids[] = self::factory()->post->create();
 		}
 
 		// This should count all of the newly-created posts as supporting AMP.
@@ -244,7 +244,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 			for ( $i = 0; $i < $number_posts_each_post_type; $i++ ) {
 				array_unshift(
 					$expected_posts,
-					$this->factory()->post->create(
+					self::factory()->post->create(
 						[
 							'post_type' => $post_type,
 						]
@@ -280,7 +280,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 			$expected_links             = array_map( 'get_term_link', get_terms( [ 'taxonomy' => $taxonomy ] ) );
 			$terms_for_current_taxonomy = [];
 			for ( $i = 0; $i < $number_links_each_taxonomy; $i++ ) {
-				$terms_for_current_taxonomy[] = $this->factory()->term->create(
+				$terms_for_current_taxonomy[] = self::factory()->term->create(
 					[
 						'taxonomy' => $taxonomy,
 					]
@@ -289,7 +289,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 
 			// Terms need to be associated with a post in order to be returned in get_terms().
 			wp_set_post_terms(
-				$this->factory()->post->create(),
+				self::factory()->post->create(),
 				$terms_for_current_taxonomy,
 				$taxonomy
 			);
@@ -319,7 +319,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 	 * @covers AMP_CLI_Validation_Command::get_author_page_urls()
 	 */
 	public function test_get_author_page_urls() {
-		$this->factory()->user->create();
+		self::factory()->user->create();
 		$users             = get_users();
 		$first_author      = $users[0];
 		$first_author_url  = get_author_posts_url( $first_author->ID, $first_author->user_nicename );
@@ -403,7 +403,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$terms           = [];
 
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
-			$post_id           = $this->factory()->post->create();
+			$post_id           = self::factory()->post->create();
 			$posts[]           = $post_id;
 			$post_permalinks[] = get_permalink( $post_id );
 		}
@@ -413,7 +413,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$this->assertEmpty( array_diff( $post_permalinks, self::get_validated_urls() ) );
 
 		for ( $i = 0; $i < $number_of_terms; $i++ ) {
-			$terms[] = $this->factory()->category->create();
+			$terms[] = self::factory()->category->create();
 		}
 
 		// Terms need to be associated with a post in order to be returned in get_terms().
@@ -433,7 +433,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 	 * @covers AMP_CLI_Validation_Command::validate_and_store_url()
 	 */
 	public function test_validate_and_store_url() {
-		$single_post_permalink = get_permalink( $this->factory()->post->create() );
+		$single_post_permalink = get_permalink( self::factory()->post->create() );
 		$this->call_private_method( $this->validation, 'validate_and_store_url', [ $single_post_permalink, 'post' ] );
 		$this->assertTrue( in_array( $single_post_permalink, self::get_validated_urls(), true ) );
 
@@ -441,7 +441,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$post_permalinks = [];
 
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
-			$permalink         = get_permalink( $this->factory()->post->create() );
+			$permalink         = get_permalink( self::factory()->post->create() );
 			$post_permalinks[] = $permalink;
 			$this->call_private_method( $this->validation, 'validate_and_store_url', [ $permalink, 'post' ] );
 		}

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -263,7 +263,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 	 */
 	public function test_process_archives_widgets() {
 		$instance_count = 2;
-		$this->factory()->post->create( [ 'post_date' => '2010-01-01 01:01:01' ] );
+		self::factory()->post->create( [ 'post_date' => '2010-01-01 01:01:01' ] );
 
 		ob_start();
 		the_widget(

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -326,7 +326,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::finish_init()
 	 */
 	public function test_finish_init_when_accessing_singular_post_that_does_not_support_amp() {
-		$post          = $this->factory()->post->create();
+		$post          = self::factory()->post->create();
 		$requested_url = get_permalink( $post );
 		$this->assertEquals( AMP_Theme_Support::READER_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 		$this->assertTrue( post_supports_amp( $post ) );
@@ -1940,7 +1940,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_prepare_response() {
 		add_theme_support( 'amp' );
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		add_filter(
 			'home_url',
@@ -2057,7 +2057,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response_standard_mode_non_amp() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_filter( 'amp_dev_mode_enabled', '__return_false' );
 		wp();
 		$original_html = $this->get_original_html();

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -228,15 +228,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_theme() );
 		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
-
-		// Test that forced validation works.
-		remove_theme_support( AMP_Theme_Support::SLUG );
-		delete_option( AMP_Options_Manager::OPTION_NAME );
-		$_GET[ AMP_Validation_Manager::VALIDATE_QUERY_VAR ] = AMP_Validation_Manager::get_amp_validate_nonce();
-		AMP_Theme_Support::read_theme_support();
-		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
-		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_theme() );
-		$this->assertTrue( get_theme_support( AMP_Theme_Support::SLUG ) );
 	}
 
 	/**
@@ -1949,6 +1940,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_prepare_response() {
 		add_theme_support( 'amp' );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		add_filter(
 			'home_url',
@@ -2065,6 +2057,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response_standard_mode_non_amp() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		add_filter( 'amp_dev_mode_enabled', '__return_false' );
 		wp();
 		$original_html = $this->get_original_html();
 		add_filter( 'amp_validation_error_sanitized', '__return_false' ); // For testing purpose only. This should not normally be done.

--- a/tests/php/test-class-dev-tools-user-access.php
+++ b/tests/php/test-class-dev-tools-user-access.php
@@ -152,7 +152,6 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::rest_get_dev_tools_enabled
 	 */
 	public function test_rest_get_dev_tools_enabled() {
-		/** @var WP_User $user */
 		$user = self::factory()->user->create_and_get( [ 'role' => 'author' ] );
 
 		$this->assertFalse( $this->dev_tools_user_access->rest_get_dev_tools_enabled( [ 'id' => $user->ID ] ) );

--- a/tests/php/test-class-dev-tools-user-access.php
+++ b/tests/php/test-class-dev-tools-user-access.php
@@ -50,8 +50,8 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::is_user_enabled
 	 */
 	public function test_is_user_enabled() {
-		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
-		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+		$admin_user  = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = self::factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$this->assertTrue( $this->dev_tools_user_access->is_user_enabled( $admin_user ) );
 		$this->assertTrue( $this->dev_tools_user_access->is_user_enabled( $admin_user->ID ) );
@@ -71,7 +71,7 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::get_user_enabled
 	 */
 	public function test_get_user_enabled() {
-		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] ) ) );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( self::factory()->user->create_and_get( [ 'role' => 'administrator' ] ) ) );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::set_user_enabled
 	 */
 	public function test_set_user_enabled() {
-		$admin_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$admin_user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		$this->assertTrue( $this->dev_tools_user_access->set_user_enabled( $admin_user, false ) );
 		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
 		$this->assertTrue( $this->dev_tools_user_access->set_user_enabled( $admin_user->ID, true ) );
@@ -106,8 +106,8 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::print_personal_options
 	 */
 	public function test_print_personal_options() {
-		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
-		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+		$admin_user  = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = self::factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		ob_start();
 		$this->dev_tools_user_access->print_personal_options( $editor_user );
@@ -129,8 +129,8 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers DevToolsUserAccess::update_user_setting
 	 */
 	public function test_update_user_setting() {
-		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
-		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+		$admin_user  = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = self::factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
 		$_POST[ DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED ] = 'true';
 

--- a/tests/php/test-class-dev-tools-user-access.php
+++ b/tests/php/test-class-dev-tools-user-access.php
@@ -39,6 +39,52 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	public function test_register() {
 		$this->dev_tools_user_access->register();
 		$this->assertEquals( 10, has_action( 'rest_api_init', [ $this->dev_tools_user_access, 'register_rest_field' ] ) );
+		$this->assertEquals( 10, has_action( 'personal_options', [ $this->dev_tools_user_access, 'print_personal_options' ] ) );
+		$this->assertEquals( 10, has_action( 'personal_options_update', [ $this->dev_tools_user_access, 'update_user_setting' ] ) );
+		$this->assertEquals( 10, has_action( 'edit_user_profile_update', [ $this->dev_tools_user_access, 'update_user_setting' ] ) );
+	}
+
+	/**
+	 * Tests DevToolsUserAccess::is_user_enabled
+	 *
+	 * @covers DevToolsUserAccess::is_user_enabled
+	 */
+	public function test_is_user_enabled() {
+		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+
+		$this->assertTrue( $this->dev_tools_user_access->is_user_enabled( $admin_user ) );
+		$this->assertTrue( $this->dev_tools_user_access->is_user_enabled( $admin_user->ID ) );
+		$this->assertFalse( $this->dev_tools_user_access->is_user_enabled( $editor_user ) );
+		$this->assertFalse( $this->dev_tools_user_access->is_user_enabled( $editor_user->ID ) );
+		wp_set_current_user( $admin_user->ID );
+		$this->assertTrue( $this->dev_tools_user_access->is_user_enabled() );
+		$this->dev_tools_user_access->set_user_enabled( $admin_user, false );
+		$this->assertFalse( $this->dev_tools_user_access->is_user_enabled() );
+		wp_set_current_user( $editor_user->ID );
+		$this->assertFalse( $this->dev_tools_user_access->is_user_enabled() );
+	}
+
+	/**
+	 * Tests DevToolsUserAccess::get_user_enabled
+	 *
+	 * @covers DevToolsUserAccess::get_user_enabled
+	 */
+	public function test_get_user_enabled() {
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] ) ) );
+	}
+
+	/**
+	 * Tests DevToolsUserAccess::set_user_enabled
+	 *
+	 * @covers DevToolsUserAccess::set_user_enabled
+	 */
+	public function test_set_user_enabled() {
+		$admin_user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$this->assertTrue( $this->dev_tools_user_access->set_user_enabled( $admin_user, false ) );
+		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+		$this->assertTrue( $this->dev_tools_user_access->set_user_enabled( $admin_user->ID, true ) );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
 	}
 
 	/**
@@ -52,6 +98,52 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 		$this->dev_tools_user_access->register_rest_field();
 
 		$this->assertArrayHasKey( 'amp_dev_tools_enabled', $wp_rest_additional_fields['user'] );
+	}
+
+	/**
+	 * Tests DevToolsUserAccess::print_personal_options
+	 *
+	 * @covers DevToolsUserAccess::print_personal_options
+	 */
+	public function test_print_personal_options() {
+		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+
+		ob_start();
+		$this->dev_tools_user_access->print_personal_options( $editor_user );
+		$this->assertEmpty( ob_get_clean() );
+
+		wp_set_current_user( $admin_user->ID );
+		ob_start();
+		$this->dev_tools_user_access->print_personal_options( $editor_user );
+		$this->assertEmpty( ob_get_clean() );
+
+		ob_start();
+		$this->dev_tools_user_access->print_personal_options( $admin_user );
+		$this->assertContains( 'checkbox', ob_get_clean() );
+	}
+
+	/**
+	 * Tests DevToolsUserAccess::update_user_setting
+	 *
+	 * @covers DevToolsUserAccess::update_user_setting
+	 */
+	public function test_update_user_setting() {
+		$admin_user  = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+
+		$_POST[ DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED ] = 'true';
+
+		$this->assertFalse( $this->dev_tools_user_access->update_user_setting( $admin_user->ID ) );
+
+		wp_set_current_user( $admin_user->ID );
+		$this->assertFalse( $this->dev_tools_user_access->update_user_setting( $editor_user->ID ) );
+
+		$this->assertTrue( $this->dev_tools_user_access->update_user_setting( $admin_user->ID ) );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+		$_POST[ DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED ] = null;
+		$this->assertTrue( $this->dev_tools_user_access->update_user_setting( $admin_user->ID ) );
+		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
 	}
 
 	/**

--- a/tests/php/test-class-monitor-css-transient-caching.php
+++ b/tests/php/test-class-monitor-css-transient-caching.php
@@ -46,7 +46,7 @@ class Test_Monitor_CSS_Transient_Caching extends WP_UnitTestCase {
 	 * @covers MonitorCssTransientCaching::deactivate()
 	 */
 	public function test_event_gets_scheduled_and_unscheduled() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$this->assertFalse( wp_next_scheduled( MonitorCssTransientCaching::EVENT_NAME ) );
 
 		$monitor = new MonitorCssTransientCaching();

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -43,7 +43,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_register() {
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( is_admin() );
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		AMP_Validated_URL_Post_Type::register();
 		$amp_post_type = get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG );
@@ -63,10 +63,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		AMP_Validated_URL_Post_Type::register();
 		$this->assertContains( AMP_Validated_URL_Post_Type::REMAINING_ERRORS, wp_removable_query_args() );
 
-		$post = $this->factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
+		$post = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertTrue( user_can( wp_get_current_user()->ID, 'edit_post', $post ) );
 
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
 		$this->assertFalse( current_user_can( 'edit_post', $post ) );
 	}
 
@@ -76,7 +76,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_hooks()
 	 */
 	public function test_add_admin_hooks() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validated_URL_Post_Type::add_admin_hooks();
 
 		$this->assertEquals( 10, has_filter( 'dashboard_glance_items', [ self::TESTED_CLASS, 'filter_dashboard_glance_items' ] ) );
@@ -117,7 +117,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count()
 	 */
 	public function test_add_admin_menu_new_invalid_url_count() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $submenu;
 		AMP_Validation_Manager::init(); // Register the post type and taxonomy.
 
@@ -1791,7 +1791,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * Test that the code ensures other plugins won't mess up the validation URL action links in the post list table.
 	 */
 	public function test_post_row_actions_filter() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validated_URL_Post_Type::add_admin_hooks();
 
 		$post = self::factory()->post->create_and_get(

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -62,6 +62,12 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		set_current_screen( 'index.php' );
 		AMP_Validated_URL_Post_Type::register();
 		$this->assertContains( AMP_Validated_URL_Post_Type::REMAINING_ERRORS, wp_removable_query_args() );
+
+		$post = $this->factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
+		$this->assertTrue( user_can( wp_get_current_user()->ID, 'edit_post', $post ) );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->assertFalse( current_user_can( 'edit_post', $post ) );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -111,6 +111,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count()
 	 */
 	public function test_add_admin_menu_new_invalid_url_count() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $submenu;
 		AMP_Validation_Manager::init(); // Register the post type and taxonomy.
 

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1004,7 +1004,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
 		$expected_submenu = [
 			'Error Index',
-			'manage_categories',
+			AMP_Validation_Manager::VALIDATE_CAPABILITY,
 			'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url',
 			'Error Index',
 		];

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -47,7 +47,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_register() {
 		global $wp_taxonomies;
 		add_theme_support( AMP_Theme_Support::SLUG );
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		AMP_Validation_Error_Taxonomy::register();
 		$taxonomy_object = $wp_taxonomies[ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ];
@@ -546,7 +546,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_add_admin_hooks() {
 		add_theme_support( AMP_Theme_Support::SLUG );
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Error_Taxonomy::register();
 
 		// add_group_terms_clauses_filter() needs the screen to be set.
@@ -952,7 +952,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::filter_tag_row_actions()
 	 */
 	public function test_filter_tag_row_actions() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $pagenow;
 		$pagenow = 'edit-tags.php';
 

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -560,7 +560,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'load-post.php', [ self::TESTED_CLASS, 'add_error_type_clauses_filter' ] ) );
 		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), [ self::TESTED_CLASS, 'render_taxonomy_filters' ] ) );
 		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), [ self::TESTED_CLASS, 'render_link_to_invalid_urls_screen' ] ) );
-		$this->assertEquals( 10, has_filter( 'user_has_cap', [ self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ] ) );
 		$this->assertEquals( 10, has_filter( 'terms_clauses', [ self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'add_admin_notices' ] ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_row_actions', [ self::TESTED_CLASS, 'filter_tag_row_actions' ] ) );
@@ -888,32 +887,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Validation_Error_Taxonomy::render_clear_empty_button();
 		$output = ob_get_clean();
 		$this->assertStringContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_CLEAR_EMPTY_ACTION, $output );
-	}
-
-	/**
-	 * Test filter_user_has_cap_for_hiding_term_list_table_checkbox.
-	 *
-	 * @covers \AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox()
-	 */
-	public function test_filter_user_has_cap_for_hiding_term_list_table_checkbox() {
-		$initial_caps = [ 'manage_options' ];
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], [] ) );
-
-		$term_id_with_description = self::factory()->term->create(
-			[
-				'description' => wp_json_encode( [ 'foo' => 'bar' ] ),
-			]
-		);
-		$args                     = [ 'delete_term', null, $term_id_with_description ];
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], $args ) );
-
-		$term_id_no_description = self::factory()->term->create(
-			[
-				'description' => wp_json_encode( [ 'foo' => 'bar' ] ),
-			]
-		);
-		$args                   = [ 'delete_term', null, $term_id_no_description ];
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], $args ) );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -215,21 +215,21 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Ensure that posts can be validated even when theme support is absent.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create() ) );
+		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( self::factory()->post->create() ) );
 
 		// Ensure normal case of validating published post when theme support present.
 		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create() ) );
+		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( self::factory()->post->create() ) );
 
 		// Trashed posts are not validatable.
-		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create( [ 'post_status' => 'trash' ] ) ) );
+		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( self::factory()->post->create( [ 'post_status' => 'trash' ] ) ) );
 
 		// An invalid post is not previewable.
 		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( 0 ) );
 
 		// Ensure non-viewable posts do not support validation.
 		register_post_type( 'not_viewable', [ 'publicly_queryable' => false ] );
-		$post = $this->factory()->post->create( [ 'post_type' => 'not_viewable' ] );
+		$post = self::factory()->post->create( [ 'post_type' => 'not_viewable' ] );
 		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $post ) );
 	}
 
@@ -477,8 +477,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::validate_queued_posts_on_frontend()
 	 */
 	public function test_handle_save_post_prompting_validation_and_validate_queued_posts_on_frontend() {
-		$admin_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
-		$editor_user_id = $this->factory()->user->create( [ 'role' => 'editor' ] );
+		$admin_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 
 		wp_set_current_user( $admin_user_id );
 		/** @var DevToolsUserAccess $service */
@@ -1452,7 +1452,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_wrap_widget_callbacks() {
 		global $wp_registered_widgets, $_wp_sidebars_widgets;
-		$this->go_to( amp_get_permalink( $this->factory()->post->create() ) );
+		$this->go_to( amp_get_permalink( self::factory()->post->create() ) );
 
 		$search_widget_id = 'search-2';
 		$this->assertArrayHasKey( $search_widget_id, $wp_registered_widgets );
@@ -2073,7 +2073,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::get_validate_response_data()
 	 */
 	public function test_get_validate_response_data() {
-		$post = $this->factory()->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 
 		$this->go_to( get_permalink( $post ) );
 		$source_html = '<style>amp-fit-text { color:red }</style><script>document.write("bad")</script><amp-fit-text width="300" height="200" layout="responsive">Lorem ipsum</amp-fit-text>';

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -692,13 +692,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_map_meta_cap() {
 		$this->assertEquals(
-			AMP_Validation_Manager::map_meta_cap( [ AMP_Validation_Manager::VALIDATE_CAPABILITY ], AMP_Validation_Manager::VALIDATE_CAPABILITY ),
-			[ 'manage_options' ]
+			[ 'manage_options' ],
+			AMP_Validation_Manager::map_meta_cap( [ AMP_Validation_Manager::VALIDATE_CAPABILITY ], AMP_Validation_Manager::VALIDATE_CAPABILITY )
 		);
 
 		$this->assertEquals(
-			AMP_Validation_Manager::map_meta_cap( [ 'install_plugins', AMP_Validation_Manager::VALIDATE_CAPABILITY, 'update_core' ], AMP_Validation_Manager::VALIDATE_CAPABILITY ),
-			[ 'install_plugins', 'manage_options', 'update_core' ]
+			[ 'install_plugins', 'manage_options', 'update_core' ],
+			AMP_Validation_Manager::map_meta_cap( [ 'install_plugins', AMP_Validation_Manager::VALIDATE_CAPABILITY, 'update_core' ], AMP_Validation_Manager::VALIDATE_CAPABILITY )
 		);
 	}
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -733,7 +733,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertFalse( AMP_Validation_Manager::has_cap() );
 		add_filter(
 			'map_meta_cap',
-			function ( $caps, $cap, $user_id ) {
+			static function ( $caps, $cap, $user_id ) {
 				if ( AMP_Validation_Manager::VALIDATE_CAPABILITY === $cap && user_can( $user_id, 'edit_others_posts' ) ) {
 					$position = array_search( $cap, $caps, true );
 					if ( false !== $position ) {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -204,18 +204,6 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test init when theme support is not present.
-	 *
-	 * @covers AMP_Validation_Manager::init()
-	 */
-	public function test_init_without_theme_support() {
-		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Validation_Manager::init();
-
-		$this->assertFalse( has_action( 'save_post', [ 'AMP_Validation_Manager', 'handle_save_post_prompting_validation' ] ) );
-	}
-
-	/**
 	 * Test \AMP_Validation_Manager::post_supports_validation.
 	 *
 	 * @covers \AMP_Validation_Manager::post_supports_validation()
@@ -224,7 +212,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Ensure that posts can be validated even when theme support is absent.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create() ) );
+		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create() ) );
 
 		// Ensure normal case of validating published post when theme support present.
 		add_theme_support( AMP_Theme_Support::SLUG );
@@ -486,6 +474,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::validate_queued_posts_on_frontend()
 	 */
 	public function test_handle_save_post_prompting_validation_and_validate_queued_posts_on_frontend() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$GLOBALS['pagenow']        = 'post.php';
@@ -2353,25 +2343,6 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertStringContains( 'css/amp-block-validation.css', $style->src );
 		$this->assertEquals( AMP__VERSION, $style->ver );
 		$this->assertContains( $slug, wp_styles()->queue );
-	}
-
-	/**
-	 * Test enqueue_block_validation.
-	 *
-	 * @covers AMP_Validation_Manager::enqueue_block_validation()
-	 */
-	public function test_enqueue_block_validation_without_amp_support() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The block editor is not available.' );
-		}
-
-		remove_theme_support( AMP_Theme_Support::SLUG );
-		global $post;
-		$post = $this->factory()->post->create_and_get();
-		$slug = 'amp-block-validation';
-		$this->set_capability();
-		AMP_Validation_Manager::enqueue_block_validation();
-		$this->assertNotContains( $slug, wp_scripts()->queue );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #2673.
Fixes #4480.
See #2069.

To accompany the “technical user” question in the onboarding wizard, there is now a Developer Tools preference on the user edit screen:

![image](https://user-images.githubusercontent.com/134745/86091886-7eca4280-ba61-11ea-81b0-032c32b65a22.png)

This checkbox is only presented to users who can `manage_options`. Actually, the checkbox is presented to users who can `amp_validate`, a new meta capability that is mapped to the `manage_options` primitive capability by default. This allows a site to customize which users can access developer tools, but by default it is limited to administrators (whereas currently it is anyone who can `edit_posts`).

As opposed to the DevTools toggle being `null` by default, it is now `true` by default. Admins can turn it off if they don't want it. The first time the wizard is entered, it does not consider the current user's preferences so it will ask whether they are technical without auto-selecting one option.

When an administrator has DevTools turned off, then the admin menu items for Validated URLs and Validation Errors do not appear:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/86092529-79212c80-ba62-11ea-9d0e-9ca1827c4843.png) | ![image](https://user-images.githubusercontent.com/134745/86092124-e5e7f700-ba61-11ea-9373-07b0ba090f11.png)

They are also hidden in the At a Glance widget on the Dashboard:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/86092405-4bd47e80-ba62-11ea-99c7-f487a17b0692.png) | ![image](https://user-images.githubusercontent.com/134745/86092145-f1d3b900-ba61-11ea-8a4c-c0f5459785a7.png)

And the admin bar simply shows a link back to the non-AMP version, with no Validate link, CSS usage info, or paired browsing (_aside: the link text is not entirely intuitive here_):

Before | After
-------|-------
 ![image](https://user-images.githubusercontent.com/134745/86092295-29dafc00-ba62-11ea-8584-9177b2c73ec4.png) | ![image](https://user-images.githubusercontent.com/134745/86092235-1760c280-ba62-11ea-8e32-fb28521ad206.png)

Nevertheless, even though an _administrator_ has turned off DevTools, they can still access them manually by going to `/wp-admin/edit.php?post_type=amp_validated_url`. All the screens then show up in the admin menu. This will be critical for allowing administrators to access the validation screens in response to the Site Health test proposed in https://github.com/ampproject/amp-wp/issues/1756#issuecomment-623864593.

Naturally, when Developer Tools are turned off, no validation warning messages will appear in the editor. Additionally, no synchronous validation is performed during saving. (Scheduling a job to validate an edit to a published post needs to be done as part of #1756.) This will address the slowness of synchronous loopback requests (#2069) for non-administrators and admins with DevTools turned off.

Additionally, loopback requests to perform validation are also no longer performed when activating a new plugin if the user has DevTools turned off.

Lastly, when DevTools are enabled they will also now apply in Reader mode for the first time.

> ![image](https://user-images.githubusercontent.com/134745/86093627-20eb2a00-ba64-11ea-8b42-56a6defaa373.png)

As part of this, the admin bar is now also shown in the Reader mode template. Please note that in order to support scripts that are added for the admin bar, this PR introduces `wp_print_head_scripts()` at `amp_post_template_head` and `wp_print_footer_scripts()` at `amp_post_template_footer`. Nevertheless, `wp_enqueue_scripts()` is not called so it's up to plugins that want to extend the sidebar in legacy Reader mode to enqueue the scripts at the `admin_bar_init` action.

While Developer Tools are restricted to administrator users who can `amp_validate` which is mapped to `manage_options` by default, this can be overridden for example to let editors access dev tools via code like this:

```php
add_filter(
	'map_meta_cap',
	function ( $caps, $cap, $user_id ) {
		if ( 'amp_validate' === $cap && user_can( $user_id, 'edit_others_posts' ) ) {
			$position = array_search( $cap, $caps, true );
			if ( false !== $position ) {
				$caps[ $position ] = 'edit_others_posts';
			}
		}
		return $caps;
	},
	10,
	3
);
```

That then moves the DevTools to the top-level menu item:

![image](https://user-images.githubusercontent.com/134745/86184506-39515800-bae9-11ea-98de-e9b4b2478564.png)

![image](https://user-images.githubusercontent.com/134745/86184663-7c133000-bae9-11ea-8df0-a18b6166227a.png)

## Todo

- [x] Add more tests.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
