### PR TITLE
Improve amp-analytics guidance when googleanalytics is selected

### DIFF
--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -22,17 +22,19 @@ import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
 
 const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
 
+const GOOGLE_ANALYTICS_NOTICE = sprintf(
+	/* translators: 1: URL to Site Kit plugin directory page, 2: Google Analytics dev guide URL */
+	__( 'For Google Analytics please consider using <a href="%1$s" target="_blank" rel="noreferrer">Site Kit by Google</a>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <a href="%2$s" target="_blank" rel="noreferrer">Adding Analytics to your AMP pages</a>.', 'amp' ),
+	__( 'https://wordpress.org/plugins/google-site-kit/', 'amp' ),
+	__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
+);
+
 const vendorConfigs = {
 	'': {
 		sample: '{}',
 	},
 	[ GOOGLE_ANALYTICS_VENDOR ]: {
-		notice: sprintf(
-			/* translators: 1: URL to Site Kit plugin directory page, 2: Google Analytics dev guide URL */
-			__( 'For Google Analytics please consider using <a href="%1$s" target="_blank" rel="noreferrer">Site Kit by Google</a>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <a href="%2$s" target="_blank" rel="noreferrer">Adding Analytics to your AMP pages</a>.', 'amp' ),
-			__( 'https://wordpress.org/plugins/google-site-kit/', 'amp' ),
-			__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
-		),
+		notice: GOOGLE_ANALYTICS_NOTICE,
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -42,6 +44,21 @@ const vendorConfigs = {
 					trackPageview: {
 						on: 'visible',
 						request: 'pageview',
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	gtag: {
+		notice: GOOGLE_ANALYTICS_NOTICE,
+		sample: JSON.stringify(
+			{
+				vars: {
+					gtag_id: '<GA_MEASUREMENT_ID>',
+					config: {
+						'<GA_MEASUREMENT_ID>': { groups: 'default' },
 					},
 				},
 			},

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +18,38 @@ import { Button, TextControl, PanelRow, BaseControl } from '@wordpress/component
  */
 import { AMPDrawer } from '../components/amp-drawer';
 import { Options } from '../components/options-context-provider';
+import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
+
+const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
+
+const vendorConfigs = {
+	'': {
+		sample: '{}',
+	},
+	[ GOOGLE_ANALYTICS_VENDOR ]: {
+		notice: sprintf(
+			/* translators: 1: URL to Site Kit plugin directory page, 2: Google Analytics dev guide URL */
+			__( 'For Google Analytics please consider using <a href="%1$s" target="_blank" rel="noreferrer">Site Kit by Google</a>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <a href="%2$s" target="_blank" rel="noreferrer">Adding Analytics to your AMP pages</a>.', 'amp' ),
+			__( 'https://wordpress.org/plugins/google-site-kit/', 'amp' ),
+			__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
+		),
+		sample: JSON.stringify(
+			{
+				vars: {
+					account: '👉 ' + __( 'Provide site tracking ID here (e.g. UA-XXXXX-Y)', 'amp' ) + ' 👈',
+				},
+				triggers: {
+					trackPageview: {
+						on: 'visible',
+						request: 'pageview',
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+};
 
 /**
  * Component for a single analytics entry.
@@ -54,6 +87,18 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 		}
 	}, [ config ] );
 
+	const isTextareaFocused = () => {
+		if ( ! textAreaRef?.current ) {
+			return false;
+		}
+		return textAreaRef.current === document.activeElement;
+	};
+
+	/** @type {string} value */
+	const value = ( '' === config.trim() || map( Object.values( vendorConfigs ), ( c ) => c.sample ).includes( config ) ) && ! isTextareaFocused()
+		? ( vendorConfigs[ type ]?.sample || '{}' )
+		: config;
+
 	return (
 		<PanelRow className="amp-analytics-entry">
 			<h4>
@@ -78,12 +123,21 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 					/>
 				</div>
 
+				{
+					vendorConfigs[ type ]?.notice && (
+						<AMPNotice size={ NOTICE_SIZE_SMALL }>
+							{ /* dangerouslySetInnerHTML reason: Injection of links. */ }
+							<span dangerouslySetInnerHTML={ { __html: vendorConfigs[ type ].notice } } />
+						</AMPNotice>
+					)
+				}
+
 				<BaseControl
 					id={ `analytics-textarea-control-${ entryIndex }` }
 					label={ __( 'JSON Configuration:', 'amp' ) }
 				>
 					<textarea
-						rows="10"
+						rows={ Math.max( 10, ( value.match( /\n/g ) || [] ).length + 1 ) }
 						cols="100"
 						className="amp-analytics-input"
 						id={ `analytics-textarea-control-${ entryIndex }` }
@@ -93,7 +147,7 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 						placeholder="{...}"
 						ref={ textAreaRef }
 						required
-						value={ config }
+						value={ value }
 					/>
 				</BaseControl>
 			</div>
@@ -137,8 +191,8 @@ function AnalyticsOptions() {
 				<p dangerouslySetInnerHTML={
 					{ __html:
 						sprintf(
-							/* translators: 1: AMP Analytics docs URL, 2: amp-analytics, 3: plugin analytics docs URL, 4: {, 5: }, 6: amp-analytics tag, 7: script tag, 8: AMP analytics vendor docs URL, 9: googleanalytics, 10: Google Analytics AMP docs URL, 11: UA-XXXXX-Y. */
-							__( 'Please see AMP project\'s <a href="%1$s" target="_blank">%2$s documentation</a> as well as the <a href="%3$s" target="_blank">plugin\'s analytics documentation</a>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %4$s and ending with a %5$s. Do not include any HTML tags like %6$s or %7$s. For the type field, supply one of the <a href="%8$s" target="_blank">available analytics vendors</a> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %9$s, but for full details see documentation for <a href="%10$s" target="_blank">Adding Analytics to your AMP pages</a>; a baseline configuration looks like the following (where %11$s is replaced with your own site\'s account number):', 'amp' ),
+							/* translators: 1: AMP Analytics docs URL, 2: amp-analytics, 3: plugin analytics docs URL, 4: {, 5: }, 6: amp-analytics tag, 7: script tag, 8: AMP analytics vendor docs URL, 9: googleanalytics. */
+							__( 'Please see AMP project\'s <a href="%1$s" target="_blank">documentation</a> for %2$s as well as the <a href="%3$s" target="_blank">plugin\'s analytics documentation</a>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %4$s and ending with a %5$s. Do not include any HTML tags like %6$s or %7$s. For the type field, supply one of the <a href="%8$s" target="_blank">available analytics vendors</a> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %9$s.', 'amp' ),
 							__( 'https://amp.dev/documentation/components/amp-analytics/', 'amp' ),
 							'<code>amp-analytics</code>',
 							__( 'https://amp-wp.org/documentation/playbooks/analytics/', 'amp' ),
@@ -147,26 +201,10 @@ function AnalyticsOptions() {
 							'<code>&lt;amp-analytics&gt;</code>',
 							'<code>&lt;script&gt;</code>',
 							__( 'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors/', 'amp' ),
-							'<code>googleanalytics</code>',
-							__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
-							'<code>UA-XXXXX-Y</code>',
+							`<code>${ GOOGLE_ANALYTICS_VENDOR }</code>`,
 						),
 					} }
 				/>
-				<pre>
-					{ `{
-	"vars": {
-		"account": "UA-XXXXX-Y"
-	},
-	"triggers": {
-		"trackPageview": {
-			"on": "visible",
-			"request": "pageview"
-		}
-	}
-}` }
-
-				</pre>
 			</details>
 			{ Object.entries( analytics || {} ).map( ( [ key, { type, config } ], index ) => (
 				<AnalyticsEntry

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
-import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -114,7 +113,7 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 	const defaultValue = vendorConfigs[ type ]?.sample || '{}';
 
 	/** @type {string} value */
-	const value = ( '' === config.trim() || map( Object.values( vendorConfigs ), ( c ) => c.sample ).includes( config ) ) && ! isTextareaFocused()
+	const value = ( '' === config.trim() || Object.values( vendorConfigs ).find( ( { sample } ) => sample === config ) ) && ! isTextareaFocused()
 		? defaultValue
 		: config;
 

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -94,9 +94,11 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 		return textAreaRef.current === document.activeElement;
 	};
 
+	const defaultValue = vendorConfigs[ type ]?.sample || '{}';
+
 	/** @type {string} value */
 	const value = ( '' === config.trim() || map( Object.values( vendorConfigs ), ( c ) => c.sample ).includes( config ) ) && ! isTextareaFocused()
-		? ( vendorConfigs[ type ]?.sample || '{}' )
+		? defaultValue
 		: config;
 
 	return (
@@ -154,7 +156,7 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 			<Button
 				isLink
 				onClick={ () => {
-					if ( '{}' === config || global.confirm( __( 'Are you sure you want to delete this entry?', 'amp' ) ) ) {
+					if ( defaultValue === config || global.confirm( __( 'Are you sure you want to delete this entry?', 'amp' ) ) ) {
 						onDelete();
 					}
 				} }

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -265,10 +265,10 @@ export function Analytics() {
 			className="amp-analytics"
 			heading={ (
 				<h3>
-					{ __( 'Analytics Options', 'amp' ) }
+					{ __( 'Analytics', 'amp' ) }
 				</h3>
 			) }
-			hiddenTitle={ __( 'Analytics Options', 'amp' ) }
+			hiddenTitle={ __( 'Analytics', 'amp' ) }
 			id="analytics-options-drawer"
 			initialOpen={ false }
 		>

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -137,8 +137,8 @@ function Root() {
 				</h2>
 				<MobileRedirection />
 				<SupportedTemplates />
-				<Analytics />
 				<PluginSuppression />
+				<Analytics />
 				<SettingsFooter />
 			</form>
 			<UnsavedChangesWarning excludeUserContext={ true } />

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -401,11 +401,6 @@ li.error-kept {
 	margin-top: 1em;
 }
 
-#analytics-options-drawer details > pre {
-	tab-size: 4;
-	overflow-x: auto;
-}
-
 #analytics-options-drawer .components-button:not(.components-panel__body-toggle) svg {
 	display: block;
 }
@@ -437,6 +432,10 @@ li.error-kept {
 
 .amp-analytics-entry__text-inputs .components-base-control__label {
 	margin-bottom: 0;
+}
+
+.amp-analytics-entry .amp-notice {
+	margin-bottom: 0.75rem;
 }
 
 .amp-analytics-input {


### PR DESCRIPTION
## Summary

This is related to deprecating the Analytics section (#2317) as well as highlighting plugins that are AMP-compatible (#2313).

This PR improves the guidance when adding an analytics entry for `googleanalytics`:

* Populate initial textarea with baseline config when googleanalytics is supplied, instead of putting the baseline config in details.
* Add a notice when `googleanalytics` is entered, encouraging users to use Site Kit instead.
* Increase height of textarea to fit the config.
* Rename “Analytics Options” section to just “Analytics”.
* Move Analytics drawer after Plugin Suppression.

This shows the difference after entering "googleanalytics" as the vendor type:

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/89728355-9cd07e80-d9e1-11ea-89de-7d302cbb3b75.png) | ![after](https://user-images.githubusercontent.com/134745/89728354-99d58e00-d9e1-11ea-84a4-64413564e739.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
