### PR TITLE
Initialize plugin_configured as true if plugin options are not empty

### DIFF
--- a/assets/src/components/options-context-provider/index.js
+++ b/assets/src/components/options-context-provider/index.js
@@ -31,8 +31,9 @@ function waitASecond() {
  * @param {Object} props Component props.
  * @param {?any} props.children Component children.
  * @param {string} props.optionsRestEndpoint REST endpoint to retrieve options.
+ * @param {boolean} props.populateDefaultValues Whether default values should be populated.
  */
-export function OptionsContextProvider( { children, optionsRestEndpoint } ) {
+export function OptionsContextProvider( { children, optionsRestEndpoint, populateDefaultValues } ) {
 	const [ updates, setUpdates ] = useState( {} );
 	const [ fetchingOptions, setFetchingOptions ] = useState( false );
 	const [ savingOptions, setSavingOptions ] = useState( false );
@@ -68,7 +69,7 @@ export function OptionsContextProvider( { children, optionsRestEndpoint } ) {
 					return;
 				}
 
-				if ( fetchedOptions.plugin_configured === false ) {
+				if ( ! populateDefaultValues && fetchedOptions.plugin_configured === false ) {
 					fetchedOptions.mobile_redirect = true;
 					fetchedOptions.reader_theme = null;
 					fetchedOptions.theme_support = null;
@@ -82,7 +83,7 @@ export function OptionsContextProvider( { children, optionsRestEndpoint } ) {
 
 			setFetchingOptions( false );
 		} )();
-	}, [ fetchingOptions, originalOptions, optionsRestEndpoint, setError ] );
+	}, [ fetchingOptions, originalOptions, optionsRestEndpoint, populateDefaultValues, setError ] );
 
 	/**
 	 * Sends options to the REST endpoint to be saved.
@@ -182,4 +183,5 @@ export function OptionsContextProvider( { children, optionsRestEndpoint } ) {
 OptionsContextProvider.propTypes = {
 	children: PropTypes.any,
 	optionsRestEndpoint: PropTypes.string.isRequired,
+	populateDefaultValues: PropTypes.bool.isRequired,
 };

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -49,6 +49,7 @@ export function Providers( { children } ) {
 	return (
 		<OptionsContextProvider
 			optionsRestEndpoint={ OPTIONS_REST_ENDPOINT }
+			populateDefaultValues={ false }
 		>
 			<UserContextProvider
 				userOptionDeveloperTools={ USER_FIELD_DEVELOPER_TOOLS_ENABLED }

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -41,7 +41,7 @@ const { ajaxurl: wpAjaxUrl } = global;
  */
 function Providers( { children } ) {
 	return (
-		<OptionsContextProvider optionsRestEndpoint={ OPTIONS_REST_ENDPOINT }>
+		<OptionsContextProvider optionsRestEndpoint={ OPTIONS_REST_ENDPOINT } populateDefaultValues={ true }>
 			<ReaderThemesContextProvider
 				currentTheme={ CURRENT_THEME }
 				readerThemesEndpoint={ READER_THEMES_REST_ENDPOINT }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -142,10 +142,12 @@ function amp_init() {
 	$options = get_option( AMP_Options_Manager::OPTION_NAME, [] );
 
 	// Initialize the plugin_configured option, setting it to true if options already exist.
-	if ( empty( $options ) ) {
-		AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, false );
-	} elseif ( ! isset( $options[ Option::PLUGIN_CONFIGURED ] ) ) {
-		AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, true );
+	if ( is_admin() && current_user_can( 'manage_options' )  ) {
+		if ( empty( $options ) ) {
+			AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, false );
+		} elseif ( ! isset( $options[ Option::PLUGIN_CONFIGURED ] ) ) {
+			AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, true );
+		}
 	}
 
 	$old_version = isset( $options[ Option::VERSION ] ) ? $options[ Option::VERSION ] : '0.0';

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -139,7 +139,15 @@ function amp_init() {
 	 * version was new option added, and in that case default would never be used for a site
 	 * upgrading from a version prior to 1.0. So this is why get_option() is currently used.
 	 */
-	$options     = get_option( AMP_Options_Manager::OPTION_NAME, [] );
+	$options = get_option( AMP_Options_Manager::OPTION_NAME, [] );
+
+	// Initialize the plugin_configured option, setting it to true if options already exist.
+	if ( empty( $options ) ) {
+		AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, false );
+	} elseif ( ! isset( $options[ Option::PLUGIN_CONFIGURED ] ) ) {
+		AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, true );
+	}
+
 	$old_version = isset( $options[ Option::VERSION ] ) ? $options[ Option::VERSION ] : '0.0';
 
 	if ( AMP__VERSION !== $old_version && is_admin() && current_user_can( 'manage_options' ) ) {
@@ -153,7 +161,9 @@ function amp_init() {
 				 * @param string $old_version Old version.
 				 */
 				do_action( 'amp_plugin_update', $old_version );
+
 				AMP_Options_Manager::update_option( Option::VERSION, AMP__VERSION );
+
 			},
 			PHP_INT_MAX
 		);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -139,19 +139,8 @@ function amp_init() {
 	 * version was new option added, and in that case default would never be used for a site
 	 * upgrading from a version prior to 1.0. So this is why get_option() is currently used.
 	 */
-	$options = get_option( AMP_Options_Manager::OPTION_NAME, [] );
-
-	// Initialize the plugin_configured option, setting it to true if options already exist.
-	if ( is_admin() && current_user_can( 'manage_options' )  ) {
-		if ( empty( $options ) ) {
-			AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, false );
-		} elseif ( ! isset( $options[ Option::PLUGIN_CONFIGURED ] ) ) {
-			AMP_Options_Manager::update_option( Option::PLUGIN_CONFIGURED, true );
-		}
-	}
-
+	$options     = get_option( AMP_Options_Manager::OPTION_NAME, [] );
 	$old_version = isset( $options[ Option::VERSION ] ) ? $options[ Option::VERSION ] : '0.0';
-
 	if ( AMP__VERSION !== $old_version && is_admin() && current_user_can( 'manage_options' ) ) {
 		// This waits to happen until the very end of init to ensure that amp theme support and amp post type support have all been added.
 		add_action(

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -141,6 +141,7 @@ function amp_init() {
 	 */
 	$options     = get_option( AMP_Options_Manager::OPTION_NAME, [] );
 	$old_version = isset( $options[ Option::VERSION ] ) ? $options[ Option::VERSION ] : '0.0';
+
 	if ( AMP__VERSION !== $old_version && is_admin() && current_user_can( 'manage_options' ) ) {
 		// This waits to happen until the very end of init to ensure that amp theme support and amp post type support have all been added.
 		add_action(
@@ -152,9 +153,7 @@ function amp_init() {
 				 * @param string $old_version Old version.
 				 */
 				do_action( 'amp_plugin_update', $old_version );
-
 				AMP_Options_Manager::update_option( Option::VERSION, AMP__VERSION );
-
 			},
 			PHP_INT_MAX
 		);

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -93,6 +93,11 @@ class AMP_Options_Manager {
 
 		$defaults = self::$defaults;
 
+		// Make sure the plugin is marked as being already configured if there saved options.
+		if ( ! empty( $options ) ) {
+			$defaults[ Option::PLUGIN_CONFIGURED ] = true;
+		}
+
 		// Migrate legacy method of specifying the mode.
 		$theme_support = AMP_Theme_Support::get_theme_support_args();
 		if ( $theme_support && ! isset( $options[ Option::THEME_SUPPORT ] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -89,6 +89,9 @@ class AMP_Options_Manager {
 		$options = get_option( self::OPTION_NAME, [] );
 		if ( empty( $options ) ) {
 			$options = []; // Ensure empty string becomes array.
+		} else {
+			// If settings exist, the plugin has been configured.
+			$options[ Option::PLUGIN_CONFIGURED ] = true;
 		}
 
 		$defaults = self::$defaults;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -89,9 +89,6 @@ class AMP_Options_Manager {
 		$options = get_option( self::OPTION_NAME, [] );
 		if ( empty( $options ) ) {
 			$options = []; // Ensure empty string becomes array.
-		} else {
-			// If settings exist, the plugin has been configured.
-			$options[ Option::PLUGIN_CONFIGURED ] = true;
 		}
 
 		$defaults = self::$defaults;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -99,12 +99,26 @@ class AMP_Options_Manager {
 		}
 
 		// Migrate legacy method of specifying the mode.
-		$theme_support = AMP_Theme_Support::get_theme_support_args();
-		if ( $theme_support && ! isset( $options[ Option::THEME_SUPPORT ] ) ) {
-			if ( empty( $theme_support[ AMP_Theme_Support::PAIRED_FLAG ] ) ) {
-				$defaults[ Option::THEME_SUPPORT ] = AMP_Theme_Support::STANDARD_MODE_SLUG;
-			} else {
-				$defaults[ Option::THEME_SUPPORT ] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
+		if ( ! isset( $options[ Option::THEME_SUPPORT ] ) ) {
+			$theme_support = AMP_Theme_Support::get_theme_support_args();
+			$template      = get_template();
+			$stylesheet    = get_stylesheet();
+			if (
+				$theme_support
+				&&
+				(
+					// If theme support was probably explicitly added by the theme (since not core).
+					! in_array( $template, AMP_Core_Theme_Sanitizer::get_supported_themes(), true )
+					||
+					// If it is a core theme no child theme is being used (which likely won't be AMP-compatible by default).
+					$template === $stylesheet
+				)
+			) {
+				if ( empty( $theme_support[ AMP_Theme_Support::PAIRED_FLAG ] ) ) {
+					$defaults[ Option::THEME_SUPPORT ] = AMP_Theme_Support::STANDARD_MODE_SLUG;
+				} else {
+					$defaults[ Option::THEME_SUPPORT ] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
+				}
 			}
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -91,7 +91,8 @@ class AMP_Options_Manager {
 			$options = []; // Ensure empty string becomes array.
 		}
 
-		$defaults = self::$defaults;
+		$defaults      = self::$defaults;
+		$theme_support = AMP_Theme_Support::get_theme_support_args();
 
 		// Make sure the plugin is marked as being already configured if there saved options.
 		if ( ! empty( $options ) ) {
@@ -99,20 +100,15 @@ class AMP_Options_Manager {
 		}
 
 		// Migrate legacy method of specifying the mode.
-		if ( ! isset( $options[ Option::THEME_SUPPORT ] ) ) {
-			$theme_support = AMP_Theme_Support::get_theme_support_args();
-			$template      = get_template();
-			$stylesheet    = get_stylesheet();
+		if ( ! isset( $options[ Option::THEME_SUPPORT ] ) && $theme_support ) {
+			$template   = get_template();
+			$stylesheet = get_stylesheet();
 			if (
-				$theme_support
-				&&
-				(
-					// If theme support was probably explicitly added by the theme (since not core).
-					! in_array( $template, AMP_Core_Theme_Sanitizer::get_supported_themes(), true )
-					||
-					// If it is a core theme no child theme is being used (which likely won't be AMP-compatible by default).
-					$template === $stylesheet
-				)
+				// If theme support was probably explicitly added by the theme (since not core).
+				! in_array( $template, AMP_Core_Theme_Sanitizer::get_supported_themes(), true )
+				||
+				// If it is a core theme no child theme is being used (which likely won't be AMP-compatible by default).
+				$template === $stylesheet
 			) {
 				if ( empty( $theme_support[ AMP_Theme_Support::PAIRED_FLAG ] ) ) {
 					$defaults[ Option::THEME_SUPPORT ] = AMP_Theme_Support::STANDARD_MODE_SLUG;

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -297,12 +297,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1
 	 */
 	public static function extend_theme_support() {
-		$args = self::get_theme_support_args( get_template() );
-
-		if ( empty( $args ) ) {
+		$template = get_template();
+		if ( ! in_array( $template, self::get_supported_themes(), true ) ) {
 			return;
 		}
 
+		$args    = self::get_theme_support_args( $template );
 		$support = AMP_Theme_Support::get_theme_support_args();
 		if ( ! is_array( $support ) ) {
 			$support = [];

--- a/tests/e2e/specs/admin/amp-options.js
+++ b/tests/e2e/specs/admin/amp-options.js
@@ -9,8 +9,6 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 import { completeWizard, cleanUpSettings, clickMode, selectReaderTheme } from '../../utils/onboarding-wizard-utils';
 import { installTheme } from '../../utils/install-theme';
 import { activateTheme } from '../../utils/activate-theme';
-import { themeInstalled } from '../../utils/theme-installed';
-import { deleteTheme } from '../../utils/delete-theme';
 
 async function testStandardAndTransitionalSupportedTemplateToggle() {
 	await expect( page ).toMatchElement( '.supported-templates' );
@@ -25,8 +23,8 @@ async function testStandardAndTransitionalSupportedTemplateToggle() {
 
 async function testMobileRedirectToggle() {
 	await expect( page ).toMatchElement( '.mobile-redirection' );
-	await expect( page ).toClick( '.mobile-redirection .amp-setting-toggle input:checked' );
-	await expect( page ).toMatchElement( '.mobile-redirection .amp-setting-toggle input:not(:checked)' );
+	await expect( page ).toClick( '.mobile-redirection .amp-setting-toggle input:not(:checked)' );
+	await expect( page ).toMatchElement( '.mobile-redirection .amp-setting-toggle input:checked' );
 }
 
 describe( 'AMP settings screen newly activated', () => {
@@ -39,11 +37,10 @@ describe( 'AMP settings screen newly activated', () => {
 	} );
 
 	it( 'has main page components', async () => {
-		await expect( page ).toMatchElement( '.amp-plugin-notice' );
 		await expect( page ).toMatchElement( 'h1', { text: 'AMP Settings' } );
 		await expect( page ).toMatchElement( 'h2', { text: 'Configure AMP' } );
 		await expect( page ).toMatchElement( 'a', { text: 'Open Wizard' } );
-		await expect( page ).not.toMatchElement( '.template-mode-selection input:checked' );
+		await expect( page ).toMatchElement( '.template-mode-selection input:checked' );
 		await expect( page ).toPassAxeTests( {
 			exclude: [
 				'#wpadminbar',
@@ -77,37 +74,12 @@ describe( 'AMP settings screen newly activated', () => {
 		await testMobileRedirectToggle();
 
 		await expect( page ).toMatchElement( '.reader-themes' );
-		await expect( page ).not.toMatchElement( '#theme-card__legacy:checked' );
-		await selectReaderTheme();
 		await expect( page ).toMatchElement( '#theme-card__legacy:checked' );
 
 		await expect( page ).not.toMatchElement( '#theme-card__twentytwenty:checked' ); // Active theme is hidden.
 
 		await selectReaderTheme( 'twentynineteen' );
 		await expect( page ).toMatchElement( '#theme-card__twentynineteen:checked' );
-	} );
-} );
-
-describe( 'Settings screen submit button', () => {
-	it( 'has the correct disabled state', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		await expect( page ).toMatchElement( '.settings-footer button:disabled' );
-
-		await clickMode( 'standard' );
-		await expect( page ).toMatchElement( '.settings-footer button:not(:disabled)' );
-
-		await clickMode( 'reader' );
-		await expect( page ).toMatchElement( '.settings-footer button:disabled' );
-
-		await clickMode( 'transitional' );
-		await expect( page ).toMatchElement( '.settings-footer button:not(:disabled)' );
-
-		await clickMode( 'reader' );
-		await expect( page ).toMatchElement( '.settings-footer button:disabled' );
-
-		await selectReaderTheme( 'twentynineteen' );
-		await expect( page ).toMatchElement( '.settings-footer button:not(:disabled)' );
 	} );
 } );
 
@@ -141,54 +113,6 @@ describe( 'Mode info notices', () => {
 
 	it.todo( 'shows expected notices for theme with paired flag false' );
 	it.todo( 'shows expected notices for theme that only supports reader mode' );
-} );
-
-describe( 'Show all templates toggle', () => {
-	it.each( [ 'reader', 'standard', 'transitional' ] )( 'shows expected supported template state for %s mode', async ( mode ) => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		await expect( page ).toMatchElement( '.hidden .supported-templates' );
-
-		await clickMode( mode );
-
-		if ( 'reader' === mode ) {
-			await expect( page ).toMatchElement( '.hidden .supported-templates' );
-			await selectReaderTheme( 'twentysixteen' );
-		}
-
-		await expect( page ).not.toMatchElement( '.hidden .supported-templates' );
-		await expect( page ).not.toMatchElement( '.amp-setting-toggle--disabled' );
-
-		if ( 'reader' === mode ) {
-			await selectReaderTheme( 'legacy' );
-			await expect( page ).toMatchElement( '.amp-setting-toggle--disabled' );
-		}
-	} );
-} );
-
-describe( 'AMP settings reader theme install', () => {
-	beforeAll( async () => {
-		if ( themeInstalled( 'twentysixteen' ) ) {
-			await deleteTheme( 'twentysixteen' );
-		}
-	} );
-
-	afterAll( async () => {
-		await cleanUpSettings();
-	} );
-
-	it( 'can install a theme', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-		await clickMode( 'reader' );
-		await selectReaderTheme( 'twentysixteen' );
-
-		await expect( page ).toClick( '.settings-footer button' );
-		await page.waitForSelector( '.settings-footer button:disabled' );
-		await page.waitForSelector( '.settings-footer button:not(:disabled)' );
-
-		const success = await themeInstalled( 'twentysixteen' );
-		expect( success ).toBe( true );
-	} );
 } );
 
 describe( 'AMP Settings Screen after wizard', () => {

--- a/tests/e2e/specs/admin/mobile-redirect.js
+++ b/tests/e2e/specs/admin/mobile-redirect.js
@@ -17,7 +17,7 @@ describe( 'Mobile redirect settings', () => {
 	} );
 
 	it( 'persists the mobile redirect setting on', async () => {
-		await completeWizard( { mode: 'reader' } );
+		await completeWizard( { mode: 'reader', mobileRedirect: true } );
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
 		await page.waitForSelector( toggleSelector );

--- a/tests/e2e/utils/onboarding-wizard-utils.js
+++ b/tests/e2e/utils/onboarding-wizard-utils.js
@@ -125,6 +125,7 @@ export function testTitle( { text, element = 'h1' } ) {
  */
 export async function cleanUpSettings() {
 	await visitAdminPage( 'admin.php', 'page=amp-options' );
+	await page.waitForSelector( '.settings-footer' );
 	await page.evaluate( async () => {
 		await Promise.all( [
 			wp.apiFetch( { path: '/wp/v2/users/me', method: 'POST', data: { amp_dev_tools_enabled: true } } ),

--- a/tests/php/data/themes/child-of-core/style.css
+++ b/tests/php/data/themes/child-of-core/style.css
@@ -1,0 +1,4 @@
+/**
+Theme Name: Child o' Twenty Twenty
+Template: twentytwenty
+ */

--- a/tests/php/data/themes/custom/index.php
+++ b/tests/php/data/themes/custom/index.php
@@ -1,0 +1,2 @@
+<?php
+the_post();

--- a/tests/php/data/themes/custom/style.css
+++ b/tests/php/data/themes/custom/style.css
@@ -1,0 +1,3 @@
+/*
+Theme Name: Custom
+*/

--- a/tests/php/src/Unit/PluginActivationNoticeTest.php
+++ b/tests/php/src/Unit/PluginActivationNoticeTest.php
@@ -30,6 +30,7 @@ class PluginActivationNoticeTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->plugin_activation_notice = new PluginActivationNotice();
+		delete_option( 'amp-options' );
 	}
 
 	/**

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -287,6 +287,42 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_options for toggling the default value of plugin_configured.
+	 *
+	 * @covers AMP_Options_Manager::get_option()
+	 * @covers AMP_Options_Manager::get_options()
+	 */
+	public function test_get_options_changing_plugin_configured_default() {
+		// Ensure plugin_configured is false when existing option is absent.
+		delete_option( AMP_Options_Manager::OPTION_NAME );
+		$this->assertFalse( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
+
+		// Ensure plugin_configured is true when existing option is absent from an old version.
+		update_option( AMP_Options_Manager::OPTION_NAME, [ Option::VERSION => '1.5.2' ] );
+		$this->assertTrue( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
+
+		// Ensure plugin_configured is true when explicitly set as such in the DB.
+		update_option(
+			AMP_Options_Manager::OPTION_NAME,
+			[
+				Option::VERSION           => AMP__VERSION,
+				Option::PLUGIN_CONFIGURED => false,
+			]
+		);
+		$this->assertFalse( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
+
+		// Ensure plugin_configured is false when explicitly set as such in the DB.
+		update_option(
+			AMP_Options_Manager::OPTION_NAME,
+			[
+				Option::VERSION           => AMP__VERSION,
+				Option::PLUGIN_CONFIGURED => true,
+			],
+		);
+		$this->assertTrue( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
+	}
+
+	/**
 	 * Test get_options when supported_post_types option is list of post types and when post type support is added for default values.
 	 *
 	 * @covers AMP_Options_Manager::get_options()

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -155,9 +155,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertSame( false, AMP_Options_Manager::get_option( 'foo' ) );
 		$this->assertSame( 'default', AMP_Options_Manager::get_option( 'foo', 'default' ) );
 
-		// Before any options are saved, plugin_configured should be false.
-		$this->assertFalse( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
-
 		// Test supported_post_types validation.
 		AMP_Options_Manager::update_option(
 			Option::SUPPORTED_POST_TYPES,
@@ -183,9 +180,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			],
 			AMP_Options_Manager::get_option( Option::SUPPORTED_TEMPLATES )
 		);
-
-		// Plugin_configured has not been explicitly set, but now that options are not empty it should be true.
-		$this->assertTrue( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
 
 		// Test analytics validation with missing fields.
 		AMP_Options_Manager::update_option(

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -317,7 +317,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			[
 				Option::VERSION           => AMP__VERSION,
 				Option::PLUGIN_CONFIGURED => true,
-			],
+			]
 		);
 		$this->assertTrue( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
 	}

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -155,6 +155,9 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertSame( false, AMP_Options_Manager::get_option( 'foo' ) );
 		$this->assertSame( 'default', AMP_Options_Manager::get_option( 'foo', 'default' ) );
 
+		// Before any options are saved, plugin_configured should be false.
+		$this->assertFalse( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
+
 		// Test supported_post_types validation.
 		AMP_Options_Manager::update_option(
 			Option::SUPPORTED_POST_TYPES,
@@ -180,6 +183,9 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			],
 			AMP_Options_Manager::get_option( Option::SUPPORTED_TEMPLATES )
 		);
+
+		// Plugin_configured has not been explicitly set, but now that options are not empty it should be true.
+		$this->assertTrue( AMP_Options_Manager::get_option( Option::PLUGIN_CONFIGURED ) );
 
 		// Test analytics validation with missing fields.
 		AMP_Options_Manager::update_option(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5020 

For the setup wizard, we added a `plugin_configured` option. When false, certain values are initialized to null in the UI until the user makes decisions about plugin configuration. 

We need to skip that behavior if the plugin was already configured at some point before `plugin_configured` was added.

With this change, when the plugin options from the database are not empty, we set `plugin_configured` to true. As a result, the UI will reflect previously selected options instead of initializing any fields to null.

### Test steps

1. Switch to a pre-1.6 version of the plugin -- e.g., checkout 1.5.5 -- reinstall composer and node modules, and rebuild
2. Clear your options: `wp option delete amp-options`
3. Visit the plugin settings page and save some settings.
4. Checkout this branch, reinstall composer and node modules, and rebuild
5. Visit the plugin settings page and confirm that your settings are not empty. They should also be reflected in the wizard

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
