### PR TITLE
Prevent scoping total error index count in admin menu

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -792,7 +792,6 @@ class AMP_Validation_Error_Taxonomy {
 		if ( get_taxonomy( self::TAXONOMY_SLUG )->show_in_menu ) {
 			add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_validation_error_item' ] );
 		}
-		add_action( 'parse_term_query', [ __CLASS__, 'parse_post_php_term_query' ] );
 		add_filter( 'manage_' . self::TAXONOMY_SLUG . '_custom_column', [ __CLASS__, 'filter_manage_custom_columns' ], 10, 3 );
 		add_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', [ __CLASS__, 'add_single_post_sortable_columns' ] );
 		add_filter( 'posts_where', [ __CLASS__, 'filter_posts_where_for_validation_error_status' ], 10, 2 );
@@ -1674,28 +1673,6 @@ class AMP_Validation_Error_Taxonomy {
 					$submenu_item[0] = $menu_item_label;
 				}
 			}
-		}
-	}
-
-	/**
-	 * Parses the term query on post.php pages (single error URL).
-	 *
-	 * This post.php page for amp_validated_url is more like an edit-tags.php page,
-	 * in that it has a WP_Terms_List_Table of terms (of type amp_validation_error).
-	 * So this needs to only show the terms (errors) associated with this amp_validated_url post.
-	 *
-	 * @param WP_Term_Query $wp_term_query Instance of WP_Term_Query.
-	 */
-	public static function parse_post_php_term_query( $wp_term_query ) {
-		global $pagenow;
-		if ( ! is_admin() || 'post.php' !== $pagenow || ! isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return;
-		}
-
-		// Only set the query var if this is the validated URL post type.
-		$post_id = (int) $_GET['post']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG === get_post_type( $post_id ) ) {
-			$wp_term_query->query_vars['object_ids'] = $post_id;
 		}
 	}
 

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -565,7 +565,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'add_admin_notices' ] ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_row_actions', [ self::TESTED_CLASS, 'filter_tag_row_actions' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_validation_error_item' ] ) );
-		$this->assertEquals( 10, has_filter( 'parse_term_query', [ self::TESTED_CLASS, 'parse_post_php_term_query' ] ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_custom_column', [ self::TESTED_CLASS, 'filter_manage_custom_columns' ] ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', [ self::TESTED_CLASS, 'add_single_post_sortable_columns' ] ) );
 		$this->assertEquals( 10, has_filter( 'posts_where', [ self::TESTED_CLASS, 'filter_posts_where_for_validation_error_status' ] ) );
@@ -1011,38 +1010,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		];
 		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );
-	}
-
-	/**
-	 * Test parse_post_php_term_query.
-	 *
-	 * @covers \AMP_Validation_Error_Taxonomy::parse_post_php_term_query()
-	 */
-	public function test_parse_post_php_term_query() {
-		$wp_term_query = new WP_Term_Query();
-
-		// If is_admin() is false, the conditional will be false and this won't add a query_var value.
-		set_current_screen( 'front' );
-		AMP_Validation_Error_Taxonomy::parse_post_php_term_query( $wp_term_query );
-		$this->assertEmpty( $wp_term_query->query_vars );
-
-		// This is now on the proper screen, but there is no post ID in $_GET['post'].
-		set_current_screen( 'post.php' );
-		$GLOBALS['pagenow'] = 'post.php';
-		AMP_Validation_Error_Taxonomy::parse_post_php_term_query( $wp_term_query );
-		$this->assertEmpty( $wp_term_query->query_vars );
-
-		// Though $_GET['post'] has a post ID, it's not for the amp_validated_url post type.
-		$post_id_wrong_type = self::factory()->post->create();
-		$_GET['post']       = $post_id_wrong_type;
-		AMP_Validation_Error_Taxonomy::parse_post_php_term_query( $wp_term_query );
-		$this->assertEmpty( $wp_term_query->query_vars );
-
-		// Now that $_GET['post'] has a post ID of the correct post type, it should be in the query var.
-		$post_id_correct_post_type = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
-		$_GET['post']              = $post_id_correct_post_type;
-		AMP_Validation_Error_Taxonomy::parse_post_php_term_query( $wp_term_query );
-		$this->assertEquals( $post_id_correct_post_type, $wp_term_query->query_vars['object_ids'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR removes the filter that scopes the total error index count in the admin bar to the currently viewed Validated URL post.

Before | After
---|---
![image](https://user-images.githubusercontent.com/16200219/89093536-e8b07180-d3aa-11ea-8298-b278907ac16f.png) | ![image](https://user-images.githubusercontent.com/16200219/89093530-da625580-d3aa-11ea-8fcd-9f4ccbc8fe11.png)

<!-- Please reference the issue this PR addresses. -->

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
