### PR TITLE
Allow mobile redirection in dev mode and allow mobile switcher link in Customizer preview (if in Transitional mode)

### DIFF
--- a/assets/src/mobile-redirection.js
+++ b/assets/src/mobile-redirection.js
@@ -45,7 +45,8 @@
 	} );
 
 	// Short-circuit if mobile redirection is disabled.
-	if ( sessionStorage.getItem( disabledStorageKey ) || isCustomizePreview || isAmpDevMode ) {
+	const isPairedBrowsing = isAmpDevMode && [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name );
+	if ( sessionStorage.getItem( disabledStorageKey ) || isCustomizePreview || isPairedBrowsing ) {
 		return;
 	}
 

--- a/assets/src/mobile-redirection.js
+++ b/assets/src/mobile-redirection.js
@@ -44,7 +44,10 @@
 		}
 	} );
 
-	// Short-circuit if mobile redirection is disabled.
+	// Short-circuit if mobile redirection is disabled. Redirection is disabled if the user opted-out by clicking the
+	// link to exit the mobile version, if they are in paired browsing (since non-AMP and AMP are forced in the respective
+	// iframes), and when in the customizer (since the Customizer is opened with a given URL and that should be the URL
+	// which is then used for Customization).
 	const isPairedBrowsing = isAmpDevMode && [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name );
 	if ( sessionStorage.getItem( disabledStorageKey ) || isCustomizePreview || isPairedBrowsing ) {
 		return;

--- a/includes/templates/amp-paired-browsing.php
+++ b/includes/templates/amp-paired-browsing.php
@@ -59,6 +59,7 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 
 			<div id="non-amp">
 				<iframe
+					name="paired-browsing-non-amp"
 					src="<?php echo esc_url( $url ); ?>"
 					sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-modals"
 					title="<?php esc_attr__( 'Non-AMP version', 'amp' ); ?>"
@@ -67,6 +68,7 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 
 			<div id="amp">
 				<iframe
+					name="paired-browsing-amp"
 					src="<?php echo esc_url( $amp_url ); ?>"
 					sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-modals"
 					title="<?php esc_attr__( 'AMP version', 'amp' ); ?>"

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -11,6 +11,7 @@ use AMP_Options_Manager;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\Attribute;
+use AMP_Theme_Support;
 
 /**
  * Service for redirecting mobile users to the AMP version of a page.
@@ -509,17 +510,19 @@ final class MobileRedirection implements Service, Registerable {
 			</a>
 		</div>
 
-		<?php if ( amp_is_dev_mode() && ! is_customize_preview() ) : ?>
+		<?php if ( amp_is_dev_mode() && ( ! is_customize_preview() || AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) ) : ?>
 			<?php
+			// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions.
 			$exports = [
 				'containerId'          => $container_id,
+				'isCustomizePreview'   => is_customize_preview(),
 				'notApplicableMessage' => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
 			];
 			?>
 			<script data-ampdevmode>
-			(function( { containerId, notApplicableMessage } ) {
+			(function( { containerId, isCustomizePreview, notApplicableMessage } ) {
 				addEventListener( 'DOMContentLoaded', () => {
-					if ( [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
+					if ( isCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
 						const link = document.querySelector( `#${containerId} a[href]` );
 						link.style.cursor = 'not-allowed';
 						link.addEventListener( 'click', ( event ) => {

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -509,18 +509,17 @@ final class MobileRedirection implements Service, Registerable {
 			</a>
 		</div>
 
-		<?php if ( amp_is_dev_mode() ) : ?>
+		<?php if ( amp_is_dev_mode() && ! is_customize_preview() ) : ?>
 			<?php
 			$exports = [
 				'containerId'          => $container_id,
-				'isCustomizePreview'   => is_customize_preview(),
 				'notApplicableMessage' => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
 			];
 			?>
 			<script data-ampdevmode>
-			(function( { containerId, isCustomizePreview, notApplicableMessage } ) {
+			(function( { containerId, notApplicableMessage } ) {
 				addEventListener( 'DOMContentLoaded', () => {
-					if ( isCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
+					if ( [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
 						const link = document.querySelector( `#${containerId} a[href]` );
 						link.style.cursor = 'not-allowed';
 						link.addEventListener( 'click', ( event ) => {

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -520,7 +520,7 @@ final class MobileRedirection implements Service, Registerable {
 			<script data-ampdevmode>
 			(function( { containerId, isCustomizePreview, notApplicableMessage } ) {
 				addEventListener( 'DOMContentLoaded', () => {
-					if ( isCustomizePreview || window.ampPairedBrowsingClient ) {
+					if ( isCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
 						const link = document.querySelector( `#${containerId} a[href]` );
 						link.style.cursor = 'not-allowed';
 						link.addEventListener( 'click', ( event ) => {


### PR DESCRIPTION
## Summary

When mobile redirection was implemented in #4796, the functionality to automatically redirect was disabled when dev mode was enabled. The reason for this is that dev mode is a dependency for accessing paired browsing, and since the JS to do the redirection needs to happen as early as possible, I thought that it was too early to determine if the JS was running in paired browsing. This is not the case, however. We can simply provide names for the paired browsing iframes, and then check `window.name` to see if it matches one of these names, and if so abort.

Mobile redirection is also disabled in the Customizer. This is still for good reason as if you open the Customizer for a given URL, then that is the URL which should be customized. However, mobile version switcher link was also being disabled in the Customizer preview (as it is also being disabled in paired browsing). This remains necessary when a site is in legacy Reader mode since there is a separate AMP toggle in the controls pane. It's also needed when a Reader theme is selected (#4984) since the Customizer for the AMP pages is entirely different than the Customizer for non-AMP pages (as two different themes are used). But the version switcher link is fine to be enabled when a site is in Transitional mode.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
