### PR TITLE
Correctly show error count for unreviewed, removed & kept errors in Error Index

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1384,82 +1384,53 @@ class AMP_Validation_Error_Taxonomy {
 		<select name="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>" id="<?php echo esc_attr( self::VALIDATION_ERROR_STATUS_QUERY_VAR ); ?>">
 			<option value="<?php echo esc_attr( self::NO_FILTER_VALUE ); ?>"><?php esc_html_e( 'All statuses', 'amp' ); ?></option>
 			<?php
-			if ( 'edit' === $screen_base ) {
-				$unreviewed_terms_text = sprintf(
-					/* translators: %s: the unreviewed terms count. */
-					_x(
-						'With unreviewed errors <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $unreviewed_count )
-				);
-			} else {
-				$unreviewed_terms_text = sprintf(
-					/* translators: %s: the unreviewed terms count. */
-					_x(
-						'Unreviewed errors <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $unreviewed_count )
-				);
-			}
-			$value = self::VALIDATION_ERROR_NEW_REJECTED_STATUS . ',' . self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS;
-			?>
-			<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $error_status_filter_value, $value ); ?>><?php echo wp_kses_post( $unreviewed_terms_text ); ?></option>
-			<?php
-			if ( 'edit' === $screen_base ) {
-				$removed_term_text = sprintf(
-					/* translators: %s: the accepted terms count. */
-					_x(
-						'With removed markup <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $accepted_term_count )
-				);
-			} else {
-				$removed_term_text = sprintf(
-					/* translators: %s: the accepted terms count. */
-					_x(
-						'Removed markup <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $accepted_term_count )
+			$options_config = [
+				[
+					'text'        => 'edit' === $screen_base ? _x( 'With unreviewed errors', 'terms', 'amp' ) : _x( 'Unreviewed errors', 'terms', 'amp' ),
+					'value'       => self::VALIDATION_ERROR_NEW_REJECTED_STATUS . ',' . self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
+					'error_count' => $unreviewed_count,
+				],
+				[
+					'text'        => 'edit' === $screen_base ? _x( 'With removed markup', 'terms', 'amp' ) : _x( 'Removed markup', 'terms', 'amp' ),
+					'value'       => self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS . ',' . self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
+					'error_count' => $accepted_term_count,
+				],
+				[
+					'text'        => 'edit' === $screen_base ? _x( 'With kept markup', 'terms', 'amp' ) : _x( 'Kept markup', 'terms', 'amp' ),
+					'value'       => self::VALIDATION_ERROR_NEW_REJECTED_STATUS . ',' . self::VALIDATION_ERROR_ACK_REJECTED_STATUS,
+					'error_count' => $rejected_term_count,
+				],
+			];
+
+			foreach ( $options_config as $option_config ) {
+				self::output_error_status_filter_option_markup(
+					$option_config['text'],
+					$option_config['value'],
+					$option_config['error_count'],
+					$error_status_filter_value
 				);
 			}
-			$value = self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS . ',' . self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS;
 			?>
-			<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $error_status_filter_value, $value ); ?>><?php echo wp_kses_post( $removed_term_text ); ?></option>
-			<?php
-			if ( 'edit' === $screen_base ) {
-				$kept_term_text = sprintf(
-					/* translators: %s: the rejected terms count. */
-					_x(
-						'With kept markup <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $rejected_term_count )
-				);
-			} else {
-				$kept_term_text = sprintf(
-					/* translators: %s: the rejected terms count. */
-					_x(
-						'Kept markup <span class="count">(%s)</span>',
-						'terms',
-						'amp'
-					),
-					number_format_i18n( $rejected_term_count )
-				);
-			}
-			$value = self::VALIDATION_ERROR_NEW_REJECTED_STATUS . ',' . self::VALIDATION_ERROR_ACK_REJECTED_STATUS;
-			?>
-			<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $error_status_filter_value, $value ); ?>><?php echo wp_kses_post( $kept_term_text ); ?></option>
 		</select>
 		<?php
+	}
+
+	/**
+	 * Output the option markup for a error status filter.
+	 *
+	 * @param string $option_text    Option text.
+	 * @param string $option_value   Option value.
+	 * @param int    $error_count    Error count for error status.
+	 * @param string $selected_value Currently selected value.
+	 */
+	private static function output_error_status_filter_option_markup( $option_text, $option_value, $error_count, $selected_value ) {
+		printf(
+				'<option value="%s" %s>%s <span class="count">(%s)</span></option>',
+				esc_attr( $option_value ),
+				selected( $selected_value, $option_value, false ),
+				esc_html( $option_text ),
+				number_format_i18n( $error_count )
+		);
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1326,7 +1326,7 @@ class AMP_Validation_Error_Taxonomy {
 				$args[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ] = $error_type;
 			}
 
-			$with_new_query = new WP_Query(
+			$with_new_query   = new WP_Query(
 				array_merge(
 					$args,
 					[
@@ -1339,27 +1339,27 @@ class AMP_Validation_Error_Taxonomy {
 			);
 			$unreviewed_count = $with_new_query->found_posts;
 
-			$with_rejected_query     = new WP_Query(
+			$with_rejected_query = new WP_Query(
 				array_merge(
 					$args,
 					[
 						self::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 							self::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 							self::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-						]
+						],
 					]
 				)
 			);
 			$rejected_term_count = $with_rejected_query->found_posts;
 
-			$with_accepted_query     = new WP_Query(
+			$with_accepted_query = new WP_Query(
 				array_merge(
 					$args,
 					[
 						self::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 							self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 							self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
-						]
+						],
 					]
 				)
 			);
@@ -1425,11 +1425,11 @@ class AMP_Validation_Error_Taxonomy {
 	 */
 	private static function output_error_status_filter_option_markup( $option_text, $option_value, $error_count, $selected_value ) {
 		printf(
-				'<option value="%s" %s>%s <span class="count">(%s)</span></option>',
-				esc_attr( $option_value ),
-				selected( $selected_value, $option_value, false ),
-				esc_html( $option_text ),
-				number_format_i18n( $error_count )
+			'<option value="%s" %s>%s <span class="count">(%s)</span></option>',
+			esc_attr( $option_value ),
+			selected( $selected_value, $option_value, false ),
+			esc_html( $option_text ),
+			esc_html( number_format_i18n( $error_count ) )
 		);
 	}
 

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -1480,9 +1480,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
 
-		$number_of_new_errors = 20;
-		$number_of_rejected   = 15;
-		$number_of_accepted   = 5;
+		$number_of_new_errors     = 20;
+		$number_of_total_rejected = 24;
+		$number_of_total_accepted = 16;
 
 		for ( $i = 0; $i < 40; $i++ ) {
 			$invalid_url_post      = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
@@ -1538,11 +1538,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			$output
 		);
 		$this->assertStringContains(
-			sprintf( 'With kept markup <span class="count">(%d)</span>', $number_of_rejected ),
+			sprintf( 'With kept markup <span class="count">(%d)</span>', $number_of_total_rejected ),
 			$output
 		);
 		$this->assertStringContains(
-			sprintf( 'With removed markup <span class="count">(%d)</span>', $number_of_accepted ),
+			sprintf( 'With removed markup <span class="count">(%d)</span>', $number_of_total_accepted ),
 			$output
 		);
 	}


### PR DESCRIPTION
## Summary

Fixes an issue with an invalid count being shown for unreviewed, removed & kept error states in the Error Index.

<!-- Please reference the issue this PR addresses. -->
Fixes #4941.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
