### PR TITLE
Harden ReaderThemesTest when custom theme directories present

### DIFF
--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -25,6 +25,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	use MarkupComparison;
 	use PrivateAccess;
 
+	private $original_theme_directories;
+
 	/**
 	 * Set up.
 	 */
@@ -34,6 +36,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$wp_styles  = null;
 		$wp_scripts = null;
 		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
+
+		global $wp_theme_directories;
+		$this->original_theme_directories = $wp_theme_directories;
+		register_theme_directory( ABSPATH . 'wp-content/themes' );
+		delete_site_transient( 'theme_roots' );
 	}
 
 	/**
@@ -44,6 +51,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		global $wp_styles, $wp_scripts;
 		$wp_styles  = null;
 		$wp_scripts = null;
+
+		global $wp_theme_directories;
+		$wp_theme_directories = $this->original_theme_directories;
+		delete_site_transient( 'theme_roots' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This fixes an issue I've started facing when running PHPUnit in the [wordpressdev](https://github.com/GoogleChromeLabs/wordpressdev) Lando environment:

```
There were 4 failures:

1) ReaderThemesTest::test_get_theme_availability with data set "twentysixteen_from_wp_future" ('non-installable', false, array('Some Theme', '99.9', '5.2', 'twentysixteen'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'non-installable'
+'installed'

/app/public/content/plugins/amp/tests/php/src/Unit/ReaderThemesTest.php:193

2) ReaderThemesTest::test_get_theme_availability with data set "twentysixteen_from_php_future" ('non-installable', false, array('Some Theme', '4.9', '99.9', 'twentysixteen'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'non-installable'
+'installed'

/app/public/content/plugins/amp/tests/php/src/Unit/ReaderThemesTest.php:193

3) ReaderThemesTest::test_get_theme_availability with data set "twentytwelve_not_requiring_wp_version" ('installable', true, array('Some Theme', false, '5.2', 'twentytwelve'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'installable'
+'installed'

/app/public/content/plugins/amp/tests/php/src/Unit/ReaderThemesTest.php:193

4) ReaderThemesTest::test_get_theme_availability with data set "twentytwelve_not_requiring_php_version" ('installable', true, array('Some Theme', '4.9', false, 'twentysixteen'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'installable'
+'installed'

/app/public/content/plugins/amp/tests/php/src/Unit/ReaderThemesTest.php:193
```

I could test `ReaderThemesTest` in isolation and pass, but it would fail when the entire test suite was run. The issue is in part that data providers are called _before_ `setUp`, so the theme directories aren't reset properly when the data provider's return value is generated. So the fix is just to create a closure in the data to defer obtaining the value while the test is being run rather than before `startUp`.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
