### PR TITLE
Abort AMP post-processing if an expected template actions are not triggered

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1923,6 +1923,20 @@ class AMP_Theme_Support {
 			);
 		}
 
+		// Abort if an expected template was not rendered.
+		$did_template_action = (
+			did_action( 'wp_head' )
+			||
+			did_action( 'wp_footer' )
+			||
+			did_action( 'amp_post_template_head' )
+			||
+			did_action( 'amp_post_template_footer' )
+		);
+		if ( ! $did_template_action ) {
+			return $response;
+		}
+
 		/*
 		 * Abort if the response was not HTML. To be post-processed as an AMP page, the output-buffered document must
 		 * have the HTML mime type and it must start with <html> followed by <head> tag (with whitespace, doctype, and comments optionally interspersed).

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2620,6 +2620,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			</head>
 			<body>
 				<span class="dashicons dashicons-admin-customizer"></span>
+				<?php wp_footer(); ?>
 			</body>
 		</html>
 		<?php

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -8,11 +8,11 @@
 
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\ConfigurationArgument;
-use AmpProject\AmpWP\MobileRedirection;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\Dom\Document;
 use org\bovigo\vfs;
 
@@ -25,6 +25,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
 	use PrivateAccess;
+	use LoadsCoreThemes;
 
 	/**
 	 * The name of the tested class.
@@ -51,6 +52,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
 		add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
 		remove_theme_support( 'amp' );
+		$this->register_core_themes();
 	}
 
 	/**
@@ -91,6 +93,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_all_filters( 'template' );
 		unregister_post_type( 'book' );
 		unregister_post_type( 'announcement' );
+		$this->restore_theme_directories();
 	}
 
 	/**
@@ -263,6 +266,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support( 'amp' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, ReaderThemes::DEFAULT_READER_THEME );
+		$this->assertTrue( amp_is_legacy() );
 		$this->go_to( amp_get_permalink( $post_id ) );
 		AMP_Theme_Support::finish_init();
 		$this->assertFalse( current_theme_supports( 'amp' ) );
@@ -271,6 +275,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_theme_support( 'amp' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentyseventeen' );
+		$this->assertFalse( amp_is_legacy() );
 		$this->go_to( amp_get_permalink( $post_id ) );
 		AMP_Theme_Support::finish_init();
 		$this->assertTrue( current_theme_supports( 'amp' ) );


### PR DESCRIPTION
## Summary

If a template being rendered does not have the expected actions being triggered (`wp_head` and `wp_footer`, or in legacy Reader mode, `amp_post_template_head` or `amp_post_template_footer`), it doesn't make sense to prepare the response as AMP even if it is an HTML page. This is because the AMP plugin relies on these standard template actions being triggered in order to do things like:

* Add the mobile redirection script.
* Add the mobile redirection link in the footer.
* Install service worker.
* Print analytics.

On the other hand, if the expected template actions are _not_ being triggered, then it is very likely that the template being rendered is not expected to be served as AMP in the first place. 

For example, pages currently served by the [Password Protected](https://wordpress.org/plugins/password-protected/
) plugin currently get the `wp-login`-styled login form rendered as an AMP page on a Standard mode site. This is not expected! 

So this PR prevents AMP post-processing if the expected template actions are not triggered in the response. For the Password Protected plugin, the difference is:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/89744276-29218680-da60-11ea-840b-9698d42139b2.png) | ![image](https://user-images.githubusercontent.com/134745/89744278-36d70c00-da60-11ea-8d6f-28af831f5055.png)

(Notice how the password input field is now focused. The plugin is using JS to focus on the field instead of using the `autofocus` attribute, for some reason. Now that the login screen is not sanitized, the expected JS is no longer stripped out.)

This issue also eliminates the need to filter `amp_is_enabled` before the `plugins_loaded` action as discussed in #5153. This was proposed as a way to prevent AMP from processing the response when a certain query parameter was present (see #5152). The use case was a [support topic](https://wordpress.org/support/topic/shortcodes-for-geo-mashup-not-working/) where I provided a way to prevent AMP from processing the response for a [Geo Mashup](https://wordpress.org/plugins/geo-mashup/) request (identified by a `geo_mashup_content` query parameter). 

The way that plugin works is [at the `template_redirect` action](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/geo-mashup.php#L239) (priority 10), which will then [load a custom template](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/geo-mashup.php#L513) and exit. The [templates](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/default-templates) it loads (e.g. [`map-frame.php`](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/default-templates/map-frame.php)) do not use the standard template actions. 

With the changes in this PR, there is no need to add any special workarounds to ensure that the map iframe renders correctly. 

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
