### PR TITLE
Wizard/settings: set reader theme to null if the selected option is uninstallable

### DIFF
--- a/assets/src/components/reader-themes-context-provider/index.js
+++ b/assets/src/components/reader-themes-context-provider/index.js
@@ -40,7 +40,7 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 	const [ downloadingTheme, setDownloadingTheme ] = useState( false );
 	const [ downloadedTheme, setDownloadedTheme ] = useState( false );
 
-	const { editedOptions, savingOptions } = useContext( Options );
+	const { editedOptions, updateOptions, savingOptions } = useContext( Options );
 	const { reader_theme: readerTheme, theme_support: themeSupport } = editedOptions;
 
 	// This component sets state inside async functions. Use this ref to prevent state updates after unmount.
@@ -53,7 +53,7 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 	 * The active reader theme.
 	 */
 	const selectedTheme = useMemo(
-		() => themes ? themes.find( ( { slug } ) => slug === readerTheme ) || { name: null } : { name: null },
+		() => themes ? themes.find( ( { slug } ) => slug === readerTheme ) || { name: null, availability: null } : { name: null, availability: null },
 		[ readerTheme, themes ],
 	);
 
@@ -62,6 +62,16 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 	 * after settings have already been saved.
 	 */
 	const [ downloadingThemeError, setDownloadingThemeError ] = useState( null );
+
+	/**
+	 * If the currently selected theme is unavailable and not installable, unset the reader theme option. This will handle cases where
+	 * the reader theme stored in the options is removed and can no longer be installed.
+	 */
+	useEffect( () => {
+		if ( selectedTheme.availability === 'non-installable' ) {
+			updateOptions( { reader_theme: null } );
+		}
+	}, [ selectedTheme.availability, updateOptions ] );
 
 	/**
 	 * Downloads the selected reader theme, if necessary, when options are saved.


### PR DESCRIPTION
This fixes #5048, a bug where it was possible to move to the end of the onboarding wizard with the selected reader theme being unavailable and not installable. With this update, the React options context provider checks the status of the currently selected theme and sets the `reader_theme` option to `null` if the theme is non-installable (which also means unavailable). 

### QA Steps

1. Set a reader theme (let's say Twenty Fifteen) via the wizard or settings screen. 
2. Delete Twenty Fifteen via the terminal or finder.
3. Add `define( 'DISALLOW_FILE_MODS', true );` to your wp-config
4. Revisit the settings screen or wizard. 
5. While Twenty Fifteen will be listed among the unavailable themes, it will not be selected. 
6. You will be required to make a valid reader theme selection in order to save settings.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
