### PR TITLE
Make sure submit_button() function exists before calling fs_connect() in ReaderThemes::can_install_theme()

### DIFF
--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -239,6 +239,7 @@ final class ReaderThemes {
 			}
 
 			ob_start(); // Prevent request_filesystem_credentials() from outputting the request-filesystem-credentials-form.
+			require_once ABSPATH . 'wp-admin/includes/template.php'; // Needed for submit_button().
 			$this->can_install_themes = true === ( new WP_Upgrader() )->fs_connect( [ get_theme_root() ] );
 			ob_clean();
 		}


### PR DESCRIPTION
## Summary

This fixes a fatal error from happening when `ReaderThemes::can_install_theme()` is invoked in on a site with a read-only filesystem, as it will call `request_filesystem_credentials()` which will then call `submit_button()`. Related to #5142.

Stack trace:

```
Uncaught Error: Call to undefined function submit_button() in …/wp-admin/includes/file.php:2232 Stack trace: 
#0 …/wp-admin/includes/class-wp-upgrader-skin.php(97): request_filesystem_credentials('', 'ftpext', false, '…/wp-conten...', Array, false) 
#1 …/wp-admin/includes/class-wp-upgrader.php(188): WP_Upgrader_Skin->request_filesystem_credentials(false, '…/wp-conten...', false) 
#2 …/wp-content/plugins/amp/src/Admin/ReaderThemes.php(242): WP_Upgrader->fs_connect(Array) 
#3 …/wp-content/plugins/amp/src/Admin/ReaderThemes.php(275): AmpProject\AmpWP\Admin\ReaderThemes->can_install_theme(Array) 
#4 …/wp-content/plugins/amp/src/Admin/ReaderThemes.php(117): AmpProject\AmpWP\Admin\ReaderThemes->get_theme_availability(Array)
...
```

cc @johnwatkins0 

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
