### PR TITLE
Lock PHPStan into stable releases again and remove unneeded ignores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "extra": {
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/lib/common/composer.json
+++ b/lib/common/composer.json
@@ -32,7 +32,7 @@
     },
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -8,5 +8,3 @@ parameters:
 		- src/
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
-		# See https://github.com/phpstan/phpstan/issues/3611
-		- '#^Class .*? has an unused method .*?\(\)\.$#'

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -33,7 +33,7 @@
     },
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/raw/master/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       }

--- a/lib/optimizer/phpstan.neon.dist
+++ b/lib/optimizer/phpstan.neon.dist
@@ -6,8 +6,3 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- src/
-	ignoreErrors:
-	# See https://github.com/phpstan/phpstan/issues/3611
-	- '#^Class .*? has an unused method .*?\(\)\.$#'
-	# See https://github.com/phpstan/phpstan/issues/3613
-	- '#^Class AmpProject\\Optimizer\\Transformer\\ReorderHead has a write-only property .*?\.$#'


### PR DESCRIPTION
## Summary

This PR locks PHPStan back into stable releases again and removes unneeded ignores.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
