### PR TITLE
Remove escaping of title in legacy post templates

### DIFF
--- a/templates/page.php
+++ b/templates/page.php
@@ -25,7 +25,7 @@ $this->load_parts( [ 'html-start' ] );
 
 <article class="amp-wp-article">
 	<header class="amp-wp-article-header">
-		<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
+		<h1 class="amp-wp-title"><?php echo $this->get( 'post_title' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
 	</header>
 
 	<?php $this->load_parts( [ 'featured-image' ] ); ?>

--- a/templates/single.php
+++ b/templates/single.php
@@ -25,7 +25,7 @@ $this->load_parts( [ 'html-start' ] );
 
 <article class="amp-wp-article">
 	<header class="amp-wp-article-header">
-		<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
+		<h1 class="amp-wp-title"><?php echo $this->get( 'post_title' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
 		<?php $this->load_parts( apply_filters( 'amp_post_article_header_meta', [ 'meta-author', 'meta-time' ] ) ); ?>
 	</header>
 


### PR DESCRIPTION
## Summary

Given a post with an emoji in the title:

> ![image](https://user-images.githubusercontent.com/134745/87230167-bf2f9780-c362-11ea-994f-a1750f5c58e7.png)

The title was getting erroneously escaped in the `h1` of the legacy post templates:

> ![image](https://user-images.githubusercontent.com/134745/87230187-f56d1700-c362-11ea-88b8-79dc2168c4a9.png)

This PR removes the escaping to prevent that from happening:

> ![image](https://user-images.githubusercontent.com/134745/87230191-0158d900-c363-11ea-83e8-99a6e332fcaf.png)

Note that escaping is not required necessary for two reasons:

* Core doesn't escape post titles in `the_title()` because it can include markup; the value returned by `$this->get( 'post_title' )` comes from `get_the_title( $this->post )`.
* The AMP plugin's sanitizers will prevent bad markup from being output.

This issue was introduced a long time ago in 6b4de15934795e23a515807a25bbc616a81bcfa3 with this change:

```diff
-		<h1 class="amp-wp-title"><?php echo wp_kses_data( $this->get( 'post_title' ) ); ?></h1>
+		<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
```

Originally reported by @delans [on Twitter](https://twitter.com/delans/status/1281967138329309184).

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
