### PR TITLE
Add garbage collection of stylesheet information from URLs validated over a week ago

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -28,6 +28,13 @@ class AMP_Validated_URL_Post_Type {
 	const POST_TYPE_SLUG = 'amp_validated_url';
 
 	/**
+	 * Postmeta key for storing stylesheet data.
+	 *
+	 * @var string
+	 */
+	const STYLESHEETS_POST_META_KEY = '_amp_stylesheets';
+
+	/**
 	 * The action to recheck URLs for AMP validity.
 	 *
 	 * @var string
@@ -915,7 +922,7 @@ class AMP_Validated_URL_Post_Type {
 		}
 		if ( isset( $args['stylesheets'] ) ) {
 			// Note that json_encode() is being used here because wp_slash() will coerce scalar values to strings.
-			update_post_meta( $post_id, '_amp_stylesheets', wp_slash( wp_json_encode( $args['stylesheets'] ) ) );
+			update_post_meta( $post_id, self::STYLESHEETS_POST_META_KEY, wp_slash( wp_json_encode( $args['stylesheets'] ) ) );
 		}
 		if ( isset( $args['php_fatal_error'] ) ) {
 			if ( empty( $args['php_fatal_error'] ) ) {
@@ -1248,7 +1255,7 @@ class AMP_Validated_URL_Post_Type {
 						$style_custom_cdata_spec = $spec_rule[ AMP_Rule_Spec::CDATA ];
 					}
 				}
-				$stylesheets = json_decode( get_post_meta( $post->ID, '_amp_stylesheets', true ), true );
+				$stylesheets = json_decode( get_post_meta( $post->ID, self::STYLESHEETS_POST_META_KEY, true ), true );
 				if ( ! is_array( $stylesheets ) || ! $style_custom_cdata_spec ) {
 					echo esc_html( _x( 'n/a', 'CSS usage not available', 'amp' ) );
 				} else {
@@ -2197,7 +2204,7 @@ class AMP_Validated_URL_Post_Type {
 	 * @return void
 	 */
 	public static function print_stylesheets_meta_box( $post ) {
-		$stylesheets = get_post_meta( $post->ID, '_amp_stylesheets', true );
+		$stylesheets = get_post_meta( $post->ID, self::STYLESHEETS_POST_META_KEY, true );
 		if ( empty( $stylesheets ) ) {
 			printf(
 				'<p><em>%s</em></p>',

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1250,7 +1250,7 @@ class AMP_Validated_URL_Post_Type {
 				}
 				$stylesheets = json_decode( get_post_meta( $post->ID, '_amp_stylesheets', true ), true );
 				if ( ! is_array( $stylesheets ) || ! $style_custom_cdata_spec ) {
-					echo '?';
+					echo esc_html( _x( 'n/a', 'CSS usage not available', 'amp' ) );
 				} else {
 					$total_size = 0;
 					foreach ( $stylesheets as $stylesheet ) {
@@ -2201,7 +2201,13 @@ class AMP_Validated_URL_Post_Type {
 		if ( empty( $stylesheets ) ) {
 			printf(
 				'<p><em>%s</em></p>',
-				esc_html__( 'No stylesheet data available. Please try re-checking this URL.', 'amp' )
+				wp_kses_post(
+					sprintf(
+						/* translators: placeholder is URL to recheck the post */
+						__( 'Stylesheet information for this URL is no longer available. Such data is automatically deleted after a week to reduce database storage. It is of little value to store long-term given that it becomes stale as themes and plugins are updated. To obtain the latest stylesheet information, <a href="%s">recheck this URL</a>.', 'amp' ),
+						esc_url( self::get_recheck_url( $post ) . '#amp_stylesheets' )
+					)
+				)
 			);
 			return;
 		}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2273,7 +2273,7 @@ class AMP_Validated_URL_Post_Type {
 				wp_kses_post(
 					sprintf(
 						/* translators: placeholder is URL to recheck the post */
-						__( 'Stylesheet information for this URL is no longer available. Such data is automatically deleted after a week to reduce database storage. It is of little value to store long-term given that it becomes stale as themes and plugins are updated. To obtain the latest stylesheet information, <a href="%s">recheck this URL</a>.', 'amp' ),
+						__( 'Stylesheet information for this URL is no longer available. Such data is automatically deleted after a week to reduce database storage. It is of little value to store long-term given that it becomes stale as themes and plugins are updated. To obtain the latest stylesheet information, <a href="%s">recheck this URL</a>.', 'amp' ),
 						esc_url( self::get_recheck_url( $post ) . '#amp_stylesheets' )
 					)
 				)

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -948,9 +948,10 @@ class AMP_Validated_URL_Post_Type {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int          $count  Count of batch size to delete. Accepts strtotime()-compatible string, or array of 'year', 'month', 'day' values.
+	 * @param int          $count  Count of batch size to delete.
 	 * @param string|array $before Date before which to find amp_validated_url posts to delete.
-	 * @return int Count of postmeta that were deleted..
+	 *                             Accepts strtotime()-compatible string, or array of 'year', 'month', 'day' values.
+	 * @return int Count of postmeta that were deleted.
 	 */
 	public static function delete_stylesheets_postmeta_batch( $count, $before ) {
 		$deleted = 0;

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -79,7 +79,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			'rest.options_controller'          => OptionsRESTController::class,
 			'server_timing'                    => ServerTiming::class,
 			'obsolete_block_attribute_remover' => ObsoleteBlockAttributeRemover::class,
-			'amo_validated_url_stylesheet_gc'  => ValidatedUrlStylesheetDataGarbageCollection::class,
+			'validated_url_stylesheet_gc'      => ValidatedUrlStylesheetDataGarbageCollection::class,
 		];
 	}
 

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -16,6 +16,7 @@ use AmpProject\AmpWP\Admin\PluginActivationNotice;
 use AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction;
 use AmpProject\AmpWP\Admin\SiteHealth;
 use AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching;
+use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
 use AmpProject\AmpWP\Infrastructure\ServiceBasedPlugin;
 use AmpProject\AmpWP\Instrumentation\ServerTiming;
 use AmpProject\AmpWP\Instrumentation\StopWatch;
@@ -78,6 +79,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			'rest.options_controller'          => OptionsRESTController::class,
 			'server_timing'                    => ServerTiming::class,
 			'obsolete_block_attribute_remover' => ObsoleteBlockAttributeRemover::class,
+			'amo_validated_url_stylesheet_gc'  => ValidatedUrlStylesheetDataGarbageCollection::class,
 		];
 	}
 

--- a/src/BackgroundTask/CronBasedBackgroundTask.php
+++ b/src/BackgroundTask/CronBasedBackgroundTask.php
@@ -132,7 +132,10 @@ abstract class CronBasedBackgroundTask implements Service, Registerable, Conditi
 
 		wp_enqueue_style( 'amp-icons' );
 
-		$actions['deactivate'] = preg_replace( '#(?=</a>)#i', ' ' . $this->get_warning_icon(), $actions['deactivate'] );
+		$warning_icon = $this->get_warning_icon();
+		if ( false === strpos( $actions['deactivate'], $warning_icon ) ) {
+			$actions['deactivate'] = preg_replace( '#(?=</a>)#i', ' ' . $this->get_warning_icon(), $actions['deactivate'] );
+		}
 
 		return $actions;
 	}
@@ -156,7 +159,11 @@ abstract class CronBasedBackgroundTask implements Service, Registerable, Conditi
 
 		wp_enqueue_style( 'amp-icons' );
 
-		$plugin_meta[] = $this->get_warning_icon() . ' ' . esc_html__( 'Large site detected. Deactivation will leave orphaned scheduled events behind.', 'amp' ) . ' ' . $this->get_warning_icon();
+		$warning = $this->get_warning_icon() . ' ' . esc_html__( 'Large site detected. Deactivation will leave orphaned scheduled events behind.', 'amp' ) . ' ' . $this->get_warning_icon();
+
+		if ( ! in_array( $warning, $plugin_meta, true ) ) {
+			$plugin_meta[] = $warning;
+		}
 
 		return $plugin_meta;
 	}

--- a/src/BackgroundTask/CronBasedBackgroundTask.php
+++ b/src/BackgroundTask/CronBasedBackgroundTask.php
@@ -134,7 +134,7 @@ abstract class CronBasedBackgroundTask implements Service, Registerable, Conditi
 
 		$warning_icon = $this->get_warning_icon();
 		if ( false === strpos( $actions['deactivate'], $warning_icon ) ) {
-			$actions['deactivate'] = preg_replace( '#(?=</a>)#i', ' ' . $this->get_warning_icon(), $actions['deactivate'] );
+			$actions['deactivate'] = preg_replace( '#(?=</a>)#i', ' ' . $warning_icon, $actions['deactivate'] );
 		}
 
 		return $actions;

--- a/src/BackgroundTask/ValidatedUrlStylesheetDataGarbageCollection.php
+++ b/src/BackgroundTask/ValidatedUrlStylesheetDataGarbageCollection.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class ValidatedUrlStylesheetDataGarbageCollection.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\BackgroundTask;
+
+use AMP_Validated_URL_Post_Type;
+
+/**
+ * Delete stylesheet data from amp_validated_url posts which have not been validated in a week.
+ *
+ * This background task will update the oldest 100 amp_validated_url posts each time it runs, excluding URLs that have
+ * been validated within the past week. The batch size of 100 follows the lead of `_wp_batch_update_comment_type()` in
+ * WordPress 5.5. Deleting data from posts older than 1 week follows the lead of `wp_delete_auto_drafts()`.
+ *
+ * @since 2.0
+ * @see _wp_batch_update_comment_type()
+ * @see wp_delete_auto_drafts()
+ *
+ * @link https://github.com/ampproject/amp-wp/issues/5132
+ * @package AmpProject\AmpWP
+ */
+final class ValidatedUrlStylesheetDataGarbageCollection extends CronBasedBackgroundTask {
+
+	/**
+	 * Name of the event to schedule.
+	 *
+	 * @var string
+	 */
+	const EVENT_NAME = 'amp_validated_url_stylesheet_gc';
+
+	/**
+	 * Get the interval to use for the event.
+	 *
+	 * @return string An existing interval name.
+	 */
+	protected function get_interval() {
+		return self::DEFAULT_INTERVAL_HOURLY;
+	}
+
+	/**
+	 * Get the event name.
+	 *
+	 * This is the "slug" of the event, not the display name.
+	 *
+	 * Note: the event name should be prefixed to prevent naming collisions.
+	 *
+	 * @return string Name of the event.
+	 */
+	protected function get_event_name() {
+		return self::EVENT_NAME;
+	}
+
+	/**
+	 * Process a single cron tick.
+	 *
+	 * @return void
+	 */
+	public function process() {
+		AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch( 100, '1 week ago' );
+	}
+}

--- a/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
+++ b/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Class ValidatedUrlStylesheetDataGarbageCollectionTest.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
+
+/** @covers ValidatedUrlStylesheetDataGarbageCollection */
+class ValidatedUrlStylesheetDataGarbageCollectionTest extends WP_UnitTestCase {
+
+	/**
+	 * Test whether an event is actually scheduled when the monitor is registered.
+	 *
+	 * @covers ValidatedUrlStylesheetDataGarbageCollection::activate()
+	 * @covers ValidatedUrlStylesheetDataGarbageCollection::deactivate()
+	 */
+	public function test_event_gets_scheduled_and_unscheduled() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertFalse( wp_next_scheduled( ValidatedUrlStylesheetDataGarbageCollection::EVENT_NAME ) );
+
+		$monitor = new ValidatedUrlStylesheetDataGarbageCollection();
+		$monitor->schedule_event();
+
+		$timestamp = wp_next_scheduled( ValidatedUrlStylesheetDataGarbageCollection::EVENT_NAME );
+
+		$this->assertNotFalse( $timestamp );
+		$this->assertInternalType( 'int', $timestamp );
+		$this->assertGreaterThan( 0, $timestamp );
+
+		$monitor->deactivate( false );
+
+		$this->assertFalse( wp_next_scheduled( ValidatedUrlStylesheetDataGarbageCollection::EVENT_NAME ) );
+	}
+
+	/**
+	 * Test whether time series are calculated and stored when the monitor is processing.
+	 *
+	 * @covers ValidatedUrlStylesheetDataGarbageCollection::process()
+	 */
+	public function test_event_can_be_processed() {
+		$monitor = new ValidatedUrlStylesheetDataGarbageCollection();
+
+		// Insert four weeks of validated URLs.
+		$post_ids = [];
+		for ( $days_ago = 1; $days_ago <= 28; $days_ago++ ) {
+			$post_date = gmdate( 'Y-m-d H:i:s', strtotime( "$days_ago days ago" ) + 2 );
+			$post_id   = AMP_Validated_URL_Post_Type::store_validation_errors(
+				[],
+				home_url( "/days-ago-$days_ago/" ),
+				[ 'stylesheets' => [ '/*...*/' ] ]
+			);
+			wp_update_post(
+				[
+					'ID'            => $post_id,
+					'post_date_gmt' => $post_date,
+					'post_date'     => $post_date,
+				]
+			);
+			$post_ids[ $days_ago ] = $post_id;
+		}
+
+		$monitor->process();
+
+		foreach ( $post_ids as $days_ago => $post_id ) {
+			if ( $days_ago > 7 ) {
+				$this->assertEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ), "Expected $days_ago days ago to be empty." );
+			} else {
+				$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ), "Expected $days_ago days ago to not be empty." );
+			}
+		}
+	}
+}

--- a/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
+++ b/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
@@ -11,7 +11,7 @@ use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
 class ValidatedUrlStylesheetDataGarbageCollectionTest extends WP_UnitTestCase {
 
 	/**
-	 * Test whether an event is actually scheduled when the monitor is registered.
+	 * Test whether an event is actually scheduled when the garbage collection is registered.
 	 *
 	 * @covers ValidatedUrlStylesheetDataGarbageCollection::activate()
 	 * @covers ValidatedUrlStylesheetDataGarbageCollection::deactivate()
@@ -35,7 +35,7 @@ class ValidatedUrlStylesheetDataGarbageCollectionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test whether time series are calculated and stored when the monitor is processing.
+	 * Test whether stylesheet data is deleted when the garbage collection is processing.
 	 *
 	 * @covers ValidatedUrlStylesheetDataGarbageCollection::process()
 	 */

--- a/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
+++ b/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
@@ -13,8 +13,8 @@ class ValidatedUrlStylesheetDataGarbageCollectionTest extends WP_UnitTestCase {
 	/**
 	 * Test whether an event is actually scheduled when the garbage collection is registered.
 	 *
-	 * @covers ValidatedUrlStylesheetDataGarbageCollection::activate()
-	 * @covers ValidatedUrlStylesheetDataGarbageCollection::deactivate()
+	 * @covers ValidatedUrlStylesheetDataGarbageCollection::get_interval()
+	 * @covers ValidatedUrlStylesheetDataGarbageCollection::get_event_name()
 	 */
 	public function test_event_gets_scheduled_and_unscheduled() {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -518,6 +518,16 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	/** @covers AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch() */
 	public function test_delete_stylesheets_postmeta_batch() {
 
+		$old_post_id = self::factory()->post->create(
+			[
+				'post_type'     => 'post',
+				'post_date'     => gmdate( 'Y-m-d H:i:s', strtotime( '1 year ago' ) ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '1 year ago' ) ),
+			]
+		);
+		add_post_meta( $old_post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY, [ 'Preserved!' ] );
+		add_post_meta( $old_post_id, 'other', 'Also preserved!' );
+
 		// Expect none to be deleted initially.
 		$this->assertEquals( 0, AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch( 10, '1 week ago' ) );
 
@@ -528,7 +538,13 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			$post_id   = AMP_Validated_URL_Post_Type::store_validation_errors(
 				[],
 				home_url( "/days-ago-$days_ago/" ),
-				[ 'stylesheets' => [ '/*...*/' ] ]
+				[
+					'stylesheets'    => [ '/*...*/' ],
+					'queried_object' => [
+						'type' => 'post',
+						'id'   => self::factory()->post->create(),
+					],
+				]
 			);
 			wp_update_post(
 				[
@@ -544,11 +560,13 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 0, AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch( 100, '1 month ago' ) );
 		foreach ( $post_ids as $post_id ) {
 			$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ) );
+			$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::QUERIED_OBJECT_POST_META_KEY ) );
 		}
 
 		// Delete just one post older than 3 weeks.
 		$this->assertEquals( 1, AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch( 1, '3 weeks ago' ) );
 		foreach ( $post_ids as $days_ago => $post_id ) {
+			$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::QUERIED_OBJECT_POST_META_KEY ) );
 			if ( $days_ago > 27 ) {
 				$this->assertEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ), "Expected $days_ago days ago to be empty." );
 			} else {
@@ -559,12 +577,17 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		// Delete everything older than 1 week, so that means 20 days of validated URLs since the 21st was deleted above .
 		$this->assertEquals( 20, AMP_Validated_URL_Post_Type::delete_stylesheets_postmeta_batch( 100, '1 week ago' ) );
 		foreach ( $post_ids as $days_ago => $post_id ) {
+			$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::QUERIED_OBJECT_POST_META_KEY ) );
 			if ( $days_ago > 7 ) {
 				$this->assertEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ), "Expected $days_ago days ago to be empty." );
 			} else {
 				$this->assertNotEmpty( get_post_meta( $post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY ), "Expected $days_ago days ago to not be empty." );
 			}
 		}
+
+		// Make sure other postmeta is retained.
+		$this->assertEquals( [ 'Preserved!' ], get_post_meta( $old_post_id, AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY, true ) );
+		$this->assertEquals( 'Also preserved!', get_post_meta( $old_post_id, 'other', true ) );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2480,7 +2480,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertEquals( $r['url'], AMP_Validated_URL_Post_Type::get_url_from_post( $r['post_id'] ) );
 		$this->assertEquals( $php_error, json_decode( get_post_meta( $r['post_id'], '_amp_php_fatal_error', true ), true ) );
 		$this->assertEquals( $queried_object, get_post_meta( $r['post_id'], '_amp_queried_object', true ) );
-		$this->assertEquals( $stylesheets, json_decode( get_post_meta( $r['post_id'], '_amp_stylesheets', true ), true ) );
+		$this->assertEquals( $stylesheets, json_decode( get_post_meta( $r['post_id'], AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY, true ), true ) );
 
 		$updated_validated_url = home_url( '/bar/' );
 		$previous_post_id      = $r['post_id'];

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2478,9 +2478,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'post_id', $r );
 		$this->assertEquals( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, get_post_type( $r['post_id'] ) );
 		$this->assertEquals( $r['url'], AMP_Validated_URL_Post_Type::get_url_from_post( $r['post_id'] ) );
-		$this->assertEquals( $php_error, json_decode( get_post_meta( $r['post_id'], '_amp_php_fatal_error', true ), true ) );
-		$this->assertEquals( $queried_object, get_post_meta( $r['post_id'], '_amp_queried_object', true ) );
+		$this->assertEquals( $php_error, json_decode( get_post_meta( $r['post_id'], AMP_Validated_URL_Post_Type::PHP_FATAL_ERROR_POST_META_KEY, true ), true ) );
+		$this->assertEquals( $queried_object, get_post_meta( $r['post_id'], AMP_Validated_URL_Post_Type::QUERIED_OBJECT_POST_META_KEY, true ) );
 		$this->assertEquals( $stylesheets, json_decode( get_post_meta( $r['post_id'], AMP_Validated_URL_Post_Type::STYLESHEETS_POST_META_KEY, true ), true ) );
+		$this->assertEquals( AMP_Validated_URL_Post_Type::get_validated_environment(), get_post_meta( $r['post_id'], AMP_Validated_URL_Post_Type::VALIDATED_ENVIRONMENT_POST_META_KEY, true ) );
 
 		$updated_validated_url = home_url( '/bar/' );
 		$previous_post_id      = $r['post_id'];


### PR DESCRIPTION
## Summary

Fixes #5132

This introduces a background task that deletes stylesheet info from URLs that were validated over a week ago. This background task runs on an hourly basis, which may be excessive, but I think it makes sense to do at least until 2.1 is released. At that time it can be changed to run daily.

URLs that were validated over a week ago will now show a CSS Usage as being “n/a” in the post list table:

![image](https://user-images.githubusercontent.com/134745/89134734-5314ff00-d4dc-11ea-8952-602ea50f3d9c.png)

This does not apply to the CSS Usage shown in the admin bar on the frontend, since it is “live” and not pulled from a cached `amp_validated_url`:

![image](https://user-images.githubusercontent.com/134745/89134799-d46c9180-d4dc-11ea-8684-e75d13259881.png)

On the validated URL screen, the Stylesheets metabox will contain a message explaining why it is empty with a link to recheck:

![image](https://user-images.githubusercontent.com/134745/89134750-7770db80-d4dc-11ea-98a0-5c765563ad85.png)


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
