### PR TITLE
Supply newly-missing ImageObject type for publisher logo in Schema.org metadata

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1659,7 +1659,10 @@ function amp_get_schemaorg_metadata() {
 
 	$publisher_logo = amp_get_publisher_logo();
 	if ( $publisher_logo ) {
-		$metadata['publisher']['logo'] = $publisher_logo;
+		$metadata['publisher']['logo'] = [
+			'@type' => 'ImageObject',
+			'url'   => $publisher_logo,
+		];
 	}
 
 	$queried_object = get_queried_object();

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1504,7 +1504,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$expected_publisher = [
 			'@type' => $publisher_type,
 			'name'  => 'Foo',
-			'logo'  => amp_get_asset_url( 'images/amp-page-fallback-wordpress-publisher-logo.png' ),
+			'logo'  => [
+				'@type' => 'ImageObject',
+				'url'   => amp_get_asset_url( 'images/amp-page-fallback-wordpress-publisher-logo.png' ),
+			],
 		];
 
 		$user_id = self::factory()->user->create(
@@ -1538,14 +1541,13 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( '@type', $metadata );
 		$this->assertArrayHasKey( 'publisher', $metadata );
 		$this->assertEquals( $expected_publisher, $metadata['publisher'] );
-		$this->assertEquals( $metadata['publisher']['logo'], amp_get_publisher_logo() );
 
 		// Set site icon which now should get used instead of default for publisher logo.
 		update_option( 'site_icon', $site_icon_attachment_id );
 		$metadata = amp_get_schemaorg_metadata();
 		$this->assertEquals(
 			wp_get_attachment_image_url( $site_icon_attachment_id, 'full', false ),
-			$metadata['publisher']['logo']
+			$metadata['publisher']['logo']['url']
 		);
 		$this->assertEquals( wp_get_attachment_image_url( $site_icon_attachment_id, 'full', false ), amp_get_publisher_logo() );
 
@@ -1554,15 +1556,15 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$metadata = amp_get_schemaorg_metadata();
 		$this->assertEquals(
 			wp_get_attachment_image_url( $custom_logo_attachment_id, 'full', false ),
-			$metadata['publisher']['logo']
+			$metadata['publisher']['logo']['url']
 		);
 		$this->assertEquals( wp_get_attachment_image_url( $custom_logo_attachment_id, 'full', false ), amp_get_publisher_logo() );
 
 		// Test amp_site_icon_url filter overrides previous.
 		add_filter( 'amp_site_icon_url', [ __CLASS__, 'mock_site_icon' ] );
 		$metadata = amp_get_schemaorg_metadata();
-		$this->assertEquals( self::MOCK_SITE_ICON, $metadata['publisher']['logo'] );
-		$this->assertEquals( $metadata['publisher']['logo'], amp_get_publisher_logo() );
+		$this->assertEquals( self::MOCK_SITE_ICON, $metadata['publisher']['logo']['url'] );
+		$this->assertEquals( $metadata['publisher']['logo']['url'], amp_get_publisher_logo() );
 
 		// Clear out all customized icons.
 		remove_filter( 'amp_site_icon_url', [ __CLASS__, 'mock_site_icon' ] );
@@ -1580,7 +1582,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( get_the_title( $page_id ), $metadata['headline'] );
 		$this->assertArrayHasKey( 'datePublished', $metadata );
 		$this->assertArrayHasKey( 'dateModified', $metadata );
-		$this->assertEquals( $metadata['publisher']['logo'], amp_get_publisher_logo() );
+		$this->assertEquals( $metadata['publisher']['logo']['url'], amp_get_publisher_logo() );
 
 		// Test post.
 		$this->go_to( get_permalink( $post_id ) );
@@ -1599,7 +1601,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			],
 			$metadata['author']
 		);
-		$this->assertEquals( $metadata['publisher']['logo'], amp_get_publisher_logo() );
+		$this->assertEquals( $metadata['publisher']['logo']['url'], amp_get_publisher_logo() );
 
 		// Test author archive.
 		$this->go_to( get_author_posts_url( $user_id ) );
@@ -1634,7 +1636,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'did_amp_post_template_metadata', $metadata );
 		$this->assertArrayHasKey( 'did_amp_schemaorg_metadata', $metadata );
 		$this->assertEquals( 'George', $metadata['author']['name'] );
-		$this->assertEquals( $metadata['publisher']['logo'], amp_get_publisher_logo() );
+		$this->assertEquals( $metadata['publisher']['logo']['url'], amp_get_publisher_logo() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As reported in a [support topic](https://wordpress.org/support/topic/error-logo-datos-estructurados/), the `publisher.logo` in the Schema.org metadata is now expected to be an `ImageObject` as opposed to just a URL string. This appears to be a new issue with how Schema.org metadata is validated by Google's [Structure Data Testing Tool](https://search.google.com/structured-data/testing-tool). I was also getting the issue on my own site which I wasn't before as far as I know.

The Google Search docs _does_ have an object as the type in its [example](https://developers.google.com/search/docs/data-types/article#logo-guidelines):

![image](https://user-images.githubusercontent.com/134745/88750844-3eff8500-d10b-11ea-8886-33d915e36a51.png)

Here is workaround plugin code that can be used until this fix is released:

```php
add_filter(
	'amp_schemaorg_metadata',
	static function ( $data ) {
		if ( isset( $data['publisher']['logo'] ) && is_string( $data['publisher']['logo'] ) ) {
			$data['publisher']['logo'] = [
				'@type' => 'ImageObject',
				'url'   => $data['publisher']['logo'],
			];
		}
		return $data;
	}
);
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
