### PR TITLE
Include theme versions in determining whether a validated URL is stale

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1002,7 +1002,7 @@ class AMP_Validated_URL_Post_Type {
 
 		return [
 			'theme'   => get_stylesheet(),
-			'plugins' => wp_list_pluck( $plugin_registry->get_plugins( true ), 'Version' ), // @todo What about multiple plugins being in the same directory?
+			'plugins' => wp_list_pluck( $plugin_registry->get_plugins( true, false ), 'Version' ), // @todo What about multiple plugins being in the same directory?
 			'options' => [
 				Option::THEME_SUPPORT => AMP_Options_Manager::get_option( Option::THEME_SUPPORT ),
 			],

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1000,8 +1000,19 @@ class AMP_Validated_URL_Post_Type {
 		/** @var PluginRegistry $plugin_registry */
 		$plugin_registry = Services::get( 'plugin_registry' );
 
+		$theme     = [];
+		$theme_obj = wp_get_theme();
+		if ( ! $theme_obj->errors() ) {
+			$theme[ $theme_obj->get_stylesheet() ] = $theme_obj->get( 'Version' );
+
+			$parent_theme_obj = $theme_obj->parent();
+			if ( $parent_theme_obj ) {
+				$theme[ $parent_theme_obj->get_stylesheet() ] = $parent_theme_obj->get( 'Version' );
+			}
+		}
+
 		return [
-			'theme'   => get_stylesheet(),
+			'theme'   => $theme,
 			'plugins' => wp_list_pluck( $plugin_registry->get_plugins( true, false ), 'Version' ), // @todo What about multiple plugins being in the same directory?
 			'options' => [
 				Option::THEME_SUPPORT => AMP_Options_Manager::get_option( Option::THEME_SUPPORT ),
@@ -1034,7 +1045,20 @@ class AMP_Validated_URL_Post_Type {
 
 		// Theme difference.
 		if ( isset( $old_validated_environment['theme'] ) && $new_validated_environment['theme'] !== $old_validated_environment['theme'] ) {
-			$staleness['theme'] = $old_validated_environment['theme'];
+			if ( is_string( $old_validated_environment['theme'] ) ) {
+				$old_validated_environment['theme'] = [
+					$old_validated_environment['theme'] => null,
+				];
+			}
+
+			$new_active_theme = array_diff_assoc( $new_validated_environment['theme'], $old_validated_environment['theme'] );
+			if ( ! empty( $new_active_theme ) ) {
+				$staleness['theme']['new'] = array_keys( $new_active_theme );
+			}
+			$old_active_theme = array_diff_assoc( $old_validated_environment['theme'], $new_validated_environment['theme'] );
+			if ( ! empty( $old_active_theme ) ) {
+				$staleness['theme']['old'] = array_keys( $old_active_theme );
+			}
 		}
 
 		// Plugin difference.
@@ -2038,10 +2062,10 @@ class AMP_Validated_URL_Post_Type {
 							echo '</b>';
 							echo '<br>';
 							if ( ! empty( $staleness['theme'] ) && ! empty( $staleness['plugins'] ) ) {
-								esc_html_e( 'Different theme and plugins were active when these results were obtained.', 'amp' );
+								esc_html_e( 'The theme and plugins have changed since these results were obtained.', 'amp' );
 								echo ' ';
 							} elseif ( ! empty( $staleness['theme'] ) ) {
-								esc_html_e( 'A different theme was active when these results were obtained.', 'amp' );
+								esc_html_e( 'The theme has changed since these results were obtained.', 'amp' );
 								echo ' ';
 							} elseif ( ! empty( $staleness['plugins'] ) ) {
 								esc_html_e( 'Plugins have been updated since these results were obtained.', 'amp' );


### PR DESCRIPTION
## Summary

Fixes #3474

Changed theme (either by switching or upgrading):

![image](https://user-images.githubusercontent.com/134745/87255839-0725eb80-c443-11ea-9a20-4e79df489c8e.png)

Changes plugin:

![image](https://user-images.githubusercontent.com/134745/87255851-27ee4100-c443-11ea-8ac0-6bb830046efc.png)

Changed theme and plugin:

![image](https://user-images.githubusercontent.com/134745/87255863-4a805a00-c443-11ea-995b-4e19a3c68307.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
