### PR TITLE
Keep non-AMP Customizer link referencing the currently-previewed URL

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -115,6 +115,14 @@
         "navigator": false,
         "sessionStorage": false
       }
+    },
+    {
+      "files": [
+        "assets/src/customizer/amp-customize-controls.js"
+      ],
+      "globals": {
+        "HTMLAnchorElement": false
+      }
     }
   ]
 }


### PR DESCRIPTION
This offers a small usability improvement for the link to switch to the non-AMP Customizer:

![image](https://user-images.githubusercontent.com/134745/88509688-78fb4a80-cf96-11ea-98e4-5571db65ef5c.png)

In particular it ensures that the URL currently being previewed is added as the `url` query parameter for that link, including after navigating around the site in the Customizer preview. This ensures that if a user switches to the non-AMP Customizer, the page in the preview will be the same page that they had seen in the AMP Customizer just before.