### PR TITLE
Ensure emoji AMP attribute can be restored if non-space whitespace used between attributes

### DIFF
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -163,7 +163,7 @@ final class Document extends DOMDocument
      *
      * @var string
      */
-    const AMP_EMOJI_ATTRIBUTE_PATTERN = '/(<html [^>]*?)('
+    const AMP_EMOJI_ATTRIBUTE_PATTERN = '/(<html\s[^>]*?)('
                                         . Attribute::AMP_EMOJI_ALT
                                         . '|'
                                         . Attribute::AMP_EMOJI
@@ -1346,7 +1346,7 @@ final class Document extends DOMDocument
         }
 
         return preg_replace(
-            '/(<html [^>]*?)' . preg_quote(self::EMOJI_AMP_ATTRIBUTE_PLACEHOLDER, '/') . '="([^"]*)"/i',
+            '/(<html\s[^>]*?)' . preg_quote(self::EMOJI_AMP_ATTRIBUTE_PLACEHOLDER, '/') . '="([^"]*)"/i',
             '\1' . $this->usedAmpEmoji . '\2',
             $html,
             1

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -40,7 +40,7 @@ class DocumentTest extends TestCase
             ],
             'emoji_amp_attribute'                      => [
                 'utf-8',
-                '<!DOCTYPE html><html ' . Attribute::AMP_EMOJI . '>' . $head . '<body></body></html>',
+                '<!DOCTYPE html><html' . PHP_EOL . Attribute::AMP_EMOJI . '>' . $head . '<body></body></html>',
                 '<!DOCTYPE html><html ' . Attribute::AMP_EMOJI . '>' . $head . '<body></body></html>',
             ],
             // The next one is different, see https://github.com/ampproject/amphtml/issues/25990.


### PR DESCRIPTION
## Summary

I noticed that the AMP emoji replacement would fail in documents like:

```html
<html
    ⚡️
    lang="en"
>
```

Notice the newline after `<html` as opposed to a ` ` space. Same issue would have also occurred if a tab were used.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
