### PR TITLE
Update amphtml validator spec to commit 3aa007a (spec file rev 1060)

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1052;
+	private static $spec_file_revision = 1060;
 	private static $minimum_validator_revision_required = 474;
 
 	private static $descendant_tag_lists = array(
@@ -247,6 +247,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-live-list',
 			'amp-pixel',
 			'amp-state',
+			'amp-story-360',
 			'amp-timeago',
 			'amp-twitter',
 			'amp-video',
@@ -621,7 +622,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#links',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#links',
 				),
 			),
 		),
@@ -777,7 +778,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-accordion',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-accordion',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-accordion/',
 				),
 			),
 		),
@@ -797,7 +798,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-action-macro',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-action-macro',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-action-macro/',
 				),
 			),
 		),
@@ -846,7 +847,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ad',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 			array(
@@ -952,7 +953,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-multi-size attribute',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 			array(
@@ -1007,7 +1008,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-enable-refresh attribute',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 		),
@@ -1123,7 +1124,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-analytics',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics/',
 				),
 			),
 		),
@@ -1170,7 +1171,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-anim',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-anim',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-anim/',
 				),
 			),
 		),
@@ -1241,7 +1242,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-apester-media',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-apester-media',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-apester-media/',
 				),
 			),
 		),
@@ -1269,7 +1270,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-app-banner',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-app-banner',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-app-banner/',
 					'unique' => true,
 				),
 			),
@@ -1343,7 +1344,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-audio',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio/',
 				),
 			),
 			array(
@@ -1403,7 +1404,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-audio',
 					),
 					'spec_name' => 'amp-story >> amp-audio',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio/',
 				),
 			),
 		),
@@ -1427,7 +1428,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-auto-ads',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-auto-ads',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-auto-ads/',
 				),
 			),
 		),
@@ -1456,6 +1457,7 @@ class AMP_Allowed_Tags_Generated {
 					'inline' => array(),
 					'items' => array(),
 					'max-entries' => array(),
+					'max-items' => array(),
 					'media' => array(),
 					'min-characters' => array(),
 					'noloading' => array(
@@ -1486,7 +1488,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-autocomplete',
 					),
 					'spec_name' => 'amp-autocomplete',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-autocomplete',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-autocomplete/',
 				),
 			),
 		),
@@ -1567,7 +1569,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-base-carousel',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel/',
 				),
 			),
 			array(
@@ -1661,7 +1663,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-base-carousel',
 					),
 					'spec_name' => 'AMP-BASE-CAROUSEL [lightbox]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel/',
 				),
 			),
 		),
@@ -1723,7 +1725,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-bind',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind/',
 				),
 			),
 		),
@@ -1772,7 +1774,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-bodymovin-animation',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-bodymovin-animation',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bodymovin-animation/',
 				),
 			),
 		),
@@ -1831,7 +1833,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-brid-player',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-brid-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-brid-player/',
 				),
 			),
 		),
@@ -1879,7 +1881,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-brightcove',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-brightcove',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-brightcove/',
 				),
 			),
 		),
@@ -1956,7 +1958,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-call-tracking',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-call-tracking',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-call-tracking/',
 				),
 			),
 		),
@@ -2018,7 +2020,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-carousel',
 					),
 					'spec_name' => 'AMP-CAROUSEL',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel/',
 				),
 			),
 			array(
@@ -2092,7 +2094,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-lightbox-gallery',
 					),
 					'spec_name' => 'AMP-CAROUSEL lightbox',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel/',
 				),
 			),
 		),
@@ -2123,7 +2125,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-connatix-player',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-connatix-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-connatix-player/',
 				),
 			),
 		),
@@ -2244,7 +2246,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-dailymotion',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-dailymotion',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-dailymotion/',
 				),
 			),
 		),
@@ -2867,7 +2869,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ad',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 			array(
@@ -2925,7 +2927,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-embed with data-multi-size attribute',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 		),
@@ -2957,7 +2959,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-embedly-card',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-embedly-card',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-embedly-card/',
 				),
 			),
 		),
@@ -2988,7 +2990,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-experiment',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment/',
 					'unique' => true,
 				),
 			),
@@ -3271,7 +3273,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-gfycat',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-gfycat',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-gfycat/',
 				),
 			),
 		),
@@ -3297,7 +3299,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-gist',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-gist',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-gist/',
 				),
 			),
 		),
@@ -3338,7 +3340,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-google-document-embed',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-google-document-embed',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-google-document-embed/',
 				),
 			),
 		),
@@ -3368,7 +3370,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-hulu',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-hulu',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-hulu/',
 				),
 			),
 		),
@@ -3511,7 +3513,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ima-video',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video/',
 				),
 			),
 		),
@@ -3574,7 +3576,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-image-slider',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider/',
 				),
 			),
 		),
@@ -3583,6 +3585,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'alt' => array(),
 					'attribution' => array(),
+					'crossorigin' => array(),
 					'data-amp-bind-alt' => array(),
 					'data-amp-bind-attribution' => array(),
 					'data-amp-bind-src' => array(),
@@ -3600,6 +3603,7 @@ class AMP_Allowed_Tags_Generated {
 					'object-fit' => array(),
 					'object-position' => array(),
 					'placeholder' => array(),
+					'referrerpolicy' => array(),
 					'src' => array(
 						'alternative_names' => array(
 							'srcset',
@@ -3627,7 +3631,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img/',
 				),
 			),
 		),
@@ -3680,7 +3684,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-inline-gallery',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery/',
 				),
 			),
 		),
@@ -3711,7 +3715,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inline-gallery',
 					),
 					'spec_name' => 'amp-inline-gallery-pagination',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery/',
 				),
 			),
 			array(
@@ -3737,7 +3741,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inline-gallery',
 					),
 					'spec_name' => 'amp-inline-gallery-pagination [inset]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery/',
 				),
 			),
 		),
@@ -3781,7 +3785,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-inline-gallery',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery/',
 				),
 			),
 		),
@@ -3923,7 +3927,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-jwplayer',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-jwplayer',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-jwplayer/',
 				),
 			),
 		),
@@ -3980,7 +3984,7 @@ class AMP_Allowed_Tags_Generated {
 							5,
 						),
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-layout',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-layout/',
 				),
 			),
 		),
@@ -4272,7 +4276,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mega-menu',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-mega-menu',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-mega-menu/',
 				),
 			),
 		),
@@ -4412,7 +4416,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-minute-media-player',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-minute-media-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-minute-media-player/',
 				),
 			),
 		),
@@ -4474,7 +4478,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-nested-menu',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-nested-menu/',
 				),
 			),
 		),
@@ -4507,7 +4511,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page with inline config',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page/',
 					'unique' => true,
 				),
 			),
@@ -4550,7 +4554,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page with src attribute',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page/',
 					'unique' => true,
 				),
 			),
@@ -4594,7 +4598,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page [type=adsense]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page/',
 					'unique' => true,
 				),
 			),
@@ -4834,7 +4838,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-pinterest',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-pinterest',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-pinterest/',
 				),
 			),
 		),
@@ -4874,7 +4878,7 @@ class AMP_Allowed_Tags_Generated {
 							1,
 						),
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-pixel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-pixel/',
 				),
 			),
 		),
@@ -5001,7 +5005,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-powr-player',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-powr-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-powr-player/',
 				),
 			),
 		),
@@ -5166,7 +5170,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-riddle-quiz',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-riddle-quiz',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-riddle-quiz/',
 				),
 			),
 		),
@@ -5312,7 +5316,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-sidebar',
 					),
 					'spec_name' => 'amp-sidebar',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar/',
 				),
 			),
 			array(
@@ -5328,7 +5332,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-sidebar',
 					),
 					'spec_name' => 'amp-story >> amp-sidebar',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar/',
 				),
 			),
 		),
@@ -5593,7 +5597,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-bind',
 					),
 					'spec_name' => 'amp-state',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind/',
 				),
 			),
 		),
@@ -5723,6 +5727,56 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-story-360' => array(
+			array(
+				'attr_spec_list' => array(
+					'duration' => array(
+						'value_regex' => '([0-9\\.]+)\\s*(s|ms)',
+					),
+					'heading-end' => array(
+						'value_regex' => '-?\\d+\\.?\\d*',
+					),
+					'heading-start' => array(
+						'value_regex' => '-?\\d+\\.?\\d*',
+					),
+					'pitch-end' => array(
+						'value_regex' => '-?\\d+\\.?\\d*',
+					),
+					'pitch-start' => array(
+						'value_regex' => '-?\\d+\\.?\\d*',
+					),
+					'zoom-end' => array(
+						'value_regex' => '\\d+\\.?\\d*',
+					),
+					'zoom-start' => array(
+						'value_regex' => '\\d+\\.?\\d*',
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'amp-img',
+						),
+						'mandatory_num_child_tags' => 1,
+					),
+					'mandatory_ancestor' => 'amp-story',
+					'requires_extension' => array(
+						'amp-story-360',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-360',
+				),
+			),
+		),
 		'amp-story-animation' => array(
 			array(
 				'attr_spec_list' => array(
@@ -5767,7 +5821,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-story-auto-ads',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads/',
 					'unique' => true,
 				),
 			),
@@ -5969,6 +6023,30 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-story-player' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							4,
+						),
+					),
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'a',
+						),
+					),
+					'requires_extension' => array(
+						'amp-story-player',
+					),
+				),
+			),
+		),
 		'amp-timeago' => array(
 			array(
 				'attr_spec_list' => array(
@@ -6000,7 +6078,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-timeago',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-timeago',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-timeago/',
 				),
 			),
 		),
@@ -6036,7 +6114,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-truncate-text',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-truncate-text',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-truncate-text/',
 				),
 			),
 		),
@@ -6256,7 +6334,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-video',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 			array(
@@ -6368,7 +6446,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video',
 					),
 					'spec_name' => 'amp-story >> amp-story-page-attachment >> amp-video',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 			array(
@@ -6479,7 +6557,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video',
 					),
 					'spec_name' => 'amp-story >> amp-video',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 		),
@@ -6557,7 +6635,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video-iframe',
 					),
 					'spec_name' => 'AMP-VIDEO-IFRAME[poster]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe/',
 				),
 			),
 			array(
@@ -6636,7 +6714,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video-iframe',
 					),
 					'spec_name' => 'AMP-VIDEO-IFRAME with [placeholder]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe/',
 				),
 			),
 		),
@@ -6825,7 +6903,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-web-push',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push/',
 				),
 			),
 		),
@@ -6856,7 +6934,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-web-push',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push/',
 				),
 			),
 		),
@@ -6925,7 +7003,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-yotpo',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo/',
 				),
 			),
 		),
@@ -7018,7 +7096,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-audio',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio/',
 				),
 			),
 		),
@@ -7094,7 +7172,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => 'html',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -7295,7 +7373,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -7383,7 +7461,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -7419,7 +7497,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -7506,7 +7584,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -7539,7 +7617,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -7692,7 +7770,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-image-slider',
 					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [first]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider/',
 				),
 			),
 			array(
@@ -7704,7 +7782,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-image-slider',
 					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [second]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider/',
 				),
 			),
 			array(
@@ -7833,7 +7911,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -7923,7 +8001,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8011,7 +8089,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8092,7 +8170,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8176,7 +8254,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8257,7 +8335,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8273,7 +8351,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8357,7 +8435,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8483,7 +8561,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8697,7 +8775,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8782,7 +8860,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8882,7 +8960,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -8990,7 +9068,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => 'html',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -9023,7 +9101,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -9046,7 +9124,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => '!doctype',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -9104,7 +9182,7 @@ class AMP_Allowed_Tags_Generated {
 						'src',
 						'srcdoc',
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-iframe/',
 				),
 			),
 		),
@@ -9210,7 +9288,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -9262,7 +9340,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-img',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img/',
 				),
 			),
 		),
@@ -9331,7 +9409,7 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 			array(
@@ -9404,7 +9482,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form [method=post]',
 					'spec_name' => 'INPUT [type=file]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 			array(
@@ -9472,7 +9550,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form [method=post]',
 					'spec_name' => 'INPUT [type=password]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 			array(
@@ -9570,7 +9648,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask] (custom mask)',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 			array(
@@ -9648,7 +9726,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=payment-card]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 			array(
@@ -9726,7 +9804,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-dd-mm-yyyy]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 			array(
@@ -9804,7 +9882,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-mm-dd-yyyy]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 			array(
@@ -9882,7 +9960,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-mm-yy]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 			array(
@@ -9960,7 +10038,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-yyyy-mm-dd]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask/',
 				),
 			),
 		),
@@ -9994,7 +10072,7 @@ class AMP_Allowed_Tags_Generated {
 					'for' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -10096,7 +10174,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -10198,7 +10276,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -10228,7 +10306,7 @@ class AMP_Allowed_Tags_Generated {
 						'template',
 					),
 					'spec_name' => 'link rel=',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10267,7 +10345,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=canonical',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -10305,7 +10383,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=manifest',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10337,7 +10415,7 @@ class AMP_Allowed_Tags_Generated {
 						'template',
 					),
 					'spec_name' => 'link rel=preload',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10367,7 +10445,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=stylesheet for fonts',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#custom-fonts',
 				),
 			),
 			array(
@@ -10397,7 +10475,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link itemprop=sameAs',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10423,7 +10501,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link itemprop=',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10449,7 +10527,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link property=',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 		),
@@ -10553,7 +10631,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -10639,7 +10717,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -10658,7 +10736,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta charset=utf-8',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -10692,7 +10770,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=viewport',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -10720,7 +10798,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=X-UA-Compatible',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10740,7 +10818,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=apple-itunes-app',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10782,7 +10860,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-3p-iframe-src',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad/',
 				),
 			),
 			array(
@@ -10960,7 +11038,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Type',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10979,7 +11057,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=content-language',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -10998,7 +11076,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=pics-label',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11017,7 +11095,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=imagetoolbar',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11039,7 +11117,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Style-Type',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11061,7 +11139,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Script-Type',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11080,7 +11158,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=origin-trial',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11099,7 +11177,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=resource-type',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11122,7 +11200,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=x-dns-prefetch-control',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
 				),
 			),
 			array(
@@ -11174,7 +11252,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11244,7 +11322,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'noscript enclosure for boilerplate',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites',
 					'unique' => true,
 				),
 			),
@@ -11292,7 +11370,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'select',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -11309,7 +11387,7 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -11413,7 +11491,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11520,7 +11598,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11529,7 +11607,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'mandatory_parent' => 'noscript',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img/',
 				),
 			),
 		),
@@ -11612,7 +11690,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11695,7 +11773,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11831,7 +11909,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -11925,7 +12003,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -12005,7 +12083,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_alternatives' => 'amphtml engine v0.js script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -12048,7 +12126,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_alternatives' => 'amphtml engine v0.js script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js lts script',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
 			),
@@ -12560,7 +12638,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-analytics',
 					),
 					'spec_name' => 'amp-analytics extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics/',
 				),
 			),
 			array(
@@ -12944,7 +13022,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-bind',
 					),
 					'spec_name' => 'amp-bind extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind/',
 				),
 			),
 			array(
@@ -13476,12 +13554,12 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'max_bytes' => 15000,
-					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment#configuration',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment/#configuration',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment/',
 				),
 			),
 			array(
@@ -13809,7 +13887,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-geo',
 					),
 					'spec_name' => 'amp-geo extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-geo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-geo/',
 				),
 			),
 			array(
@@ -14772,7 +14850,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'AMP-NEXT-PAGE > SCRIPT[type=application/json]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page/',
 				),
 			),
 			array(
@@ -15254,14 +15332,14 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'max_bytes' => 10000,
-					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-script#faq',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-script/#faq',
 				),
 				'tag_spec' => array(
 					'requires_extension' => array(
 						'amp-script',
 					),
 					'spec_name' => 'amp-script extension local script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-script',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-script/',
 				),
 			),
 			array(
@@ -15527,6 +15605,36 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-story-360',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-story-auto-ads',
 						'requires_usage' => true,
 						'version' => array(
@@ -15560,7 +15668,37 @@ class AMP_Allowed_Tags_Generated {
 						'amp-story-auto-ads',
 					),
 					'spec_name' => 'amp-story-auto-ads config script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads/',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-story-player',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
 				),
 			),
 			array(
@@ -15661,12 +15799,12 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'max_bytes' => 15000,
-					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment#configuration',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment/#configuration',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment story extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment/',
 				),
 			),
 			array(
@@ -16265,7 +16403,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo/',
 				),
 			),
 			array(
@@ -16389,7 +16527,7 @@ class AMP_Allowed_Tags_Generated {
 					'size' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -16483,7 +16621,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -16508,7 +16646,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'picture',
 					'spec_name' => 'picture > source',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img/',
 				),
 			),
 			array(
@@ -16530,7 +16668,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > source',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 			array(
@@ -16552,7 +16690,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > source',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio/',
 				),
 			),
 			array(
@@ -16575,7 +16713,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > source',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio/',
 				),
 			),
 			array(
@@ -16598,7 +16736,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > source',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 			array(
@@ -16674,7 +16812,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'lineargradient',
 					'spec_name' => 'lineargradient > stop',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 			array(
@@ -16687,7 +16825,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'radialgradient',
 					'spec_name' => 'radialgradient > stop',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -16743,12 +16881,12 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'doc_css_bytes' => true,
 					'max_bytes' => 75000,
-					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'style amp-custom',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets',
 					'unique' => true,
 				),
 			),
@@ -16771,7 +16909,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'head > style[amp-boilerplate]',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites',
 					'unique' => true,
 				),
 			),
@@ -16795,7 +16933,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'head',
 					'mandatory_parent' => 'noscript',
 					'spec_name' => 'noscript > style[amp-boilerplate]',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites',
 					'unique' => true,
 				),
 			),
@@ -16827,7 +16965,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'doc_css_bytes' => false,
 					'max_bytes' => 500000,
-					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#keyframes-stylesheet',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#keyframes-stylesheet',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
@@ -16946,7 +17084,7 @@ class AMP_Allowed_Tags_Generated {
 					'zoomandpan' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17025,7 +17163,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17106,7 +17244,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17340,7 +17478,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17395,7 +17533,7 @@ class AMP_Allowed_Tags_Generated {
 					'wrap' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form/',
 				),
 			),
 		),
@@ -17496,7 +17634,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17563,7 +17701,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
 					'spec_name' => 'svg title',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -17925,7 +18063,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > track[kind=subtitles]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video/',
 				),
 			),
 		),
@@ -18023,7 +18161,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -18110,7 +18248,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -18231,7 +18369,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -18267,7 +18405,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-video',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video/',
 				),
 			),
 		),
@@ -18287,7 +18425,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -18307,7 +18445,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg',
 				),
 			),
 		),
@@ -18512,6 +18650,11 @@ class AMP_Allowed_Tags_Generated {
 				'amp-subscriptions',
 			),
 		),
+		'subscriptions-google-rtc' => array(
+			'requires_extension' => array(
+				'amp-subscriptions-google',
+			),
+		),
 		'subscriptions-lang' => array(
 			'requires_extension' => array(
 				'amp-subscriptions',
@@ -18611,7 +18754,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-LIVE-LIST [items]',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#items',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list/#items',
 			),
 		),
 		'AMP-LIVE-LIST [items] item' => array(
@@ -18628,7 +18771,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [items] item',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#items',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list/#items',
 			),
 		),
 		'AMP-LIVE-LIST [pagination]' => array(
@@ -18639,7 +18782,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [pagination]',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#pagination',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list/#pagination',
 			),
 		),
 		'AMP-LIVE-LIST [update]' => array(
@@ -18650,7 +18793,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [update]',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#update',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list/#update',
 			),
 		),
 		'AMP-MEGA-MENU > AMP-LIST' => array(
@@ -18858,7 +19001,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-SELECTOR option',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-selector',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-selector/',
 			),
 		),
 		'AMP-STORY-CTA-LAYER animate-in' => array(
@@ -18910,7 +19053,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-CTA-LAYER animate-in',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story/',
 			),
 		),
 		'AMP-STORY-GRID-LAYER animate-in' => array(
@@ -18981,7 +19124,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-GRID-LAYER animate-in',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story/',
 			),
 		),
 		'AMP-STORY-GRID-LAYER default' => array(
@@ -19107,7 +19250,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-GRID-LAYER default',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story/',
 			),
 		),
 		'AMP-VIDEO-IFRAME > [placeholder]' => array(
@@ -19118,7 +19261,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-VIDEO-IFRAME > [placeholder]',
-				'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe/',
 			),
 		),
 	);

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -523,6 +523,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 							</amp-story-page>
 							<amp-story-page id="my-second-page">
 								<amp-analytics config="https://example.com/analytics.account.config.json"></amp-analytics>
+								<amp-story-grid-layer template="fill">
+									<amp-story-360 layout="responsive" width="100" height="100" heading-start="-45" pitch-start="-20" heading-end="95" pitch-end="-10" zoom-end="4" duration="30s">
+										<amp-img src="img/panorama1.jpg" layout="fixed" width="200" height="100" crossorigin="anonymous" referrerpolicy="origin"></amp-img>
+									</amp-story-360>
+								</amp-story-grid-layer>
 								<amp-story-grid-layer template="thirds">
 									<amp-img grid-area="bottom-third" src="https://example.ampproject.org/helloworld/bg2.gif" width="900" height="1600">
 									</amp-img>
@@ -559,7 +564,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					return [
 						$html,
 						preg_replace( '#<\w+[^>]*>bad</\w+>#', '', $html ),
-						[ 'amp-story', 'amp-analytics', 'amp-twitter', 'amp-youtube', 'amp-video' ],
+						[ 'amp-story', 'amp-analytics', 'amp-story-360', 'amp-twitter', 'amp-youtube', 'amp-video' ],
 						[
 							[
 								'code'      => AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_DESCENDANT_TAG,
@@ -570,6 +575,36 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					];
 				}
 			),
+
+			'amp_story_player'                             => [
+				'
+				<amp-story-player width="360" height="600">
+					<a href="https://www.example.com" class="story">
+						<span class="title">A local’s guide to what to eat and do in New York City</span>
+					</a>
+					<a href="https://www.example.com2" class="story">
+						<span class="title">A local’s guide to what to eat and do in Mexico City</span>
+					</a>
+				</amp-story-player>
+				',
+				null,
+				[ 'amp-story-player' ],
+			],
+
+			'amp_story_360'                                => [
+				'
+				<amp-story-player width="360" height="600">
+					<a href="https://www.example.com" class="story">
+						<span class="title">A local’s guide to what to eat and do in New York City</span>
+					</a>
+					<a href="https://www.example.com2" class="story">
+						<span class="title">A local’s guide to what to eat and do in Mexico City</span>
+					</a>
+				</amp-story-player>
+				',
+				null,
+				[ 'amp-story-player' ],
+			],
 
 			'reference-points-bad'                         => [
 				'<div lightbox-thumbnail-id update items pagination separator option selected disabled>BAD REFERENCE POINTS</div>',
@@ -2212,7 +2247,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'amp-autocomplete'                             => [
 				'
 					<form method="post" action-xhr="/form/echo-json/post" target="_blank" on="submit-success:AMP.setState({result: event.response})">
-						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0" inline="@">
+						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0" inline="@" max-items="10">
 							<input type="text" id="input">
 							<script type="application/json" id="script">
 							{ "items" : ["apple", "banana", "orange"] }


### PR DESCRIPTION
## Summary

Previously #4892.

This preempts a stable release of the validator in order to make sure that `amp-story-player` is included for the Web Stories plugin to utilize.

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [ ] ~Update spec generator as needed based on spec format changes.~
- [ ] ~Modify validating sanitizer based on changes to spec, if needed.~
- [ ] ~Add tests for key changes.~

### Changelog

* Add `amp-story-player` component.
* Add `amp-story-360` component.
* Add `max-items` attribute to `amp-autocomplete`.
* Add `crossorigin` and `referrerpolicy` attributes to `amp-img`.
* Add global attribute `subscriptions-google-rtc`.
* Update amp.dev URLs for docs.

# Details

```bash
(
    PREV_VERSION=2006112352000;
    THIS_VERSION=3aa007a; 
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details>
<summary>2006112352000...3aa007a</summary>

```diff
diff --git a/extensions/amp-accordion/validator-amp-accordion.protoascii b/extensions/amp-accordion/validator-amp-accordion.protoascii
index c1f007a2a..2296ddacb 100644
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -59,7 +59,7 @@ tags: {  # <amp-accordion>
   child_tags: {
     child_tag_name_oneof: "SECTION"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-accordion"
+  spec_url: "https://amp.dev/documentation/components/amp-accordion/"
   amp_layout: {
     supported_layouts: CONTAINER
   }
@@ -71,6 +71,7 @@ tags: {  # <amp-accordion> > <section>
   html_format: ACTIONS
   tag_name: "SECTION"
   spec_name: "amp-accordion > section"
+  descriptive_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"
   attrs: { name: "expanded" value: "" }
   # amp-bind
diff --git a/extensions/amp-action-macro/validator-amp-action-macro.protoascii b/extensions/amp-action-macro/validator-amp-action-macro.protoascii
index 63ab2755c..a60ac468b 100644
--- a/extensions/amp-action-macro/validator-amp-action-macro.protoascii
+++ b/extensions/amp-action-macro/validator-amp-action-macro.protoascii
@@ -37,5 +37,5 @@ tags: {  # <amp-action-macro>
     mandatory: true
   }
   attr_lists: "mandatory-id-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-action-macro"
+  spec_url: "https://amp.dev/documentation/components/amp-action-macro/"
 }
diff --git a/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii b/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
index 0a725539c..d31e7d12b 100644
--- a/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
+++ b/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
@@ -35,7 +35,7 @@ tags: {  # <amp-ad-exit>
     mandatory_num_child_tags: 1
     child_tag_name_oneof: "SCRIPT"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-ad-exit"
+  spec_url: "https://amp.dev/documentation/components/amp-ad-exit/"
   amp_layout {
     supported_layouts: NODISPLAY
     supported_layouts: CONTAINER  # To allow an unspecified layout (container is default).
@@ -55,5 +55,5 @@ tags: {  # amp-ad-exit config JSON
     dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   attr_lists: "nonce-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-ad-exit"
+  spec_url: "https://amp.dev/documentation/components/amp-ad-exit/"
 }
diff --git a/extensions/amp-ad/validator-amp-ad.protoascii b/extensions/amp-ad/validator-amp-ad.protoascii
index 52d5cfa40..26e0a2cff 100644
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -65,7 +65,7 @@ tags: {  # <amp-ad>
   attrs: { name: "template" }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -147,7 +147,7 @@ tags: {  # <amp-ad data-multi-size>
   }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -191,7 +191,7 @@ tags: {  # <amp-ad data-enable-refresh>
   }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -223,7 +223,7 @@ tags: {  # <amp-embed>
   }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -267,7 +267,7 @@ tags: {  # <amp-embed data-multi-size>
   }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-analytics/validator-amp-analytics.protoascii b/extensions/amp-analytics/validator-amp-analytics.protoascii
index 8befc7df0..29b460e93 100644
--- a/extensions/amp-analytics/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/validator-amp-analytics.protoascii
@@ -35,6 +35,7 @@ tags: {  # amp-analytics (json)
   html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "amp-analytics extension .json script"
+  descriptive_name: "amp-analytics extension .json script"
   requires_extension: "amp-analytics"
   mandatory_parent: "AMP-ANALYTICS"
   attrs: {
@@ -50,7 +51,7 @@ tags: {  # amp-analytics (json)
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-analytics"
+  spec_url: "https://amp.dev/documentation/components/amp-analytics/"
 }
 tags: {  # <amp-analytics>
   html_format: AMP
@@ -68,5 +69,5 @@ tags: {  # <amp-analytics>
     disallowed_value_regex: "__amp_source_origin"
   }
   attrs: { name: "type" }
-  spec_url: "https://amp.dev/documentation/components/amp-analytics"
+  spec_url: "https://amp.dev/documentation/components/amp-analytics/"
 }
diff --git a/extensions/amp-anim/validator-amp-anim.protoascii b/extensions/amp-anim/validator-amp-anim.protoascii
index b6656fbfd..7e9a569c7 100644
--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -51,7 +51,7 @@ tags: {  # <amp-anim>
   attrs: { name: "object-position" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-or-srcset"
-  spec_url: "https://amp.dev/documentation/components/amp-anim"
+  spec_url: "https://amp.dev/documentation/components/amp-anim/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -73,7 +73,7 @@ tags: {  # <amp-anim>
   attrs: { name: "attribution" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-amp4email"
-  spec_url: "https://amp.dev/documentation/components/amp-anim"
+  spec_url: "https://amp.dev/documentation/components/amp-anim/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-apester-media/validator-amp-apester-media.protoascii b/extensions/amp-apester-media/validator-amp-apester-media.protoascii
index 1ecb27d54..30dbb269d 100644
--- a/extensions/amp-apester-media/validator-amp-apester-media.protoascii
+++ b/extensions/amp-apester-media/validator-amp-apester-media.protoascii
@@ -49,5 +49,5 @@ tags: {  # <amp-apester-media>
       supported_layouts: NODISPLAY
       supported_layouts: RESPONSIVE
   }
-  spec_url: "https://amp.dev/documentation/components/amp-apester-media"
+  spec_url: "https://amp.dev/documentation/components/amp-apester-media/"
 }
diff --git a/extensions/amp-app-banner/validator-amp-app-banner.protoascii b/extensions/amp-app-banner/validator-amp-app-banner.protoascii
index 8d85d3a37..47b766cad 100644
--- a/extensions/amp-app-banner/validator-amp-app-banner.protoascii
+++ b/extensions/amp-app-banner/validator-amp-app-banner.protoascii
@@ -37,7 +37,7 @@ tags: {  # <amp-app-banner>
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-id-attr"
   unique: true
-  spec_url: "https://amp.dev/documentation/components/amp-app-banner"
+  spec_url: "https://amp.dev/documentation/components/amp-app-banner/"
   amp_layout: {
     supported_layouts: NODISPLAY
   }
diff --git a/extensions/amp-audio/validator-amp-audio.protoascii b/extensions/amp-audio/validator-amp-audio.protoascii
index 752a20819..a489a0dfc 100644
--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -70,7 +70,7 @@ tags: {  # <amp-audio> for AMP (autoplay attribute allowed)
   }
   attr_lists: "amp-audio-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
   amp_layout {
     defines_default_height: true
     # TODO(johannes): in the longer run, defines_default_width should
@@ -95,7 +95,7 @@ tags: {  # <amp-audio> for AMP, amp-story (autoplay attribute mandatory)
   }
   attr_lists: "amp-audio-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
   amp_layout {
     supported_layouts: NODISPLAY
   }
@@ -108,7 +108,7 @@ tags: {  # <amp-audio> for A4A (autoplay attribute disallowed)
   requires_extension: "amp-audio"
   attr_lists: "amp-audio-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
   amp_layout {
     defines_default_height: true
     defines_default_width: true
diff --git a/extensions/amp-auto-ads/validator-amp-auto-ads.protoascii b/extensions/amp-auto-ads/validator-amp-auto-ads.protoascii
index fd0e152c4..08b1bdb8a 100644
--- a/extensions/amp-auto-ads/validator-amp-auto-ads.protoascii
+++ b/extensions/amp-auto-ads/validator-amp-auto-ads.protoascii
@@ -33,5 +33,5 @@ tags: {  # <amp-auto-ads>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-auto-ads"
+  spec_url: "https://amp.dev/documentation/components/amp-auto-ads/"
 }
diff --git a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
index 608aa0f58..d40824239 100644
--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -63,6 +63,7 @@ tags: {  # <amp-autocomplete>
   attrs: { name: "inline" }
   attrs: { name: "items" }
   attrs: { name: "max-entries" }
+  attrs: { name: "max-items" }
   attrs: { name: "min-characters" }
   attrs: {
     name: "query"
@@ -87,7 +88,7 @@ tags: {  # <amp-autocomplete>
     name: "[src]"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-autocomplete"
+  spec_url: "https://amp.dev/documentation/components/amp-autocomplete/"
   amp_layout: {
     supported_layouts: CONTAINER
   }
@@ -105,6 +106,7 @@ tags: {  # <amp-autocomplete>
   attrs: { name: "inline" }
   attrs: { name: "items" }
   attrs: { name: "max-entries" }
+  attrs: { name: "max-items" }
   attrs: { name: "min-characters" }
   attrs: {
     name: "query"
diff --git a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
index e950ffe63..e7132e6bc 100644
--- a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
+++ b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
@@ -121,7 +121,7 @@ tags: {  # <amp-base-carousel>
   requires_extension: "amp-base-carousel"
   attr_lists: "amp-base-carousel-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-base-carousel"
+  spec_url: "https://amp.dev/documentation/components/amp-base-carousel/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -146,7 +146,7 @@ tags: {  # <amp-base-carousel lightbox>
   }
   attr_lists: "amp-base-carousel-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-base-carousel"
+  spec_url: "https://amp.dev/documentation/components/amp-base-carousel/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-bind/validator-amp-bind.protoascii b/extensions/amp-bind/validator-amp-bind.protoascii
index 4f27be6b4..36e16935f 100644
--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -68,7 +68,7 @@ tags: {  # <amp-state> (json)
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-bind"
+  spec_url: "https://amp.dev/documentation/components/amp-bind/"
 }
 tags: {  # <amp-state>
   html_format: AMP
@@ -95,7 +95,7 @@ tags: {  # <amp-state>
   child_tags: {
     first_child_tag_name_oneof: "SCRIPT"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-bind"
+  spec_url: "https://amp.dev/documentation/components/amp-bind/"
 }
 # AMP4ADS and AMP4EMAIL enforces the the same restrictions on the 'src'
 # attribute of AMP-IMG and AMP-LIST on the src attribute of AMP-STATE. Use of
@@ -113,7 +113,7 @@ tags: {  # <amp-state>
   child_tags: {
     first_child_tag_name_oneof: "SCRIPT"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-bind"
+  spec_url: "https://amp.dev/documentation/components/amp-bind/"
 }
 # ACTIONS <amp-state> with POST identity
 tags: { # <amp-state>
@@ -145,7 +145,7 @@ tags: { # <amp-state>
   child_tags: {
     first_child_tag_name_oneof: "SCRIPT"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-bind"
+  spec_url: "https://amp.dev/documentation/components/amp-bind/"
 }
 tags: {  # <amp-bind-macro>
   html_format: AMP
@@ -161,5 +161,5 @@ tags: {  # <amp-bind-macro>
     mandatory: true
   }
   attr_lists: "mandatory-id-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-bind"
+  spec_url: "https://amp.dev/documentation/components/amp-bind/"
 }
diff --git a/extensions/amp-bodymovin-animation/validator-amp-bodymovin-animation.protoascii b/extensions/amp-bodymovin-animation/validator-amp-bodymovin-animation.protoascii
index e500cc7d5..a00b1ca88 100644
--- a/extensions/amp-bodymovin-animation/validator-amp-bodymovin-animation.protoascii
+++ b/extensions/amp-bodymovin-animation/validator-amp-bodymovin-animation.protoascii
@@ -52,7 +52,7 @@ tags: {  # <amp-bodymovin-animation>
     value_casei: "svg"
     value_casei: "html"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-bodymovin-animation"
+  spec_url: "https://amp.dev/documentation/components/amp-bodymovin-animation/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-brid-player/validator-amp-brid-player.protoascii b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
index e00484b0c..58a1b1c26 100644
--- a/extensions/amp-brid-player/validator-amp-brid-player.protoascii
+++ b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
@@ -65,7 +65,7 @@ tags: {  # <amp-brid-player>
     requires_extension: "amp-video-docking"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-brid-player"
+  spec_url: "https://amp.dev/documentation/components/amp-brid-player/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-brightcove/validator-amp-brightcove.protoascii b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
index c9079d25c..e38295a94 100644
--- a/extensions/amp-brightcove/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
@@ -51,7 +51,7 @@ tags: {  # <amp-brightcove>
   attrs: { name: "[data-video-id]" }
   attrs: { name: "[data-referrer]" }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-brightcove"
+  spec_url: "https://amp.dev/documentation/components/amp-brightcove/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii b/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
index 55488b574..128183afe 100644
--- a/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
+++ b/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
@@ -43,7 +43,7 @@ tags: {  # <amp-call-tracking>
     mandatory_num_child_tags: 1
     child_tag_name_oneof: "A"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-call-tracking"
+  spec_url: "https://amp.dev/documentation/components/amp-call-tracking/"
   amp_layout: {
     supported_layouts: CONTAINER
     supported_layouts: FILL
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index f94eefebe..0549b2bbf 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -92,7 +92,7 @@ tags: {  # <amp-carousel>
   requires_extension: "amp-carousel"
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-carousel"
+  spec_url: "https://amp.dev/documentation/components/amp-carousel/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -115,7 +115,7 @@ tags: {  # <amp-carousel lightbox>
   }
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-carousel"
+  spec_url: "https://amp.dev/documentation/components/amp-carousel/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-connatix-player/validator-amp-connatix-player.protoascii b/extensions/amp-connatix-player/validator-amp-connatix-player.protoascii
index bbb627dea..62e45b974 100644
--- a/extensions/amp-connatix-player/validator-amp-connatix-player.protoascii
+++ b/extensions/amp-connatix-player/validator-amp-connatix-player.protoascii
@@ -33,7 +33,7 @@ tags: {  # <amp-connatix-player>
     name: "data-player-id"
     mandatory: true
   }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-connatix-player"
+  spec_url: "https://amp.dev/documentation/components/amp-connatix-player/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
index c66072a02..ca2a7249c 100644
--- a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
@@ -73,7 +73,7 @@ tags: {  # <amp-dailymotion>
     requires_extension: "amp-video-docking"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-dailymotion"
+  spec_url: "https://amp.dev/documentation/components/amp-dailymotion/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-embedly-card/validator-amp-embedly-card.protoascii b/extensions/amp-embedly-card/validator-amp-embedly-card.protoascii
index 5cf25c484..2d7abb6f4 100644
--- a/extensions/amp-embedly-card/validator-amp-embedly-card.protoascii
+++ b/extensions/amp-embedly-card/validator-amp-embedly-card.protoascii
@@ -38,7 +38,7 @@ tags: {  # <amp-embedly-card>
     }
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-embedly-card"
+  spec_url: "https://amp.dev/documentation/components/amp-embedly-card/"
   amp_layout: {
     supported_layouts: RESPONSIVE
   }
diff --git a/extensions/amp-experiment/validator-amp-experiment.protoascii b/extensions/amp-experiment/validator-amp-experiment.protoascii
index b23847d4d..d84b5ec70 100644
--- a/extensions/amp-experiment/validator-amp-experiment.protoascii
+++ b/extensions/amp-experiment/validator-amp-experiment.protoascii
@@ -44,13 +44,13 @@ tags: {  # amp-experiment (json)
   attr_lists: "nonce-attr"
   cdata: {
     max_bytes: 15000
-    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-experiment#configuration"
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-experiment/#configuration"
     disallowed_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-experiment"
+  spec_url: "https://amp.dev/documentation/components/amp-experiment/"
 }
 tags: {  # <amp-experiment>
   html_format: AMP
@@ -58,5 +58,5 @@ tags: {  # <amp-experiment>
   tag_name: "AMP-EXPERIMENT"
   requires_extension: "amp-experiment"
   unique: true
-  spec_url: "https://amp.dev/documentation/components/amp-experiment"
+  spec_url: "https://amp.dev/documentation/components/amp-experiment/"
 }
diff --git a/extensions/amp-geo/validator-amp-geo.protoascii b/extensions/amp-geo/validator-amp-geo.protoascii
index 24968fa0c..47dfac932 100644
--- a/extensions/amp-geo/validator-amp-geo.protoascii
+++ b/extensions/amp-geo/validator-amp-geo.protoascii
@@ -57,5 +57,5 @@ tags: {  # amp-geo (json)
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-geo"
+  spec_url: "https://amp.dev/documentation/components/amp-geo/"
 }
diff --git a/extensions/amp-gfycat/validator-amp-gfycat.protoascii b/extensions/amp-gfycat/validator-amp-gfycat.protoascii
index 4e5fa19b2..38c657d4c 100644
--- a/extensions/amp-gfycat/validator-amp-gfycat.protoascii
+++ b/extensions/amp-gfycat/validator-amp-gfycat.protoascii
@@ -39,7 +39,7 @@ tags: {  # <amp-gfycat>
     value: ""
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-gfycat"
+  spec_url: "https://amp.dev/documentation/components/amp-gfycat/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-gist/validator-amp-gist.protoascii b/extensions/amp-gist/validator-amp-gist.protoascii
index a004a3949..a7987896c 100644
--- a/extensions/amp-gist/validator-amp-gist.protoascii
+++ b/extensions/amp-gist/validator-amp-gist.protoascii
@@ -33,7 +33,7 @@ tags: {  # <amp-gist>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-gist"
+  spec_url: "https://amp.dev/documentation/components/amp-gist/"
   amp_layout: {
     supported_layouts: FIXED_HEIGHT
   }
diff --git a/extensions/amp-google-document-embed/validator-amp-google-document-embed.protoascii b/extensions/amp-google-document-embed/validator-amp-google-document-embed.protoascii
index eae073a6a..97e981bd8 100644
--- a/extensions/amp-google-document-embed/validator-amp-google-document-embed.protoascii
+++ b/extensions/amp-google-document-embed/validator-amp-google-document-embed.protoascii
@@ -41,7 +41,7 @@ tags: {  # <amp-google-document-embed>
   attrs: { name: "[src]" }
   attrs: { name: "[title]" }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-google-document-embed"
+  spec_url: "https://amp.dev/documentation/components/amp-google-document-embed/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-hulu/validator-amp-hulu.protoascii b/extensions/amp-hulu/validator-amp-hulu.protoascii
index c304c710d..ad59e815e 100644
--- a/extensions/amp-hulu/validator-amp-hulu.protoascii
+++ b/extensions/amp-hulu/validator-amp-hulu.protoascii
@@ -33,7 +33,7 @@ tags: {  # <amp-hulu>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-hulu"
+  spec_url: "https://amp.dev/documentation/components/amp-hulu/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-ima-video/validator-amp-ima-video.protoascii b/extensions/amp-ima-video/validator-amp-ima-video.protoascii
index ae2614ee6..8689c01ef 100644
--- a/extensions/amp-ima-video/validator-amp-ima-video.protoascii
+++ b/extensions/amp-ima-video/validator-amp-ima-video.protoascii
@@ -58,7 +58,7 @@ tags: {  # <amp-ima-video>
     value: ""
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-ima-video"
+  spec_url: "https://amp.dev/documentation/components/amp-ima-video/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-image-slider/validator-amp-image-slider.protoascii b/extensions/amp-image-slider/validator-amp-image-slider.protoascii
index 0d6cefc86..a41808f4a 100644
--- a/extensions/amp-image-slider/validator-amp-image-slider.protoascii
+++ b/extensions/amp-image-slider/validator-amp-image-slider.protoascii
@@ -48,7 +48,7 @@ tags: {  # <amp-image-slider>
     child_tag_name_oneof: "DIV"
     mandatory_min_num_child_tags: 2
   }
-  spec_url: "https://amp.dev/documentation/components/amp-image-slider"
+  spec_url: "https://amp.dev/documentation/components/amp-image-slider/"
   amp_layout: {
     supported_layouts: FIXED
     supported_layouts: INTRINSIC
@@ -82,7 +82,7 @@ tags: {  # <amp-image-slider>
     child_tag_name_oneof: "I-AMPHTML-SIZER"
     mandatory_min_num_child_tags: 2
   }
-  spec_url: "https://amp.dev/documentation/components/amp-image-slider"
+  spec_url: "https://amp.dev/documentation/components/amp-image-slider/"
   amp_layout: {
     supported_layouts: FIXED
     supported_layouts: INTRINSIC
@@ -99,7 +99,7 @@ tags: {
     name: "first"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-image-slider"
+  spec_url: "https://amp.dev/documentation/components/amp-image-slider/"
 }
 tags: {
   html_format: AMP
@@ -110,5 +110,5 @@ tags: {
     name: "second"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-image-slider"
+  spec_url: "https://amp.dev/documentation/components/amp-image-slider/"
 }
diff --git a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
index 0b6a55144..5839d81a8 100644
--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -29,7 +29,7 @@ tags: {  # <amp-inline-gallery>
   tag_name: "AMP-INLINE-GALLERY"
   requires_extension: "amp-inline-gallery"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"
   amp_layout: {
     supported_layouts: CONTAINER
   }
@@ -40,7 +40,7 @@ tags: {  # <amp-inline-gallery-pagination>
   spec_name: "amp-inline-gallery-pagination"
   requires_extension: "amp-inline-gallery"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"
   mandatory_ancestor: "AMP-INLINE-GALLERY"
   amp_layout: {
     supported_layouts: FILL
@@ -62,7 +62,7 @@ tags: {  # <amp-inline-gallery-pagination inset>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"
   mandatory_ancestor: "AMP-INLINE-GALLERY"
   amp_layout: {
     supported_layouts: NODISPLAY
@@ -96,7 +96,7 @@ tags: {  # <amp-inline-gallery-thumbnails>
     value: "false"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"
   mandatory_ancestor: "AMP-INLINE-GALLERY"
   amp_layout: {
     supported_layouts: FILL
diff --git a/extensions/amp-inputmask/validator-amp-inputmask.protoascii b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
index e01878f6c..6d08dcfb9 100644
--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -53,7 +53,7 @@ tags: {
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
   attrs: { name: "[type]" }
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 tags: {
@@ -70,7 +70,7 @@ tags: {
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 tags: {
@@ -87,7 +87,7 @@ tags: {
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 tags: {
@@ -104,7 +104,7 @@ tags: {
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 tags: {
@@ -121,7 +121,7 @@ tags: {
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 tags: {
@@ -138,7 +138,7 @@ tags: {
   attr_lists: "amp-inputmask-common-attr"
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-inputmask"
+  spec_url: "https://amp.dev/documentation/components/amp-inputmask/"
 }
 
 attr_lists: {
diff --git a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
index a87bb3739..9e48a1094 100644
--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
@@ -61,5 +61,5 @@ tags: {  # <amp-jwplayer>
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
-  spec_url: "https://amp.dev/documentation/components/amp-jwplayer"
+  spec_url: "https://amp.dev/documentation/components/amp-jwplayer/"
 }
diff --git a/extensions/amp-live-list/validator-amp-live-list.protoascii b/extensions/amp-live-list/validator-amp-live-list.protoascii
index abda4a5c3..350fa7db4 100644
--- a/extensions/amp-live-list/validator-amp-live-list.protoascii
+++ b/extensions/amp-live-list/validator-amp-live-list.protoascii
@@ -74,17 +74,19 @@ tags: {
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
   spec_name : "AMP-LIVE-LIST [update]"
+  descriptive_name : "amp-live-list [update]"
   attrs: {
     name: "update"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-live-list#update"
+  spec_url: "https://amp.dev/documentation/components/amp-live-list/#update"
 }
 tags: {
   html_format: AMP
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-LIVE-LIST [items]"
+  descriptive_name : "amp-live-list [items]"
   attrs: {
     name: "items"
     mandatory: true
@@ -92,24 +94,26 @@ tags: {
   reference_points: {
     tag_spec_name: "AMP-LIVE-LIST [items] item"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-live-list#items"
+  spec_url: "https://amp.dev/documentation/components/amp-live-list/#items"
 }
 tags: {
   html_format: AMP
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
   spec_name : "AMP-LIVE-LIST [pagination]"
+  descriptive_name : "amp-live-list [pagination]"
   attrs: {
     name: "pagination"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-live-list#pagination"
+  spec_url: "https://amp.dev/documentation/components/amp-live-list/#pagination"
 }
 tags: {
   html_format: AMP
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
   spec_name : "AMP-LIVE-LIST [items] item"
+  descriptive_name : "amp-live-list [items] item"
   attrs: {
     name: "data-sort-time"
     mandatory: true
@@ -117,5 +121,5 @@ tags: {
   attrs: { name: "data-tombstone" }
   attrs: { name: "data-update-time" }
   attr_lists: "mandatory-id-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-live-list#items"
+  spec_url: "https://amp.dev/documentation/components/amp-live-list/#items"
 }
diff --git a/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii b/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
index cb3900c3a..d2cc8f3b5 100644
--- a/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
+++ b/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
@@ -28,7 +28,7 @@ tags: {  # <amp-mega-menu>
   tag_name: "AMP-MEGA-MENU"
   requires_extension: "amp-mega-menu"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-mega-menu"
+  spec_url: "https://amp.dev/documentation/components/amp-mega-menu/"
   descendant_tag_list: "amp-mega-menu-allowed-descendants"
   # We want to support both of the cases below:
   # <amp-mega-menu> > <nav> > ... and
@@ -53,6 +53,7 @@ tags: {  # <amp-mega-menu> <nav>
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU > NAV"
+  descriptive_name: "amp-mega-menu > nav"
   siblings_disallowed: true
   child_tags: {
     mandatory_num_child_tags: 1
@@ -67,6 +68,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU > AMP-LIST"
+  descriptive_name: "amp-mega-menu > amp-list"
   # Include mandatory amp-list attrs so that <amp-mega-menu> > <nav>
   # does not match to this tag.
   attrs: {
@@ -89,6 +91,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU > AMP-LIST > TEMPLATE"
+  descriptive_name: "amp-mega-menu > amp-list > template"
   mandatory_parent: "AMP-LIST"
   child_tags: {
     mandatory_num_child_tags: 1
@@ -102,6 +105,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU NAV > UL/OL"
+  descriptive_name: "amp-mega-menu nav > ul/ol"
   mandatory_parent: "NAV"
   child_tags: {
     mandatory_min_num_child_tags: 1
@@ -115,6 +119,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU NAV > UL/OL > LI"
+  descriptive_name: "amp-mega-menu nav > ul/ol > li"
   child_tags: {
     mandatory_min_num_child_tags: 1
     child_tag_name_oneof: "A"
@@ -142,6 +147,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU item-heading"
+  descriptive_name: "amp-mega-menu item-heading"
   attrs: {
     name: "role"
     value: "button"
@@ -151,6 +157,7 @@ tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-MEGA-MENU item-content"
+  descriptive_name: "amp-mega-menu item-content"
   # Disallow role=menu until supported by implementation.
   attrs: {
     name: "role"
diff --git a/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
index 156a0ce30..bfda96922 100644
--- a/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
+++ b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
@@ -52,7 +52,7 @@ tags: {  # <amp-minute-media-player>
     requires_extension: "amp-video-docking"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-minute-media-player"
+  spec_url: "https://amp.dev/documentation/components/amp-minute-media-player/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
index d32aef668..d1a438034 100644
--- a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -39,7 +39,7 @@ tags: {  # amp-nested-menu
     supported_layouts: FILL
   }
   descendant_tag_list: "amp-nested-menu-allowed-descendants"
-  spec_url: "https://amp.dev/documentation/components/amp-nested-menu"
+  spec_url: "https://amp.dev/documentation/components/amp-nested-menu/"
 }
 tags: {  # <amp-nested-menu> <div amp-nested-submenu(-open/-close)>
   html_format: AMP
diff --git a/extensions/amp-next-page/validator-amp-next-page.protoascii b/extensions/amp-next-page/validator-amp-next-page.protoascii
index 52f200bb1..1bf35d805 100644
--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -36,7 +36,7 @@ tags: {  # amp-next-page: JSON Config
     value_casei: "application/json"
     dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/components/amp-next-page"
+  spec_url: "https://amp.dev/documentation/components/amp-next-page/"
 }
 tags: {
   html_format: AMP
@@ -96,7 +96,7 @@ tags: {  # <amp-next-page>
     mandatory: true
     unique: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-next-page"
+  spec_url: "https://amp.dev/documentation/components/amp-next-page/"
 }
 tags: {  # <amp-next-page src>
   html_format: AMP
@@ -135,7 +135,7 @@ tags: {  # <amp-next-page src>
     tag_spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
     unique: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-next-page"
+  spec_url: "https://amp.dev/documentation/components/amp-next-page/"
 }
 tags: {  # <amp-next-page type="adsense">
   html_format: AMP
@@ -177,5 +177,5 @@ tags: {  # <amp-next-page type="adsense">
     tag_spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
     unique: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-next-page"
+  spec_url: "https://amp.dev/documentation/components/amp-next-page/"
 }
diff --git a/extensions/amp-pinterest/validator-amp-pinterest.protoascii b/extensions/amp-pinterest/validator-amp-pinterest.protoascii
index 3dafb56e6..52b6359d7 100644
--- a/extensions/amp-pinterest/validator-amp-pinterest.protoascii
+++ b/extensions/amp-pinterest/validator-amp-pinterest.protoascii
@@ -40,7 +40,7 @@ tags: {  # <amp-pinterest>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-pinterest"
+  spec_url: "https://amp.dev/documentation/components/amp-pinterest/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-powr-player/validator-amp-powr-player.protoascii b/extensions/amp-powr-player/validator-amp-powr-player.protoascii
index a3f5c5d7a..6c6b3bab8 100644
--- a/extensions/amp-powr-player/validator-amp-powr-player.protoascii
+++ b/extensions/amp-powr-player/validator-amp-powr-player.protoascii
@@ -50,7 +50,7 @@ tags: {  # <amp-powr-player>
     value_regex: "[0-9a-zA-Z-]+"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-powr-player"
+  spec_url: "https://amp.dev/documentation/components/amp-powr-player/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-riddle-quiz/validator-amp-riddle-quiz.protoascii b/extensions/amp-riddle-quiz/validator-amp-riddle-quiz.protoascii
index 1e495c0a2..0da6fde73 100644
--- a/extensions/amp-riddle-quiz/validator-amp-riddle-quiz.protoascii
+++ b/extensions/amp-riddle-quiz/validator-amp-riddle-quiz.protoascii
@@ -37,5 +37,5 @@ tags: {  # <amp-riddle-quiz>
   amp_layout: {
       supported_layouts: RESPONSIVE
   }
-  spec_url: "https://amp.dev/documentation/components/amp-riddle-quiz"
+  spec_url: "https://amp.dev/documentation/components/amp-riddle-quiz/"
 }
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index f6d2a8cfc..e168ea8d3 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -171,13 +171,13 @@ tags: {  # <amp-script> (local script)
   attr_lists: "nonce-attr"
   cdata: {
     max_bytes: 10000
-    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script/#faq"
     disallowed_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-script"
+  spec_url: "https://amp.dev/documentation/components/amp-script/"
 }
 tags: {  # <amp-script>
   html_format: AMP
diff --git a/extensions/amp-selector/validator-amp-selector.protoascii b/extensions/amp-selector/validator-amp-selector.protoascii
index 1c6580e19..7f00ca210 100644
--- a/extensions/amp-selector/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/validator-amp-selector.protoascii
@@ -112,7 +112,7 @@ tags: {
     name: "selected"
     value: ""
   }
-  spec_url: "https://amp.dev/documentation/components/amp-selector"
+  spec_url: "https://amp.dev/documentation/components/amp-selector/"
 }
 tags: {
   html_format: AMP
diff --git a/extensions/amp-sidebar/validator-amp-sidebar.protoascii b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
index 5c3df0a18..18125e475 100644
--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -57,7 +57,7 @@ tags: {  # <amp-sidebar> not in amp-story or email
   mark_descendants {
     marker: AUTOSCROLL
   }
-  spec_url: "https://amp.dev/documentation/components/amp-sidebar"
+  spec_url: "https://amp.dev/documentation/components/amp-sidebar/"
 }
 tags: {  # <amp-sidebar> in email
   html_format: AMP4EMAIL
@@ -73,7 +73,7 @@ tags: {  # <amp-sidebar> in email
   amp_layout: {
     supported_layouts: NODISPLAY
   }
-  spec_url: "https://amp.dev/documentation/components/amp-sidebar"
+  spec_url: "https://amp.dev/documentation/components/amp-sidebar/"
 }
 tags: { # <amp-sidebar> in amp-story
   html_format: AMP
@@ -85,7 +85,7 @@ tags: { # <amp-sidebar> in amp-story
   mark_descendants {
     marker: AUTOSCROLL
   }
-  spec_url: "https://amp.dev/documentation/components/amp-sidebar"
+  spec_url: "https://amp.dev/documentation/components/amp-sidebar/"
 }
 tags: {  # amp-sidebar > nav
   html_format: AMP
diff --git a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii b/extensions/amp-story-360/validator-amp-story-360.protoascii
similarity index 54%
copy from extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
copy to extensions/amp-story-360/validator-amp-story-360.protoascii
index a87bb3739..3812325a3 100644
--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-story-360/validator-amp-story-360.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,44 +14,53 @@
 # limitations under the license.
 #
 
-tags: {  # amp-jwplayer
+tags: {  # amp-story-360
   html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
-    name: "amp-jwplayer"
+    name: "amp-story-360"
     version: "0.1"
     version: "latest"
-    requires_usage: EXEMPTED
-    deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-jwplayer>
+tags: {  # <amp-story-360>
   html_format: AMP
-  tag_name: "AMP-JWPLAYER"
-  requires_extension: "amp-jwplayer"
+  tag_name: "AMP-STORY-360"
+  requires_extension: "amp-story-360"
+  mandatory_ancestor: "AMP-STORY"
+  spec_url: "https://amp.dev/documentation/components/amp-story-360"
   attrs: {
-    name: "autoplay"
-    value: ""
+    name: "duration"
+    value_regex: "([0-9\\.]+)\\s*(s|ms)"
   }
   attrs: {
-    name: "data-media-id"
-    mandatory_oneof: "['data-media-id', 'data-playlist-id']"
-    value_regex_casei: "[0-9a-z]{8}"
+    name: "heading-start"
+    value_regex: "-?\\d+\\.?\\d*"
   }
   attrs: {
-    name: "data-player-id"
-    mandatory: true
-    value_regex_casei: "[0-9a-z]{8}"
+    name: "pitch-start"
+    value_regex: "-?\\d+\\.?\\d*"
   }
   attrs: {
-    name: "data-playlist-id"
-    mandatory_oneof: "['data-media-id', 'data-playlist-id']"
-    value_regex_casei: "[0-9a-z]{8}"
+    name: "zoom-start"
+    value_regex: "\\d+\\.?\\d*"
   }
   attrs: {
-    name: "dock"
-    requires_extension: "amp-video-docking"
+    name: "heading-end"
+    value_regex: "-?\\d+\\.?\\d*"
+  }
+  attrs: {
+    name: "pitch-end"
+    value_regex: "-?\\d+\\.?\\d*"
+  }
+  attrs: {
+    name: "zoom-end"
+    value_regex: "\\d+\\.?\\d*"
+  }
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "AMP-IMG"
   }
   amp_layout: {
     supported_layouts: FILL
@@ -61,5 +70,4 @@ tags: {  # <amp-jwplayer>
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
-  spec_url: "https://amp.dev/documentation/components/amp-jwplayer"
 }
diff --git a/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii b/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii
index 3aed4e0fe..053bd1b74 100644
--- a/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii
+++ b/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii
@@ -34,7 +34,7 @@ tags: {  # <amp-story-auto-ads>
   requires_extension: "amp-story-auto-ads"
   mandatory_parent: "AMP-STORY"
   unique: true
-  spec_url: "https://amp.dev/documentation/components/amp-story-auto-ads"
+  spec_url: "https://amp.dev/documentation/components/amp-story-auto-ads/"
 }
 tags: {  # amp-story-auto-ads (json config)
   html_format: AMP
@@ -55,7 +55,7 @@ tags: {  # amp-story-auto-ads (json config)
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-story-auto-ads"
+  spec_url: "https://amp.dev/documentation/components/amp-story-auto-ads/"
 }
 # HTML5, 4.11.3 The template element
 tags: {
diff --git a/extensions/amp-hulu/validator-amp-hulu.protoascii b/extensions/amp-story-player/validator-amp-story-player.protoascii
similarity index 73%
copy from extensions/amp-hulu/validator-amp-hulu.protoascii
copy to extensions/amp-story-player/validator-amp-story-player.protoascii
index c304c710d..a798d42c3 100644
--- a/extensions/amp-hulu/validator-amp-hulu.protoascii
+++ b/extensions/amp-story-player/validator-amp-story-player.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,23 @@
 # limitations under the license.
 #
 
-tags: {  # amp-hulu
+tags: {  # amp-story-player
   html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
-    name: "amp-hulu"
+    name: "amp-story-player"
     version: "0.1"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-hulu>
+tags: {  # <amp-story-player>
   html_format: AMP
-  tag_name: "AMP-HULU"
-  requires_extension: "amp-hulu"
-  attrs: {
-    name: "data-eid"
-    mandatory: true
+  tag_name: "AMP-STORY-PLAYER"
+  requires_extension: "amp-story-player"
+  child_tags: {
+    child_tag_name_oneof: "A"
   }
-  attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-hulu"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index e6dc551c1..f9e494e0a 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -277,7 +277,7 @@ tags: {
   reference_points: {
     tag_spec_name: "AMP-STORY-GRID-LAYER animate-in"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-story"
+  spec_url: "https://amp.dev/documentation/components/amp-story/"
 }
 tags: {
   html_format: AMP
@@ -345,7 +345,7 @@ tags: {
   reference_points: {
     tag_spec_name: "AMP-STORY-GRID-LAYER animate-in"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-story"
+  spec_url: "https://amp.dev/documentation/components/amp-story/"
 }
 tags: {  # <amp-story-bookend>
   html_format: AMP
@@ -451,13 +451,13 @@ tags: {  # amp-experiment (json)
   attr_lists: "nonce-attr"
   cdata: {
     max_bytes: 15000
-    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-experiment#configuration"
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-experiment/#configuration"
     disallowed_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"
     }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-experiment"
+  spec_url: "https://amp.dev/documentation/components/amp-experiment/"
 }
 tags: {
   html_format: AMP
@@ -507,7 +507,7 @@ tags: {
   reference_points: {
     tag_spec_name: "AMP-STORY-CTA-LAYER animate-in"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-story"
+  spec_url: "https://amp.dev/documentation/components/amp-story/"
 }
 descendant_tag_list: {
   name: "amp-story-cta-layer-allowed-descendants"
@@ -639,6 +639,7 @@ descendant_tag_list: {
   tag: "AMP-LIVE-LIST"
   tag: "AMP-PIXEL"
   tag: "AMP-STATE"
+  tag: "AMP-STORY-360"
   tag: "AMP-TIMEAGO"
   tag: "AMP-TWITTER"
   tag: "AMP-VIDEO"
diff --git a/extensions/amp-timeago/validator-amp-timeago.protoascii b/extensions/amp-timeago/validator-amp-timeago.protoascii
index f80feff41..e9cc76e30 100644
--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -58,7 +58,7 @@ tags: {  # <amp-timeago>
   attrs: { name: "[datetime]" }
   attrs: { name: "[title]" }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-timeago"
+  spec_url: "https://amp.dev/documentation/components/amp-timeago/"
   amp_layout: {
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
diff --git a/extensions/amp-truncate-text/validator-amp-truncate-text.protoascii b/extensions/amp-truncate-text/validator-amp-truncate-text.protoascii
index de404c184..25d77b090 100644
--- a/extensions/amp-truncate-text/validator-amp-truncate-text.protoascii
+++ b/extensions/amp-truncate-text/validator-amp-truncate-text.protoascii
@@ -34,7 +34,7 @@ tags: {  # <amp-truncate-text>
     value: "right"
     value: "default"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-truncate-text"
+  spec_url: "https://amp.dev/documentation/components/amp-truncate-text/"
   amp_layout: {
     supported_layouts: CONTAINER
     supported_layouts: FILL
diff --git a/extensions/amp-video-iframe/validator-amp-video-iframe.protoascii b/extensions/amp-video-iframe/validator-amp-video-iframe.protoascii
index 4905f1141..28b0b6eee 100644
--- a/extensions/amp-video-iframe/validator-amp-video-iframe.protoascii
+++ b/extensions/amp-video-iframe/validator-amp-video-iframe.protoascii
@@ -77,7 +77,7 @@ tags: {  # <amp-video-iframe> with poster
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-iframe-common"
   attr_lists: "lightboxable-elements"
-  spec_url: "https://amp.dev/documentation/components/amp-video-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-video-iframe/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -98,7 +98,7 @@ tags: {  # <amp-video-iframe> with [placeholder]
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-iframe-common"
   attr_lists: "lightboxable-elements"
-  spec_url: "https://amp.dev/documentation/components/amp-video-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-video-iframe/"
   reference_points: {
     tag_spec_name: "AMP-VIDEO-IFRAME > [placeholder]"
     mandatory: true
@@ -124,7 +124,7 @@ tags: {  # <amp-video-iframe> with [placeholder] (transformed)
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-iframe-common"
   attr_lists: "lightboxable-elements"
-  spec_url: "https://amp.dev/documentation/components/amp-video-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-video-iframe/"
   reference_points: {
     tag_spec_name: "AMP-VIDEO-IFRAME > [placeholder]"
     mandatory: true
@@ -152,7 +152,7 @@ tags: {
     name: "placeholder"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-video-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-video-iframe/"
 }
 
 tags: {
@@ -171,5 +171,5 @@ tags: {
     }
     css_declaration: { name: "padding-top" }
   }
-  spec_url: "https://amp.dev/documentation/components/amp-video-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-video-iframe/"
 }
diff --git a/extensions/amp-video/validator-amp-video.protoascii b/extensions/amp-video/validator-amp-video.protoascii
index b6e582688..fea8c62c8 100644
--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -121,7 +121,7 @@ tags: {  # <amp-video> not in amp-story.
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
   attr_lists: "lightboxable-elements"
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -144,7 +144,7 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
   attr_lists: "lightboxable-elements"
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -184,7 +184,7 @@ tags: {  # <amp-video> in amp-story
   }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
diff --git a/extensions/amp-web-push/validator-amp-web-push.protoascii b/extensions/amp-web-push/validator-amp-web-push.protoascii
index 1a6fbca25..9a850dea5 100644
--- a/extensions/amp-web-push/validator-amp-web-push.protoascii
+++ b/extensions/amp-web-push/validator-amp-web-push.protoascii
@@ -64,7 +64,7 @@ tags: {  # <amp-web-push>
     }
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-web-push"
+  spec_url: "https://amp.dev/documentation/components/amp-web-push/"
   amp_layout: {
     supported_layouts: NODISPLAY
   }
@@ -81,7 +81,7 @@ tags: {  # <amp-web-push-widget>
     value: "unsubscribed"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-web-push"
+  spec_url: "https://amp.dev/documentation/components/amp-web-push/"
   amp_layout: {
     supported_layouts: FIXED
   }
diff --git a/extensions/amp-yotpo/validator-amp-yotpo.protoascii b/extensions/amp-yotpo/validator-amp-yotpo.protoascii
index 03a19f6bd..005404975 100644
--- a/extensions/amp-yotpo/validator-amp-yotpo.protoascii
+++ b/extensions/amp-yotpo/validator-amp-yotpo.protoascii
@@ -24,7 +24,7 @@ tags: {  # amp-yotpo
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
-  spec_url: "https://amp.dev/documentation/components/amp-yotpo"
+  spec_url: "https://amp.dev/documentation/components/amp-yotpo/"
 }
 tags: {  # <amp-yotpo>
   html_format: AMP
@@ -32,7 +32,7 @@ tags: {  # <amp-yotpo>
   tag_name: "AMP-YOTPO"
   requires_extension: "amp-yotpo"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-yotpo"
+  spec_url: "https://amp.dev/documentation/components/amp-yotpo/"
   attrs: {
     name: "data-app-key"
     mandatory: true
diff --git a/validator/validator-css.protoascii b/validator/validator-css.protoascii
index ce9521022..169692072 100644
--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -301,17 +301,27 @@ declaration_list {
   declaration: { name: "clip-path" }
 }
 
+declaration_list {
+  name: "EMAIL_SPECIFIC_VENDOR_PREFIXES"
+  # data-css-strict AMP Email does not enable automatic expansion of vendor
+  # prefixes on CSS properties. Instead, these are the only 3 vendor-prefixed
+  # CSS properties which data-css-strict email explicitly supports.
+  declaration: { name: "-moz-appearance" }
+  declaration: { name: "-webkit-appearance" }
+  declaration: { name: "-webkit-tap-highlight-color" }
+}
+
 # DocCSS rules for AMP for non-transformed documents.
 css {
   html_format: AMP
   disabled_by: "transformed"
   spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   max_bytes: 75000
   max_bytes_per_inline_style: 1000
   max_bytes_spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
   # This is a legacy requirement. Style tags support all declarations while
@@ -344,12 +354,12 @@ css {
 css {
   html_format: AMP
   enabled_by: "transformed"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   max_bytes: 75000
   max_bytes_per_inline_style: 1000
   max_bytes_spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: false
 
   allow_all_declaration_in_style_tag: true
@@ -376,7 +386,7 @@ css {
 css {
   html_format: ACTIONS
   spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   # Due to a bug, we allowed unlimited doc-level bytes for CSS in ACTIONS
   # formats. To avoid breaking existing docs, this is temporarily allowed until
@@ -384,7 +394,7 @@ css {
   # max_bytes: 75000
   # max_bytes_per_inline_style: 1000
   max_bytes_spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
   allow_all_declaration_in_style_tag: true
@@ -409,13 +419,13 @@ css {
 # DocCss rules for AMP4ADS.
 css {
   html_format: AMP4ADS
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec#css"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec/#css"
 
   # AMP4ADS currently allows unlimited inline style, and only limits style in
   # the <style amp-custom> tag in the document head.
   # max_bytes: 20000
   # max_bytes_per_inline_style: 1000
-  max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec#css"
+  max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec/#css"
 
   allow_all_declaration_in_style_tag: true
   allow_important: false
@@ -436,10 +446,11 @@ css {
   declaration_list_svg: "SVG_BASIC_DECLARATIONS"
 }
 
-# DocCss rules for AMP4EMAIL
+# DocCss rules for AMP4EMAIL, not data-css-strict
 css {
   html_format: AMP4EMAIL
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  disabled_by: "data-css-strict"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 
   # Due to a bug, we allowed unlimited doc-level bytes for CSS in AMP4EMAIL
   # formats. To avoid breaking emails, this is temporarily set to a warning but
@@ -449,7 +460,7 @@ css {
   max_bytes_per_inline_style: 1000
 
   max_bytes_spec_url:
-  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
   url_bytes_included: true
 
   # This is a legacy requirement. Style tags support all declarations while
@@ -466,6 +477,31 @@ css {
   declaration_list_svg: "SVG_BASIC_DECLARATIONS"
 }
 
+# DocCss rules for AMP4EMAIL, data-css-strict
+css {
+  html_format: AMP4EMAIL
+  enabled_by: "data-css-strict"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
+
+  max_bytes_is_warning: false
+  max_bytes: 75000
+  max_bytes_per_inline_style: 1000
+
+  max_bytes_spec_url:
+  "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
+  url_bytes_included: true
+
+  allow_all_declaration_in_style_tag: false
+  allow_important: false
+  image_url_spec: {
+    protocol: "https"
+  }
+  expand_vendor_prefixes: false
+  declaration_list: "BASIC_DECLARATIONS"
+  declaration_list: "EMAIL_SPECIFIC_VENDOR_PREFIXES"
+  declaration_list_svg: "SVG_BASIC_DECLARATIONS"
+}
+
 # This variant of <style amp-custom> is designed to help developers see how
 # close they are to the byte limit, even if the page is passing. By changing
 # the attribute to <style amp-custom-length-check>, this tagspec will be used
@@ -480,6 +516,7 @@ tags: {  # <style amp-custom-length-check>, ALL FORMATS
   html_format: ACTIONS
   tag_name: "STYLE"
   spec_name: "style amp-custom-length-check"
+  descriptive_name: "style amp-custom-length-check"
   unique: true
   mandatory_parent: "HEAD"
   attrs: {
@@ -504,6 +541,7 @@ tags: {  # <style amp-custom>, [AMP, ACTIONS]
   html_format: ACTIONS
   tag_name: "STYLE"
   spec_name: "style amp-custom"
+  descriptive_name: "style amp-custom"
   named_id: STYLE_AMP_CUSTOM
   unique: true
   mandatory_parent: "HEAD"
@@ -526,7 +564,7 @@ tags: {  # <style amp-custom>, [AMP, ACTIONS]
     doc_css_bytes: true
     max_bytes: 75000
     max_bytes_spec_url:
-    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
 
     css_spec: {
       at_rule_spec: { name: 'font-face' }
@@ -546,13 +584,14 @@ tags: {  # <style amp-custom>, [AMP, ACTIONS]
       error_message: "CSS i-amphtml- name prefix"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 }
 
 tags: {  # <style amp-custom>, AMP4ADS
   html_format: AMP4ADS
   tag_name: "STYLE"
   spec_name: "style amp-custom (AMP4ADS)"
+  descriptive_name: "style amp-custom"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -574,7 +613,7 @@ tags: {  # <style amp-custom>, AMP4ADS
     doc_css_bytes: true
     max_bytes: 20000  # Smaller than AMP, which is 75,000.
     max_bytes_spec_url:
-    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
     css_spec: {
       at_rule_spec: { name: 'font-face' }
       at_rule_spec: { name: 'keyframes' }
@@ -607,7 +646,7 @@ tags: {  # <style amp-custom>, AMP4ADS
       error_message: "CSS i-amphtml- name prefix"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec#css"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec/#css"
 }
 
 tags: {  # <style amp-custom>, AMP4EMAIL, not data-css-strict
@@ -615,6 +654,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, not data-css-strict
   disabled_by: "data-css-strict"
   tag_name: "STYLE"
   spec_name: "style amp-custom (AMP4EMAIL)"
+  descriptive_name: "style amp-custom"
   unique: true
   mandatory_parent: "HEAD"
   attrs: {
@@ -636,7 +676,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, not data-css-strict
     doc_css_bytes: true
     max_bytes: 75000
     max_bytes_spec_url:
-    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
 
     css_spec: {
       at_rule_spec: {
@@ -665,7 +705,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, not data-css-strict
       error_message: "CSS i-amphtml- name prefix"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 }
 
 tags: {  # <style amp-custom>, AMP4EMAIL, data-css-strict
@@ -673,6 +713,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, data-css-strict
   enabled_by: "data-css-strict"
   tag_name: "STYLE"
   spec_name: "style amp-custom (css-strict)"
+  descriptive_name: "style amp-custom"
   unique: true
   mandatory_parent: "HEAD"
   attrs: {
@@ -694,7 +735,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, data-css-strict
     doc_css_bytes: true
     max_bytes: 75000
     max_bytes_spec_url:
-    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
+    "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size"
 
     css_spec: {
       at_rule_spec: {
@@ -764,7 +805,7 @@ tags: {  # <style amp-custom>, AMP4EMAIL, data-css-strict
       error_message: "CSS i-amphtml- name prefix"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 }
 
 tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
@@ -773,6 +814,7 @@ tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
   disabled_by: "transformed"
   tag_name: "STYLE"
   spec_name: "head > style[amp-boilerplate]"
+  descriptive_name: "head > style[amp-boilerplate]"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -789,7 +831,7 @@ tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;?\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 
 tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
@@ -798,6 +840,7 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
   enabled_by: "transformed"
   tag_name: "STYLE"
   spec_name: "head > style[amp-boilerplate] (transformed)"
+  descriptive_name: "head > style[amp-boilerplate]"
   unique: true
   mandatory_parent: "HEAD"
   attrs: {
@@ -812,13 +855,14 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;?\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 
 tags: {  # `<style amp4ads-boilerplate>`, AMP4ADS
   html_format: AMP4ADS
   tag_name: "STYLE"
   spec_name: "head > style[amp4ads-boilerplate]"
+  descriptive_name: "head > style[amp4ads-boilerplate]"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -836,13 +880,14 @@ tags: {  # `<style amp4ads-boilerplate>`, AMP4ADS
     # pretty printing tools some latitude.
     cdata_regex: "\\s*body\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec?format=ads#boilerplate"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec/?format=ads#boilerplate"
 }
 
 tags: {  # `<style amp4email-boilerplate>`, AMP4EMAIL
   html_format: AMP4EMAIL
   tag_name: "STYLE"
   spec_name: "head > style[amp4email-boilerplate]"
+  descriptive_name: "head > style[amp4email-boilerplate]"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -858,7 +903,7 @@ tags: {  # `<style amp4email-boilerplate>`, AMP4EMAIL
     # is required in the boilerplate. It was made by replacing ' ' with \\s+.
     cdata_regex: "\\s*body\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/amp-email-format?format=email#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-format/?format=email#required-markup"
 }
 
 tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
@@ -867,6 +912,7 @@ tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
   disabled_by: "transformed"
   tag_name: "STYLE"
   spec_name: "noscript > style[amp-boilerplate]"
+  descriptive_name: "noscript > style[amp-boilerplate]"
   mandatory: true
   unique: true
   mandatory_parent: "NOSCRIPT"
@@ -882,7 +928,7 @@ tags: {  # `<style amp-boilerplate>`, [AMP, ACTIONS]
     doc_css_bytes: false
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*none;\\s*-moz-animation:\\s*none;\\s*-ms-animation:\\s*none;\\s*animation:\\s*none;?\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 
 tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
@@ -891,6 +937,7 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
   enabled_by: "transformed"
   tag_name: "STYLE"
   spec_name: "noscript > style[amp-boilerplate] (transformed)"
+  descriptive_name: "noscript > style[amp-boilerplate]"
   unique: true
   mandatory_parent: "NOSCRIPT"
   mandatory_ancestor: "HEAD"
@@ -904,7 +951,7 @@ tags: {  # `<style amp-boilerplate>`, transformed [AMP, ACTIONS]
     doc_css_bytes: false
     cdata_regex: "\\s*body\\s*{\\s*-webkit-animation:\\s*none;\\s*-moz-animation:\\s*none;\\s*-ms-animation:\\s*none;\\s*animation:\\s*none;?\\s*}\\s*"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 
 tags: {  # `<style amp-keyframes>`, [AMP, AMP4ADS, ACTIONS]
@@ -913,6 +960,7 @@ tags: {  # `<style amp-keyframes>`, [AMP, AMP4ADS, ACTIONS]
   html_format: ACTIONS
   tag_name: "STYLE"
   spec_name: "style[amp-keyframes]"
+  descriptive_name: "style[amp-keyframes]"
   unique: true
   mandatory_parent: "BODY"
   mandatory_last_child: true
@@ -928,7 +976,7 @@ tags: {  # `<style amp-keyframes>`, [AMP, AMP4ADS, ACTIONS]
     # to animation keyframes rules.
     doc_css_bytes: false
     max_bytes: 500000
-    max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#keyframes-stylesheet"
+    max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#keyframes-stylesheet"
     css_spec: {
       at_rule_spec: { name: 'keyframes' }
       at_rule_spec: { name: 'media' }
@@ -948,6 +996,7 @@ tags: {  # '<style amp-runtime>`, transformed AMP
   enabled_by: "transformed"
   tag_name: "STYLE"
   spec_name: "style[amp-runtime] (transformed)"
+  descriptive_name: "style[amp-runtime]"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -962,5 +1011,5 @@ tags: {  # '<style amp-runtime>`, transformed AMP
     mandatory: true
     value_regex: "^\\d{15}|latest$"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#stylesheets"
 }
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index 10d0848aa..7efdb8ba0 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,9 +26,9 @@ min_validator_revision_required: 474
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1052
+spec_file_revision: 1060
 
-styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
+styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
 
 # Validator extensions.
@@ -47,6 +47,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "!DOCTYPE"
   spec_name: "html doctype"
+  descriptive_name: "html !doctype"
   mandatory_parent: "$ROOT"
   mandatory: true
   unique: true
@@ -61,7 +62,7 @@ tags: {
   attrs: {
     name: "lang"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # AMP4ADS may need time to transition <!doctype> to using explicit attrs only.
 # Tracking in b/123227526 to merge into tagspec with spec name "html doctype".
@@ -69,6 +70,7 @@ tags: {
   html_format: AMP4ADS
   tag_name: "!DOCTYPE"
   spec_name: "html doctype (AMP4ADS)"
+  descriptive_name: "html !doctype"
   mandatory_parent: "$ROOT"
   mandatory: true
   unique: true
@@ -77,7 +79,7 @@ tags: {
     mandatory: true
     value: ""
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 
 # Below, we list the allowed elements in the order in which they are appear
@@ -104,7 +106,7 @@ tags: {  # HTML tag for non-transformed AMP.
     disallowed_value_regex: "false"
   }
   unique: true
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 tags: {  # HTML tag for transformed AMP.
   html_format: AMP
@@ -123,7 +125,7 @@ tags: {  # HTML tag for transformed AMP.
     name: "i-amphtml-no-boilerplate"
     value: ""
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 
 # 4.2 Document metadata
@@ -137,7 +139,7 @@ tags: {
   mandatory: true
   mandatory_parent: "HTML"
   unique: true
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # 4.2.2 The title element
 tags: {
@@ -231,13 +233,14 @@ tags: {
     # origins, not on the AMP Cache.
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 tags: {
   html_format: AMP
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link rel=canonical"
+  descriptive_name: "link rel=canonical"
   mandatory_parent: "HEAD"
   mandatory: true
   unique: true
@@ -257,7 +260,7 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # Allow <link rel="manifest" ...> but not <link rel="manifest foo" ...>
 tags: {
@@ -265,6 +268,7 @@ tags: {
   html_format: AMP4ADS
   tag_name: "LINK"
   spec_name: "link rel=manifest"
+  descriptive_name: "link rel=manifest"
   mandatory_parent: "HEAD"
   satisfies: "amp-app-banner data source"
   attrs: {
@@ -282,7 +286,7 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 tags: {
   html_format: AMP
@@ -290,6 +294,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link rel=preload"
+  descriptive_name: "link rel=preload"
   disallowed_ancestor: "TEMPLATE"
   attrs: { name: "as" }
   attrs: { name: "href" }
@@ -300,7 +305,7 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # Allowlisted font providers
 tags: {
@@ -309,6 +314,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link rel=stylesheet for fonts"
+  descriptive_name: "link rel=stylesheet for fonts"
   named_id: LINK_FONT_STYLESHEET
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -344,7 +350,7 @@ tags: {
     name: "type"
     value_casei: "text/css"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#custom-fonts"
 }
 # itemprop=sameAs is allowed per schema.org, needs not be in head
 tags: {
@@ -353,6 +359,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link itemprop=sameAs"
+  descriptive_name: "link itemprop=sameAs"
   attrs: {
     name: "href"
     mandatory: true
@@ -364,7 +371,7 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # rel= isn't mandatory when itemprop= is present.
 tags: {
@@ -373,6 +380,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link itemprop="
+  descriptive_name: "link itemprop="
   attrs: {
     name: "href"
     mandatory: true
@@ -382,7 +390,7 @@ tags: {
     mandatory: true
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # rel= isn't mandatory when property= is present.
 tags: {
@@ -391,6 +399,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LINK"
   spec_name: "link property="
+  descriptive_name: "link property="
   attrs: {
     name: "href"
     mandatory: true
@@ -400,7 +409,7 @@ tags: {
     mandatory: true
   }
   attr_lists: "common-link-attrs"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # 4.2.5 the meta element
 # Charset must be utf8, and a specific viewport is required.
@@ -411,6 +420,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "META"
   spec_name: "meta charset=utf-8"
+  descriptive_name: "meta charset=utf-8"
   mandatory: true
   mandatory_parent: "HEAD"
   unique: true
@@ -420,7 +430,7 @@ tags: {
     mandatory: true
     value_casei: "utf-8"
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 tags: {
   html_format: AMP
@@ -428,6 +438,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "META"
   spec_name: "meta name=viewport"
+  descriptive_name: "meta name=viewport"
   mandatory: true
   mandatory_parent: "HEAD"
   unique: true
@@ -451,7 +462,7 @@ tags: {
     value: "viewport"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # This tag is a hack to tell IE 10 to use its modern rendering engine as opposed
 # to the IE8 engine. So it's explicitly allowed.
@@ -461,6 +472,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "META"
   spec_name: "meta http-equiv=X-UA-Compatible"
+  descriptive_name: "meta http-equiv=X-UA-Compatible"
   mandatory_ancestor: "HEAD"
   attrs: {
     name: "content"
@@ -476,7 +488,7 @@ tags: {
     value_casei: "x-ua-compatible"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # Tag specific to apple-itunes-app installs, see also <amp-app-banner>.
 tags: {
@@ -498,7 +510,7 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # AMP & AMP4ADS metadata, name=amp-experiments-opt-in
 # https://github.com/lannka/amphtml/blob/master/tools/experiments/README.md
@@ -538,7 +550,7 @@ tags: {
     value_casei: "amp-3p-iframe-src"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/components/amp-ad"
+  spec_url: "https://amp.dev/documentation/components/amp-ad/"
 }
 # AMP metadata, name=amp-consent-blocking
 tags: {
@@ -745,7 +757,7 @@ tags: {
     value_casei: "content-type"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv content-language tag
 tags: {
@@ -765,7 +777,7 @@ tags: {
     value_casei: "content-language"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv pics-label tag
 # https://www.w3.org/PICS/
@@ -786,7 +798,7 @@ tags: {
     value_casei: "pics-label"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv imagetoolbar tag
 # https://msdn.microsoft.com/en-us/library/ms532986(v=vs.85).aspx
@@ -807,7 +819,7 @@ tags: {
     value_casei: "imagetoolbar"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv content-style-type
 # https://www.w3.org/TR/REC-html40/present/styles#h-14.2.1
@@ -829,7 +841,7 @@ tags: {
     value_casei: "content-style-type"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv content-script-type
 # https://www.w3.org/TR/html4/interact/scripts#h-18.2.2.1
@@ -851,7 +863,7 @@ tags: {
     value_casei: "content-script-type"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv origin-trial tag
 tags: {
@@ -871,7 +883,7 @@ tags: {
     value_casei: "origin-trial"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv resource-type
 # http://www.metatags.info/meta_http_equiv_resource_type
@@ -892,7 +904,7 @@ tags: {
     value_casei: "resource-type"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # http-equiv x-dns-prefetch-control
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
@@ -913,7 +925,7 @@ tags: {
     value_casei: "x-dns-prefetch-control"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
 # AMP metadata, name=amp-ad-enable-refresh
 # Enables Refresh for amp-ad doubleclick Fast Fetch
@@ -1046,7 +1058,7 @@ tags: {
   mandatory: true
   unique: true
   mandatory_parent: "HTML"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # 4.3.2 The article element
 tags: {
@@ -1429,7 +1441,7 @@ tags: {
   attr_lists: "name-attr"
   # <amp-bind>
   attrs: { name: "[href]" }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#links"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#links"
 }
 # AMP4EMAIL restricts the use of mustache delimiters in href. The only allowed
 # protocols for href are http, https and mailto. Relative urls are disallowed.
@@ -1771,7 +1783,7 @@ tags: {
   tag_name: "IMG"
   mandatory_ancestor: "NOSCRIPT"
   mandatory_ancestor_suggested_alternative: "AMP-IMG"
-  spec_url: "https://amp.dev/documentation/components/amp-img"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
   attrs: { name: "border" }  # Not valid html5 but commonly used and supported.
@@ -1815,7 +1827,7 @@ tags: {
   tag_name: "IFRAME"
   mandatory_ancestor: "NOSCRIPT"
   mandatory_ancestor_suggested_alternative: "AMP-IFRAME"
-  spec_url: "https://amp.dev/documentation/components/amp-iframe"
+  spec_url: "https://amp.dev/documentation/components/amp-iframe/"
   attrs: {
     name: "frameborder"
     value: "0"
@@ -1869,7 +1881,7 @@ tags: {
   attrs: {
     name: "muted"
     deprecation: "autoplay"
-    deprecation_url: "https://amp.dev/documentation/components/amp-video"
+    deprecation_url: "https://amp.dev/documentation/components/amp-video/"
   }
   attrs: { name: "playsinline" }
   attrs: { name: "poster" }
@@ -1884,7 +1896,7 @@ tags: {
     disallowed_value_regex: "__amp_source_origin"
   }
   attrs: { name: "width" }
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
 }
 # 4.7.7 The audio element
 # Only allowed in noscript tags. Otherwise use amp-audio.
@@ -1907,7 +1919,7 @@ tags: {
     }
     disallowed_value_regex: "__amp_source_origin"
   }
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
 }
 # 4.7.7 The picture element
 # Only allowed in noscript tags which support img tags.
@@ -1915,7 +1927,7 @@ tags: {
   html_format: AMP
   tag_name: "PICTURE"
   mandatory_parent: "NOSCRIPT"
-  spec_url: "https://amp.dev/documentation/components/amp-img"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
 }
 # 4.7.8 The source element
 tags: {
@@ -1936,7 +1948,7 @@ tags: {
     disallowed_value_regex: "__amp_source_origin"
   }
   attrs: { name: "type" }
-  spec_url: "https://amp.dev/documentation/components/amp-img"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
 }
 tags: {
   html_format: AMP
@@ -1958,7 +1970,7 @@ tags: {
   # <amp-bind>
   attrs: { name: "[src]" }
   attrs: { name: "[type]" }
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
 }
 tags: {
   html_format: AMP
@@ -1980,7 +1992,7 @@ tags: {
   # <amp-bind>
   attrs: { name: "[src]" }
   attrs: { name: "[type]" }
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
 }
 tags: {
   html_format: AMP
@@ -2003,7 +2015,7 @@ tags: {
     name: "type"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-audio"
+  spec_url: "https://amp.dev/documentation/components/amp-audio/"
 }
 tags: {
   html_format: AMP
@@ -2026,7 +2038,7 @@ tags: {
     name: "type"
     mandatory: true
   }
-  spec_url: "https://amp.dev/documentation/components/amp-video"
+  spec_url: "https://amp.dev/documentation/components/amp-video/"
 }
 tags: {
   html_format: AMP
@@ -2216,7 +2228,7 @@ tags: {
   attrs: { name: "[src]" }
   attrs: { name: "[srclang]" }
   attr_lists: "track-attrs-subtitles"
-  spec_url: "https://amp.dev/documentation/components/amp-ima-video"
+  spec_url: "https://amp.dev/documentation/components/amp-ima-video/"
 }
 
 
@@ -2363,7 +2375,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2383,7 +2395,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2401,7 +2413,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2439,7 +2451,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2460,7 +2472,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2470,7 +2482,7 @@ tags: {
   mandatory_ancestor: "SVG"
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2487,7 +2499,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2500,7 +2512,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2526,7 +2538,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2538,7 +2550,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2553,7 +2565,7 @@ tags: {
   attrs: { name: "zoomandpan" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # Shapes
 tags: {
@@ -2572,7 +2584,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2591,7 +2603,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2610,7 +2622,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2626,7 +2638,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2642,7 +2654,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2663,7 +2675,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # Text
 tags: {
@@ -2686,7 +2698,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2703,7 +2715,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2717,7 +2729,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2737,7 +2749,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # Rendering
 tags: {
@@ -2753,7 +2765,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2773,7 +2785,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2788,7 +2800,7 @@ tags: {
   attrs: { name: "u2" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2808,7 +2820,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2827,7 +2839,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2850,7 +2862,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2872,7 +2884,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2885,7 +2897,7 @@ tags: {
   attrs: { name: "stop-color" }
   attrs: { name: "stop-opacity" }
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2898,7 +2910,7 @@ tags: {
   attrs: { name: "stop-color" }
   attrs: { name: "stop-opacity" }
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2913,7 +2925,7 @@ tags: {
   attrs: { name: "u2" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # Special
 tags: {
@@ -2928,7 +2940,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2944,7 +2956,7 @@ tags: {
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2963,7 +2975,7 @@ tags: {
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
   attr_lists: "svg-xlink-attributes"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # Filters
 tags: {
@@ -2979,7 +2991,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -2998,7 +3010,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3010,7 +3022,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3025,7 +3037,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3037,7 +3049,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3048,7 +3060,7 @@ tags: {
   attrs: { name: "in" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3063,7 +3075,7 @@ tags: {
   attr_lists: "svg-filter-primitive-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 # ARIA
 tags: {
@@ -3074,7 +3086,7 @@ tags: {
   mandatory_ancestor: "SVG"
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 tags: {
   html_format: AMP
@@ -3085,7 +3097,7 @@ tags: {
   mandatory_ancestor: "SVG"
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-style-attr"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#svg"
 }
 
 # 4.8 Links
@@ -3685,7 +3697,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "LABEL"
   attrs: { name: "for" }
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.5 The input element.
 # The input tag is also defined by extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -3714,7 +3726,7 @@ tags: {
   }
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 tags: {
   html_format: AMP
@@ -3738,7 +3750,7 @@ tags: {
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
   mandatory_ancestor: "FORM [method=POST]"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 tags: {
   html_format: AMP
@@ -3757,7 +3769,7 @@ tags: {
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
   mandatory_ancestor: "FORM [method=POST]"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.6 The button element
 tags: {
@@ -3844,7 +3856,7 @@ tags: {
   attrs: { name: "[required]" }
   attrs: { name: "[size]" }
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.8 The datalist element
 tags: {
@@ -3853,7 +3865,7 @@ tags: {
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "DATALIST"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.9 The optgroup element
 tags: {
@@ -3868,7 +3880,7 @@ tags: {
   # <amp-bind>
   attrs: { name: "[disabled]" }
   attrs: { name: "[label]" }
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.10 The option element
 tags: {
@@ -3886,7 +3898,7 @@ tags: {
   attrs: { name: "[label]" }
   attrs: { name: "[selected]" }
   attrs: { name: "[value]" }
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.11 The textarea element
 tags: {
@@ -3963,7 +3975,7 @@ tags: {
   attrs: { name: "[spellcheck]" }
   attrs: { name: "[wrap]" }
   attr_lists: "name-attr"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
+  spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.13 The output element
 tags: {
@@ -4077,6 +4089,7 @@ tags: {
   html_format: AMP
   tag_name: "SCRIPT"
   spec_name: "amphtml engine v0.js script"
+  descriptive_name: "amphtml engine v0.js script"
   mandatory_alternatives: "amphtml engine v0.js script"
   unique: true
   mandatory_parent: "HEAD"
@@ -4094,12 +4107,13 @@ tags: {
       error_message: "contents"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 tags: {
   html_format: AMP
   tag_name: "SCRIPT"
   spec_name: "amphtml engine v0.js lts script"
+  descriptive_name: "amphtml engine v0.js script"
   mandatory_alternatives: "amphtml engine v0.js script"
   unique: true
   mandatory_parent: "HEAD"
@@ -4117,13 +4131,14 @@ tags: {
       error_message: "contents"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 tags: {
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "amphtml engine v0.js script [AMP4EMAIL,ACTIONS]"
+  descriptive_name: "amphtml engine v0.js script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -4141,12 +4156,13 @@ tags: {
       error_message: "contents"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 tags: {
   html_format: AMP4ADS
   tag_name: "SCRIPT"
   spec_name: "amp4ads engine amp4ads-v0.js script"
+  descriptive_name: "amphtml engine amp4ads-v0.js script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -4164,7 +4180,7 @@ tags: {
       error_message: "contents"
     }
   }
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
 # JSON Linked Data
 tags: {
@@ -4174,6 +4190,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "script type=application/ld+json"
+  descriptive_name: "script type=application/ld+json"
   attr_lists: "nonce-attr"
   attrs: {
     name: "type"
@@ -4221,6 +4238,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "amp-ima-video > script[type=application/json]"
+  descriptive_name: "script type=application/ld+json"
   mandatory_parent: "AMP-IMA-VIDEO"
   attrs: {
     name: "type"
@@ -4243,10 +4261,11 @@ tags: {
   disabled_by: "transformed"
   tag_name: "NOSCRIPT"
   spec_name: "noscript enclosure for boilerplate"
+  descriptive_name: "noscript enclosure for boilerplate"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 tags: {
   html_format: AMP
@@ -4254,9 +4273,10 @@ tags: {
   enabled_by: "transformed"
   tag_name: "NOSCRIPT"
   spec_name: "noscript enclosure for boilerplate (transformed)"
+  descriptive_name: "noscript enclosure for boilerplate"
   unique: true
   mandatory_parent: "HEAD"
-  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites"
 }
 # We allow noscript in the body to contain tags otherwise disallowed by AMP.
 tags: {
@@ -4456,9 +4476,11 @@ tags: {  # <amp-img>
   tag_name: "AMP-IMG"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "crossorigin" }
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: { name: "placeholder" }
+  attrs: { name: "referrerpolicy" }
   # <amp-bind>
   attrs: { name: "[alt]" }
   attrs: { name: "[attribution]" }
@@ -4467,7 +4489,7 @@ tags: {  # <amp-img>
   attr_lists: "extended-amp-global"
   attr_lists: "lightboxable-elements"
   attr_lists: "mandatory-src-or-srcset"
-  spec_url: "https://amp.dev/documentation/components/amp-img"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -4487,12 +4509,13 @@ tags: {  # <amp-img>
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
   attrs: { name: "placeholder" }
+  attrs: { name: "referrerpolicy" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-amp4email"
   # <amp-bind>
   attrs: { name: "[alt]" }
   attrs: { name: "[attribution]" }
-  spec_url: "https://amp.dev/documentation/components/amp-img"
+  spec_url: "https://amp.dev/documentation/components/amp-img/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -4509,7 +4532,7 @@ tags: {  # <amp-layout>
   html_format: ACTIONS
   tag_name: "AMP-LAYOUT"
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-layout"
+  spec_url: "https://amp.dev/documentation/components/amp-layout/"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -4542,7 +4565,7 @@ tags: {  # <amp-pixel>
     disallowed_value_regex: "__amp_source_origin"
   }
   attr_lists: "extended-amp-global"
-  spec_url: "https://amp.dev/documentation/components/amp-pixel"
+  spec_url: "https://amp.dev/documentation/components/amp-pixel/"
   amp_layout {
     defines_default_height: true
     defines_default_width: true
@@ -5755,6 +5778,12 @@ attr_lists: {
     name: "subscriptions-service"
     requires_extension: "amp-subscriptions"
   }
+  # amp-subscriptions-google specific attributes, see
+  # https://amp.dev/documentation/components/amp-subscriptions-google
+  attrs: {
+    name: "subscriptions-google-rtc"
+    requires_extension: "amp-subscriptions-google"
+  }
   # amp-next-page specific attributes, see
   # https://amp.dev/documentation/components/amp-next-page
   attrs: {
```

</details>