### PR TITLE
Allow non-core themes to be installed if added by amp_reader_themes filter

### DIFF
--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -228,19 +228,7 @@ final class ReaderThemes {
 	 * @return bool True if themes can be installed.
 	 */
 	public function can_install_theme( $theme ) {
-		// @todo Add support for installing non-default reader themes. Until that is done, themes that are provided via
-		// the amp_reader_themes filter will show on the reader themes screen but will need to be manually installed on
-		// the site.
-		$default_reader_theme_slugs = array_diff(
-			AMP_Core_Theme_Sanitizer::get_supported_themes(),
-			[ 'twentyten' ]
-		);
-
 		if ( ! current_user_can( 'install_themes' ) ) {
-			return false;
-		}
-
-		if ( ! in_array( $theme['slug'], $default_reader_theme_slugs, true ) ) {
 			return false;
 		}
 

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -69,7 +69,6 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	 * @covers ReaderThemes::get_themes
 	 * @covers ReaderThemes::get_default_reader_themes
 	 * @covers ReaderThemes::get_classic_mode
-	 * @covers ReaderThemes::get_default_raw_reader_themes
 	 */
 	public function test_get_themes() {
 		$themes = $this->reader_themes->get_themes();

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -11,6 +11,7 @@ namespace AmpProject\AmpWP\Tests\Admin;
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
 use WP_UnitTestCase;
+use Closure;
 
 /**
  * Tests for reader themes.
@@ -108,40 +109,40 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	 */
 	public function get_availability_test_themes() {
 		return [
-			'twentysixteen_from_wp_future'           => [
-				static function () {
-					return wp_get_theme( 'twentysixteen' )->exists() ? ReaderThemes::STATUS_INSTALLED : ReaderThemes::STATUS_NON_INSTALLABLE;
-				},
-				false,
-				[
-					'name'         => 'Some Theme',
-					'requires'     => '99.9',
-					'requires_php' => '5.2',
-					'slug'         => 'twentysixteen',
-				],
-			],
-			'twentysixteen_from_php_future'          => [
-				static function () {
-					return wp_get_theme( 'twentysixteen' )->exists() ? ReaderThemes::STATUS_INSTALLED : ReaderThemes::STATUS_NON_INSTALLABLE;
-				},
-				false,
-				[
-					'name'         => 'Some Theme',
-					'requires'     => '4.9',
-					'requires_php' => '99.9',
-					'slug'         => 'twentysixteen',
-				],
-			],
-			'non_reader_theme'                       => [
+			'from_wp_future'                         => [
 				static function () {
 					return ReaderThemes::STATUS_NON_INSTALLABLE;
 				},
 				false,
 				[
 					'name'         => 'Some Theme',
+					'requires'     => '99.9',
+					'requires_php' => '5.2',
+					'slug'         => 'from_wp_future',
+				],
+			],
+			'from_php_future'                        => [
+				static function () {
+					return ReaderThemes::STATUS_NON_INSTALLABLE;
+				},
+				false,
+				[
+					'name'         => 'Some Theme',
+					'requires'     => '4.9',
+					'requires_php' => '99.9',
+					'slug'         => 'from_php_future',
+				],
+			],
+			'non_reader_theme'                       => [
+				static function () {
+					return wp_get_theme( 'neve' )->exists() ? ReaderThemes::STATUS_INSTALLED : ReaderThemes::STATUS_INSTALLABLE;
+				},
+				true,
+				[
+					'name'         => 'Neve',
 					'requires'     => false,
 					'requires_php' => '5.2',
-					'slug'         => 'some-nondefault-theme',
+					'slug'         => 'neve',
 				],
 			],
 			'twentytwelve_not_requiring_wp_version'  => [
@@ -208,17 +209,33 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	 * @covers ReaderThemes::can_install_theme
 	 */
 	public function test_can_install_theme() {
-		$installable_theme = [
-			'name'         => 'Some Theme',
+		$core_theme = [
+			'name'         => 'Twenty Twelve',
 			'requires'     => false,
 			'requires_php' => '5.2',
 			'slug'         => 'twentytwelve',
 		];
 
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'author' ] ) );
-		$this->assertFalse( $this->reader_themes->can_install_theme( $installable_theme ) );
+		$neve_theme = [
+			'name'         => 'Neve',
+			'requires'     => false,
+			'requires_php' => '5.2',
+			'slug'         => 'neve',
+		];
 
-		wp_set_current_user( 1 );
-		$this->assertTrue( $this->reader_themes->can_install_theme( $installable_theme ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'author' ] ) );
+		$this->assertFalse( $this->reader_themes->can_install_theme( $core_theme ) );
+		$this->assertFalse( $this->reader_themes->can_install_theme( $neve_theme ) );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertTrue( $this->reader_themes->can_install_theme( $core_theme ) );
+		$this->assertTrue( $this->reader_themes->can_install_theme( $neve_theme ) );
+
+		$core_theme['requires'] = '999.9';
+		$this->assertFalse( $this->reader_themes->can_install_theme( $core_theme ) );
+
+		$core_theme['requires']     = false;
+		$core_theme['requires_php'] = '999.9';
+		$this->assertFalse( $this->reader_themes->can_install_theme( $core_theme ) );
 	}
 }


### PR DESCRIPTION
## Summary

While testing I tried to use the `amp_reader_themes` filter to select a non-core theme:

```php
add_filter( 'amp_reader_themes', function ( $reader_themes ) {
	$reader_themes[] = [
		'name' => 'Neve',
		'slug' => 'neve',
		'preview_url' => 'https://wp-themes.com/neve',
		'screenshot_url' => 'https://i0.wp.com/themes.svn.wordpress.org/neve/2.7.5/screenshot.png?w=1144&strip=all',
		'homepage' => 'https://themeisle.com/themes/neve/',
		'description' => 'Neve is a super fast, easily customizable, multi-purpose theme.',
	];
	return $reader_themes;
} );
```

When I did this, the theme did show up in the list but it was listed as an unavailable theme.

This PR removes some old code that is no longer relevant.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
