### PR TITLE
Use UI font for mobile version switcher link

### DIFF
--- a/templates/style.php
+++ b/templates/style.php
@@ -161,7 +161,8 @@ blockquote p:last-child {
 .amp-wp-tax-tag,
 .amp-wp-comments-link,
 .amp-wp-footer p,
-.back-to-top {
+.back-to-top,
+#amp-mobile-version-switcher {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 }
 


### PR DESCRIPTION
## Summary

The mobile switcher link was not using the same system UI font as the header.

Before | After
-------|------
![fonts-before](https://user-images.githubusercontent.com/134745/89598112-d605c480-d810-11ea-996f-e1583028342f.png) | ![fonts-after-just-mobile-switcher](https://user-images.githubusercontent.com/134745/89598121-dc943c00-d810-11ea-96fa-e5a8a317fd2b.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
