### PR TITLE
Start output buffering for AMP post-processing at end of template_redirect instead of beginning

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -982,11 +982,12 @@ class AMP_Theme_Support {
 		add_action( 'wp_footer', 'amp_print_analytics' );
 
 		/*
-		 * Start output buffering at very low priority for sake of plugins and themes that use template_redirect
-		 * instead of template_include.
+		 * Start output buffering at very end of template_redirect to avoid processing custom templates which are output
+		 * earlier during this action followed by exit. In this way, the plugin will only do post-processing for normal
+		 * WordPress templates that are loaded via the template-loader after being passed through the template_include
+		 * filter.
 		 */
-		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-		add_action( 'template_redirect', [ __CLASS__, 'start_output_buffering' ], $priority );
+		add_action( 'template_redirect', [ __CLASS__, 'start_output_buffering' ], PHP_INT_MAX );
 
 		// Commenting hooks.
 		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ], PHP_INT_MAX );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -937,8 +937,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'customize_partial_render', [ self::TESTED_CLASS, 'filter_customize_partial_render' ] ) );
 		$this->assertEquals( 10, has_action( 'wp_footer', 'amp_print_analytics' ) );
 		$this->assertEquals( 10, has_action( 'admin_bar_init', [ self::TESTED_CLASS, 'init_admin_bar' ] ) );
-		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-		$this->assertEquals( $priority, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
 
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_form_defaults', [ self::TESTED_CLASS, 'filter_comment_form_defaults' ] ) );
 		$this->assertEquals( 10, has_filter( 'comment_reply_link', [ self::TESTED_CLASS, 'filter_comment_reply_link' ] ) );


### PR DESCRIPTION
## Summary

This should fix compatibility with caching plugins that start output buffering at `template_redirect`. For example, the Cache Enabler plugin starts output buffering at `template_redirect` priority 0, meaning that its output buffer will be contained inside the output buffer for the AMP plugin which currently starts at the minimum `template_redirect` priority. The Cache Enabler plugin's output buffer then closes first, and the output is stored for serving future cached responses, but the AMP plugin's output buffer hasn't closed yet. This means the AMP-unprocessed output is cached and served unexpectedly. See https://github.com/keycdn/cache-enabler/issues/78#issuecomment-670979112.

Note that server-side redirection has moved to run at the end of `template_redirect` in #5203 as well.

Related: #5202, #5203

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
