### PR TITLE
Decouple supported post types from whether all templates are supported

### DIFF
--- a/assets/src/block-editor/plugins/amp-toggle.js
+++ b/assets/src/block-editor/plugins/amp-toggle.js
@@ -61,11 +61,9 @@ function AMPToggle( { isEnabled, onChange } ) {
 								</summary>
 								{
 									errorMessages.map( ( message, index ) => (
-										<p key={ index }>
-											<RawHTML>
-												{ message }
-											</RawHTML>
-										</p>
+										<RawHTML key={ index }>
+											{ message }
+										</RawHTML>
 									) )
 								}
 							</details>

--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -56,8 +56,5 @@ AMPSettingToggle.propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	text: PropTypes.string,
-	title: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.node,
-	] ).isRequired,
+	title: PropTypes.node,
 };

--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -56,5 +56,5 @@ AMPSettingToggle.propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	text: PropTypes.string,
-	title: PropTypes.node,
+	title: PropTypes.node.isRequired,
 };

--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { ToggleControl } from '@wordpress/components';
+import { isValidElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,22 +21,25 @@ import './style.css';
  * @param {boolean} props.checked Whether the toggle is on.
  * @param {boolean} props.disabled Whether the toggle is disabled.
  * @param {Function} props.onChange Change handler.
- * @param {?string} props.text Toggle text.
- * @param {string} props.title Toggle title.
- * @param {number} props.headingLevel Heading level for title.
+ * @param {string} props.text Toggle text.
+ * @param {Object|string} props.title Toggle title.
  */
-export function AMPSettingToggle( { checked, disabled = false, onChange, text, title, headingLevel } ) {
-	const Heading = headingLevel ? `h${ headingLevel }` : 'h3';
-
+export function AMPSettingToggle( { checked, disabled = false, onChange, text, title } ) {
 	return (
 		<div className={ `amp-setting-toggle ${ disabled ? 'amp-setting-toggle--disabled' : '' }` }>
 			<ToggleControl
 				checked={ ! disabled && checked }
 				label={ (
 					<div className="amp-setting-toggle__label-text">
-						<Heading>
-							{ title }
-						</Heading>
+						{
+							isValidElement( title )
+								? title
+								: (
+									<h3>
+										{ title }
+									</h3>
+								)
+						}
 						{ text && (
 							<p>
 								{ text }
@@ -52,6 +56,8 @@ AMPSettingToggle.propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	text: PropTypes.string,
-	headingLevel: PropTypes.number,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.elementType,
+	] ).isRequired,
 };

--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -22,17 +22,20 @@ import './style.css';
  * @param {Function} props.onChange Change handler.
  * @param {?string} props.text Toggle text.
  * @param {string} props.title Toggle title.
+ * @param {number} props.headingLevel Heading level for title.
  */
-export function AMPSettingToggle( { checked, disabled = false, onChange, text, title } ) {
+export function AMPSettingToggle( { checked, disabled = false, onChange, text, title, headingLevel } ) {
+	const Heading = headingLevel ? `h${ headingLevel }` : 'h3';
+
 	return (
 		<div className={ `amp-setting-toggle ${ disabled ? 'amp-setting-toggle--disabled' : '' }` }>
 			<ToggleControl
 				checked={ ! disabled && checked }
 				label={ (
 					<div className="amp-setting-toggle__label-text">
-						<h3>
+						<Heading>
 							{ title }
-						</h3>
+						</Heading>
 						{ text && (
 							<p>
 								{ text }
@@ -49,5 +52,6 @@ AMPSettingToggle.propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	text: PropTypes.string,
+	headingLevel: PropTypes.number,
 	title: PropTypes.string.isRequired,
 };

--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -58,6 +58,6 @@ AMPSettingToggle.propTypes = {
 	text: PropTypes.string,
 	title: PropTypes.oneOfType( [
 		PropTypes.string,
-		PropTypes.elementType,
+		PropTypes.node,
 	] ).isRequired,
 };

--- a/assets/src/components/redirect-toggle/index.js
+++ b/assets/src/components/redirect-toggle/index.js
@@ -24,7 +24,7 @@ export function RedirectToggle( { direction = 'bottom' } ) {
 		<div className={ `selectable selectable--${ direction }` }>
 			<AMPSettingToggle
 				checked={ true === mobileRedirect }
-				title={ __( 'Redirect mobile visitors to AMP.', 'amp' ) }
+				title={ __( 'Redirect mobile visitors to AMP', 'amp' ) }
 				onChange={ () => {
 					updateOptions( { mobile_redirect: ! mobileRedirect } );
 				} }

--- a/assets/src/components/redirect-toggle/test/__snapshots__/redirect-toggle.js.snap
+++ b/assets/src/components/redirect-toggle/test/__snapshots__/redirect-toggle.js.snap
@@ -38,7 +38,7 @@ exports[`RedirectToggle matches snapshot 1`] = `
             className="amp-setting-toggle__label-text"
           >
             <h3>
-              Redirect mobile visitors to AMP.
+              Redirect mobile visitors to AMP
             </h3>
           </div>
         </label>

--- a/assets/src/components/supported-templates-toggle/index.js
+++ b/assets/src/components/supported-templates-toggle/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import './style.css';
 import { Options } from '../options-context-provider';
 import { AMPSettingToggle } from '../amp-setting-toggle';
 
@@ -25,8 +26,11 @@ export function SupportedTemplatesToggle() {
 	return (
 		<AMPSettingToggle
 			checked={ true === allTemplatesSupported }
-			title={ __( 'Serve all templates as AMP', 'amp' ) }
-			headingLevel={ 5 }
+			title={ (
+				<p>
+					{ __( 'Serve all templates as AMP', 'amp' ) }
+				</p>
+			) }
 			onChange={ () => {
 				updateOptions( { all_templates_supported: ! allTemplatesSupported } );
 			} }

--- a/assets/src/components/supported-templates-toggle/index.js
+++ b/assets/src/components/supported-templates-toggle/index.js
@@ -25,8 +25,8 @@ export function SupportedTemplatesToggle() {
 	return (
 		<AMPSettingToggle
 			checked={ true === allTemplatesSupported }
-			text={ __( 'This will allow all of the URLs on your site to be served as AMP by default.', 'amp' ) }
-			title={ __( 'Serve all templates as AMP regardless of what is being queried.', 'amp' ) }
+			title={ __( 'Serve all templates as AMP', 'amp' ) }
+			headingLevel={ 5 }
 			onChange={ () => {
 				updateOptions( { all_templates_supported: ! allTemplatesSupported } );
 			} }

--- a/assets/src/components/supported-templates-toggle/style.css
+++ b/assets/src/components/supported-templates-toggle/style.css
@@ -1,0 +1,8 @@
+.amp .supported-templates .amp-setting-toggle .components-form-toggle {
+	margin-right: 1rem;
+}
+
+.supported-templates .amp-setting-toggle .amp-setting-toggle__label-text > p {
+	margin: 0;
+	font-weight: bold;
+}

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -64,27 +64,19 @@ PostTypeCheckbox.propTypes = {
 function SupportedPostTypesFieldset() {
 	const { editedOptions } = useContext( Options );
 
-	const {
-		theme_support: themeSupport,
-		reader_theme: readerTheme,
-		supportable_post_types: supportablePostTypes,
-	} = editedOptions || {};
+	const { supportable_post_types: supportablePostTypes } = editedOptions || {};
 
 	if ( ! supportablePostTypes ) {
 		return null;
 	}
 
-	const isLegacy = 'reader' === themeSupport && 'legacy' === readerTheme;
-
 	return (
 		<fieldset id="supported_post_types_fieldset">
-			{ ! isLegacy && (
-				<h4 className="title">
-					{ __( 'Content Types', 'amp' ) }
-				</h4>
-			) }
+			<h4 className="title">
+				{ __( 'Content Types', 'amp' ) }
+			</h4>
 			<p>
-				{ __( 'The following content types will be available as AMP:', 'amp' ) }
+				{ __( 'Content types enabled for AMP:', 'amp' ) }
 			</p>
 			<ul>
 				{ supportablePostTypes.map( ( postTypeObject ) => {
@@ -186,7 +178,12 @@ SupportedTemplatesCheckboxes.propTypes = {
 export function SupportedTemplatesFieldset() {
 	const { editedOptions } = useContext( Options );
 
-	const { theme_support: themeSupport, supportable_templates: supportableTemplates, reader_theme: readerTheme } = editedOptions || {};
+	const {
+		all_templates_supported: allTemplatesSupported,
+		theme_support: themeSupport,
+		supportable_templates: supportableTemplates,
+		reader_theme: readerTheme,
+	} = editedOptions || {};
 
 	if ( ( 'reader' === themeSupport && 'legacy' === readerTheme ) || ! supportableTemplates ) {
 		return null;
@@ -198,18 +195,31 @@ export function SupportedTemplatesFieldset() {
 				{ __( 'Templates', 'amp' ) }
 			</h4>
 
-			{ /* dangerouslySetInnerHTML reason: Link embedded in translation string. */ }
-			<p
-				dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						/* translators: placeholder is link to WordPress handbook page about the template hierarchy. */
-						__( 'You may enable AMP for a subset of the WordPress <a href="%s" target="_blank" rel="noreferrer">Template Hierarchy</a>:', 'amp' ),
-						'https://developer.wordpress.org/themes/basics/template-hierarchy/',
-					),
-				} }
-			/>
+			<SupportedTemplatesToggle />
 
-			<SupportedTemplatesCheckboxes supportableTemplates={ supportableTemplates } />
+			{ ! allTemplatesSupported ? (
+				<>
+					{ /* dangerouslySetInnerHTML reason: Link embedded in translation string. */ }
+					<p
+						dangerouslySetInnerHTML={ {
+							__html: sprintf(
+								/* translators: placeholder is link to WordPress handbook page about the template hierarchy. */
+								__( 'Limit AMP on a subset of the WordPress <a href="%s" target="_blank" rel="noreferrer">Template Hierarchy</a>:', 'amp' ),
+								'https://developer.wordpress.org/themes/basics/template-hierarchy/',
+							),
+						} }
+					/>
+
+					{ supportableTemplates
+						? <SupportedTemplatesCheckboxes supportableTemplates={ supportableTemplates } />
+						: (
+							<p>
+								{ __( 'Your site does not provide any templates to support.', 'amp' ) }
+							</p>
+						)
+					}
+				</>
+			) : null }
 		</fieldset>
 	);
 }
@@ -218,26 +228,16 @@ export function SupportedTemplatesFieldset() {
  * Component rendering the supported templates section of the settings page, including the "Serve all templates as AMP" toggle.
  */
 export function SupportedTemplates() {
-	const { editedOptions } = useContext( Options );
-
-	const { all_templates_supported: allTemplatesSupported, theme_support: themeSupport, reader_theme: readerTheme } = editedOptions || {};
-
-	const isLegacy = 'reader' === themeSupport && 'legacy' === readerTheme;
-
 	return (
 		<section>
 			<h2>
 				{ __( 'Supported Templates', 'amp' ) }
 			</h2>
 			<Selectable className="supported-templates">
-				<SupportedTemplatesToggle />
-				{ ( ! allTemplatesSupported || isLegacy ) && (
-					<div className="supported-templates__fields">
-						<SupportedPostTypesFieldset />
-						<SupportedTemplatesFieldset />
-					</div>
-				) }
-
+				<div className="supported-templates__fields">
+					<SupportedPostTypesFieldset />
+					<SupportedTemplatesFieldset />
+				</div>
 			</Selectable>
 		</section>
 	);

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -62,7 +62,7 @@ function PostTypeCheckbox( { postTypeObject } ) {
 						if ( ! newChecked && hasPageOnFront && ! allTemplatesSupported && 'page' === postTypeObject.name ) {
 							let warning = '';
 							if ( isBlogTemplateSupported && isFrontPageTemplateSupported ) {
-								warning = __( 'Note that disabling Pages will prevent you from serving your homepage and posts page (blog index) as AMP.', 'amp' );
+								warning = __( 'Note that disabling pages will prevent you from serving your homepage and posts page (blog index) as AMP.', 'amp' );
 							} else if ( isBlogTemplateSupported ) {
 								warning = __( 'Note that disabling pages will prevent you from serving your posts page (blog index) as AMP.', 'amp' );
 							} else if ( isFrontPageTemplateSupported ) {

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -121,7 +121,9 @@ export function SupportedTemplatesCheckboxes( { supportableTemplates } ) {
 		return null;
 	}
 
-	const hasPageOnFront = supportedTemplates.includes( 'is_front_page' );
+	const hasPageOnFront = Boolean( supportableTemplates.find( ( supportableTemplate ) => {
+		return supportableTemplate.id === 'is_front_page';
+	} ) );
 	const isPageSupported = supportedPostTypes.includes( 'page' );
 	const relevantSupportableTemplates = ! hasPageOnFront ? supportableTemplates : supportableTemplates.filter( ( supportableTemplate ) => {
 		return (

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -115,15 +115,25 @@ function getInclusiveDescendantTemplatesIds( supportableTemplate ) {
 export function SupportedTemplatesCheckboxes( { supportableTemplates } ) {
 	const { editedOptions, updateOptions } = useContext( Options );
 
-	const { supported_templates: supportedTemplates } = editedOptions || {};
+	const { supported_templates: supportedTemplates, supported_post_types: supportedPostTypes } = editedOptions || {};
 
 	if ( ! supportableTemplates.length ) {
 		return null;
 	}
 
+	const hasPageOnFront = supportedTemplates.includes( 'is_front_page' );
+	const isPageSupported = supportedPostTypes.includes( 'page' );
+	const relevantSupportableTemplates = ! hasPageOnFront ? supportableTemplates : supportableTemplates.filter( ( supportableTemplate ) => {
+		return (
+			! hasPageOnFront ||
+			isPageSupported ||
+			! [ 'is_home', 'is_front_page' ].includes( supportableTemplate.id )
+		);
+	} );
+
 	return (
 		<ul>
-			{ supportableTemplates.map( ( supportableTemplate ) => (
+			{ relevantSupportableTemplates.map( ( supportableTemplate ) => (
 				<li key={ supportableTemplate.id }>
 					<CheckboxControl
 						checked={ supportedTemplates.includes( supportableTemplate.id ) }

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -144,7 +144,7 @@ class AMP_Post_Meta_Box {
 			isset( $screen->base ) &&
 			'post' === $screen->base &&
 			( ! isset( $screen->is_block_editor ) || ! $screen->is_block_editor ) &&
-			is_post_type_viewable( $post->post_type )
+			in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true )
 		);
 
 		if ( ! $validate ) {
@@ -208,7 +208,7 @@ class AMP_Post_Meta_Box {
 	 */
 	public function enqueue_block_assets() {
 		$post = get_post();
-		if ( ! is_post_type_viewable( $post->post_type ) ) {
+		if ( ! in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true ) ) {
 			return;
 		}
 
@@ -278,7 +278,7 @@ class AMP_Post_Meta_Box {
 		$verify = (
 			isset( $post->ID )
 			&&
-			is_post_type_viewable( $post->post_type )
+			in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true )
 			&&
 			current_user_can( 'edit_post', $post->ID )
 		);

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -57,7 +57,7 @@ class AMP_Post_Type_Support {
 		 *
 		 * @param string[] $post_types Post types.
 		 */
-		return apply_filters( 'amp_supportable_post_types', $post_types );
+		return array_values( (array) apply_filters( 'amp_supportable_post_types', $post_types ) );
 	}
 
 	/**

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -49,7 +49,7 @@ class AMP_Post_Type_Support {
 		);
 
 		/**
-		 * Filters the list of post types eligible for AMP.
+		 * Filters the list of post types which may be supported for AMP.
 		 *
 		 * By default the list includes those which are public.
 		 *
@@ -57,7 +57,7 @@ class AMP_Post_Type_Support {
 		 *
 		 * @param string[] $post_types Post types.
 		 */
-		return apply_filters( 'amp_eligible_post_types', $post_types );
+		return apply_filters( 'amp_supportable_post_types', $post_types );
 	}
 
 	/**

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -39,7 +39,7 @@ class AMP_Post_Type_Support {
 	 * @return string[] Post types eligible for AMP.
 	 */
 	public static function get_eligible_post_types() {
-		return array_values(
+		$post_types = array_values(
 			get_post_types(
 				[
 					'public' => true,
@@ -47,6 +47,17 @@ class AMP_Post_Type_Support {
 				'names'
 			)
 		);
+
+		/**
+		 * Filters the list of post types eligible for AMP.
+		 *
+		 * By default the list includes those which are public.
+		 *
+		 * @since 1.6
+		 *
+		 * @param string[] $post_types Post types.
+		 */
+		return apply_filters( 'amp_eligible_post_types', $post_types );
 	}
 
 	/**
@@ -73,10 +84,11 @@ class AMP_Post_Type_Support {
 	 * @return string[] List of post types that support AMP.
 	 */
 	public static function get_supported_post_types() {
+		$eligible_post_types = self::get_eligible_post_types();
 		if ( ! amp_is_legacy() && AMP_Options_Manager::get_option( Option::ALL_TEMPLATES_SUPPORTED ) ) {
-			return self::get_eligible_post_types();
+			return $eligible_post_types;
 		}
-		return AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES, [] );
+		return array_intersect( AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES, [] ), $eligible_post_types );
 	}
 
 	/**

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -84,11 +84,10 @@ class AMP_Post_Type_Support {
 	 * @return string[] List of post types that support AMP.
 	 */
 	public static function get_supported_post_types() {
-		$eligible_post_types = self::get_eligible_post_types();
-		if ( ! amp_is_legacy() && AMP_Options_Manager::get_option( Option::ALL_TEMPLATES_SUPPORTED ) ) {
-			return $eligible_post_types;
-		}
-		return array_intersect( AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES, [] ), $eligible_post_types );
+		return array_intersect(
+			AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES, [] ),
+			self::get_eligible_post_types()
+		);
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -27,7 +27,7 @@ class AMP_Options_Manager {
 	 */
 	protected static $defaults = [
 		Option::THEME_SUPPORT           => AMP_Theme_Support::READER_MODE_SLUG,
-		Option::SUPPORTED_POST_TYPES    => [ 'post' ],
+		Option::SUPPORTED_POST_TYPES    => [ 'post', 'page' ],
 		Option::ANALYTICS               => [],
 		Option::ALL_TEMPLATES_SUPPORTED => true,
 		Option::SUPPORTED_TEMPLATES     => [ 'is_singular' ],

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -206,13 +206,7 @@ class AMP_Options_Manager {
 		// Migrate options from 1.5 to 1.6.
 		if ( isset( $options['version'] ) && version_compare( $options['version'], '1.6', '<' ) ) {
 
-			// Make sure programmatic post type support is persisted in the DB.
-			$options[ Option::SUPPORTED_POST_TYPES ] = array_merge(
-				$options[ Option::SUPPORTED_POST_TYPES ],
-				(array) get_post_types_by_support( 'amp' )
-			);
-
-			// It also used to be that the themes_supported flag overrode the options, so make sure the option gets updated to reflect the theme support.
+			// It used to be that the themes_supported flag overrode the options, so make sure the option gets updated to reflect the theme support.
 			if ( isset( $theme_support['templates_supported'] ) ) {
 				if ( 'all' === $theme_support['templates_supported'] ) {
 					$options[ Option::ALL_TEMPLATES_SUPPORTED ] = true;
@@ -236,6 +230,20 @@ class AMP_Options_Manager {
 						)
 					);
 				}
+			}
+
+			// Make sure programmatic post type support is persisted in the DB, as from now on the DB option is the source of truth.
+			$options[ Option::SUPPORTED_POST_TYPES ] = array_merge(
+				$options[ Option::SUPPORTED_POST_TYPES ],
+				(array) get_post_types_by_support( AMP_Post_Type_Support::SLUG )
+			);
+
+			// Make sure that all post types get enabled if all templates were supported since they are now independently controlled.
+			if ( ! empty( $options[ Option::ALL_TEMPLATES_SUPPORTED ] ) ) {
+				$options[ Option::SUPPORTED_POST_TYPES ] = array_merge(
+					$options[ Option::SUPPORTED_POST_TYPES ],
+					AMP_Post_Type_Support::get_eligible_post_types()
+				);
 			}
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -336,7 +336,7 @@ class AMP_Options_Manager {
 					$options[ Option::SUPPORTED_POST_TYPES ][] = $post_type;
 				}
 			}
-			$options[ Option::SUPPORTED_POST_TYPES ] = array_unique( $options[ Option::SUPPORTED_POST_TYPES ] );
+			$options[ Option::SUPPORTED_POST_TYPES ] = array_values( array_unique( $options[ Option::SUPPORTED_POST_TYPES ] ) );
 		}
 
 		// Update all_templates_supported.
@@ -353,7 +353,7 @@ class AMP_Options_Manager {
 					$options[ Option::SUPPORTED_TEMPLATES ][] = $template_id;
 				}
 			}
-			$options[ Option::SUPPORTED_TEMPLATES ] = array_unique( $options[ Option::SUPPORTED_TEMPLATES ] );
+			$options[ Option::SUPPORTED_TEMPLATES ] = array_values( array_unique( $options[ Option::SUPPORTED_TEMPLATES ] ) );
 		}
 
 		// Validate wizard completion.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -272,7 +272,7 @@ class AMP_Validation_Manager {
 
 		return (
 			// Skip if the post type is not viewable on the frontend, since we need a permalink to validate.
-			is_post_type_viewable( $post->post_type )
+			in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true )
 			&&
 			! wp_is_post_autosave( $post )
 			&&

--- a/tests/php/src/OptionsRESTControllerTest.php
+++ b/tests/php/src/OptionsRESTControllerTest.php
@@ -93,8 +93,8 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 		$this->assertEquals( $data['preview_permalink'], null );
 		$this->assertEquals( $data['suppressed_plugins'], [] );
 		$this->assertEquals( $data['suppressible_plugins'], [] );
-		$this->assertContains( 'post', wp_list_pluck( $data['supportable_post_types'], 'name' ) );
-		$this->assertEquals( $data['supported_post_types'], [ 'post' ] );
+		$this->assertEquals( [ 'post', 'page', 'attachment' ], wp_list_pluck( $data['supportable_post_types'], 'name' ) );
+		$this->assertEquals( $data['supported_post_types'], [ 'post', 'page' ] );
 		$this->assertContains( 'is_singular', wp_list_pluck( $data['supportable_templates'], 'id' ) );
 		$this->assertEquals( $data['supported_templates'], [ 'is_singular' ] );
 	}

--- a/tests/php/src/OptionsRESTControllerTest.php
+++ b/tests/php/src/OptionsRESTControllerTest.php
@@ -93,7 +93,7 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 		$this->assertEquals( null, $data['preview_permalink'] );
 		$this->assertEquals( [], $data['suppressed_plugins'] );
 		$this->assertEquals( [], $data['suppressible_plugins'] );
-		$this->assertEquals( [ 'post', 'page', 'attachment' ], wp_list_pluck( $data['supportable_post_types'], 'name' ) );
+		$this->assertArraySubset( [ 'post', 'page', 'attachment' ], wp_list_pluck( $data['supportable_post_types'], 'name' ) );
 		$this->assertEquals( [ 'post', 'page' ], $data['supported_post_types'] );
 		$this->assertContains( 'is_singular', wp_list_pluck( $data['supportable_templates'], 'id' ) );
 		$this->assertEquals( [ 'is_singular' ], $data['supported_templates'] );

--- a/tests/php/src/OptionsRESTControllerTest.php
+++ b/tests/php/src/OptionsRESTControllerTest.php
@@ -94,7 +94,7 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 		$this->assertEquals( $data['suppressed_plugins'], [] );
 		$this->assertEquals( $data['suppressible_plugins'], [] );
 		$this->assertEquals( [ 'post', 'page', 'attachment' ], wp_list_pluck( $data['supportable_post_types'], 'name' ) );
-		$this->assertEquals( $data['supported_post_types'], [ 'post', 'page' ] );
+		$this->assertEquals( [ 'post', 'page' ], $data['supported_post_types'] );
 		$this->assertContains( 'is_singular', wp_list_pluck( $data['supportable_templates'], 'id' ) );
 		$this->assertEquals( $data['supported_templates'], [ 'is_singular' ] );
 	}

--- a/tests/php/src/OptionsRESTControllerTest.php
+++ b/tests/php/src/OptionsRESTControllerTest.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-namespace AmpProject\AmpWP\Tests\Unit;
+namespace AmpProject\AmpWP\Tests;
 
 use AMP_Options_Manager;
 use AmpProject\AmpWP\Admin\ReaderThemes;
@@ -70,7 +70,6 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 	public function test_get_items() {
 		$data = $this->controller->get_items( new WP_REST_Request( 'GET', '/amp/v1/options' ) )->get_data();
 		$this->assertEquals(
-			array_keys( $data ),
 			[
 				'theme_support',
 				'reader_theme',
@@ -86,17 +85,18 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 				'supportable_templates',
 				'onboarding_wizard_link',
 				'customizer_link',
-			]
+			],
+			array_keys( $data )
 		);
 
-		$this->assertEquals( $data['suppressible_plugins'], [] );
-		$this->assertEquals( $data['preview_permalink'], null );
-		$this->assertEquals( $data['suppressed_plugins'], [] );
-		$this->assertEquals( $data['suppressible_plugins'], [] );
+		$this->assertEquals( [], $data['suppressible_plugins'] );
+		$this->assertEquals( null, $data['preview_permalink'] );
+		$this->assertEquals( [], $data['suppressed_plugins'] );
+		$this->assertEquals( [], $data['suppressible_plugins'] );
 		$this->assertEquals( [ 'post', 'page', 'attachment' ], wp_list_pluck( $data['supportable_post_types'], 'name' ) );
 		$this->assertEquals( [ 'post', 'page' ], $data['supported_post_types'] );
 		$this->assertContains( 'is_singular', wp_list_pluck( $data['supportable_templates'], 'id' ) );
-		$this->assertEquals( $data['supported_templates'], [ 'is_singular' ] );
+		$this->assertEquals( [ 'is_singular' ], $data['supported_templates'] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -49,11 +49,11 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		parent::tearDown();
 		$GLOBALS['_wp_using_ext_object_cache'] = $this->was_wp_using_ext_object_cache;
 		unregister_post_type( 'foo' );
+		unregister_post_type( 'book' );
 
 		foreach ( get_post_types() as $post_type ) {
 			remove_post_type_support( $post_type, 'amp' );
 		}
-		unregister_post_type( 'book' );
 
 		global $wp_theme_directories;
 		$wp_theme_directories = $this->original_theme_directories;

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -492,6 +492,14 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		);
 		$migrated_options = AMP_Options_Manager::get_options();
 		$this->assertTrue( $migrated_options[ Option::ALL_TEMPLATES_SUPPORTED ] );
+		$this->assertEqualSets(
+			[
+				'post',
+				'page',
+				'attachment',
+			],
+			array_unique( $migrated_options[ Option::SUPPORTED_POST_TYPES ] )
+		);
 	}
 
 	/**

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -53,6 +53,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		foreach ( get_post_types() as $post_type ) {
 			remove_post_type_support( $post_type, 'amp' );
 		}
+		unregister_post_type( 'book' );
 
 		global $wp_theme_directories;
 		$wp_theme_directories = $this->original_theme_directories;
@@ -151,7 +152,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				Option::THEME_SUPPORT           => AMP_Theme_Support::READER_MODE_SLUG,
-				Option::SUPPORTED_POST_TYPES    => [ 'post' ],
+				Option::SUPPORTED_POST_TYPES    => [ 'post', 'page' ],
 				Option::ANALYTICS               => [],
 				Option::ALL_TEMPLATES_SUPPORTED => true,
 				Option::SUPPORTED_TEMPLATES     => [ 'is_singular' ],
@@ -388,13 +389,21 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			remove_post_type_support( $post_type, 'amp' );
 		}
 
+		register_post_type(
+			'book',
+			[
+				'public'   => true,
+				'supports' => [ 'amp' ],
+			]
+		);
+
 		// Make sure the post type support get migrated.
 		delete_option( AMP_Options_Manager::OPTION_NAME );
-		add_post_type_support( 'page', 'amp' );
 		$this->assertEquals(
 			[
 				'post', // Enabled by default.
-				'page',
+				'page', // Enabled by default.
+				'book',
 			],
 			AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES )
 		);

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -55,6 +55,24 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 			],
 			AMP_Post_Type_Support::get_eligible_post_types()
 		);
+
+		add_filter(
+			'amp_supportable_post_types',
+			static function ( $post_types ) {
+				$post_types[] = 'secret';
+				return array_diff( $post_types, [ 'attachment' ] );
+			}
+		);
+
+		$this->assertEqualSets(
+			[
+				'post',
+				'page',
+				'secret',
+				'book',
+			],
+			AMP_Post_Type_Support::get_eligible_post_types()
+		);
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -89,6 +89,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_HTTP::$headers_sent = [];
 		remove_all_filters( 'theme_root' );
 		remove_all_filters( 'template' );
+		unregister_post_type( 'book' );
+		unregister_post_type( 'announcement' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #5050.

This PR is a continuation of the work done in #5010 which revamped how the AMP plugin determines whether AMP can be enabled/disabled.

In the past if the user had enabled the “Serve all templates as AMP” checkbox, then this implied that all post types and all templates would be forced to be served as AMP. This turns out to not be ideal for some use cases. For example, you may want to serve AMP for your whole site, but you have e-commerce and want to turn off AMP for the `product` post type. The options available to you have been:

1. Uncheck the “Serve all templates as AMP” checkbox and then uncheck the Product post type while making sure that all of the template checkboxes are checked.
1. Add an `amp_skip_post` filter which prevents singular query for the post type from being served as AMP.
1. Register a new template via the `amp_supportable_templates` which has `is_singular` as a parent, has an ID of `is_singular[product]` and `is_singular( 'product' )` as the `callback`. This would then appear in the list of Supportable Templates and could then be turned off.

In all three cases, the “Product” post type would still appear in the list of post types even though you may want to omit it entirely. In all three cases as well, this simple scenario is not intuitive to fix.

We can rectify this situation by decoupling the Post Types from being tied to the the “All templates supported” checkbox, so that post types can be turned off even while all templates otherwise are served as AMP:

All Templates | Before | After
--------------|-------|------
Enabled | ![image](https://user-images.githubusercontent.com/134745/87734473-90148e00-c787-11ea-8e56-9f73b85b8910.png) |![image](https://user-images.githubusercontent.com/134745/87737441-d8d04500-c78f-11ea-8a59-e14d89d104d7.png)
Disabled | ![image](https://user-images.githubusercontent.com/134745/87734493-9c98e680-c787-11ea-80e8-6d47006813a0.png) | ![image](https://user-images.githubusercontent.com/134745/87737425-cbb35600-c78f-11ea-85fe-482b2560d1c5.png)

The list of post types are all those which are defined as being `public`. In order to provide more fine-grained control over which of the `public` posts should be available to be served as AMP, or even to include a non-`public` post type among those available, this PR introduces a filter `amp_supportable_post_types` which allows the list to be filtered. For example, if you never want attachments to be served as AMP, this filter code will do the trick:

```php
add_filter(
	'amp_supportable_post_types',
	function ( $post_types ) {
		return array_diff( $post_types, [ 'attachment' ] );
	}
);
```

The Attachment post type no longer appears in the list of post types:

![image](https://user-images.githubusercontent.com/134745/87737505-ff8e7b80-c78f-11ea-81f2-c7eaae91622c.png)

In order to facilitate sites that previously had “All templates supported” enabled prior to upgrading, the upgrade routing will ensure that all supportable post types be enabled in the DB even though previously only `post` was enabled (since the post types were hidden/irrelevant when all templates were supported). So when running the following command to reset the DB to the state in v1.5 with all templates supported but only the post type enabled:

```bash
echo '{"theme_support":"transitional","supported_post_types":["post"],"analytics":[],"all_templates_supported":true,"supported_templates":["is_singular"],"version":"1.5.5"}' | wp option set amp-options --format=json
```

Upon accessing the settings screen the user will see all post types checked:

![image](https://user-images.githubusercontent.com/134745/87737563-277ddf00-c790-11ea-9f10-19ea8aeb825a.png)

Additionally, as a continuation of #4593, now when a post type is disabled from being served as AMP, the “AMP Unavailable” notice will no longer be displayed in the editor:

![image](https://user-images.githubusercontent.com/134745/87735669-0961b000-c78b-11ea-8594-398d3f3f1d03.png)

It will still be displayed if a post _could_ be enabled via the settings screen (i.e. if it is a supportable post type):

![image](https://user-images.githubusercontent.com/134745/87616253-80367480-c6c9-11ea-951d-edacafb8c0b0.png)

Two other new aspects of the Content Type list and the Templates List:

* If a static front page has been set in WordPress and the Homepage or Blog templates have been enabled for AMP, then when attempting to uncheck the Page content type, a confirmation dialog is displayed.
* If the confirmation is dismissed, the Homepage and Blog templates are both removed from the list.

Lastly, this PR enables Pages to be served as AMP by default in addition to Posts.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
