### PR TITLE
Add checking for whether AMP query var is defined too late for Reader themes

### DIFF
--- a/assets/src/setup/pages/choose-reader-theme/index.js
+++ b/assets/src/setup/pages/choose-reader-theme/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useContext, useMemo } from '@wordpress/element';
 
 /**
@@ -12,6 +12,11 @@ import { Navigation } from '../../components/navigation-context-provider';
 import { Options } from '../../components/options-context-provider';
 import { ReaderThemes } from '../../components/reader-themes-context-provider';
 import { ThemeCard } from './theme-card';
+
+/**
+ * External Dependencies.
+ */
+import { AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR, LEGACY_THEME_SLUG, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-setup'; // From WP inline script.
 
 /**
  * Screen for choosing the Reader theme.
@@ -43,7 +48,7 @@ export function ChooseReaderTheme() {
 	const { availableThemes, unavailableThemes } = useMemo(
 		() => themes.reduce(
 			( collections, theme ) => {
-				if ( theme.availability === 'non-installable' ) {
+				if ( ( AMP_QUERY_VAR_CUSTOMIZED_LATE && theme.slug !== LEGACY_THEME_SLUG ) || theme.availability === 'non-installable' ) {
 					collections.unavailableThemes.push( theme );
 				} else {
 					collections.availableThemes.push( theme );
@@ -96,7 +101,10 @@ export function ChooseReaderTheme() {
 							{ __( 'Unavailable themes', 'amp' ) }
 						</h3>
 						<p>
-							{ __( 'The following themes are compatible but cannot be installed automatically. Please install them manually, or contact your host if you are not able to do so.', 'amp' ) }
+							{ AMP_QUERY_VAR_CUSTOMIZED_LATE
+								? sprintf( __( 'The following themes are not available because your site (probably the active theme) has customized the AMP query var too late (it is set to “%1$s” as opposed to the default of “%2$s”). Please make sure that any customizations done by defining the AMP_QUERY_VAR constant or adding an amp_query_var filter are done before the `plugins_loaded` action with priority 8.', 'amp' ), AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR )
+								: __( 'The following themes are compatible but cannot be installed automatically. Please install them manually, or contact your host if you are not able to do so.', 'amp' )
+							}
 						</p>
 						<ul className="choose-reader-theme__grid">
 							{ unavailableThemes.map( ( theme ) => (

--- a/assets/src/setup/pages/choose-reader-theme/index.js
+++ b/assets/src/setup/pages/choose-reader-theme/index.js
@@ -37,10 +37,15 @@ export function ChooseReaderTheme() {
 			return;
 		}
 
-		if ( themes && readerTheme && canGoForward === false ) {
-			if ( themes.map( ( { slug } ) => slug ).includes( readerTheme ) ) {
-				setCanGoForward( true );
-			}
+		if (
+			themes &&
+			readerTheme &&
+			canGoForward === false &&
+			! AMP_QUERY_VAR_CUSTOMIZED_LATE
+				? themes.map( ( { slug } ) => slug ).includes( readerTheme )
+				: readerTheme === LEGACY_THEME_SLUG
+		) {
+			setCanGoForward( true );
 		}
 	}, [ canGoForward, setCanGoForward, readerTheme, themes, themeSupport ] );
 

--- a/assets/src/setup/pages/choose-reader-theme/index.js
+++ b/assets/src/setup/pages/choose-reader-theme/index.js
@@ -107,7 +107,20 @@ export function ChooseReaderTheme() {
 						</h3>
 						<p>
 							{ AMP_QUERY_VAR_CUSTOMIZED_LATE
-								? sprintf( __( 'The following themes are not available because your site (probably the active theme) has customized the AMP query var too late (it is set to “%1$s” as opposed to the default of “%2$s”). Please make sure that any customizations done by defining the AMP_QUERY_VAR constant or adding an amp_query_var filter are done before the `plugins_loaded` action with priority 8.', 'amp' ), AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR )
+								/* dangerouslySetInnerHTML reason: Injection of code tags. */
+								? <span
+									dangerouslySetInnerHTML={ {
+										__html: sprintf(
+											/* translators: 1: customized AMP query var, 2: default query var, 3: the AMP_QUERY_VAR constant name, 4: the amp_query_var filter, 5: the plugins_loaded action */
+											__( 'The following themes are not available because your site (probably the active theme) has customized the AMP query var too late (it is set to %1$s as opposed to the default of %2$s). Please make sure that any customizations done by defining the %3$s constant or adding an %4$s filter are done before the %5$s action with priority 8.', 'amp' ),
+											`<code>${ AMP_QUERY_VAR }</code>`,
+											`<code>${ DEFAULT_AMP_QUERY_VAR }</code>`,
+											'<code>AMP_QUERY_VAR</code>',
+											'<code>amp_query_var</code>',
+											'<code>plugins_loaded</code>',
+										),
+									} }
+								/>
 								: __( 'The following themes are compatible but cannot be installed automatically. Please install them manually, or contact your host if you are not able to do so.', 'amp' )
 							}
 						</p>

--- a/assets/src/setup/pages/choose-reader-theme/index.js
+++ b/assets/src/setup/pages/choose-reader-theme/index.js
@@ -5,6 +5,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useContext, useMemo } from '@wordpress/element';
 
 /**
+ * External dependencies
+ */
+import { AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR, LEGACY_THEME_SLUG, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-setup'; // From WP inline script.
+
+/**
  * Internal dependencies
  */
 import { Loading } from '../../components/loading';
@@ -12,11 +17,6 @@ import { Navigation } from '../../components/navigation-context-provider';
 import { Options } from '../../components/options-context-provider';
 import { ReaderThemes } from '../../components/reader-themes-context-provider';
 import { ThemeCard } from './theme-card';
-
-/**
- * External Dependencies.
- */
-import { AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR, LEGACY_THEME_SLUG, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-setup'; // From WP inline script.
 
 /**
  * Screen for choosing the Reader theme.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -535,9 +535,10 @@ function amp_redirect_old_slug_to_new_url( $link ) {
  *
  * @since 0.7
  *
+ * @param bool $define_constant Whether store the query var in the AMP_QUERY_VAR constant.
  * @return string Slug used for query var, endpoint, and post type support.
  */
-function amp_get_slug() {
+function amp_get_slug( $define_constant = true ) {
 	if ( defined( 'AMP_QUERY_VAR' ) ) {
 		return AMP_QUERY_VAR;
 	}
@@ -553,7 +554,9 @@ function amp_get_slug() {
 	 */
 	$query_var = apply_filters( 'amp_query_var', QueryVars::AMP );
 
-	define( 'AMP_QUERY_VAR', $query_var );
+	if ( $define_constant ) {
+		define( 'AMP_QUERY_VAR', $query_var );
+	}
 
 	return $query_var;
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -535,14 +535,9 @@ function amp_redirect_old_slug_to_new_url( $link ) {
  *
  * @since 0.7
  *
- * @param bool $define_constant Whether store the query var in the AMP_QUERY_VAR constant.
  * @return string Slug used for query var, endpoint, and post type support.
  */
-function amp_get_slug( $define_constant = true ) {
-	if ( defined( 'AMP_QUERY_VAR' ) ) {
-		return AMP_QUERY_VAR;
-	}
-
+function amp_get_slug() {
 	/**
 	 * Filter the AMP query variable.
 	 *
@@ -552,13 +547,7 @@ function amp_get_slug( $define_constant = true ) {
 	 *
 	 * @param string $query_var The AMP query variable.
 	 */
-	$query_var = apply_filters( 'amp_query_var', QueryVars::AMP );
-
-	if ( $define_constant ) {
-		define( 'AMP_QUERY_VAR', $query_var );
-	}
-
-	return $query_var;
+	return apply_filters( 'amp_query_var', defined( 'AMP_QUERY_VAR' ) ? AMP_QUERY_VAR : QueryVars::AMP );
 }
 
 /**

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -5,7 +5,10 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\QueryVars;
+use AmpProject\AmpWP\Services;
 
 /**
  * AMP_Options_Menu class.
@@ -134,6 +137,9 @@ class AMP_Options_Menu {
 	public function render_theme_support() {
 		$theme_support = AMP_Options_Manager::get_option( Option::THEME_SUPPORT );
 
+		/** @var AmpSlugCustomizationWatcher $amp_slug_customization_watcher */
+		$amp_slug_customization_watcher = Services::get( 'amp_slug_customization_watcher' );
+
 		/* translators: %s: URL to the documentation. */
 		$standard_description = sprintf( __( 'The active theme integrates AMP as the framework for your site by using its templates and styles to render webpages. This means your site is <b>AMP-first</b> and your canonical URLs are AMP! Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		/* translators: %s: URL to the documentation. */
@@ -205,15 +211,51 @@ class AMP_Options_Menu {
 				<dd>
 					<p><?php echo wp_kses_post( $reader_description ); ?></p>
 
-					<p>
-						<?php
-						/* translators: %s is the reader theme */
-						echo esc_html( sprintf( __( 'The "%s" theme is currently selected in the wizard. The ability to change it from the admin screen will come soon.', 'amp' ), AMP_Options_Manager::get_option( Option::READER_THEME ) ) );
-						?>
-					</p>
+					<div class="notice notice-info notice-alt inline">
+						<p>
+							<?php
+							/* translators: %s is the reader theme */
+							echo esc_html( sprintf( __( 'The "%s" theme is currently selected in the wizard. The ability to change it from the admin screen will come soon.', 'amp' ), AMP_Options_Manager::get_option( Option::READER_THEME ) ) );
+							?>
+						</p>
+					</div>
 
 					<?php if ( AMP_Options_Manager::get_option( Option::READER_THEME ) === get_template() ) : ?>
-						<p><?php esc_html_e( 'The currently-selected Reader theme is the same as the active theme. This means that Reader mode is disabled since it is no different from Transitional mode at this point.', 'amp' ); ?></p>
+						<div class="notice notice-info notice-alt inline">
+							<p><?php esc_html_e( 'The currently-selected Reader theme is the same as the active theme. This means that Reader mode is disabled since it is no different from Transitional mode at this point.', 'amp' ); ?></p>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( $amp_slug_customization_watcher->did_customize_late() ) : ?>
+						<div class="notice notice-warning notice-alt inline">
+							<p>
+								<?php
+								echo wp_kses_post(
+									sprintf(
+									/* translators: 1: customized AMP query var, 2: default AMP query var */
+										esc_html__( 'Warning: You customized your AMP query var too late. This means that Reader themes will not be available to you. You customized it to be %1$s instead of the default %2$s.', 'amp' ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( $amp_slug_customization_watcher->get_customized_slug() ) ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )
+									)
+								);
+								?>
+							</p>
+						</div>
+					<?php elseif ( $amp_slug_customization_watcher->did_customize_early() ) : ?>
+						<div class="notice notice-info notice-alt inline">
+							<p>
+								<?php
+								echo wp_kses_post(
+									sprintf(
+									/* translators: 1: customized AMP query var, 2: default AMP query var */
+										esc_html__( 'You customized your query var to be %1$s instead of the default %2$s.', 'amp' ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( $amp_slug_customization_watcher->get_customized_slug() ) ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )
+									)
+								);
+								?>
+							</p>
+						</div>
 					<?php endif; ?>
 				</dd>
 			</dl>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -234,7 +234,7 @@ class AMP_Options_Menu {
 									sprintf(
 									/* translators: 1: customized AMP query var, 2: default AMP query var */
 										esc_html__( 'Warning: You customized your AMP query var too late. This means that Reader themes will not be available to you. You customized it to be %1$s instead of the default %2$s.', 'amp' ),
-										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( $amp_slug_customization_watcher->get_customized_slug() ) ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( amp_get_slug() ) ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )
 									)
 								);
@@ -249,7 +249,7 @@ class AMP_Options_Menu {
 									sprintf(
 									/* translators: 1: customized AMP query var, 2: default AMP query var */
 										esc_html__( 'You customized your query var to be %1$s instead of the default %2$s.', 'amp' ),
-										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( $amp_slug_customization_watcher->get_customized_slug() ) ),
+										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( amp_get_slug() ) ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )
 									)
 								);

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -232,7 +232,7 @@ class AMP_Options_Menu {
 								<?php
 								echo wp_kses_post(
 									sprintf(
-									/* translators: 1: customized AMP query var, 2: default AMP query var */
+										/* translators: 1: customized AMP query var, 2: default AMP query var */
 										esc_html__( 'Warning: You customized your AMP query var too late. This means that Reader themes will not be available to you. You customized it to be %1$s instead of the default %2$s.', 'amp' ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( amp_get_slug() ) ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )
@@ -247,7 +247,7 @@ class AMP_Options_Menu {
 								<?php
 								echo wp_kses_post(
 									sprintf(
-									/* translators: 1: customized AMP query var, 2: default AMP query var */
+										/* translators: 1: customized AMP query var, 2: default AMP query var */
 										esc_html__( 'You customized your query var to be %1$s instead of the default %2$s.', 'amp' ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', esc_html( amp_get_slug() ) ),
 										sprintf( '&#8220;<code>%s</code>&#8221;', QueryVars::AMP )

--- a/includes/options/views/class-amp-setup-wizard-submenu-page.php
+++ b/includes/options/views/class-amp-setup-wizard-submenu-page.php
@@ -7,6 +7,10 @@
  */
 
 use AmpProject\AmpWP\Admin\DevToolsUserAccess;
+use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
+use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\QueryVars;
+use AmpProject\AmpWP\Services;
 
 /**
  * AMP setup wizard submenu page class.
@@ -104,6 +108,9 @@ final class AMP_Setup_Wizard_Submenu_Page {
 			return;
 		}
 
+		/** @var AmpSlugCustomizationWatcher $amp_slug_customization_watcher */
+		$amp_slug_customization_watcher = Services::get( 'amp_slug_customization_watcher' );
+
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';
 		$asset        = require $asset_file;
 		$dependencies = $asset['dependencies'];
@@ -145,6 +152,9 @@ final class AMP_Setup_Wizard_Submenu_Page {
 		$setup_wizard_data = [
 			'AMP_OPTIONS_KEY'                    => AMP_Options_Manager::OPTION_NAME,
 			'AMP_QUERY_VAR'                      => amp_get_slug(),
+			'DEFAULT_AMP_QUERY_VAR'              => QueryVars::AMP,
+			'AMP_QUERY_VAR_CUSTOMIZED_LATE'      => $amp_slug_customization_watcher->did_customize_late(),
+			'LEGACY_THEME_SLUG'                  => AMP_Reader_Themes::DEFAULT_READER_THEME,
 			'APP_ROOT_ID'                        => self::APP_ROOT_ID,
 			'CUSTOMIZER_LINK'                    => add_query_arg(
 				[

--- a/src/AmpSlugCustomizationWatcher.php
+++ b/src/AmpSlugCustomizationWatcher.php
@@ -18,13 +18,6 @@ use AmpProject\AmpWP\Infrastructure\Service;
 final class AmpSlugCustomizationWatcher implements Service, Registerable {
 
 	/**
-	 * The slug (query var) that was customized.
-	 *
-	 * @var string|null
-	 */
-	protected $customized_slug = null;
-
-	/**
 	 * Whether the slug was customized early (at plugins_loaded action, priority 8).
 	 *
 	 * @var bool
@@ -66,26 +59,6 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	}
 
 	/**
-	 * Whether the slug was customized.
-	 *
-	 * @return bool
-	 */
-	public function did_customize_slug() {
-		return null !== $this->customized_slug;
-	}
-
-	/**
-	 * Get the customized slug.
-	 *
-	 * Returns null if it was not customized.
-	 *
-	 * @return string|null
-	 */
-	public function get_customized_slug() {
-		return $this->customized_slug;
-	}
-
-	/**
 	 * Peek at the customized slug.
 	 *
 	 * This does not call amp_get_slug(true) because if it did then it would end up defining AMP_QUERY_VAR and destroy
@@ -93,7 +66,7 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	 *
 	 * @return string Query var.
 	 */
-	public function peek_customized_slug() {
+	protected function peek_customized_slug() {
 		return amp_get_slug( false );
 	}
 
@@ -108,7 +81,6 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	public function determine_early_customization() {
 		$slug = $this->peek_customized_slug();
 		if ( QueryVars::AMP !== $slug ) {
-			$this->customized_slug     = $slug;
 			$this->is_customized_early = true;
 		} else {
 			add_action( 'after_setup_theme', [ $this, 'determine_late_customization' ], 4 );
@@ -132,7 +104,6 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	public function determine_late_customization() {
 		$slug = $this->peek_customized_slug();
 		if ( QueryVars::AMP !== $slug ) {
-			$this->customized_slug    = $slug;
 			$this->is_customized_late = true;
 		}
 	}

--- a/src/AmpSlugCustomizationWatcher.php
+++ b/src/AmpSlugCustomizationWatcher.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class AmpSlugCustomizationWatcher.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP;
+
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+
+/**
+ * Service for redirecting mobile users to the AMP version of a page.
+ *
+ * @package AmpProject\AmpWP
+ */
+final class AmpSlugCustomizationWatcher implements Service, Registerable {
+
+	/**
+	 * The slug (query var) that was customized.
+	 *
+	 * @var string|null
+	 */
+	protected $customized_slug = null;
+
+	/**
+	 * Whether the slug was customized early (at plugins_loaded action, priority 8).
+	 *
+	 * @var bool
+	 */
+	protected $is_customized_early = false;
+
+	/**
+	 * Whether the slug was customized early (at after_setup_theme action, priority 4).
+	 *
+	 * @var bool
+	 */
+	protected $is_customized_late = false;
+
+	/**
+	 * Register.
+	 */
+	public function register() {
+		// This is at priority 8 because ReaderThemeLoader::override_theme runs at priority 9, which in turn runs right
+		// before _wp_customize_include at priority 10. A slug is customized early if it is customized at priority 8.
+		add_action( 'plugins_loaded', [ $this, 'determine_early_customization' ], 8 );
+	}
+
+	/**
+	 * Whether the slug was customized early (at plugins_loaded action, priority 8).
+	 *
+	 * @return bool
+	 */
+	public function did_customize_early() {
+		return $this->is_customized_early;
+	}
+
+	/**
+	 * Whether the slug was customized early (at after_setup_theme action, priority 4).
+	 *
+	 * @return bool
+	 */
+	public function did_customize_late() {
+		return $this->is_customized_late;
+	}
+
+	/**
+	 * Whether the slug was customized.
+	 *
+	 * @return bool
+	 */
+	public function did_customize_slug() {
+		return null !== $this->customized_slug;
+	}
+
+	/**
+	 * Get the customized slug.
+	 *
+	 * Returns null if it was not customized.
+	 *
+	 * @return string|null
+	 */
+	public function get_customized_slug() {
+		return $this->customized_slug;
+	}
+
+	/**
+	 * Peek at the customized slug.
+	 *
+	 * This does not call amp_get_slug(true) because if it did then it would end up defining AMP_QUERY_VAR and destroy
+	 * the ability for us to determine when exactly a theme or plugin is customizing it.
+	 *
+	 * @return string Query var.
+	 */
+	public function peek_customized_slug() {
+		return amp_get_slug( false );
+	}
+
+	/**
+	 * Determine if the slug was customized early.
+	 *
+	 * Early customization happens by plugins_loaded action at priority 8; this is required in order for the slug to be
+	 * used by `ReaderThemeLoader::override_theme()` which runs at priority 9; this method in turn must run before
+	 * before `_wp_customize_include()` which runs at plugins_loaded priority 10. At that point the current theme gets
+	 * determined, so for Reader themes to apply the logic in `ReaderThemeLoader` must run beforehand.
+	 */
+	public function determine_early_customization() {
+		$slug = $this->peek_customized_slug();
+		if ( QueryVars::AMP !== $slug ) {
+			$this->customized_slug     = $slug;
+			$this->is_customized_early = true;
+		} else {
+			add_action( 'after_setup_theme', [ $this, 'determine_late_customization' ], 4 );
+		}
+	}
+
+	/**
+	 * Determine if the slug was defined late.
+	 *
+	 * Late slug customization often happens when a theme itself defines `AMP_QUERY_VAR`. This is too late for the plugin
+	 * to be able to offer Reader themes which must have `AMP_QUERY_VAR` defined by plugins_loaded priority 9. Also,
+	 * defining `AMP_QUERY_VAR` is fundamentally incompatible since loading a Reader theme means preventing the original
+	 * theme from ever being loaded, and thus the theme's customized `AMP_QUERY_VAR` will never be read.
+	 *
+	 * This method must run before `amp_after_setup_theme()` which runs at the after_setup_theme action priority 5. In
+	 * this function, the `amp_get_slug()` function is called which will then set the query var for the remainder of the
+	 * request.
+	 *
+	 * @see amp_after_setup_theme()
+	 */
+	public function determine_late_customization() {
+		$slug = $this->peek_customized_slug();
+		if ( QueryVars::AMP !== $slug ) {
+			$this->customized_slug    = $slug;
+			$this->is_customized_late = true;
+		}
+	}
+}

--- a/src/AmpSlugCustomizationWatcher.php
+++ b/src/AmpSlugCustomizationWatcher.php
@@ -59,18 +59,6 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	}
 
 	/**
-	 * Peek at the customized slug.
-	 *
-	 * This does not call amp_get_slug(true) because if it did then it would end up defining AMP_QUERY_VAR and destroy
-	 * the ability for us to determine when exactly a theme or plugin is customizing it.
-	 *
-	 * @return string Query var.
-	 */
-	protected function peek_customized_slug() {
-		return amp_get_slug( false );
-	}
-
-	/**
 	 * Determine if the slug was customized early.
 	 *
 	 * Early customization happens by plugins_loaded action at priority 8; this is required in order for the slug to be
@@ -79,8 +67,7 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	 * determined, so for Reader themes to apply the logic in `ReaderThemeLoader` must run beforehand.
 	 */
 	public function determine_early_customization() {
-		$slug = $this->peek_customized_slug();
-		if ( QueryVars::AMP !== $slug ) {
+		if ( QueryVars::AMP !== amp_get_slug() ) {
 			$this->is_customized_early = true;
 		} else {
 			add_action( 'after_setup_theme', [ $this, 'determine_late_customization' ], 4 );
@@ -102,8 +89,7 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	 * @see amp_after_setup_theme()
 	 */
 	public function determine_late_customization() {
-		$slug = $this->peek_customized_slug();
-		if ( QueryVars::AMP !== $slug ) {
+		if ( QueryVars::AMP !== amp_get_slug() ) {
 			$this->is_customized_late = true;
 		}
 	}

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -63,6 +63,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			'plugin_suppression'               => PluginSuppression::class,
 			'mobile_redirection'               => MobileRedirection::class,
 			'reader_theme_loader'              => ReaderThemeLoader::class,
+			'amp_slug_customization_watcher'   => AmpSlugCustomizationWatcher::class,
 		];
 	}
 

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -51,8 +51,6 @@ final class ReaderThemeLoader implements Service, Registerable, Conditional {
 			AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT )
 			&&
 			AMP_Reader_Themes::DEFAULT_READER_THEME !== AMP_Options_Manager::get_option( Option::READER_THEME )
-			&&
-			isset( $_GET[ amp_get_slug() ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		);
 	}
 
@@ -85,6 +83,15 @@ final class ReaderThemeLoader implements Service, Registerable, Conditional {
 	 * @see WP_Customize_Manager::start_previewing_theme() which provides for much of the inspiration here.
 	 */
 	public function override_theme() {
+		// The false parameter is passed to prevent persisting the query var as the AMP_QUERY_VAR constant. This
+		// prevents interference with AmpSlugCustomizationWatcher.
+		$query_var = amp_get_slug( false );
+
+		// Short-circuit if the request does not include the AMP query var.
+		if ( ! isset( $_GET[ $query_var ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
 		$theme = $this->get_reader_theme();
 		if ( ! $theme instanceof WP_Theme ) {
 			return;

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -83,12 +83,8 @@ final class ReaderThemeLoader implements Service, Registerable, Conditional {
 	 * @see WP_Customize_Manager::start_previewing_theme() which provides for much of the inspiration here.
 	 */
 	public function override_theme() {
-		// The false parameter is passed to prevent persisting the query var as the AMP_QUERY_VAR constant. This
-		// prevents interference with AmpSlugCustomizationWatcher.
-		$query_var = amp_get_slug( false );
-
 		// Short-circuit if the request does not include the AMP query var.
-		if ( ! isset( $_GET[ $query_var ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET[ amp_get_slug() ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/tests/php/src/Unit/AmpSlugCustomizationWatcherTest.php
+++ b/tests/php/src/Unit/AmpSlugCustomizationWatcherTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests\Unit;
+
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+use WP_UnitTestCase;
+
+/** @covers AmpSlugCustomizationWatcher */
+final class AmpSlugCustomizationWatcherTest extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
+
+	/** @var AmpSlugCustomizationWatcher */
+	private $instance;
+
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new AmpSlugCustomizationWatcher();
+	}
+
+	/** @covers AmpSlugCustomizationWatcher::__construct() */
+	public function test__construct() {
+		$this->assertInstanceOf( AmpSlugCustomizationWatcher::class, $this->instance );
+		$this->assertInstanceOf( Service::class, $this->instance );
+		$this->assertInstanceOf( Registerable::class, $this->instance );
+	}
+
+	/** @covers AmpSlugCustomizationWatcher::register() */
+	public function test_register() {
+		$this->instance->register();
+		$this->assertEquals( 8, has_action( 'plugins_loaded', [ $this->instance, 'determine_early_customization' ] ) );
+	}
+
+	/** @covers AmpSlugCustomizationWatcher::determine_early_customization() */
+	public function test_determine_early_customization() {
+		$this->assertFalse( $this->instance->did_customize_early() );
+		$this->assertFalse( $this->instance->did_customize_late() );
+
+		$early_slug = 'early';
+		$this->add_query_var_filter( $early_slug );
+		$this->assertEquals( $early_slug, amp_get_slug() );
+		$this->instance->determine_early_customization();
+		$this->assertFalse( has_action( 'after_setup_theme', [ $this->instance, 'determine_late_customization' ] ) );
+
+		$this->assertTrue( $this->instance->did_customize_early() );
+		$this->assertFalse( $this->instance->did_customize_late() );
+	}
+
+	/**
+	 * @covers AmpSlugCustomizationWatcher::determine_early_customization()
+	 * @covers AmpSlugCustomizationWatcher::determine_late_customization()
+	 */
+	public function test_determine_late_customization() {
+		$this->assertFalse( $this->instance->did_customize_early() );
+		$this->assertFalse( $this->instance->did_customize_late() );
+
+		$this->instance->determine_early_customization();
+		$this->assertEquals( 4, has_action( 'after_setup_theme', [ $this->instance, 'determine_late_customization' ] ) );
+
+		$late_slug = 'late';
+		$this->add_query_var_filter( $late_slug );
+		$this->assertEquals( $late_slug, amp_get_slug() );
+
+		$this->instance->determine_late_customization();
+
+		$this->assertFalse( $this->instance->did_customize_early() );
+		$this->assertTrue( $this->instance->did_customize_late() );
+	}
+
+	/**
+	 * Add query var filter.
+	 *
+	 * @param string $value Query var.
+	 */
+	private function add_query_var_filter( $value ) {
+		remove_alL_filters( 'amp_query_var' );
+		add_filter(
+			'amp_query_var',
+			function () use ( $value ) {
+				return $value;
+			}
+		);
+	}
+}

--- a/tests/php/src/Unit/AmpSlugCustomizationWatcherTest.php
+++ b/tests/php/src/Unit/AmpSlugCustomizationWatcherTest.php
@@ -76,10 +76,10 @@ final class AmpSlugCustomizationWatcherTest extends WP_UnitTestCase {
 	 * @param string $value Query var.
 	 */
 	private function add_query_var_filter( $value ) {
-		remove_alL_filters( 'amp_query_var' );
+		remove_all_filters( 'amp_query_var' );
 		add_filter(
 			'amp_query_var',
-			function () use ( $value ) {
+			static function () use ( $value ) {
 				return $value;
 			}
 		);


### PR DESCRIPTION
## Summary

This is a sub-PR as part #4984 and closely related to theme compatibility scanning (#4795).

Addresses this todo:

> Being able to select a Reader theme is dependent on a site not customizing the AMP endpoint (query var). So if a site changes the query var from amp to something else like lite, then a warning needs to be displayed. Same goes for a theme registering a custom post type, etc.

It also makes this line mostly obsolete from the prototype PR #4644:

> Being able to select a Reader theme is dependent on a site not customizing the AMP endpoint (query var). So if a site changes the query var from `amp` to something else like `lite`, then a warning is displayed instead of the theme list.

In other words, a site _will_ be able to still customize their query var (as part of #2204) as long as they do it _before_ the `plugins_loaded` action (at priority 8). If they don't, then they will see this warning at the moment in the settings screen:

> ![image](https://user-images.githubusercontent.com/134745/86858346-56e86980-c075-11ea-93c2-c97edbe3e966.png)

And then, importantly, all non-legacy themes will no longer be available (with the explanation why provided), and the Next button is disabled if the previously-selected Reader theme is now no longer available:

> ![image](https://user-images.githubusercontent.com/134745/86873645-90c86880-c093-11ea-9102-e566db1e3fd7.png)

In order to test the failure condition introduced in this PR, add a plugin that does the following:

```php
add_action(
	'after_setup_theme',
	function () {
		define( 'AMP_QUERY_VAR', 'late' );
	},
	~PHP_INT_MAX
);
```

You could also just add a `define( 'AMP_QUERY_VAR', 'late' )` to the active theme's `functions.php`.

By contrast, to customize the query var successfully with a Reader theme, use this plugin code (just defining the constant straight away in the plugin file):

```php
define( 'AMP_QUERY_VAR', 'early' );
```

## Todo

- [x] Disable the Next button when the selected theme is among those which are unavailable.
- [x] Add tests.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
