### PR TITLE
Prevent printing the request-filesystem-credentials-form in the head

### DIFF
--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -238,7 +238,9 @@ final class ReaderThemes {
 				require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 			}
 
+			ob_start(); // Prevent request_filesystem_credentials() from outputting the request-filesystem-credentials-form.
 			$this->can_install_themes = true === ( new WP_Upgrader() )->fs_connect( [ get_theme_root() ] );
+			ob_clean();
 		}
 
 		if ( ! $this->can_install_themes ) {


### PR DESCRIPTION
## Summary

On an environment where the filesystem is not writable (e.g. Git mode on Pantheon), the `request-filesystem-credentials-form` is printed at the call to:

https://github.com/ampproject/amp-wp/blob/2ce1e5c39cf684eef741864b95204475c36d0171/src/Admin/ReaderThemes.php#L241

This is probably happening now that the screen's REST API responses preloaded (see #5118). 

This PR adds output buffering to prevent the form from being printed when calling `fs_connect` (which otherwise returns `true` when filesystem credentials are not needed).

cc @johnwatkins0 

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
