### PR TITLE
Fix PHPStan false positives

### DIFF
--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -8,3 +8,5 @@ parameters:
 		- src/
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
+		# See https://github.com/phpstan/phpstan/issues/3611
+		- '#^Class .*? has an unused method .*?\(\)\.$#'

--- a/lib/optimizer/phpstan.neon.dist
+++ b/lib/optimizer/phpstan.neon.dist
@@ -6,3 +6,6 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- src/
+	ignoreErrors:
+	# See https://github.com/phpstan/phpstan/issues/3611
+	- '#^Class .*? has an unused method .*?\(\)\.$#'

--- a/lib/optimizer/phpstan.neon.dist
+++ b/lib/optimizer/phpstan.neon.dist
@@ -9,3 +9,5 @@ parameters:
 	ignoreErrors:
 	# See https://github.com/phpstan/phpstan/issues/3611
 	- '#^Class .*? has an unused method .*?\(\)\.$#'
+	# See https://github.com/phpstan/phpstan/issues/3613
+	- '#^Class AmpProject\\Optimizer\\Transformer\\ReorderHead has a write-only property .*?\.$#'


### PR DESCRIPTION
## Summary

This PR includes the following changes:
- ignores PHPStan error messages of type `Class <class> has an unused method <method>().`.
	These are caused by a false positive reported upstream here: https://github.com/phpstan/phpstan/issues/3611
- ignores PHPStan error messages of type `Class AmpProject\Optimizer\Transformer\ReorderHead has a write-only
         property <property>.`.
	These are caused by a false positive reported upstream here: https://github.com/phpstan/phpstan/issues/3613

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
