### PR TITLE
Move amp_is_enabled filter to amp_bootstrap_plugin()

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -251,4 +251,4 @@ register_activation_hook( __FILE__, 'amp_activate' );
 
 register_deactivation_hook( __FILE__, 'amp_deactivate' );
 
-amp_bootstrap_plugin();
+add_action( 'plugins_loaded', 'amp_bootstrap_plugin', 8 );

--- a/amp.php
+++ b/amp.php
@@ -251,4 +251,4 @@ register_activation_hook( __FILE__, 'amp_activate' );
 
 register_deactivation_hook( __FILE__, 'amp_deactivate' );
 
-add_action( 'plugins_loaded', 'amp_bootstrap_plugin', 8 );
+add_action( 'plugins_loaded', 'amp_bootstrap_plugin', defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -60,7 +60,7 @@ function amp_bootstrap_plugin() {
 	 * Useful if the plugin is network activated and you want to turn it off on select sites.
 	 *
 	 * @since 0.2
-	 * @since 2.0 Postponed to run at plugins_loaded:8 instead of right after file load.
+	 * @since 2.0 Filter now runs earlier at plugins_loaded (with earliest priority) rather than at the after_setup_theme action.
 	 */
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
 		return;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -68,8 +68,9 @@ function amp_bootstrap_plugin() {
 
 	AmpWpPluginFactory::create()->register();
 
-	// The plugins_loaded action is the earliest we can run this since that is when pluggable.php has been required and wp_hash() is available.
-	add_action( 'plugins_loaded', [ 'AMP_Validation_Manager', 'init_validate_request' ], ~PHP_INT_MAX );
+	// The amp_bootstrap_plugin() function is called at the plugins_loaded action with the earliest priority. This is
+	// the earliest we can run this since that is when pluggable.php has been required and wp_hash() is available.
+	AMP_Validation_Manager::init_validate_request();
 
 	/*
 	 * Register AMP scripts regardless of whether AMP is enabled or it is the AMP endpoint

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -231,6 +231,22 @@ function amp_init() {
 function amp_after_setup_theme() {
 	amp_get_slug(); // Ensure AMP_QUERY_VAR is set.
 
+	/** This filter is documented in includes/amp-helper-functions.php */
+	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
+		_doing_it_wrong(
+			'add_filter',
+			esc_html(
+				sprintf(
+					/* translators: 1: amp_is_enabled filter name, 2: plugins_loaded action */
+					__( 'Filter for "%1$s" added too late. To disable AMP, this filter must be added before the "%2$s" action.', 'amp' ),
+					'amp_is_enabled',
+					'plugins_loaded'
+				)
+			),
+			'2.0'
+		);
+	}
+
 	add_action( 'init', 'amp_init', 0 ); // Must be 0 because widgets_init happens at init priority 1.
 }
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -60,6 +60,7 @@ function amp_bootstrap_plugin() {
 	 * Useful if the plugin is network activated and you want to turn it off on select sites.
 	 *
 	 * @since 0.2
+	 * @since 2.0 Postponed to run at plugins_loaded:8 instead of right after file load.
 	 */
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
 		return;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -54,6 +54,17 @@ function amp_deactivate( $network_wide = false ) {
  * @since 1.5
  */
 function amp_bootstrap_plugin() {
+	/**
+	 * Filters whether AMP is enabled on the current site.
+	 *
+	 * Useful if the plugin is network activated and you want to turn it off on select sites.
+	 *
+	 * @since 0.2
+	 */
+	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
+		return;
+	}
+
 	AmpWpPluginFactory::create()->register();
 
 	// The plugins_loaded action is the earliest we can run this since that is when pluggable.php has been required and wp_hash() is available.
@@ -218,17 +229,6 @@ function amp_init() {
  */
 function amp_after_setup_theme() {
 	amp_get_slug(); // Ensure AMP_QUERY_VAR is set.
-
-	/**
-	 * Filters whether AMP is enabled on the current site.
-	 *
-	 * Useful if the plugin is network activated and you want to turn it off on select sites.
-	 *
-	 * @since 0.2
-	 */
-	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
-		return;
-	}
 
 	add_action( 'init', 'amp_init', 0 ); // Must be 0 because widgets_init happens at init priority 1.
 }

--- a/src/PluginSuppression.php
+++ b/src/PluginSuppression.php
@@ -50,7 +50,6 @@ final class PluginSuppression implements Service, Registerable {
 	public function register() {
 		add_filter( 'amp_default_options', [ $this, 'filter_default_options' ] );
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
-		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 
 		// When a Reader theme is selected and an AMP request is being made, start suppressing as early as possible.
 		// This can be done because we know it is an AMP page due to the query parameter, but it also _has_ to be done
@@ -60,11 +59,13 @@ final class PluginSuppression implements Service, Registerable {
 		// but there is no similar need to suppress the registration of Customizer controls in Transitional mode since
 		// there is no separate Customizer for AMP in Transitional mode (or legacy Reader mode).
 		if ( $this->is_reader_theme_request() ) {
-			add_action( 'plugins_loaded', [ $this, 'suppress_plugins' ], $priority );
+			$this->suppress_plugins();
 		} else {
+			$min_priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
+
 			// In Standard mode we _have_ to wait for the wp action because with the absence of a query parameter
 			// we have to rely on is_amp_endpoint() and the WP_Query to determine whether a plugin should be suppressed.
-			add_action( 'wp', [ $this, 'maybe_suppress_plugins' ], $priority );
+			add_action( 'wp', [ $this, 'maybe_suppress_plugins' ], $min_priority );
 		}
 	}
 

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -218,11 +218,11 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$_GET[ amp_get_slug() ] = 1;
 		$this->assertTrue( $instance->is_reader_theme_request() );
 
+		$this->init_plugins();
+		$this->update_suppressed_plugins_option( array_fill_keys( $this->get_bad_plugin_file_slugs(), true ) );
 		$instance->register();
-		$this->assertEquals(
-			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX, // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-			has_action( 'plugins_loaded', [ $instance, 'suppress_plugins' ] )
-		);
+		$this->assertFalse( has_action( 'plugins_loaded', [ $instance, 'suppress_plugins' ] ), 'Expected suppression to happen immediately.' );
+		$this->assertEquals( '', do_shortcode( '[bad]' ), 'Expected suppression to happen immediately.' );
 		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $instance, 'filter_default_options' ] ) );
 	}
 

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -189,6 +189,24 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( AMP__VERSION, $saved_option['version'] );
 	}
 
+	/** @covers ::amp_after_setup_theme() */
+	public function test_amp_after_setup_theme() {
+		remove_all_actions( 'init' );
+		amp_after_setup_theme();
+		$this->assertSame( 0, has_action( 'init', 'amp_init' ) );
+	}
+
+	/**
+	 * @expectedIncorrectUsage add_filter
+	 * @covers ::amp_after_setup_theme()
+	 */
+	public function test_amp_after_setup_theme_bad_filter() {
+		remove_all_actions( 'init' );
+		add_filter( 'amp_is_enabled', '__return_false' );
+		amp_after_setup_theme();
+		$this->assertSame( 0, has_action( 'init', 'amp_init' ) );
+	}
+
 	/**
 	 * Test amp_get_slug().
 	 *

--- a/tests/php/test-amp.php
+++ b/tests/php/test-amp.php
@@ -104,9 +104,9 @@ class Test_AMP extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that init_validate_request will be called super early.
+	 * Test that amp_bootstrap_plugin() will be called as early as possible upon plugins_loaded.
 	 */
-	public function test_init_validate_request_added_to_plugins_loaded_action() {
-		$this->assertSame( ~PHP_INT_MAX, has_action( 'plugins_loaded', [ 'AMP_Validation_Manager', 'init_validate_request' ] ) );
+	public function test_amp_bootstrap_plugin_priority() {
+		$this->assertSame( ~PHP_INT_MAX, has_action( 'plugins_loaded', 'amp_bootstrap_plugin' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #5152

* Bootstrap plugin at `plugins_loaded` at earliest priority. 
* Short-circuit plugin bootstrapping if `amp_is_enabled` is filtered to be `false`. 
* Warn when `amp_is_enabled` is attempted to be filtered after `plugins_loaded` action is done.
* Update `AMP_Validation_Manager` and `PluginSuppression` to initialize immediately rather than waiting for `plugins_loaded` since bootstrapping now happens at `plugins_loaded`.
* Add tests to ensure that `amp_is_enabled` is working as expected.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
