### PR TITLE
Add plugin activation notice

### DIFF
--- a/src/Admin/DevToolsUserAccess.php
+++ b/src/Admin/DevToolsUserAccess.php
@@ -9,7 +9,6 @@
 
 namespace AmpProject\AmpWP\Admin;
 
-use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use WP_Error;

--- a/src/Admin/PluginActivationNotice.php
+++ b/src/Admin/PluginActivationNotice.php
@@ -12,6 +12,7 @@
 namespace AmpProject\AmpWP\Admin;
 
 use AMP_Options_Manager;
+use AMP_Setup_Wizard_Submenu;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
@@ -26,7 +27,7 @@ final class PluginActivationNotice implements Delayed, Service, Registerable {
 
 	/**
 	 * The ID of the plugin activation notice.
-	 * 
+	 *
 	 * @var string
 	 */
 	const NOTICE_ID = 'amp-plugin-notice-1';
@@ -76,7 +77,7 @@ final class PluginActivationNotice implements Delayed, Service, Registerable {
 			<div>
 				<h2><?php esc_html_e( 'Welcome to AMP for WordPress', 'amp' ); ?></h2>
 				<p><?php esc_html_e( 'Bring the speed and features of the open source AMP project to your site, complete with the tools to support content authoring and website development.', 'amp' ); ?></p>
-				<p><a href="https://amp-wp.org/getting-started/"><?php esc_html_e( 'Configure the plugin', 'amp' ); ?></a></p>
+				<p><a href="<?php menu_page_url( AMP_Setup_Wizard_Submenu::SCREEN_ID ); ?>"><?php esc_html_e( 'Configure the plugin', 'amp' ); ?></a></p>
 			</div>
 		</div>
 

--- a/src/Admin/PluginActivationNotice.php
+++ b/src/Admin/PluginActivationNotice.php
@@ -95,7 +95,7 @@ final class PluginActivationNotice implements Delayed, Service, Registerable {
 		<style type="text/css">
 			.amp-plugin-notice {
 				background: #E8F5F9;
-				box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1), inset 4px 0px 0px #419ECD;
+				box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), inset 4px 0 0 #419ECD;
 				display: flex;
 				padding: 21px 23px;
 			}

--- a/src/Admin/PluginActivationNotice.php
+++ b/src/Admin/PluginActivationNotice.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Class PluginActivationNotice.
+ *
+ * Adds an admin notice to the plugins screen after the plugin is activated.
+ *
+ * @since 1.6.0
+ *
+ * @package AMP
+ */
+
+namespace AmpProject\AmpWP\Admin;
+
+use AMP_Options_Manager;
+use AmpProject\AmpWP\Infrastructure\Delayed;
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Option;
+
+/**
+ * Class PluginActivationNotice
+ *
+ * @since 1.6.0
+ */
+final class PluginActivationNotice implements Delayed, Service, Registerable {
+
+	/**
+	 * The ID of the plugin activation notice.
+	 * 
+	 * @var string
+	 */
+	const NOTICE_ID = 'amp-plugin-notice-1';
+
+	/**
+	 * Get the action to use for registering the service.
+	 *
+	 * @return string Registration action to use.
+	 */
+	public static function get_registration_action() {
+		return 'admin_init';
+	}
+
+	/**
+	 * Runs on instantiation.
+	 */
+	public function register() {
+		add_action( 'admin_notices', [ $this, 'render_notice' ] );
+	}
+
+	/**
+	 * Renders a notice on the plugins screen after the plugin is activated. Persists until it is closed or setup has been completed.
+	 */
+	public function render_notice() {
+		if ( 'plugins' !== get_current_screen()->id && 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME !== get_current_screen()->id ) {
+			return;
+		}
+
+		if ( AMP_Options_Manager::get_option( Option::WIZARD_COMPLETED ) ) {
+			return;
+		}
+
+		$dismissed = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
+		if ( in_array( self::NOTICE_ID, explode( ',', (string) $dismissed ), true ) ) {
+			return;
+		}
+
+		?>
+		<div class="amp-plugin-notice notice notice-info is-dismissible" id="<?php echo esc_attr( self::NOTICE_ID ); ?>">
+			<div class="notice-dismiss"></div>
+			<div class="amp-plugin-notice-icon-holder">
+				<svg width="69" height="69" viewBox="0 0 69 69" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M34.4424 68.875C53.2201 68.875 68.4424 53.6527 68.4424 34.875C68.4424 16.0973 53.2201 0.875 34.4424 0.875C15.6647 0.875 0.442383 16.0973 0.442383 34.875C0.442383 53.6527 15.6647 68.875 34.4424 68.875Z" fill="#0479C2"/>
+					<path d="M36.9847 29.7355H45.2206C45.2206 29.7355 46.9573 29.7355 46.0621 31.7049L31.8641 55.3384H29.2322L31.7388 39.8871L23.3775 39.8334C23.3775 39.8334 21.8915 39.2426 23.0195 37.3268L36.9847 14.2305H39.724L36.9847 29.7355Z" fill="white"/>
+				</svg>
+			</div>
+			<div>
+				<h2><?php esc_html_e( 'Welcome to AMP for WordPress', 'amp' ); ?></h2>
+				<p><?php esc_html_e( 'Bring the speed and features of the open source AMP project to your site, complete with the tools to support content authoring and website development.', 'amp' ); ?></p>
+				<p><a href="https://amp-wp.org/getting-started/"><?php esc_html_e( 'Configure the plugin', 'amp' ); ?></a></p>
+			</div>
+		</div>
+
+		<script>
+		jQuery( function( $ ) {
+			// On dismissing the notice, make a POST request to store this notice with the dismissed WP pointers so it doesn't display again.
+			$( <?php echo wp_json_encode( '#' . self::NOTICE_ID ); ?> ).on( 'click', '.notice-dismiss', function() {
+				$.post( ajaxurl, {
+					pointer: <?php echo wp_json_encode( self::NOTICE_ID ); ?>,
+					action: 'dismiss-wp-pointer'
+				} );
+			} );
+		} );
+		</script>
+		<style type="text/css">
+			.amp-plugin-notice {
+				background: #E8F5F9;
+				box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1), inset 4px 0px 0px #419ECD;
+				display: flex;
+				padding: 21px 23px;
+			}
+			.amp-plugin-notice + .notice {
+				clear: both;
+			}
+			.amp-plugin-notice-icon-holder {
+				padding-right: 17px;
+			}
+			.amp-plugin-notice h2 {
+				margin-bottom: 8px;
+				margin-top: 0;
+			}
+			.amp-plugin-notice p {
+				margin-bottom: 2px;
+				margin-top: 2px;
+			}
+
+		</style>
+		<?php
+	}
+}

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -8,6 +8,7 @@
 namespace AmpProject\AmpWP;
 
 use AmpProject\AmpWP\Admin\DevToolsUserAccess;
+use AmpProject\AmpWP\Admin\PluginActivationNotice;
 use AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction;
 use AmpProject\AmpWP\Admin\SiteHealth;
 use AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching;
@@ -57,6 +58,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			'css_transient_cache.monitor'      => MonitorCssTransientCaching::class,
 			'css_transient_cache.ajax_handler' => ReenableCssTransientCachingAjaxAction::class,
 			'site_health_integration'          => SiteHealth::class,
+			'plugin_activation_notice'         => PluginActivationNotice::class,
 			'plugin_registry'                  => PluginRegistry::class,
 			'plugin_suppression'               => PluginSuppression::class,
 			'mobile_redirection'               => MobileRedirection::class,

--- a/tests/php/test-class-plugin-activation-notice.php
+++ b/tests/php/test-class-plugin-activation-notice.php
@@ -67,6 +67,8 @@ class Test_PluginActivationNotice extends WP_UnitTestCase {
 		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
 
 		delete_user_meta( get_current_user_id(), 'dismissed_wp_pointers' );
+
+		set_current_screen( null );
 	}
 
 	/**
@@ -84,5 +86,7 @@ class Test_PluginActivationNotice extends WP_UnitTestCase {
 		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
 
 		AMP_Options_Manager::update_option( Option::WIZARD_COMPLETED, $original_option );
+
+		set_current_screen( null );
 	}
 }

--- a/tests/php/test-class-plugin-activation-notice.php
+++ b/tests/php/test-class-plugin-activation-notice.php
@@ -68,7 +68,7 @@ class Test_PluginActivationNotice extends WP_UnitTestCase {
 
 		delete_user_meta( get_current_user_id(), 'dismissed_wp_pointers' );
 
-		set_current_screen( null );
+		$GLOBALS['current_screen'] = null;
 	}
 
 	/**
@@ -87,6 +87,6 @@ class Test_PluginActivationNotice extends WP_UnitTestCase {
 
 		AMP_Options_Manager::update_option( Option::WIZARD_COMPLETED, $original_option );
 
-		set_current_screen( null );
+		$GLOBALS['current_screen'] = null;
 	}
 }

--- a/tests/php/test-class-plugin-activation-notice.php
+++ b/tests/php/test-class-plugin-activation-notice.php
@@ -57,7 +57,7 @@ class Test_PluginActivationNotice extends WP_UnitTestCase {
 	 * @covers PluginActivationNotice::render_notice
 	 */
 	public function test_user_can_dismiss_notice() {
-		wp_set_current_user( 1 ); 
+		wp_set_current_user( 1 );
 		update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', PluginActivationNotice::NOTICE_ID );
 
 		set_current_screen( 'plugins' );

--- a/tests/php/test-class-plugin-activation-notice.php
+++ b/tests/php/test-class-plugin-activation-notice.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for PluginActivationNotice class.
+ *
+ * @package AMP
+ */
+
+use AmpProject\AmpWP\Admin\PluginActivationNotice;
+use AmpProject\AmpWP\Option;
+
+/**
+ * Tests for PluginActivationNotice class.
+ *
+ * @group plugin-activation-notice
+ *
+ * @since 1.6.0
+ *
+ * @covers PluginActivationNotice
+ */
+class Test_PluginActivationNotice extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var PluginActivationNotice
+	 */
+	private $plugin_activation_notice;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->plugin_activation_notice = new PluginActivationNotice();
+	}
+
+	/**
+	 * Tests PluginActivationNotice::register
+	 *
+	 * @covers PluginActivationNotice::register
+	 */
+	public function test_register() {
+		$this->plugin_activation_notice->register();
+		$this->assertEquals( 10, has_action( 'admin_notices', [ $this->plugin_activation_notice, 'render_notice' ] ) );
+	}
+
+	/**
+	 * @covers PluginActivationNotice::render_notice
+	 */
+	public function test_user_sees_notice() {
+		set_current_screen( 'plugins' );
+		$this->assertContains( 'class="amp-plugin-notice', get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+
+		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
+		$this->assertContains( 'class="amp-plugin-notice', get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+	}
+
+	/**
+	 * @covers PluginActivationNotice::render_notice
+	 */
+	public function test_user_can_dismiss_notice() {
+		wp_set_current_user( 1 ); 
+		update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', PluginActivationNotice::NOTICE_ID );
+
+		set_current_screen( 'plugins' );
+		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+
+		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
+		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+
+		delete_user_meta( get_current_user_id(), 'dismissed_wp_pointers' );
+	}
+
+	/**
+	 * @covers PluginActivationNotice::render_notice
+	 */
+	public function test_notice_doesnt_show_if_wizard_completed() {
+		$original_option = AMP_Options_Manager::get_option( Option::WIZARD_COMPLETED );
+
+		AMP_Options_Manager::update_option( Option::WIZARD_COMPLETED, true );
+
+		set_current_screen( 'plugins' );
+		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+
+		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
+		$this->assertEmpty( get_echo( [ $this->plugin_activation_notice, 'render_notice' ] ) );
+
+		AMP_Options_Manager::update_option( Option::WIZARD_COMPLETED, $original_option );
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4961 

This adds a new plugin activation notice, shown below. The notice shows on the plugins screen and the main amp settings screen. It persists until it is dismissed or the onboarding wizard is completed. To reset the wizard flag, you can use this WP-CLI command:

```bash
wp eval "AMP_Options_Manager::update_option('wizard_completed', false);"
```

To reset your admin pointers (assuming your user ID is `1`):

```bash
wp user meta delete 1 dismissed_wp_pointers
```

<img width="1291" alt="Screen Shot 2020-06-30 at 10 40 43 AM" src="https://user-images.githubusercontent.com/9020968/86146770-4147d280-babe-11ea-8627-f0ea9b56a5b1.png">
<img width="1289" alt="Screen Shot 2020-06-30 at 10 40 30 AM" src="https://user-images.githubusercontent.com/9020968/86146774-43119600-babe-11ea-8a2b-65b7ce10157d.png">


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
