### PR TITLE
Add Settings link to the AMP admin bar item when Dev Tools enabled

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -462,7 +462,7 @@ class AMP_Validation_Manager {
 				[
 					'parent' => 'amp',
 					'id'     => 'amp-settings',
-					'title'  => __( 'Settings', 'amp' ),
+					'title'  => esc_html__( 'Settings', 'amp' ),
 					'href'   => esc_url( admin_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, 'admin.php' ) ) ),
 				]
 			);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -456,6 +456,18 @@ class AMP_Validation_Manager {
 			$wp_admin_bar->add_node( $paired_browsing_item );
 		}
 
+		// Add settings link to admin bar.
+		if ( current_user_can( 'manage_options' ) ) {
+			$wp_admin_bar->add_node(
+				[
+					'parent' => 'amp',
+					'id'     => 'amp-settings',
+					'title'  => __( 'Settings', 'amp' ),
+					'href'   => esc_url( admin_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, 'admin.php' ) ) ),
+				]
+			);
+		}
+
 		self::$amp_admin_bar_item_added = true;
 	}
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -359,6 +359,18 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertInternalType( 'object', $view_item );
 		$this->assertEqualSets( [ QueryVars::AMP ], array_keys( $this->get_url_query_vars( $view_item->href ) ) );
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
+
+		// Lastly, confirm that the settings item is added if the user is an admin.
+		wp_set_current_user( 0 );
+		$admin_bar = new WP_Admin_Bar();
+		$this->assertFalse( current_user_can( 'manage_options' ) );
+		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
+		$this->assertNull( $admin_bar->get_node( 'amp-settings' ) );
+		$admin_bar = new WP_Admin_Bar();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertTrue( current_user_can( 'manage_options' ) );
+		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
+		$this->assertObjectHasAttribute( 'href', $admin_bar->get_node( 'amp-settings' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Something I often find I need access to is the AMP Settings screen. This PR adds a Settings item to the AMP menu (when DevTools is enabled):

![image](https://user-images.githubusercontent.com/134745/86671032-1c65ca80-bfaa-11ea-8e38-80ea17b9427a.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
