### PR TITLE
Allow boolean attributes to repeat repeat attribute name as attribute value

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1687,7 +1687,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			$spec_values = (array) $spec_values;
 		}
 		foreach ( $spec_values as $spec_value ) {
-			if ( $spec_value === $attr_value ) {
+			if ( $spec_value === $attr_value || ( '' === $spec_value && strtolower( $attr_value ) === $attr_name ) ) {
 				return true;
 			}
 

--- a/tests/php/src/Helpers/MarkupComparison.php
+++ b/tests/php/src/Helpers/MarkupComparison.php
@@ -22,7 +22,7 @@ trait MarkupComparison {
 	 */
 	protected function assertEqualMarkup( $expected, $actual ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 		// Normalize boolean attributes for which libxml will drop the value.
-		$expected = preg_replace( '/(?<=\s)(checked|disabled|readonly|selected)="\1"/i', '$1', $expected );
+		$expected = preg_replace( '/(?<=\s)(checked|disabled|selected|readonly)="(?:\1|)"/i', '$1', $expected );
 
 		$actual   = preg_replace( '/\s+/', ' ', $actual );
 		$expected = preg_replace( '/\s+/', ' ', $expected );

--- a/tests/php/src/Helpers/MarkupComparison.php
+++ b/tests/php/src/Helpers/MarkupComparison.php
@@ -21,6 +21,9 @@ trait MarkupComparison {
 	 * @param string $actual   Actual markup.
 	 */
 	protected function assertEqualMarkup( $expected, $actual ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
+		// Normalize boolean attributes for which libxml will drop the value.
+		$expected = preg_replace( '/(?<=\s)(checked|disabled|readonly|selected)="\1"/i', '$1', $expected );
+
 		$actual   = preg_replace( '/\s+/', ' ', $actual );
 		$expected = preg_replace( '/\s+/', ' ', $expected );
 		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -769,8 +769,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					<form method="get" action="/form/search-html/get" target="_blank">
 						<fieldset>
 							<label><span>Search for</span><input type="search" placeholder="test" name="term" required></label>
-							<input type="checkbox" checked disabled>
-							<input type="checkbox" checked="CHECKED" disabled="disabled">
+							<input type="checkbox" checked disabled readonly>
+							<input type="checkbox" checked="CHECKED" disabled="disabled" readonly="">
 							<input type="submit" value="Search" enterkeyhint="search"><input type="button" value="Open Lightbox" on="tap:lb1.open">
 						</fieldset>
 					</form>
@@ -2532,6 +2532,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								layout="responsive"
 								width="450"
 								noloading="noloading"
+								height="300"></amp-img>
+						<amp-img
+								src="/static/inline-examples/images/image4.jpg"
+								layout="responsive"
+								width="450"
+								noloading=""
 								height="300"></amp-img>
 					</amp-base-carousel>
 					<amp-inline-gallery-pagination layout="nodisplay" inset>

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -765,7 +765,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'form'                                         => [
-				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search" enterkeyhint="search"><input type="button" value="Open Lightbox" on="tap:lb1.open"></fieldset></form>',
+				'
+					<form method="get" action="/form/search-html/get" target="_blank">
+						<fieldset>
+							<label><span>Search for</span><input type="search" placeholder="test" name="term" required></label>
+							<input type="checkbox" checked disabled>
+							<input type="checkbox" checked="CHECKED" disabled="disabled">
+							<input type="submit" value="Search" enterkeyhint="search"><input type="button" value="Open Lightbox" on="tap:lb1.open">
+						</fieldset>
+					</form>
+				',
 				null,
 				[ 'amp-form' ],
 			],
@@ -1250,7 +1259,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					[ "\n", "\t" ],
 					'',
 					'
-						<amp-story standalone title="Stories in AMP - Hello World" publisher="AMP Project" publisher-logo-src="https://ampbyexample.com/favicons/coast-228x228.png" poster-portrait-src="https://ampbyexample.com/img/story_dog2_portrait.jpg">
+						<amp-story standalone="standalone" title="Stories in AMP - Hello World" publisher="AMP Project" publisher-logo-src="https://ampbyexample.com/favicons/coast-228x228.png" poster-portrait-src="https://ampbyexample.com/img/story_dog2_portrait.jpg">
 							<amp-sidebar id="sidebar1" layout="nodisplay">
 								<ul>
 									<li><a href="https://www.ampproject.org"> External Link </a></li>
@@ -1616,6 +1625,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								</li>
 								<li>
 									<amp-img src="/img2.png" width="50" height="50" option="2" disabled></amp-img>
+								</li>
+								<li>
+									<amp-img src="/img3.png" width="50" height="50" option="2" disabled="disabled"></amp-img>
 								</li>
 								<li option="na" selected>None of the Above</li>
 							</ul>
@@ -2513,11 +2525,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								src="/static/inline-examples/images/image2.jpg"
 								layout="responsive"
 								width="450"
+								noloading
 								height="300"></amp-img>
 						<amp-img
 								src="/static/inline-examples/images/image3.jpg"
 								layout="responsive"
 								width="450"
+								noloading="noloading"
 								height="300"></amp-img>
 					</amp-base-carousel>
 					<amp-inline-gallery-pagination layout="nodisplay" inset>


### PR DESCRIPTION
## Summary

Fixes #5156.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
