### PR TITLE
Wizard: move close button to the top in mobile view

### DIFF
--- a/assets/src/common/constants.js
+++ b/assets/src/common/constants.js
@@ -7,3 +7,4 @@ export const FILE_TYPE_ERROR_VIEW = 'select-file-type-error';
 export const READER = 'reader';
 export const STANDARD = 'standard';
 export const TRANSITIONAL = 'transitional';
+export const DEFAULT_MOBILE_BREAKPOINT = 783;

--- a/assets/src/components/carousel/index.js
+++ b/assets/src/components/carousel/index.js
@@ -35,7 +35,7 @@ export function Carousel( {
 	namespace = 'amp-carousel',
 	highlightedItemIndex = 0,
 } ) {
-	const windowWidth = useWindowWidth();
+	const { windowWidth } = useWindowWidth();
 	const [ currentPage, originalSetCurrentPage ] = useState( null );
 	const [ pageWidth, setPageWidth ] = useState( 0 );
 	const carouselListRef = useRef();

--- a/assets/src/components/reader-theme-carousel/index.js
+++ b/assets/src/components/reader-theme-carousel/index.js
@@ -25,7 +25,7 @@ import { useWindowWidth } from '../../utils/use-window-width';
  * Component for selecting a reader theme.
  */
 export function ReaderThemeCarousel() {
-	const windowWidth = useWindowWidth();
+	const { windowWidth } = useWindowWidth();
 
 	/**
 	 * @typedef Theme

--- a/assets/src/css/core-components.css
+++ b/assets/src/css/core-components.css
@@ -12,14 +12,9 @@
 
 .amp .components-button:not(.components-panel__body-toggle) svg {
 	fill: currentColor;
-	display: none;
-	margin-left: 0.5rem;
+	margin: 0 0.5rem;
 	height: 18px;
 	width: 18px;
-
-	@media screen and (min-width: 783px) {
-		display: block;
-	}
 }
 
 .amp .components-panel__body-title button {

--- a/assets/src/onboarding-wizard/components/nav/index.js
+++ b/assets/src/onboarding-wizard/components/nav/index.js
@@ -21,6 +21,33 @@ import { Options } from '../../../components/options-context-provider';
 import { User } from '../user-context-provider';
 import { READER } from '../../../common/constants';
 import { ReaderThemes } from '../../../components/reader-themes-context-provider';
+import { useWindowWidth } from '../../../utils/use-window-width';
+
+/**
+ * Renders a link to leave the onboarding wizard.
+ *
+ * @param {Object} props Component props.
+ * @param {string} props.closeLink The link URL.
+ */
+export function CloseLink( { closeLink } ) {
+	return (
+		<Button isLink href={ closeLink }>
+			<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<mask id="close-icon" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="19">
+					<path fillRule="evenodd" clipRule="evenodd" d="M19.895 3.71875H5.89502C4.79502 3.71875 3.89502 4.61875 3.89502 5.71875V19.7188C3.89502 20.8188 4.79502 21.7188 5.89502 21.7188H19.895C21.005 21.7188 21.895 20.8188 21.895 19.7188V15.7188H19.895V19.7188H5.89502V5.71875H19.895V9.71875H21.895V5.71875C21.895 4.61875 21.005 3.71875 19.895 3.71875ZM13.395 17.7188L14.805 16.3088L12.225 13.7188H21.895V11.7188H12.225L14.805 9.12875L13.395 7.71875L8.39502 12.7188L13.395 17.7188Z" fill="white" />
+				</mask>
+				<g mask="url(#close-icon)">
+					<rect width="24" height="24" transform="matrix(-1 0 0 1 24.895 0.71875)" fill="#2459E7" />
+				</g>
+			</svg>
+
+			{ __( 'Close', 'amp' ) }
+		</Button>
+	);
+}
+CloseLink.propTypes = {
+	closeLink: PropTypes.string.isRequired,
+};
 
 /**
  * Navigation component.
@@ -30,6 +57,7 @@ import { ReaderThemes } from '../../../components/reader-themes-context-provider
  * @param {string} props.finishLink Link to exit the application.
  */
 export function Nav( { closeLink, finishLink } ) {
+	const { isMobile } = useWindowWidth();
 	const { activePageIndex, canGoForward, isLastPage, moveBack, moveForward } = useContext( Navigation );
 	const {
 		savingOptions,
@@ -62,19 +90,8 @@ export function Nav( { closeLink, finishLink } ) {
 		<div className="onboarding-wizard-nav">
 			<div className="onboarding-wizard-nav__inner">
 				<div className="onboarding-wizard-nav__close">
-					{ ( ! isLastPage || READER === themeSupport ) && (
-						<Button isLink href={ closeLink }>
-							<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-								<mask id="close-icon" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="19">
-									<path fillRule="evenodd" clipRule="evenodd" d="M19.895 3.71875H5.89502C4.79502 3.71875 3.89502 4.61875 3.89502 5.71875V19.7188C3.89502 20.8188 4.79502 21.7188 5.89502 21.7188H19.895C21.005 21.7188 21.895 20.8188 21.895 19.7188V15.7188H19.895V19.7188H5.89502V5.71875H19.895V9.71875H21.895V5.71875C21.895 4.61875 21.005 3.71875 19.895 3.71875ZM13.395 17.7188L14.805 16.3088L12.225 13.7188H21.895V11.7188H12.225L14.805 9.12875L13.395 7.71875L8.39502 12.7188L13.395 17.7188Z" fill="white" />
-								</mask>
-								<g mask="url(#close-icon)">
-									<rect width="24" height="24" transform="matrix(-1 0 0 1 24.895 0.71875)" fill="#2459E7" />
-								</g>
-							</svg>
-
-							{ __( 'Close', 'amp' ) }
-						</Button>
+					{ ! isMobile && ( ! isLastPage || READER === themeSupport ) && (
+						<CloseLink closeLink={ closeLink } />
 					) }
 				</div>
 				<div className="onboarding-wizard-nav__prev-next">

--- a/assets/src/onboarding-wizard/setup-wizard.js
+++ b/assets/src/onboarding-wizard/setup-wizard.js
@@ -15,8 +15,9 @@ import PropTypes from 'prop-types';
  */
 import { Logo } from '../components/svg/logo';
 import { UnsavedChangesWarning } from '../components/unsaved-changes-warning';
+import { useWindowWidth } from '../utils/use-window-width';
 import { Stepper } from './components/stepper';
-import { Nav } from './components/nav';
+import { Nav, CloseLink } from './components/nav';
 import { Navigation } from './components/navigation-context-provider';
 
 /**
@@ -42,6 +43,7 @@ function PageComponentSideEffects( { children } ) {
  * @param {string} props.finishLink Exit link.
  */
 export function SetupWizard( { closeLink, finishLink } ) {
+	const { isMobile } = useWindowWidth();
 	const { activePageIndex, currentPage: { title, PageComponent, showTitle }, moveBack, moveForward, pages } = useContext( Navigation );
 
 	const PageComponentWithSideEffects = useMemo( () => () => (
@@ -55,14 +57,21 @@ export function SetupWizard( { closeLink, finishLink } ) {
 		<div className="amp-onboarding-wizard-container">
 			<div className="amp-onboarding-wizard">
 				<div className="amp-stepper-container">
-					<div className="amp-onboarding-wizard__logo-container">
-						<Logo />
-						<h1>
-							{ __( 'AMP', 'amp' ) }
-						</h1>
-					</div>
-					<div className="amp-onboarding-wizard-plugin-name">
-						{ __( 'Official WordPress Plugin', 'amp' ) }
+					<div className="amp-stepper-container__header">
+						{
+							isMobile && (
+								<CloseLink closeLink={ closeLink } />
+							)
+						}
+						<div className="amp-onboarding-wizard__logo-container">
+							<Logo />
+							<h1>
+								{ __( 'AMP', 'amp' ) }
+							</h1>
+						</div>
+						<div className="amp-onboarding-wizard-plugin-name">
+							{ __( 'Official WordPress Plugin', 'amp' ) }
+						</div>
 					</div>
 					<Stepper
 						activePageIndex={ activePageIndex }

--- a/assets/src/onboarding-wizard/style.css
+++ b/assets/src/onboarding-wizard/style.css
@@ -111,8 +111,9 @@ body {
 	}
 }
 
-.amp-stepper-container__header > .is-link {
+.amp .amp-stepper-container__header > .is-link {
 	float: right;
+	padding: 8px;
 }
 
 .amp-stepper ul {

--- a/assets/src/onboarding-wizard/style.css
+++ b/assets/src/onboarding-wizard/style.css
@@ -111,6 +111,10 @@ body {
 	}
 }
 
+.amp-stepper-container__header > .is-link {
+	float: right;
+}
+
 .amp-stepper ul {
 	display: flex;
 	justify-content: space-between;

--- a/assets/src/utils/use-window-width.js
+++ b/assets/src/utils/use-window-width.js
@@ -4,9 +4,24 @@
 import { useEffect, useState } from '@wordpress/element';
 
 /**
- * Hook providing the current window width as state.
+ * Internal dependencies
  */
-export function useWindowWidth() {
+import { DEFAULT_MOBILE_BREAKPOINT } from '../common/constants';
+
+/**
+ * Hook providing the current window width as state.
+ *
+ * @param {Object} args Hook arguments.
+ * @param {number} args.mobileBreakpoint The mobile breakpoint in pixels.
+ */
+export function useWindowWidth( args = {} ) {
+	args = {
+		...args,
+		mobileBreakpoint: DEFAULT_MOBILE_BREAKPOINT,
+	};
+
+	const { mobileBreakpoint } = args;
+
 	const [ width, setWidth ] = useState( window.innerWidth );
 
 	useEffect( () => {
@@ -21,5 +36,5 @@ export function useWindowWidth() {
 		};
 	}, [] );
 
-	return width;
+	return { windowWidth: width, isMobile: width < mobileBreakpoint };
 }

--- a/tests/e2e/specs/amp-onboarding/close-button.js
+++ b/tests/e2e/specs/amp-onboarding/close-button.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_MOBILE_BREAKPOINT } from '../../../../assets/src/common/constants';
+
+describe( 'Close button placement', () => {
+	beforeEach( async () => {
+		await visitAdminPage( 'admin.php', 'page=amp-onboarding-wizard' );
+		await page.waitForSelector( '.onboarding-wizard-nav__prev-next' );
+	} );
+
+	it( 'should show in footer above breakpoint, in sidebar below breakpoint', async () => {
+		await expect( page ).toMatchElement( '.welcome' );
+
+		const { height } = await page.viewport();
+		await page.setViewport( { width: DEFAULT_MOBILE_BREAKPOINT, height } );
+		await expect( page ).toMatchElement( '.onboarding-wizard-nav .is-link', { text: /Close/ } );
+		await expect( page ).not.toMatchElement( '.amp-stepper-container__header .is-link', { text: /Close/ } );
+
+		await page.setViewport( { width: DEFAULT_MOBILE_BREAKPOINT - 1, height } );
+		await expect( page ).not.toMatchElement( '.onboarding-wizard-nav .is-link', { text: /Close/ } );
+		await expect( page ).toMatchElement( '.amp-stepper-container__header .is-link', { text: /Close/ } );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
This fixes #5193 by moving the wizard's "Close" button to the top right of the screen at mobile widths. This opens up space for the other buttons, particularly on the final screen in reader mode, where the "Customize" button was being pushed to the right.

Before | After
-------|------
<img src="https://user-images.githubusercontent.com/9020968/89809776-a9e48f00-db01-11ea-8e45-21004daa7767.png" alt="before" width="100%" />|<img src="https://user-images.githubusercontent.com/9020968/89809800-b2d56080-db01-11ea-8bcf-3689bdb3e063.png" alt="before" width="100%" />


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
