### PR TITLE
Update AMP Customizer with info option notices on controls, notice on Menus panel, and update AMP panel description

### DIFF
--- a/assets/css/src/amp-customizer.css
+++ b/assets/css/src/amp-customizer.css
@@ -1,5 +1,5 @@
 #customize-controls .customize-info .preview-notice {
 	display: block;
-	line-height: 1.4em;
+	line-height: 1.4;
 	margin-right: 28px;
 }

--- a/assets/css/src/amp-customizer.css
+++ b/assets/css/src/amp-customizer.css
@@ -1,5 +1,5 @@
-#customize-info .preview-notice {
+#customize-controls .customize-info .preview-notice {
 	display: block;
-	line-height: 1.5;
+	line-height: 1.4em;
 	margin-right: 28px;
 }

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -10,6 +10,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 				ampVersionNotice: '',
 				optionSettingNotice: '',
 				navMenusPanelNotice: '',
+				rootPanelDescription: '',
 			},
 			optionSettings: [],
 		},
@@ -25,6 +26,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 		component.data = data;
 
 		component.updatePreviewNotice();
+		component.extendRootDescription();
 
 		$.ajaxPrefilter( component.injectAmpIntoAjaxRequests );
 		api.bind( 'ready', component.forceAmpPreviewUrl );
@@ -38,6 +40,24 @@ window.ampCustomizeControls = ( function( api, $ ) {
 	component.updatePreviewNotice = function updatePreviewNotice() {
 		const previewNotice = $( '#customize-info .preview-notice' );
 		previewNotice.text( component.data.l10n.ampVersionNotice );
+	};
+
+	/**
+	 * Add AMP-specific info to the root panel description.
+	 */
+	component.extendRootDescription = function extendRootDescription() {
+		const panelDescription = $( '#customize-info .customize-panel-description' );
+
+		// Ensure the original description is in a paragraph (where normally it is not).
+		if ( panelDescription.find( 'p' ).length === 0 ) {
+			const originalParagraph = $( '<p></p>' );
+			originalParagraph.html( panelDescription.html() );
+			panelDescription.html( '' );
+			panelDescription.append( originalParagraph );
+		}
+
+		const ampDescription = $( '<p>' + component.data.l10n.rootPanelDescription + '</p>' ); // Contents have been sanitized with wp_kses_post().
+		panelDescription.append( ampDescription );
 	};
 
 	/**

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -39,7 +39,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 	 */
 	component.updatePreviewNotice = function updatePreviewNotice() {
 		const previewNotice = $( '#customize-info .preview-notice' );
-		previewNotice.html( component.data.l10n.ampVersionNotice ); // Contents have been sanitiuzed with wp_kses_post().
+		previewNotice.html( component.data.l10n.ampVersionNotice ); // Contents have been sanitized with wp_kses_post().
 	};
 
 	/**

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -8,7 +8,9 @@ window.ampCustomizeControls = ( function( api, $ ) {
 			queryVar: '',
 			l10n: {
 				ampVersionNotice: '',
+				optionSettingNotice: '',
 			},
+			optionSettings: [],
 		},
 	};
 
@@ -25,6 +27,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 
 		$.ajaxPrefilter( component.injectAmpIntoAjaxRequests );
 		wp.customize.bind( 'ready', component.forceAmpPreviewUrl );
+		wp.customize.bind( 'ready', component.addOptionSettingNotices );
 	};
 
 	/**
@@ -68,6 +71,24 @@ window.ampCustomizeControls = ( function( api, $ ) {
 				return val;
 			};
 		}( api.previewer.previewUrl.validate ) );
+	};
+
+	/**
+	 * Add notice to all settings for options.
+	 */
+	component.addOptionSettingNotices = function addOptionSettingNotices() {
+		for ( const settingId of component.data.optionSettings ) {
+			wp.customize( settingId, ( setting ) => {
+				const notification = new wp.customize.Notification(
+					'option_setting',
+					{
+						type: 'info',
+						message: component.data.l10n.optionSettingNotice,
+					},
+				);
+				setting.notifications.add( notification.code, notification );
+			} );
+		}
 	};
 
 	return component;

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -39,7 +39,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 	 */
 	component.updatePreviewNotice = function updatePreviewNotice() {
 		const previewNotice = $( '#customize-info .preview-notice' );
-		previewNotice.text( component.data.l10n.ampVersionNotice );
+		previewNotice.html( component.data.l10n.ampVersionNotice ); // Contents have been sanitiuzed with wp_kses_post().
 	};
 
 	/**

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -26,8 +26,8 @@ window.ampCustomizeControls = ( function( api, $ ) {
 		component.updatePreviewNotice();
 
 		$.ajaxPrefilter( component.injectAmpIntoAjaxRequests );
-		wp.customize.bind( 'ready', component.forceAmpPreviewUrl );
-		wp.customize.bind( 'ready', component.addOptionSettingNotices );
+		api.bind( 'ready', component.forceAmpPreviewUrl );
+		api.bind( 'ready', component.addOptionSettingNotices );
 	};
 
 	/**
@@ -78,8 +78,8 @@ window.ampCustomizeControls = ( function( api, $ ) {
 	 */
 	component.addOptionSettingNotices = function addOptionSettingNotices() {
 		for ( const settingId of component.data.optionSettings ) {
-			wp.customize( settingId, ( setting ) => {
-				const notification = new wp.customize.Notification(
+			api( settingId, ( setting ) => {
+				const notification = new api.Notification(
 					'option_setting',
 					{
 						type: 'info',

--- a/assets/src/customizer/amp-customize-controls.js
+++ b/assets/src/customizer/amp-customize-controls.js
@@ -9,6 +9,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 			l10n: {
 				ampVersionNotice: '',
 				optionSettingNotice: '',
+				navMenusPanelNotice: '',
 			},
 			optionSettings: [],
 		},
@@ -28,6 +29,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 		$.ajaxPrefilter( component.injectAmpIntoAjaxRequests );
 		api.bind( 'ready', component.forceAmpPreviewUrl );
 		api.bind( 'ready', component.addOptionSettingNotices );
+		api.bind( 'ready', component.addNavMenuPanelNotice );
 	};
 
 	/**
@@ -80,7 +82,7 @@ window.ampCustomizeControls = ( function( api, $ ) {
 		for ( const settingId of component.data.optionSettings ) {
 			api( settingId, ( setting ) => {
 				const notification = new api.Notification(
-					'option_setting',
+					'amp_option_setting',
 					{
 						type: 'info',
 						message: component.data.l10n.optionSettingNotice,
@@ -89,6 +91,28 @@ window.ampCustomizeControls = ( function( api, $ ) {
 				setting.notifications.add( notification.code, notification );
 			} );
 		}
+	};
+
+	/**
+	 * Add notice to the nav menus panel.
+	 */
+	component.addNavMenuPanelNotice = function addNavMenuPanelNotice() {
+		api.panel( 'nav_menus', ( panel ) => {
+			// Fix bug in WP where the Nav Menus panel lacks a notifications container.
+			if ( ! panel.notifications.container.length ) {
+				panel.notifications.container = $( '<div class="customize-control-notifications-container"></div>' );
+				panel.container.find( '.panel-meta:first' ).append( panel.notifications.container );
+			}
+
+			const notification = new api.Notification(
+				'amp_version',
+				{
+					type: 'info',
+					message: component.data.l10n.navMenusPanelNotice,
+				},
+			);
+			panel.notifications.add( notification.code, notification );
+		} );
 	};
 
 	return component;

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -222,8 +222,7 @@ class AMP_Template_Customizer {
 			[
 				'type'        => 'amp',
 				'title'       => __( 'AMP', 'amp' ),
-				/* translators: placeholder is URL to AMP project. */
-				'description' => sprintf( __( '<a href="%s" target="_blank">The AMP Project</a> is a Google-led initiative that dramatically improves loading speeds on phones and tablets. You can use the Customizer to preview changes to your AMP template before publishing them.', 'amp' ), 'https://ampproject.org' ),
+				'description' => $this->get_amp_panel_description(),
 			]
 		);
 
@@ -236,6 +235,18 @@ class AMP_Template_Customizer {
 		 * @param WP_Customize_Manager $manager Manager.
 		 */
 		do_action( 'amp_customizer_register_ui', $this->wp_customize );
+	}
+
+	/**
+	 * Get AMP panel description.
+	 *
+	 * This is also added to the root panel description in the AMP Customizer when a Reader theme is being customized.
+	 *
+	 * @return string Description, with markup.
+	 */
+	protected function get_amp_panel_description() {
+		/* translators: placeholder is URL to AMP project. */
+		return wp_kses_post( sprintf( __( '<a href="%s" target="_blank">The AMP Project</a> is a Google-led initiative that dramatically improves loading speeds on phones and tablets. You can use the Customizer to preview changes to your AMP template before publishing them.', 'amp' ), 'https://ampproject.org' ) );
 	}
 
 	/**
@@ -292,9 +303,10 @@ class AMP_Template_Customizer {
 						'queryVar'       => amp_get_slug(),
 						'optionSettings' => $option_settings,
 						'l10n'           => [
-							'ampVersionNotice'    => __( 'You are customizing the AMP version of your site.', 'amp' ),
-							'optionSettingNotice' => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
-							'navMenusPanelNotice' => __( 'The menus here are shared with the non-AMP version of your site. Assign existing menus to menu locations in the Reader theme or create new AMP-specific menus.', 'amp' ),
+							'ampVersionNotice'     => __( 'You are customizing the AMP version of your site.', 'amp' ),
+							'optionSettingNotice'  => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
+							'navMenusPanelNotice'  => __( 'The menus here are shared with the non-AMP version of your site. Assign existing menus to menu locations in the Reader theme or create new AMP-specific menus.', 'amp' ),
+							'rootPanelDescription' => $this->get_amp_panel_description(),
 						],
 					]
 				)

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -294,6 +294,7 @@ class AMP_Template_Customizer {
 						'l10n'           => [
 							'ampVersionNotice'    => __( 'You are customizing the AMP version of your site.', 'amp' ),
 							'optionSettingNotice' => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
+							'navMenusPanelNotice' => __( 'The menus here are shared with the non-AMP version of your site. Assign existing menus to menu locations in the Reader theme or create new AMP-specific menus.', 'amp' ),
 						],
 					]
 				)

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -100,7 +100,7 @@ class AMP_Template_Customizer {
 		}
 
 		$self->set_refresh_setting_transport();
-		$self->deactivate_cover_template_section();
+		$self->remove_cover_template_section();
 		$self->remove_homepage_settings_section();
 		return $self;
 	}
@@ -128,12 +128,12 @@ class AMP_Template_Customizer {
 	}
 
 	/**
-	 * Deactivate the Cover Template section if needed.
+	 * Remove the Cover Template section if needed.
 	 *
 	 * Prevent showing the "Cover Template" section if the active (non-Reader) theme does not have the same template
 	 * as Twenty Twenty, as otherwise the user would be shown a section that would never reflect any preview change.
 	 */
-	protected function deactivate_cover_template_section() {
+	protected function remove_cover_template_section() {
 		if ( ! $this->reader_theme_loader->is_theme_overridden() ) {
 			return;
 		}
@@ -159,21 +159,11 @@ class AMP_Template_Customizer {
 			return;
 		}
 
-		add_filter(
-			'customize_section_active',
-			function ( $active, WP_Customize_Section $section ) {
-				if ( 'cover_template_options' === $section->id ) {
-					$active = false;
-				}
-				return $active;
-			},
-			10,
-			2
-		);
+		$this->wp_customize->remove_section( 'cover_template_options' );
 	}
 
 	/**
-	 * Remove the Homepage Settings section in the AMP Customizer for a Reader theme.
+	 * Remove the Homepage Settings section in the AMP Customizer for a Reader theme if needed.
 	 *
 	 * The Homepage Settings section exclusively contains controls for options which apply to both AMP and non-AMP.
 	 * If this is the case and there are no other controls added to it, then remove the section. Otherwise, the controls

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -309,7 +309,8 @@ class AMP_Template_Customizer {
 						'queryVar'       => amp_get_slug(),
 						'optionSettings' => $option_settings,
 						'l10n'           => [
-							'ampVersionNotice'     => __( 'You are customizing the AMP version of your site.', 'amp' ),
+							/* translators: placeholder is URL to non-AMP Customizer. */
+							'ampVersionNotice'     => wp_kses_post( sprintf( __( 'You are customizing the AMP version of your site. <a href="%s">Customize non-AMP version</a>.', 'amp' ), esc_url( admin_url( 'customize.php' ) ) ) ),
 							'optionSettingNotice'  => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
 							'navMenusPanelNotice'  => __( 'The menus here are shared with the non-AMP version of your site. Assign existing menus to menu locations in the Reader theme or create new AMP-specific menus.', 'amp' ),
 							'rootPanelDescription' => $this->get_amp_panel_description(),

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -248,7 +248,7 @@ class AMP_Template_Customizer {
 		return wp_kses_post(
 			sprintf(
 				/* translators: 1: URL to AMP project, 2: URL to admin settings screen */
-				__( '<a href="%1$s" target="_blank">AMP</a> is a project that emphasizes user experience. While AMP also applies to desktop pages, your site is <a href="%2$s" target="_blank">currently configured</a> in Reader mode to serve AMP pages to mobile visitors. These settings customize the experience for these users.', 'amp' ),
+				__( 'While <a href="%1$s" target="_blank">AMP</a> works well on both desktop and mobile pages, your site is <a href="%2$s" target="_blank">currently configured</a> in Reader mode to serve AMP pages to mobile visitors. These settings customize the experience for these users.', 'amp' ),
 				'https://amp.dev',
 				admin_url( 'admin.php?page=amp-options' )
 			)
@@ -311,7 +311,7 @@ class AMP_Template_Customizer {
 						'l10n'           => [
 							/* translators: placeholder is URL to non-AMP Customizer. */
 							'ampVersionNotice'     => wp_kses_post( sprintf( __( 'You are customizing the AMP version of your site. <a href="%s">Customize non-AMP version</a>.', 'amp' ), esc_url( admin_url( 'customize.php' ) ) ) ),
-							'optionSettingNotice'  => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
+							'optionSettingNotice'  => __( 'Also applies to non-AMP version of your site.', 'amp' ),
 							'navMenusPanelNotice'  => __( 'The menus here are shared with the non-AMP version of your site. Assign existing menus to menu locations in the Reader theme or create new AMP-specific menus.', 'amp' ),
 							'rootPanelDescription' => $this->get_amp_panel_description(),
 						],

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -252,15 +252,25 @@ class AMP_Template_Customizer {
 			true
 		);
 
+		$option_settings = [];
+		foreach ( $this->wp_customize->settings() as $setting ) {
+			/** @var WP_Customize_Setting $setting */
+			if ( 'option' === $setting->type ) {
+				$option_settings[] = $setting->id;
+			}
+		}
+
 		wp_add_inline_script(
 			'amp-customize-controls',
 			sprintf(
 				'ampCustomizeControls.boot( %s );',
 				wp_json_encode(
 					[
-						'queryVar' => amp_get_slug(),
-						'l10n'     => [
-							'ampVersionNotice' => __( 'You are customizing the AMP version of your site.', 'amp' ),
+						'queryVar'       => amp_get_slug(),
+						'optionSettings' => $option_settings,
+						'l10n'           => [
+							'ampVersionNotice'    => __( 'You are customizing the AMP version of your site.', 'amp' ),
+							'optionSettingNotice' => __( 'This also applies to the non-AMP version of your site.', 'amp' ),
 						],
 					]
 				)

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -245,8 +245,14 @@ class AMP_Template_Customizer {
 	 * @return string Description, with markup.
 	 */
 	protected function get_amp_panel_description() {
-		/* translators: placeholder is URL to AMP project. */
-		return wp_kses_post( sprintf( __( '<a href="%s" target="_blank">The AMP Project</a> is a Google-led initiative that dramatically improves loading speeds on phones and tablets. You can use the Customizer to preview changes to your AMP template before publishing them.', 'amp' ), 'https://ampproject.org' ) );
+		return wp_kses_post(
+			sprintf(
+				/* translators: 1: URL to AMP project, 2: URL to admin settings screen */
+				__( '<a href="%1$s" target="_blank">AMP</a> is a project that emphasizes user experience. While AMP also applies to desktop pages, your site is <a href="%2$s" target="_blank">currently configured</a> in Reader mode to serve AMP pages to mobile visitors. These settings customize the experience for these users.', 'amp' ),
+				'https://amp.dev',
+				admin_url( 'admin.php?page=amp-options' )
+			)
+		);
 	}
 
 	/**

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -101,6 +101,7 @@ class AMP_Template_Customizer {
 
 		$self->set_refresh_setting_transport();
 		$self->deactivate_cover_template_section();
+		$self->remove_homepage_settings_section();
 		return $self;
 	}
 
@@ -169,6 +170,38 @@ class AMP_Template_Customizer {
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Remove the Homepage Settings section in the AMP Customizer for a Reader theme.
+	 *
+	 * The Homepage Settings section exclusively contains controls for options which apply to both AMP and non-AMP.
+	 * If this is the case and there are no other controls added to it, then remove the section. Otherwise, the controls
+	 * will all get the same notice added to them.
+	 */
+	protected function remove_homepage_settings_section() {
+		if ( ! $this->reader_theme_loader->is_theme_overridden() ) {
+			return;
+		}
+
+		$section_id  = 'static_front_page';
+		$control_ids = [];
+		foreach ( $this->wp_customize->controls() as $control ) {
+			/** @var WP_Customize_Control $control */
+			if ( $section_id === $control->section ) {
+				$control_ids[] = $control->id;
+			}
+		}
+
+		$static_front_page_control_ids = [
+			'show_on_front',
+			'page_on_front',
+			'page_for_posts',
+		];
+
+		if ( count( array_diff( $control_ids, $static_front_page_control_ids ) ) === 0 ) {
+			$this->wp_customize->remove_section( $section_id );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -108,7 +108,8 @@ class Test_AMP_Template_Customizer extends WP_UnitTestCase {
 	 * @covers AMP_Template_Customizer::register_legacy_ui()
 	 * @covers AMP_Template_Customizer::register_legacy_settings()
 	 * @covers AMP_Template_Customizer::set_refresh_setting_transport()
-	 * @covers AMP_Template_Customizer::deactivate_cover_template_section()
+	 * @covers AMP_Template_Customizer::remove_cover_template_section()
+	 * @covers AMP_Template_Customizer::remove_homepage_settings_section()
 	 */
 	public function test_init_legacy_reader() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
@@ -139,13 +140,15 @@ class Test_AMP_Template_Customizer extends WP_UnitTestCase {
 		foreach ( [ $header_video_setting, $external_header_video_setting ] as $setting ) {
 			$this->assertEquals( 'postMessage', $setting->transport );
 		}
-		$this->assertTrue( $wp_customize->get_section( 'cover_template_options' )->active() );
+		$this->assertInstanceOf( WP_Customize_Section::class, $wp_customize->get_section( 'cover_template_options' ) );
+		$this->assertInstanceOf( WP_Customize_Section::class, $wp_customize->get_section( 'static_front_page' ) );
 	}
 
 	/**
 	 * @covers AMP_Template_Customizer::init()
 	 * @covers AMP_Template_Customizer::set_refresh_setting_transport()
-	 * @covers AMP_Template_Customizer::deactivate_cover_template_section()
+	 * @covers AMP_Template_Customizer::remove_cover_template_section()
+	 * @covers AMP_Template_Customizer::remove_homepage_settings_section()
 	 */
 	public function test_init_reader_theme() {
 		if ( ! wp_get_theme( 'twentynineteen' )->exists() || ! wp_get_theme( 'twentytwenty' )->exists() ) {
@@ -191,8 +194,8 @@ class Test_AMP_Template_Customizer extends WP_UnitTestCase {
 			$this->assertEquals( 'refresh', $setting->transport );
 		}
 
-		$this->assertFalse( $wp_customize->get_section( 'cover_template_options' )->active() );
-		$this->assertTrue( $wp_customize->get_section( 'title_tagline' )->active() );
+		$this->assertNull( $wp_customize->get_section( 'cover_template_options' ) );
+		$this->assertNull( $wp_customize->get_section( 'static_front_page' ) );
 	}
 
 	/** @covers AMP_Template_Customizer::init_legacy_preview() */


### PR DESCRIPTION
## Summary

Fixes #5008
Fixes #4784

### Option Control Notices

Add a “applies to non-AMP version” notice to each Customizer control that is associated with an `option` setting, since such settings impact both versions of the site. This prevents confusion for users who think they are only changing the AMP version when in reality they are changing both.

> ![image](https://user-images.githubusercontent.com/134745/87329167-63dce100-c4eb-11ea-8962-a22a7286a40b.png)

### Menus Panel Notice

Add special notice to Menus panel explaining that menus are shared between AMP and non-AMP version, but that they need to make sure that they assign existing menus to AMP-specific locations as desired, or create new AMP-specific menus.

(Aside: We need to try to auto-populate the menus!)

> ![image](https://user-images.githubusercontent.com/134745/87329202-70f9d000-c4eb-11ea-9013-c0811adaa5a8.png)

### Remove Homepage Settings Section

Hide the Homepage Setting section if it just has the default set of controls (show on front, front page, and page for posts). All of these controls are for options, which mean they all impact the non-AMP version. Therefore, instead of showing the “applies to non-AMP version” notice on all these controls, the section as a whole is removed to prevent confusion for users.

> ![image](https://user-images.githubusercontent.com/134745/87329130-56bff200-c4eb-11ea-9107-0ddb5ecac2ea.png)

### Improve Preview Notice

Add link to non-AMP Customizer and reduce line height of the overall preview notice:

> ![image](https://user-images.githubusercontent.com/134745/87333258-be793b80-c4f1-11ea-9a0f-5e9c4dd08671.png)

### Add AMP Panel Description to Root Description

In the AMP Customizer (when customizing a Reader theme), append amend the original root panel description with the description that is used for the legacy Reader mode AMP panel. Update the panel description to fix #4784:

> ![image](https://user-images.githubusercontent.com/134745/87333312-ccc75780-c4f1-11ea-84e4-8128f9e3942c.png)

In legacy Reader mode, this description serves as the sole text:

> ![image](https://user-images.githubusercontent.com/134745/87332381-5544f880-c4f0-11ea-8764-aefcfd9d2cb1.png)


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
