### PR TITLE
Ensure save screen has all option data

### DIFF
--- a/assets/src/setup/pages/save/index.js
+++ b/assets/src/setup/pages/save/index.js
@@ -120,7 +120,7 @@ function Preview() {
 export function Save() {
 	const {
 		didSaveOptions,
-		updates: { theme_support: themeSupport, reader_theme: readerTheme },
+		editedOptions: { theme_support: themeSupport, reader_theme: readerTheme },
 		originalOptions: { preview_permalink: previewPermalink },
 		saveOptions,
 		savingOptions,


### PR DESCRIPTION
## Summary

Fixes #4971 

This fixes a bug @westonruter brought up on Slack where the save screen sometimes doesn't have all data. This was because one portion of the screen was using the `updates` object from the options state. `updates` only contains options updated in the current session. This came about during an intermediate stage of development, and later on most instances of `updates` needed to be changed to `editedOptions`, which contains the original fetched options with updates applied. I missed this one earlier.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
