### PR TITLE
Add missing context element for XPath when processing video shortcodes text widgets

### DIFF
--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -350,7 +350,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			 * MediaElement.js is not used in AMP this stylesheet is not included. In any case, videos in AMP are
 			 * responsive so this is built-in. Note also the style rule for .wp-video in amp-default.css.
 			 */
-			foreach ( $dom->xpath->query( './/div[ @class = "wp-video" and @style ]' ) as $element ) {
+			foreach ( $dom->xpath->query( './/div[ @class = "wp-video" and @style ]', $text_widget ) as $element ) {
 				$element->removeAttribute( 'style' );
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #5066

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
