### PR TITLE
Suppress plugins early when making a Reader theme request

### DIFF
--- a/src/PluginSuppression.php
+++ b/src/PluginSuppression.php
@@ -53,7 +53,7 @@ final class PluginSuppression implements Service, Registerable {
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 
-		// When a Reader theme is selected and and an AMP request is being made, start suppressing as early as possible
+		// When a Reader theme is selected and an AMP request is being made, start suppressing as early as possible.
 		// This can be done because we know it is an AMP page due to the query parameter, but it also _has_ to be done
 		// specifically for the case of accessing the AMP Customizer (in which customize.php is requested with the query
 		// parameter) in order to prevent the registration of Customizer controls from suppressed plugins. Suppression

--- a/tests/php/src/Unit/PluginSuppressionTest.php
+++ b/tests/php/src/Unit/PluginSuppressionTest.php
@@ -39,6 +39,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		$this->prevent_block_pre_render();
+		$this->add_reader_themes_request_filter();
 
 		$this->reset_widgets();
 		add_filter(
@@ -381,7 +382,6 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 * @covers AMP_Validated_URL_Post_Type::get_recent_validation_errors_by_source()
 	 */
 	public function test_sanitize_options() {
-		$this->add_reader_themes_request_filter();
 		$instance = $this->get_instance();
 		$instance->register();
 


### PR DESCRIPTION
## Summary

Fixes #4477. 
Amends PR #4657

I realized that when a Reader theme is selected, accessing the AMP Customizer currently results in Customizer controls et al being registered even for plugins that are suppressed. The reason for this is that suppression was happening at the `wp` action which is too late (and never even fires) when accessing `customize.php`. Therefore, this PR fixes that problem by checking if the current request is for an AMP Reader theme (whether on the frontend or the Customizer) and, if so, suppresses plugins immediately at `plugins_loaded` as early as possible.

This early-suppression could also be done in legacy Reader mode or Transitional mode since there is a query var which indicates it is an AMP request. Nevertheless, this is unnecessary to do because neither Transitional mode nor legacy Reader mode have separate Customizers. Therefore, only “Reader theme” mode needs this early suppression.

To test this:

0. Activate Reader mode and select a Reader theme.
1. Install the latest version of my my Bad Block plugin: https://gist.github.com/westonruter/e4331b3f6d03aac075b86b226acd3ba5
2. Add the Bad block to a post.
3. View the AMP page.
4. Click on Customize to open that AMP URL in the AMP Customizer.
5. Modify the "Bad Block Background Color" in the Colors section.
6. Validate the AMP URL (again).
7. Navigate to AMP settings and suppress Bad Block from running.
8. Navigate back to the AMP page and verify the block is not outputting anything.
9. Open the AMP Customizer for that post and verify the Customizer control for Bad Block Background Color is absent.

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/86994280-da2fbb00-c15a-11ea-815f-99098b3f5532.png) | ![after](https://user-images.githubusercontent.com/134745/86994285-def46f00-c15a-11ea-9f76-6ee86d3f4b36.png)

(The screenshot isn't correct as the Before shouldn't be showing the bad block!)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
