### PR TITLE
Restore noscript head elements immediately after parsing rather than at serialization

### DIFF
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -560,7 +560,7 @@ final class Document extends DOMDocument
      */
     private function extractNodeViaFragmentBoundaries(DOMNode $node)
     {
-        $boundary      = 'fragment_boundary:' . $this->rand();
+        $boundary      = $this->getUniqueId('fragment_boundary');
         $startBoundary = $boundary . ':start';
         $endBoundary   = $boundary . ':end';
         $commentStart  = $this->createComment($startBoundary);
@@ -881,7 +881,7 @@ final class Document extends DOMDocument
                     return preg_replace_callback(
                         '#<noscript[^>]*>.*?</noscript>#si',
                         function ($noscriptMatches) {
-                            $id = 'noscript-' . (string)$this->rand();
+                            $id = $this->getUniqueId('noscript');
                             $this->noscriptPlaceholderComments[$id] = $noscriptMatches[0];
                             return sprintf('<meta class="noscript-placeholder" id="%s">', $id);
                         },
@@ -1535,6 +1535,25 @@ final class Document extends DOMDocument
     }
 
     /**
+     * Get auto-incremented ID unique to this class's instantiation.
+     *
+     * @param string $prefix Prefix.
+     * @return string ID.
+     */
+    private function getUniqueId( $prefix = '' ) {
+        if (array_key_exists($prefix, $this->indexCounter)) {
+            ++$this->indexCounter[$prefix];
+        } else {
+            $this->indexCounter[$prefix] = 0;
+        }
+        $uniqueId = (string)$this->indexCounter[$prefix];
+        if ( $prefix ) {
+            $uniqueId = "{$prefix}-{$uniqueId}";
+        }
+        return $uniqueId;
+    }
+
+    /**
      * Get the ID for an element.
      *
      * If the element does not have an ID, create one first.
@@ -1549,17 +1568,9 @@ final class Document extends DOMDocument
             return $element->getAttribute('id');
         }
 
-        if (array_key_exists($prefix, $this->indexCounter)) {
-            ++$this->indexCounter[$prefix];
-        } else {
-            $this->indexCounter[$prefix] = 0;
-        }
-
-        $id = "{$prefix}-{$this->indexCounter[ $prefix ]}";
-
+        $id = $this->getUniqueId($prefix);
         while ($this->getElementById($id) instanceof DOMElement) {
-            ++$this->indexCounter[$prefix];
-            $id = "{$prefix}-{$this->indexCounter[ $prefix ]}";
+            $id = $this->getUniqueId($prefix);
         }
 
         $element->setAttribute('id', $id);

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1524,14 +1524,15 @@ final class Document extends DOMDocument
      * @param string $prefix Prefix.
      * @return string ID.
      */
-    private function getUniqueId( $prefix = '' ) {
+    private function getUniqueId($prefix = '')
+    {
         if (array_key_exists($prefix, $this->indexCounter)) {
             ++$this->indexCounter[$prefix];
         } else {
             $this->indexCounter[$prefix] = 0;
         }
         $uniqueId = (string)$this->indexCounter[$prefix];
-        if ( $prefix ) {
+        if ($prefix) {
             $uniqueId = "{$prefix}-{$uniqueId}";
         }
         return $uniqueId;

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1297,7 +1297,6 @@ final class Document extends DOMDocument
 
         if (null === $placeholders) {
             $placeholders = [];
-            $salt         = $this->rand();
 
             // Note: The order of these tokens is important, as it determines the order of the replacements.
             $tokens = [
@@ -1311,7 +1310,7 @@ final class Document extends DOMDocument
             ];
 
             foreach ($tokens as $token) {
-                $placeholders[$token] = '_amp_mustache_' . md5($salt . $token);
+                $placeholders[$token] = '_amp_mustache_' . md5(uniqid($token));
             }
         }
 

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1365,21 +1365,6 @@ final class Document extends DOMDocument
     }
 
     /**
-     * Produce a random number to use in hashes.
-     *
-     * ⚠️ This is not cryptographically secure!
-     *
-     * @return int A random number.
-     */
-    private function rand()
-    {
-        if (function_exists('mt_rand')) {
-            return mt_rand();
-        }
-        return rand();
-    }
-
-    /**
      * Secure the original doctype node.
      *
      * We need to keep elements around that were prepended to the doctype, like comment node used for source-tracking.

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1370,23 +1370,14 @@ final class Document extends DOMDocument
      *
      * ⚠️ This is not cryptographically secure!
      *
-     * @param int $min Lower limit for the generated number. Defaults to 0.
-     * @param int $max Upper limit for the generated number. Defaults to max random number.
-     * @return int A random number between min and max
+     * @return int A random number.
      */
-    private function rand($min = 0, $max = null)
+    private function rand()
     {
         if (function_exists('mt_rand')) {
-            if ($max === null) {
-                $max = mt_getrandmax();
-            }
-            return mt_rand($min, $max);
+            return mt_rand();
         }
-
-        if ($max === null) {
-            $max = getrandmax();
-        }
-        return rand($min, $max);
+        return rand();
     }
 
     /**

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1375,7 +1375,7 @@ final class Document extends DOMDocument
      * @param int $max Upper limit for the generated number
      * @return int A random number between min and max
      */
-    private function rand($min = 0, $max = 0)
+    private function rand($min = 0, $max = PHP_INT_MAX)
     {
         if (function_exists('mt_rand')) {
             return mt_rand($min, $max);

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -1370,16 +1370,22 @@ final class Document extends DOMDocument
      *
      * ⚠️ This is not cryptographically secure!
      *
-     * @param int $min Lower limit for the generated number
-     * @param int $max Upper limit for the generated number
+     * @param int $min Lower limit for the generated number. Defaults to 0.
+     * @param int $max Upper limit for the generated number. Defaults to max random number.
      * @return int A random number between min and max
      */
-    private function rand($min = 0, $max = PHP_INT_MAX)
+    private function rand($min = 0, $max = null)
     {
         if (function_exists('mt_rand')) {
+            if ($max === null) {
+                $max = mt_getrandmax();
+            }
             return mt_rand($min, $max);
         }
 
+        if ($max === null) {
+            $max = getrandmax();
+        }
         return rand($min, $max);
     }
 

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -208,9 +208,12 @@ final class Document extends DOMDocument
     private $originalEncoding;
 
     /**
-     * Store the placeholder comments that were generated to replace <noscript> elements.
+     * Store the <noscript> markup that was extracted to preserve it during parsing.
+     *
+     * The array keys are the element IDs for placeholder <meta> tags.
      *
      * @see maybeReplaceNoscriptElements()
+     * @see maybeRestoreNoscriptElements()
      *
      * @var string[]
      */
@@ -868,7 +871,6 @@ final class Document extends DOMDocument
      * @param string $html HTML string to adapt.
      * @return string Adapted HTML string.
      * @see maybeRestoreNoscriptElements() Reciprocal function.
-     *
      */
     private function maybeReplaceNoscriptElements($html)
     {
@@ -879,11 +881,9 @@ final class Document extends DOMDocument
                     return preg_replace_callback(
                         '#<noscript[^>]*>.*?</noscript>#si',
                         function ($noscriptMatches) {
-                            $id   = 'noscript-' . (string)$this->rand();
-                            $meta = sprintf('<meta id="%s">', $id);
-
+                            $id = 'noscript-' . (string)$this->rand();
                             $this->noscriptPlaceholderComments[$id] = $noscriptMatches[0];
-                            return $meta;
+                            return sprintf('<meta class="noscript-placeholder" id="%s">', $id);
                         },
                         $headMatches[0]
                     );
@@ -907,7 +907,6 @@ final class Document extends DOMDocument
      * in the body otherwise.
      *
      * @see maybeReplaceNoscriptElements() Reciprocal function.
-     *
      */
     private function maybeRestoreNoscriptElements()
     {

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -470,13 +470,15 @@ class DocumentTest extends TestCase
      */
     public function testRand()
     {
-        $doc   = new Document();
-        $rands = [];
-        $n     = 100;
+        $doc    = new Document();
+        $method = (new ReflectionClass($doc))->getMethod('rand');
+        $method->setAccessible(true);
+        $rands  = [];
+        $n      = 100;
         for ($i = 0; $i < $n; $i++) {
-            $rands[] = $this->callPrivateMethod($doc, 'rand');
+            $rands[] = $method->invokeArgs($doc, []);
         }
-        $this->assertCount($n, array_unique($rands), 'Expected no duplicate random numbers.');
+        $this->assertGreaterThan(1, count(array_unique($rands)), "Expected rand() to return at least more than 1 random number after $n invocations.");
     }
 
     /**
@@ -859,22 +861,5 @@ class DocumentTest extends TestCase
         $dom->body->appendChild($element);
 
         $this->assertEquals('some-prefix-3', $dom->getElementId($element, 'some-prefix'));
-    }
-
-    /**
-     * Call a private method as if it was public.
-     *
-     * @param object|string $object     Object instance or class string to call the method of.
-     * @param string        $methodName Name of the method to call.
-     * @param array         $args       Optional. Array of arguments to pass to the method.
-     * @return mixed Return value of the method call.
-     * @throws ReflectionException If the object could not be reflected upon.
-     */
-    private function callPrivateMethod($object, $methodName, $args = [])
-    {
-        $method = (new ReflectionClass($object))->getMethod($methodName);
-        $method->setAccessible(true);
-
-        return $method->invokeArgs($object, $args);
     }
 }

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -428,6 +428,42 @@ class DocumentTest extends TestCase
     }
 
     /**
+     * Test handling noscript elements in the head.
+     *
+     * @covers Document::maybeReplaceNoscriptElements()
+     * @covers Document::maybeRestoreNoscriptElements()
+     */
+    public function testHeadNoscriptElementHandling()
+    {
+        $original = '
+            <html>
+                <head>
+                    <noscript>
+                        <style>/*1*/</style>
+                    </noscript>
+                    <title>Hello</title>
+                    <noscript>
+                        <style>/*2*/</style>
+                    </noscript>
+                </head>
+                <body>
+                    <noscript>
+                        <style>/*3*/</style>
+                    </noscript>
+                </body>
+            </html>
+        ';
+
+        $dom = Document::fromHtml($original);
+        $noscripts = $dom->getElementsByTagName('noscript');
+
+        $this->assertEquals(3, $noscripts->length);
+        $this->assertEquals('head', $noscripts->item(0)->parentNode->nodeName);
+        $this->assertEquals('head', $noscripts->item(1)->parentNode->nodeName);
+        $this->assertEquals('body', $noscripts->item(2)->parentNode->nodeName);
+    }
+
+    /**
      * Test getting random number.
      *
      * @covers Document::rand()

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -7,6 +7,8 @@ use AmpProject\Dom\Document;
 use AmpProject\Tests\AssertContainsCompatibility;
 use DOMNode;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
 
 /**
  * Tests for AmpProject\Dom\Document.
@@ -426,6 +428,22 @@ class DocumentTest extends TestCase
     }
 
     /**
+     * Test getting random number.
+     *
+     * @covers Document::rand()
+     */
+    public function testRand()
+    {
+        $doc   = new Document();
+        $rands = [];
+        $n     = 100;
+        for ($i = 0; $i < $n; $i++) {
+            $rands[] = $this->callPrivateMethod($doc, 'rand');
+        }
+        $this->assertCount($n, array_unique($rands), 'Expected no duplicate random numbers.');
+    }
+
+    /**
      * Get Table Row Iterations.
      *
      * @return array An array of arrays holding an integer representation of iterations.
@@ -805,5 +823,22 @@ class DocumentTest extends TestCase
         $dom->body->appendChild($element);
 
         $this->assertEquals('some-prefix-3', $dom->getElementId($element, 'some-prefix'));
+    }
+
+    /**
+     * Call a private method as if it was public.
+     *
+     * @param object|string $object     Object instance or class string to call the method of.
+     * @param string        $methodName Name of the method to call.
+     * @param array         $args       Optional. Array of arguments to pass to the method.
+     * @return mixed Return value of the method call.
+     * @throws ReflectionException If the object could not be reflected upon.
+     */
+    private function callPrivateMethod($object, $methodName, $args = [])
+    {
+        $method = (new ReflectionClass($object))->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
     }
 }

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -464,24 +464,6 @@ class DocumentTest extends TestCase
     }
 
     /**
-     * Test getting random number.
-     *
-     * @covers Document::rand()
-     */
-    public function testRand()
-    {
-        $doc    = new Document();
-        $method = (new ReflectionClass($doc))->getMethod('rand');
-        $method->setAccessible(true);
-        $rands  = [];
-        $n      = 100;
-        for ($i = 0; $i < $n; $i++) {
-            $rands[] = $method->invokeArgs($doc, []);
-        }
-        $this->assertGreaterThan(1, count(array_unique($rands)), "Expected rand() to return at least more than 1 random number after $n invocations.");
-    }
-
-    /**
      * Get Table Row Iterations.
      *
      * @return array An array of arrays holding an integer representation of iterations.

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -444,7 +444,7 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 							'private' => false,
 						],
 						'amp_libxml_version'      => [
-							'label'   => 'LIBXML Version',
+							'label'   => 'libxml Version',
 							'value'   => LIBXML_DOTTED_VERSION,
 							'private' => false,
 						],

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -443,6 +443,11 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 							'value'   => $this->css_transient_caching->get_time_series(),
 							'private' => false,
 						],
+						'amp_libxml_version'      => [
+							'label'   => 'LIBXML Version',
+							'value'   => LIBXML_DOTTED_VERSION,
+							'private' => false,
+						],
 					],
 				],
 			]

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -687,10 +687,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'
 				<html>
 					<head>
+						<noscript>
+							<style>h2.one { color: green }</style>
+						</noscript>
 					</head>
 					<body>
 						<style>
-							h2.one { color: green }
 							h2.two { color: red }
 						</style>
 						<template type="amp-mustache">
@@ -703,7 +705,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				</html>
 				',
 				[
-					'h2.one{color:green}h2.two{color:red}',
+					'h2.one{color:green}',
+					'h2.two{color:red}',
 				],
 				[],
 			],


### PR DESCRIPTION
## Summary

This fixes an issue where a site has a `noscript` element in the `head` that contains markup which needs to be sanitized, for example a `style` element, a validation error would ensue for sites that have a libxml version older than 2.8.

This issue has been raised a couple times in the support forums:

* https://wordpress.org/support/topic/amp-paired-two-errors/
* https://wordpress.org/support/topic/error-in-theme-8

Specifically, it has been raised in the context of WooCommerce via this [PHP code](https://github.com/woocommerce/woocommerce/blob/aafb06929ac62765a75a2329a2c68b552f62df51/includes/wc-template-functions.php#L117-L127):

```php
function wc_gallery_noscript() {
	?>
	<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
	<?php
}
add_action( 'wp_head', 'wc_gallery_noscript' );
```

Prior to the changes in this PR, the `noscript` element here would get removed from the HTML prior to parsing and then restored at _serialization_. The result is that none of the sanitizers would see any validation errors inside of `noscript` tags, when a site has an old version of libxml.

This PR also fixes a big related bug with `\AmpProject\Dom\Document::rand()` where it would return `0` every time when no arguments were passed. This is likely the source of various bugs related to `noscript` elements, Mustache placeholders, and even serializing HTML documents in PHP<7.3

Lastly, this PR includes the `LIBXML_DOTTED_VERSION` constant among the Site Health info. If this had been available then the Site Health info from support topics would have identified the low version as being in common.

In order to test this the original issue, include the above WooCommerce code on a site, and force the `maybeReplaceNoscriptElements` logic to run even when you have a current version of libxml, by patching your `Document.php` like so:

```diff
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -874,7 +874,7 @@ final class Document extends DOMDocument
      */
     private function maybeReplaceNoscriptElements($html)
     {
-        if (version_compare(LIBXML_DOTTED_VERSION, '2.8', '<')) {
+        if (true) {
             $html = preg_replace_callback(
                 '#^.+?(?=<body)#is',
                 function ($headMatches) {
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
