### PR TITLE
Optimize AMP_Tag_And_Attribute_Sanitizer::get_missing_mandatory_attributes()

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1413,8 +1413,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Fetch external stylesheet.
 	 *
-	 * @todo Use Cache-Control max-age for transient.
-	 *
 	 * @param string $url External stylesheet URL.
 	 * @return string|WP_Error Stylesheet contents or WP_Error.
 	 */

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -830,14 +830,21 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function get_missing_mandatory_attributes( $attr_spec, DOMElement $node ) {
 		$missing_attributes = [];
+
 		foreach ( $attr_spec as $attr_name => $attr_spec_rule_value ) {
+			if ( ! isset( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY ] ) || ! $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY ] ) {
+				continue;
+			}
+
 			if ( '\u' === substr( $attr_name, 0, 2 ) ) {
 				$attr_name = html_entity_decode( '&#x' . substr( $attr_name, 2 ) . ';' ); // Probably ⚡.
 			}
+
 			if ( ! $node->hasAttribute( $attr_name ) && AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_mandatory( $node, $attr_name, $attr_spec_rule_value ) ) {
 				$missing_attributes[] = $attr_name;
 			}
 		}
+
 		return $missing_attributes;
 	}
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -832,7 +832,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		$missing_attributes = [];
 
 		foreach ( $attr_spec as $attr_name => $attr_spec_rule_value ) {
-			if ( ! isset( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY ] ) || ! $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY ] ) {
+			if ( empty( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

While doing an initial test run with Blackfire (see #3361), I noticed the following:

![Image 2020-07-06 at 8 25 33 PM](https://user-images.githubusercontent.com/83631/86626431-f26ed100-bfc6-11ea-9f1e-283f3ab599b9.png)

Of the 2.61s AMP page generation time, the `AMP_Tag_And_Attribute_Sanitizer::get_missing_mandatory_attributes()` method was accounting for more than 50% of the execution time.

It was calling:
 - 58262x into `substr()`
 - 58262x into `DOMElement::hasAttribute()`
 - 57606x into `AMP_Tag_And_Attribute_Sanitizer::check_attr_spec_rule_mandatory()`

As you can see from the flamegraph, the AMP generation is disproportionally large because of that:
![Image 2020-07-06 at 8 29 58 PM](https://user-images.githubusercontent.com/83631/86626827-8e004180-bfc7-11ea-8f08-9cfcd2fd23b8.png)

The problem is that the method loops over all nodes, and then for each of them loops over all specs, and then checks whether something is mandatory.

The current PR addresses this by extracting one conditional out of `AMP_Tag_And_Attribute_Sanitizer::check_attr_spec_rule_mandatory()` and puts it as the first check within `AMP_Tag_And_Attribute_Sanitizer::get_missing_mandatory_attributes()`. This check is the most important one: is this spec mandatory? The entire rest of the logic can be skipped if that is not the case.

Here's the result:

![Image 2020-07-06 at 8 45 54 PM](https://user-images.githubusercontent.com/83631/86628760-a3c33600-bfca-11ea-8bb2-3c0d6834889f.png)

The method has dropped out of the captured graph of Blackfire, meaning it accounts for less than 1% of the execution time in any way. To get a more detailed overview, I'd have to re-run with `blackfire curl --debug` to disable this pruning, but it doesn't allow me to do that right now it seems.

Anyway, the function went from being more than 50% of the total page generation time, to being insignificant.

The flamegraph also looks completely different now:

![Image 2020-07-06 at 8 35 11 PM](https://user-images.githubusercontent.com/83631/86627210-36160a80-bfc8-11ea-9c2c-cb8bbacea591.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
