### PR TITLE
Improve styling of Plugin Suppression table

### DIFF
--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -229,68 +229,62 @@ function PluginRow( { pluginKey, pluginDetails } ) {
 				/>
 			</th>
 			<td className="column-plugin">
-				<div className="inner-cell">
-					<ConditionalDetails
-						summary={ (
-							<PluginName />
-						) }
-					>
-
-						{ [
-							pluginDetails.Author && (
-								<p className="plugin-author-uri" key={ `${ pluginKey }-details-author` }>
-									{ pluginDetails.AuthorURI ? (
-										<a href={ pluginDetails.AuthorURI } target="_blank" rel="noreferrer">
-											{
-												/* translators: placeholder is an author name. */
-												sprintf( __( 'By %s' ), pluginDetails.Author )
-											}
-										</a> )
-										: (
+				<ConditionalDetails
+					summary={ (
+						<PluginName />
+					) }
+				>
+					{ [
+						pluginDetails.Author && (
+							<p className="plugin-author-uri" key={ `${ pluginKey }-details-author` }>
+								{ pluginDetails.AuthorURI ? (
+									<a href={ pluginDetails.AuthorURI } target="_blank" rel="noreferrer">
+										{
 											/* translators: placeholder is an author name. */
 											sprintf( __( 'By %s' ), pluginDetails.Author )
-										)
-									}
+										}
+									</a> )
+									: (
+										/* translators: placeholder is an author name. */
+										sprintf( __( 'By %s' ), pluginDetails.Author )
+									)
+								}
 
-								</p>
-							),
-							pluginDetails.Description && (
-								<div
-									key={ `${ pluginKey }-details-description` }
-									className="plugin-description"
-									dangerouslySetInnerHTML={ { __html: autop( pluginDetails.Description ) } }
-								/>
-							),
-							pluginDetails.PluginURI && (
-								<a href={ pluginDetails.PluginURI } target="_blank" rel="noreferrer" key={ `${ pluginKey }-details-plugin-uri` }>
-									{ __( 'More details', 'amp' ) }
-								</a>
-							),
+							</p>
+						),
+						pluginDetails.Description && (
+							<div
+								key={ `${ pluginKey }-details-description` }
+								className="plugin-description"
+								dangerouslySetInnerHTML={ { __html: autop( pluginDetails.Description ) } }
+							/>
+						),
+						pluginDetails.PluginURI && (
+							<a href={ pluginDetails.PluginURI } target="_blank" rel="noreferrer" key={ `${ pluginKey }-details-plugin-uri` }>
+								{ __( 'More details', 'amp' ) }
+							</a>
+						),
 
-						].filter( ( child ) => child ) }
-
-					</ConditionalDetails>
-				</div>
+					].filter( ( child ) => child ) }
+				</ConditionalDetails>
 			</td>
 			<td className="column-details">
-				<div className="inner-cell">
-					{
-						isOriginallySuppressed ? (
-							<p>
-								<SuppressedPluginTime suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
-								{ ' ' }
-								<SuppressedPluginUsername suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
-								{ '  ' }
-								<SuppressedPluginVersion
-									pluginDetails={ pluginDetails }
-									suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] }
-								/>
-							</p>
-						) : (
-							<ValidationErrorDetails errors={ pluginDetails.validation_errors } />
-						)
-					}
-				</div>
+				{
+					isOriginallySuppressed ? (
+						<p>
+							<SuppressedPluginTime suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
+							{ ' ' }
+							<SuppressedPluginUsername suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
+							{ '  ' }
+							<SuppressedPluginVersion
+								pluginDetails={ pluginDetails }
+								suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] }
+							/>
+						</p>
+					) : (
+						<ValidationErrorDetails errors={ pluginDetails.validation_errors } />
+					)
+				}
 			</td>
 		</tr>
 	);

--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -203,7 +203,13 @@ function PluginRow( { pluginKey, pluginDetails } ) {
 	);
 
 	return (
-		<tr className={ classnames( { 'has-validation-errors': pluginDetails.validation_errors.length } ) }>
+		<tr className={ classnames(
+			{
+				'has-border-color': isSuppressed || pluginDetails.validation_errors.length,
+				'has-validation-errors': ! isSuppressed && pluginDetails.validation_errors.length,
+				'is-suppressed': isSuppressed,
+			},
+		) }>
 			<th className="column-status" scope="row">
 				<SelectControl
 					hideLabelFromVision={ true }
@@ -326,7 +332,7 @@ export function PluginSuppression() {
 			<p>
 				{ __( 'When a plugin adds markup that is not allowed in AMP you may let the AMP plugin remove it, or you may suppress the plugin from running on AMP pages. The following list includes all active plugins on your site, with any of those detected to be generating invalid AMP markup appearing first.', 'amp' ) }
 			</p>
-			<table id="suppressed-plugins-table" className="wp-list-table widefat fixed striped">
+			<table id="suppressed-plugins-table" className="wp-list-table widefat fixed">
 				<thead>
 					<tr>
 						<th className="column-status" scope="col">

--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -229,65 +229,68 @@ function PluginRow( { pluginKey, pluginDetails } ) {
 				/>
 			</th>
 			<td className="column-plugin">
-				<ConditionalDetails
-					summary={ pluginDetails.PluginURI ? (
-						<PluginName />
-					)
-						: <PluginName /> }
-				>
+				<div className="inner-cell">
+					<ConditionalDetails
+						summary={ (
+							<PluginName />
+						) }
+					>
 
-					{ [
-						pluginDetails.Author && (
-							<p className="plugin-author-uri" key={ `${ pluginKey }-details-author` }>
-								{ pluginDetails.AuthorURI ? (
-									<a href={ pluginDetails.AuthorURI } target="_blank" rel="noreferrer">
-										{
+						{ [
+							pluginDetails.Author && (
+								<p className="plugin-author-uri" key={ `${ pluginKey }-details-author` }>
+									{ pluginDetails.AuthorURI ? (
+										<a href={ pluginDetails.AuthorURI } target="_blank" rel="noreferrer">
+											{
+												/* translators: placeholder is an author name. */
+												sprintf( __( 'By %s' ), pluginDetails.Author )
+											}
+										</a> )
+										: (
 											/* translators: placeholder is an author name. */
 											sprintf( __( 'By %s' ), pluginDetails.Author )
-										}
-									</a> )
-									: (
-										/* translators: placeholder is an author name. */
-										sprintf( __( 'By %s' ), pluginDetails.Author )
-									)
-								}
+										)
+									}
 
-							</p>
-						),
-						pluginDetails.Description && (
-							<div
-								key={ `${ pluginKey }-details-description` }
-								className="plugin-description"
-								dangerouslySetInnerHTML={ { __html: autop( pluginDetails.Description ) } }
-							/>
-						),
-						pluginDetails.PluginURI && (
-							<a href={ pluginDetails.PluginURI } target="_blank" rel="noreferrer" key={ `${ pluginKey }-details-plugin-uri` }>
-								{ __( 'More details', 'amp' ) }
-							</a>
-						),
+								</p>
+							),
+							pluginDetails.Description && (
+								<div
+									key={ `${ pluginKey }-details-description` }
+									className="plugin-description"
+									dangerouslySetInnerHTML={ { __html: autop( pluginDetails.Description ) } }
+								/>
+							),
+							pluginDetails.PluginURI && (
+								<a href={ pluginDetails.PluginURI } target="_blank" rel="noreferrer" key={ `${ pluginKey }-details-plugin-uri` }>
+									{ __( 'More details', 'amp' ) }
+								</a>
+							),
 
-					].filter( ( child ) => child ) }
+						].filter( ( child ) => child ) }
 
-				</ConditionalDetails>
+					</ConditionalDetails>
+				</div>
 			</td>
 			<td className="column-details">
-				{
-					isOriginallySuppressed ? (
-						<p>
-							<SuppressedPluginTime suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
-							{ ' ' }
-							<SuppressedPluginUsername suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
-							{ ' ' }
-							<SuppressedPluginVersion
-								pluginDetails={ pluginDetails }
-								suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] }
-							/>
-						</p>
-					) : (
-						<ValidationErrorDetails errors={ pluginDetails.validation_errors } />
-					)
-				}
+				<div className="inner-cell">
+					{
+						isOriginallySuppressed ? (
+							<p>
+								<SuppressedPluginTime suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
+								{ ' ' }
+								<SuppressedPluginUsername suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
+								{ '  ' }
+								<SuppressedPluginVersion
+									pluginDetails={ pluginDetails }
+									suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] }
+								/>
+							</p>
+						) : (
+							<ValidationErrorDetails errors={ pluginDetails.validation_errors } />
+						)
+					}
+				</div>
 			</td>
 		</tr>
 	);

--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -275,7 +275,7 @@ function PluginRow( { pluginKey, pluginDetails } ) {
 							<SuppressedPluginTime suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
 							{ ' ' }
 							<SuppressedPluginUsername suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] } />
-							{ '  ' }
+							{ ' ' }
 							<SuppressedPluginVersion
 								pluginDetails={ pluginDetails }
 								suppressedPlugin={ originalSuppressedPlugins[ pluginKey ] }

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -121,7 +121,7 @@
 
 #suppressed-plugins-table th,
 #suppressed-plugins-table td {
-	padding: 8px 10px;
+	padding: 10px;
 }
 
 #suppressed-plugins-table .column-status {
@@ -152,10 +152,6 @@
 	margin: 0;
 }
 
-#suppressed-plugins-table .column-details summary {
-	font-weight: bold;
-}
-
 #suppressed-plugins-table tbody th,
 #suppressed-plugins-table tbody td {
 	vertical-align: top;
@@ -165,12 +161,25 @@
 	background-color: #fef7f1;
 }
 
-#suppressed-plugins-table tbody tr > th.column-status {
-	border-left: solid 4px transparent;
+#suppressed-plugins-table tbody tr.is-suppressed {
+	background-color: #f7fcfe;
+}
+
+#suppressed-plugins-table tbody tr:not(.has-border-color) > th.column-status {
+	padding-left: 10px;
+}
+
+#suppressed-plugins-table tbody tr.has-border-color > th.column-status {
+	border-left: solid 4px;
+	padding-left: 6px;
 }
 
 #suppressed-plugins-table tbody tr.has-validation-errors > th.column-status {
 	border-color: #d54e21;
+}
+
+#suppressed-plugins-table tbody tr.is-suppressed > th.column-status {
+	border-color: #00a0d2;
 }
 
 #suppressed-plugins-table tbody tr:not(:last-child) > th,

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -199,10 +199,6 @@
 	cursor: pointer;
 }
 
-#suppressed-plugins-table summary:hover {
-	color: var(--amp-settings-color-brand);
-}
-
 #suppressed-plugins-table tbody .column-plugin,
 #suppressed-plugins-table tbody .column-details {
 	padding-top: 18px;

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -203,10 +203,9 @@
 	color: var(--amp-settings-color-brand);
 }
 
-#suppressed-plugins-table .inner-cell {
-	display: flex;
-	min-height: 34px;
-	align-items: center;
+#suppressed-plugins-table tbody .column-plugin,
+#suppressed-plugins-table tbody .column-details {
+	padding-top: 18px;
 }
 
 li.error-removed {
@@ -227,8 +226,9 @@ li.error-kept {
 		font-size: inherit;
 	}
 
-	#suppressed-plugins-table .inner-cell {
-		min-height: 42px;
+	#suppressed-plugins-table tbody .column-plugin,
+	#suppressed-plugins-table tbody .column-details {
+		padding-top: 21px;
 	}
 
 	#suppressed-plugins-table {

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -162,7 +162,7 @@
 }
 
 #suppressed-plugins-table tbody tr.is-suppressed {
-	background-color: #f7fcfe;
+	background-color: #effbff;
 }
 
 #suppressed-plugins-table tbody tr:not(.has-border-color) > th.column-status {
@@ -179,7 +179,7 @@
 }
 
 #suppressed-plugins-table tbody tr.is-suppressed > th.column-status {
-	border-color: #00a0d2;
+	border-color: var(--amp-settings-color-brand);
 }
 
 #suppressed-plugins-table tbody tr:not(:last-child) > th,
@@ -199,10 +199,14 @@
 	cursor: pointer;
 }
 
-#suppressed-plugins-table .plugin-name,
-#suppressed-plugins-table .column-details p,
-#suppressed-plugins-table .column-details summary {
-	line-height: 30px; /* To match .wp-core-ui select */
+#suppressed-plugins-table summary:hover {
+	color: var(--amp-settings-color-brand);
+}
+
+#suppressed-plugins-table .inner-cell {
+	display: flex;
+	min-height: 34px;
+	align-items: center;
 }
 
 li.error-removed {
@@ -215,10 +219,16 @@ li.error-kept {
 
 @media screen and (max-width: 782px) {
 
-	#suppressed-plugins-table .plugin-name,
-	#suppressed-plugins-table .column-details p,
-	#suppressed-plugins-table .column-details summary {
-		line-height: 40px; /* To match .wp-core-ui select */
+	#suppressed-plugins-table .column-status {
+		width: 130px;
+	}
+
+	#suppressed-plugins-table .column-status .components-select-control__input {
+		font-size: inherit;
+	}
+
+	#suppressed-plugins-table .inner-cell {
+		min-height: 42px;
 	}
 
 	#suppressed-plugins-table {


### PR DESCRIPTION
## Summary

Fixes #5145

* Increase vertical margins between rows to match plugins list table.
* Add blue background styling for suppressed plugin rows, matching styling of active plugins in plugin list table.
* Remove zebra striping since not used on plugin list table and because it conflicts with orange/blue colorization.
* Fix gap in border on non-highlighted rows.
* Improve rendering of wrapped lines in table by not using excessive `line-height` to handle vertical alignment.

Before | After
-------|-----
<img alt="Screen Shot 2020-08-03 at 16 44 56" src="https://user-images.githubusercontent.com/134745/89238527-385d8b80-d5ab-11ea-9615-c9a72a9995b3.png"> | <img alt="Screen Shot 2020-08-03 at 17 00 43" src="https://user-images.githubusercontent.com/134745/89245278-53d19200-d5bd-11ea-936c-6e8dcc0b13d7.png">

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
