### PR TITLE
Require user to be able to manage_options to obtain verbose Server-Timing

### DIFF
--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -116,6 +116,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 				// is_user_logged_in() breaks because it's used too early.
 				'verbose' => static function () {
 					return is_user_logged_in()
+						&& current_user_can( 'manage_options' )
 						&& isset( $_GET[ QueryVar::VERBOSE_SERVER_TIMING ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						&& filter_var(
 							$_GET[ QueryVar::VERBOSE_SERVER_TIMING ], // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/tests/php/src/Instrumentation/ServerTimingTest.php
+++ b/tests/php/src/Instrumentation/ServerTimingTest.php
@@ -331,7 +331,7 @@ final class ServerTimingTest extends WP_UnitTestCase {
 			)
 		);
 	}
-	
+
 	public function test_it_sends_restricted_output_with_query_var_and_logged_in() {
 		$_GET[ QueryVar::VERBOSE_SERVER_TIMING ] = '1';
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );

--- a/tests/php/src/Instrumentation/ServerTimingTest.php
+++ b/tests/php/src/Instrumentation/ServerTimingTest.php
@@ -331,6 +331,18 @@ final class ServerTimingTest extends WP_UnitTestCase {
 			)
 		);
 	}
+	
+	public function test_it_sends_restricted_output_with_query_var_and_logged_in() {
+		$_GET[ QueryVar::VERBOSE_SERVER_TIMING ] = '1';
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$server_timing = $this->injector->make( ServerTiming::class );
+		$this->assertFalse(
+			$this->get_private_property(
+				$server_timing,
+				'verbose'
+			)
+		);
+	}
 
 	public function test_it_sends_verbose_output_with_query_var_and_logged_in() {
 		$_GET[ QueryVar::VERBOSE_SERVER_TIMING ] = '1';


### PR DESCRIPTION
## Summary

See https://github.com/ampproject/amp-wp/pull/5005#discussion_r456712681

Fixes #4970

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
