### PR TITLE
Close output buffer in addition to cleaning after calling fs_connect

### DIFF
--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -241,7 +241,7 @@ final class ReaderThemes {
 			ob_start(); // Prevent request_filesystem_credentials() from outputting the request-filesystem-credentials-form.
 			require_once ABSPATH . 'wp-admin/includes/template.php'; // Needed for submit_button().
 			$this->can_install_themes = true === ( new WP_Upgrader() )->fs_connect( [ get_theme_root() ] );
-			ob_clean();
+			ob_end_clean();
 		}
 
 		if ( ! $this->can_install_themes ) {


### PR DESCRIPTION
## Summary

When running unit tests locally I noticed a lot of `R` (risky) tests like:

> 1) AMP_Analytics_Options_Test::test_one_option_inserted
> Test code or tested code did not (only) close its own output buffers

Turns out this is because I used `ob_clean()` but should have used `ob_end_clean()` in #5142.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
