### PR TITLE
Make settings screen 4.9 compatible

### DIFF
--- a/assets/src/polyfills/api-fetch.js
+++ b/assets/src/polyfills/api-fetch.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line import/no-unresolved
+import apiFetch from '@wordpress/api-fetch__non-shim';
+
+global.wp = global.wp || {};
+global.wp.apiFetch = apiFetch;
+
+export default apiFetch;

--- a/assets/src/settings-page/welcome.js
+++ b/assets/src/settings-page/welcome.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Options } from '../components/options-context-provider';
+import { AMPNotice, NOTICE_SIZE_LARGE } from '../components/amp-notice';
 
 /**
  * Welcome component on the settings screen.
@@ -20,6 +21,14 @@ export function Welcome() {
 		onboarding_wizard_link: onboardingWizardLink,
 		plugin_configured: pluginConfigured,
 	} = editedOptions;
+
+	if ( ! onboardingWizardLink ) {
+		return (
+			<AMPNotice size={ NOTICE_SIZE_LARGE }>
+				{ __( 'You are using an old version of WordPress. Please upgrade to access all of the features of the AMP plugin.', 'amp' ) }
+			</AMPNotice>
+		);
+	}
 
 	return (
 		<div className="settings-welcome">
@@ -76,14 +85,10 @@ export function Welcome() {
 						{ __( 'The AMP configuration wizard can help you choose the best settings for your theme, plugins, and technical capabilities.', 'amp' ) }
 					</p>
 
-					{
-						onboardingWizardLink && (
-							<a className="components-button is-primary settings-welcome__button" href={ onboardingWizardLink } >
-								{ pluginConfigured ? __( 'Reopen Wizard', 'amp' ) : __( 'Open Wizard', 'amp' ) }
-							</a>
-						)
+					<a className="components-button is-primary settings-welcome__button" href={ onboardingWizardLink } >
+						{ pluginConfigured ? __( 'Reopen Wizard', 'amp' ) : __( 'Open Wizard', 'amp' ) }
+					</a>
 
-					}
 					{
 						customizerLink && (
 							<a className="components-button is-link" href={ customizerLink } rel="noreferrer">

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -162,12 +162,10 @@ function amp_init() {
 	add_action(
 		'rest_api_init',
 		static function() {
-			if ( amp_should_use_new_onboarding() ) {
-				$reader_themes = new ReaderThemes();
+			$reader_themes = new ReaderThemes();
 
-				$reader_theme_controller = new AMP_Reader_Theme_REST_Controller( $reader_themes );
-				$reader_theme_controller->register_routes();
-			}
+			$reader_theme_controller = new AMP_Reader_Theme_REST_Controller( $reader_themes );
+			$reader_theme_controller->register_routes();
 		}
 	);
 

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -235,8 +235,6 @@ class OptionsMenu implements Conditional, Service, Registerable {
 			return;
 		}
 
-		$asset_handle = self::ASSET_HANDLE;
-
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';
 		$asset        = require $asset_file;
 		$dependencies = $asset['dependencies'];

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -167,7 +167,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 	}
 
 	/**
-	 * Provides core assets in environments where they're not enqueued by default (i.e., WP <5.0).
+	 * Registers shimmed assets not guaranteed to be available in core.
 	 */
 	public function register_shimmed_assets() {
 		if ( ! wp_script_is( 'wp-api-fetch', 'registered' ) ) {

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -165,6 +165,9 @@ class OptionsMenu implements Conditional, Service, Registerable {
 		return sprintf( 'toplevel_page_%s', AMP_Options_Manager::OPTION_NAME );
 	}
 
+	/**
+	 * Provides core assets in environments where they're not enqueued by default (i.e., WP <5.0).
+	 */
 	private function register_shimmed_assets() {
 		if ( ! wp_script_is( 'wp-api-fetch', 'registered' ) ) {
 			$asset_handle = 'wp-api-fetch';

--- a/src/Admin/PluginActivationNotice.php
+++ b/src/Admin/PluginActivationNotice.php
@@ -79,6 +79,8 @@ final class PluginActivationNotice implements Delayed, Service, Registerable {
 
 				<?php if ( amp_should_use_new_onboarding() ) : ?>
 					<p><a href="<?php menu_page_url( OnboardingWizardSubmenu::SCREEN_ID ); ?>"><?php esc_html_e( 'Configure the plugin', 'amp' ); ?></a></p>
+				<?php else : ?>
+					<p><a href="<?php menu_page_url( AMP_Options_Manager::OPTION_NAME ); ?>"><?php esc_html_e( 'Configure the plugin', 'amp' ); ?></a></p>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -262,60 +262,13 @@ const setup = {
 const settingsPage = {
 	...sharedConfig,
 	entry: {
-		'amp-settings': [
-			'./assets/src/settings-page',
-		],
-	},
-	externals: {
-		'amp-settings': 'ampSettings',
-	},
-	plugins: [
-		...sharedConfig.plugins.filter(
-			( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
-		),
-		new DependencyExtractionWebpackPlugin( {
-			useDefaults: false,
-			// Most dependencies will be bundled for the AMP setup screen for compatibility across WP versions.
-			requestToHandle: ( handle ) => {
-				switch ( handle ) {
-					case '@wordpress/api-fetch':
-					case '@wordpress/dom-ready':
-					case '@wordpress/html-entities':
-						return defaultRequestToHandle( handle );
-
-					default:
-						return undefined;
-				}
-			},
-			requestToExternal: ( external ) => {
-				switch ( external ) {
-					case '@wordpress/api-fetch':
-					case '@wordpress/dom-ready':
-					case '@wordpress/html-entities':
-						return defaultRequestToExternal( external );
-
-					default:
-						return undefined;
-				}
-			},
-		} ),
-		new WebpackBar( {
-			name: 'Settings page',
-			color: '#67b255',
-		} ),
-	],
-};
-
-const settingsPage49 = {
-	...sharedConfig,
-	entry: {
 		'wp-api-fetch': [
 			'./assets/src/polyfills/api-fetch.js',
 		],
 		'wp-components': [
 			'@wordpress/components/build-style/style.css',
 		],
-		'amp-settings-4-9': [
+		'amp-settings': [
 			'./assets/src/settings-page',
 		],
 	},
@@ -354,7 +307,7 @@ const settingsPage49 = {
 			},
 		} ),
 		new WebpackBar( {
-			name: '4.9 Settings page',
+			name: 'Settings page',
 			color: '#67b255',
 		} ),
 	],
@@ -383,6 +336,5 @@ module.exports = [
 	wpPolyfills,
 	setup,
 	settingsPage,
-	settingsPage49,
 	mobileRedirection,
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -306,6 +306,60 @@ const settingsPage = {
 	],
 };
 
+const settingsPage49 = {
+	...sharedConfig,
+	entry: {
+		'wp-api-fetch': [
+			'./assets/src/polyfills/api-fetch.js',
+		],
+		'wp-components': [
+			'@wordpress/components/build-style/style.css',
+		],
+		'amp-settings-4-9': [
+			'./assets/src/settings-page',
+		],
+	},
+	externals: {
+		'amp-settings': 'ampSettings',
+	},
+	resolve: {
+		alias: {
+			'@wordpress/api-fetch__non-shim': require.resolve( '@wordpress/api-fetch' ),
+		},
+	},
+	plugins: [
+		...sharedConfig.plugins.filter(
+			( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
+		),
+		new DependencyExtractionWebpackPlugin( {
+			useDefaults: false,
+			// Most dependencies will be bundled for the AMP setup screen for compatibility across WP versions.
+			requestToHandle: ( handle ) => {
+				switch ( handle ) {
+					case '@wordpress/api-fetch':
+						return defaultRequestToHandle( handle );
+
+					default:
+						return undefined;
+				}
+			},
+			requestToExternal: ( external ) => {
+				switch ( external ) {
+					case '@wordpress/api-fetch':
+						return defaultRequestToExternal( external );
+
+					default:
+						return undefined;
+				}
+			},
+		} ),
+		new WebpackBar( {
+			name: '4.9 Settings page',
+			color: '#67b255',
+		} ),
+	],
+};
+
 const mobileRedirection = {
 	...sharedConfig,
 	entry: {
@@ -329,5 +383,6 @@ module.exports = [
 	wpPolyfills,
 	setup,
 	settingsPage,
+	settingsPage49,
 	mobileRedirection,
 ];


### PR DESCRIPTION
## Summary

Made a separate branch off `feature/5018-settings-screen-ui` to make these changes easier to review.

As @pierlon pointed out today, the settings screen was not loading in 4.9. 

To fix this, I provided shims for `apiFetch` and the `wp-components` CSS that our CSS inherits from. After verifying that it worked 4.9, I thought we might as well go ahead and use the same webpack config across all versions.

In theory I think this approach could be extended to the onboarding wizard, but I don't have time to verify and work out any kinks this week. 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
