### PR TITLE
Fix height of "Serve all templates" toggle

### DIFF
--- a/assets/src/components/amp-setting-toggle/index.js
+++ b/assets/src/components/amp-setting-toggle/index.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { ToggleControl } from '@wordpress/components';
+import { isValidElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,22 +21,25 @@ import './style.css';
  * @param {boolean} props.checked Whether the toggle is on.
  * @param {boolean} props.disabled Whether the toggle is disabled.
  * @param {Function} props.onChange Change handler.
- * @param {?string} props.text Toggle text.
- * @param {string} props.title Toggle title.
- * @param {number} props.headingLevel Heading level for title.
+ * @param {string} props.text Toggle text.
+ * @param {Object|string} props.title Toggle title.
  */
-export function AMPSettingToggle( { checked, disabled = false, onChange, text, title, headingLevel } ) {
-	const Heading = headingLevel ? `h${ headingLevel }` : 'h3';
-
+export function AMPSettingToggle( { checked, disabled = false, onChange, text, title } ) {
 	return (
 		<div className={ `amp-setting-toggle ${ disabled ? 'amp-setting-toggle--disabled' : '' }` }>
 			<ToggleControl
 				checked={ ! disabled && checked }
 				label={ (
 					<div className="amp-setting-toggle__label-text">
-						<Heading>
-							{ title }
-						</Heading>
+						{
+							isValidElement( title )
+								? title
+								: (
+									<h3>
+										{ title }
+									</h3>
+								)
+						}
 						{ text && (
 							<p>
 								{ text }
@@ -52,6 +56,8 @@ AMPSettingToggle.propTypes = {
 	disabled: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	text: PropTypes.string,
-	headingLevel: PropTypes.number,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.elementType,
+	] ).isRequired,
 };

--- a/assets/src/components/supported-templates-toggle/index.js
+++ b/assets/src/components/supported-templates-toggle/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import './style.css';
 import { Options } from '../options-context-provider';
 import { AMPSettingToggle } from '../amp-setting-toggle';
 
@@ -25,8 +26,11 @@ export function SupportedTemplatesToggle() {
 	return (
 		<AMPSettingToggle
 			checked={ true === allTemplatesSupported }
-			title={ __( 'Serve all templates as AMP', 'amp' ) }
-			headingLevel={ 5 }
+			title={ (
+				<p>
+					{ __( 'Serve all templates as AMP', 'amp' ) }
+				</p>
+			) }
 			onChange={ () => {
 				updateOptions( { all_templates_supported: ! allTemplatesSupported } );
 			} }

--- a/assets/src/components/supported-templates-toggle/style.css
+++ b/assets/src/components/supported-templates-toggle/style.css
@@ -1,0 +1,8 @@
+.amp .supported-templates .amp-setting-toggle .components-form-toggle {
+	margin-right: 1rem;
+}
+
+.supported-templates .amp-setting-toggle .amp-setting-toggle__label-text > p {
+	margin: 0;
+	font-weight: bold;
+}


### PR DESCRIPTION
## Summary

Fixes the height of the `Serve all templates as AMP` toggle.

### Screenshot:

![image](https://user-images.githubusercontent.com/16200219/87736614-22d51d00-c7c8-11ea-957b-ecf65bbdc021.png)
