### PR TITLE
Indicate reviewed status when viewing an individual validation error

### DIFF
--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -315,6 +315,11 @@ body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {
 	margin-top: 1px;
 }
 
+.notice.error-details.unreviewed {
+	border-left-color: #d54e21;
+	background-color: #fef7f1;
+}
+
 .wp-heading-inline .status-text {
 	display: inline-block;
 	vertical-align: middle;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1711,8 +1711,13 @@ class AMP_Validated_URL_Post_Type {
 			$error_details = AMP_Validation_Error_Taxonomy::render_single_url_error_details( $validation_error, $error, false, false );
 			$error_details = str_replace( '<dl class="detailed">', '<dl class="detailed">' . $status_detail, $error_details );
 
+			$class = 'notice error-details';
+			if ( ! ( $sanitization['term_status'] & AMP_Validation_Error_Taxonomy::ACKNOWLEDGED_VALIDATION_ERROR_BIT_MASK ) ) {
+				$class .= ' unreviewed';
+			}
+
 			?>
-			<div class="notice error-details">
+			<div class="<?php echo esc_attr( $class ); ?>">
 				<ul>
 					<?php echo $error_details; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</ul>

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1705,7 +1705,7 @@ class AMP_Validated_URL_Post_Type {
 				echo '</p></div>';
 			}
 
-			$status_text   = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization );
+			$status_text   = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization, true );
 			$status_detail = sprintf( '<dt>%s</dt><dd>%s</dd>', esc_html__( 'Status', 'amp' ), wp_kses_post( $status_text ) );
 
 			$error_details = AMP_Validation_Error_Taxonomy::render_single_url_error_details( $validation_error, $error, false, false );

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3327,10 +3327,11 @@ class AMP_Validation_Error_Taxonomy {
 	 *
 	 * @see \AMP_Validation_Error_Taxonomy::get_validation_error_sanitization()
 	 *
-	 * @param array $sanitization Sanitization.
+	 * @param array $sanitization     Sanitization.
+	 * @param bool  $include_reviewed Include reviewed/unreviewed status.
 	 * @return string Status text.
 	 */
-	public static function get_status_text_with_icon( $sanitization ) {
+	public static function get_status_text_with_icon( $sanitization, $include_reviewed = false ) {
 		if ( $sanitization['term_status'] & self::ACCEPTED_VALIDATION_ERROR_BIT_MASK ) {
 			$icon = Icon::valid();
 			$text = __( 'Removed', 'amp' );
@@ -3339,13 +3340,15 @@ class AMP_Validation_Error_Taxonomy {
 			$text = __( 'Kept', 'amp' );
 		}
 
-		$text .= ' (';
-		if ( $sanitization['term_status'] & self::ACKNOWLEDGED_VALIDATION_ERROR_BIT_MASK ) {
-			$text .= __( 'Reviewed', 'amp' );
-		} else {
-			$text .= __( 'Unreviewed', 'amp' );
+		if ( $include_reviewed ) {
+			$text .= ' (';
+			if ( $sanitization['term_status'] & self::ACKNOWLEDGED_VALIDATION_ERROR_BIT_MASK ) {
+				$text .= __( 'Reviewed', 'amp' );
+			} else {
+				$text .= __( 'Unreviewed', 'amp' );
+			}
+			$text .= ')';
 		}
-		$text .= ')';
 
 		return sprintf( '<span class="status-text">%s %s</span>', $icon->to_html(), esc_html( $text ) );
 	}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3338,6 +3338,15 @@ class AMP_Validation_Error_Taxonomy {
 			$icon = Icon::invalid();
 			$text = __( 'Kept', 'amp' );
 		}
+
+		$text .= ' (';
+		if ( $sanitization['term_status'] & self::ACKNOWLEDGED_VALIDATION_ERROR_BIT_MASK ) {
+			$text .= __( 'Reviewed', 'amp' );
+		} else {
+			$text .= __( 'Unreviewed', 'amp' );
+		}
+		$text .= ')';
+
 		return sprintf( '<span class="status-text">%s %s</span>', $icon->to_html(), esc_html( $text ) );
 	}
 }

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1196,7 +1196,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		// Test the 'status' block in the switch for the error taxonomy page.
 		$GLOBALS['pagenow'] = 'edit-tags.php';
 		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'status', $term_id );
-		$this->assertStringContains( '<span class="status-text"><span class="amp-icon amp-invalid"></span> Kept</span>', $filtered_content );
+		$this->assertStringContains( 'amp-invalid', $filtered_content );
+		$this->assertStringContains( 'Kept', $filtered_content );
 
 		// Test the 'status' block switch for the single error page.
 		$GLOBALS['pagenow'] = 'post.php';


### PR DESCRIPTION
## Summary

Fixes #4805

Given a URL that has errors in all 4 states:

<img width="921" alt="Screen Shot 2020-08-06 at 18 56 53" src="https://user-images.githubusercontent.com/134745/89600432-eb7ded00-d816-11ea-8614-52a2709dc78a.png">

<details><summary><del>The error index will now indicate the state in the Markup Status column (in parentheses):</del> <ins>The error index table remains unchanged.</del></summary>

Obsolete screenshot:

<img width="1433" alt="Screen Shot 2020-08-06 at 18 57 23" src="https://user-images.githubusercontent.com/134745/89600496-0fd9c980-d817-11ea-9311-39654062425e.png">
</details>

And when looking at an individual validation error, the reviewed state is also indicated in parentheses with the status in addition to the same orange coloration(where previously it was just white):

Reviewed | Unreviewed
-------|------
<img width="883" alt="Screen Shot 2020-08-06 at 18 57 45" src="https://user-images.githubusercontent.com/134745/89600573-3566d300-d817-11ea-80a6-27a39551000e.png"> | <img width="879" alt="Screen Shot 2020-08-06 at 18 57 38" src="https://user-images.githubusercontent.com/134745/89600582-3992f080-d817-11ea-9937-d9f4f95970a2.png">

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
