### PR TITLE
Improve presentation of selected AMP Reader theme in themes list

### DIFF
--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -136,6 +136,12 @@ final class ReaderThemeLoader implements Service, Registerable {
 			// Prevent Reader theme from being deleted.
 			unset( $prepared_themes[ $reader_theme ]['actions']['delete'] );
 
+			// Make sure the Customize link goes to AMP.
+			$prepared_themes[ $reader_theme ]['actions']['customize'] = amp_get_customizer_url();
+
+			// Force the theme to be styled as Active.
+			$prepared_themes[ $reader_theme ]['active'] = true;
+
 			// Add AMP Reader theme notice.
 			$notice = sprintf(
 				'<span class="reader-theme-notice notice notice-info notice-alt inline" style="display:block; margin-bottom: 1em;"><span style="display: block; margin: 0.5em 0; padding:2px;">%s</span></span>',


### PR DESCRIPTION
## Summary

This is somewhat experimental/hacky but I think it is an overall good improvement to ensuring the theme selected as the Reader theme is marked as such in the Themes list.

* Make selected Reader theme the second in the list after the active theme.
* Mark the Reader theme as _also_ being an active theme (a “current” theme).
* Show notice in theme lightbox for the Reader theme that it has been selected as the Reader theme. (Note: The way I've done this is _hacky_ but I don't see a cleaner way to do it.)
* Make sure the theme action button for the Reader theme will link to the AMP Customizer.
* Prevent accidental deletion of Reader theme by removing the Delete action in the same way as core removes the Delete action for parent themes of an active child theme.

See screenshots where Twenty Twenty is the selected Reader theme:

Screen | Before | After
--------|--------|-----
Themes List | ![image](https://user-images.githubusercontent.com/134745/88014404-b2821080-cad3-11ea-9eee-b032bd44349c.png) | ![image](https://user-images.githubusercontent.com/134745/88099988-d172b800-cb50-11ea-9ecb-56d2ae94ed53.png)
Theme Lightbox | ![image](https://user-images.githubusercontent.com/134745/88016625-a187ce00-cad8-11ea-80c0-9137287bd1b0.png) | ![image](https://user-images.githubusercontent.com/134745/88019868-84a2c900-cadf-11ea-8fef-635b9274de47.png)

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
