### PR TITLE
Defer mobile redirection to end of template_redirect action

### DIFF
--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -46,7 +46,7 @@ final class MobileRedirection implements Service, Registerable {
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
 
 		if ( AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
-			add_action( 'wp', [ $this, 'redirect' ] );
+			add_action( 'template_redirect', [ $this, 'redirect' ], PHP_INT_MAX );
 		}
 	}
 

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -41,9 +41,11 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 
 	/** @covers MobileRedirection::register() */
 	public function test_register() {
+		AMP_Options_Manager::update_option( Option::MOBILE_REDIRECT, true );
 		$this->instance->register();
 		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
 		$this->assertEquals( 10, has_filter( 'amp_options_updating', [ $this->instance, 'sanitize_options' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_action( 'template_redirect', [ $this->instance, 'redirect' ] ) );
 	}
 
 	/** @covers MobileRedirection::filter_default_options() */


### PR DESCRIPTION
## Summary

When a site has server-side redirection enabled (via `add_filter( 'amp_mobile_client_side_redirection', '__return_false' )`), the redirection us currently performed by `MobileRedirection::redirect()` at the `wp` action. This is the soonest we can call the `amp_is_available()` and `is_amp_endpoint()` functions to determine if we should redirect. 

However, as discussed in #5202, this can cause a problem. For example, the [Geo Mashup](https://wordpress.org/plugins/geo-mashup/) plugin will serve a custom template when the `geo_mashup_content` query parameter is present: [at the `template_redirect` action](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/geo-mashup.php#L239) (priority 10) it [loads a custom template](https://plugins.trac.wordpress.org/browser/geo-mashup/tags/1.12.3/geo-mashup.php#L513) and then exits. This template should not ever be served as an AMP page, but because the redirection is happening at `wp` the result is that when server-side mobile redirection is enabled, the iframe request can unexpectedly be redirected to try to serve the AMP version at `?amp`.

The fix is we simply need to defer the server-side redirection to late in `template_redirect` after the Geo Mashup has exited from rendering its own template, rather than redirecting prematurely at the `wp` action before other plugins have a chance to render their own templates as desired.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/89745382-4c503400-da68-11ea-8da8-996ef5f3822a.png) | ![image](https://user-images.githubusercontent.com/134745/89745387-61c55e00-da68-11ea-9e42-126d6917f87c.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
