### PR TITLE
Make homepage, description, and name all optional fields for Reader themes

### DIFF
--- a/assets/src/components/theme-card/index.js
+++ b/assets/src/components/theme-card/index.js
@@ -88,11 +88,15 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 
 				</p>
 			</label>
-			<p className="theme-card__theme-link">
-				<a href={ homepage } target="_blank" rel="noreferrer noopener">
-					{ __( 'Learn more', 'amp' ) }
-				</a>
-			</p>
+			{
+				homepage && (
+					<p className="theme-card__theme-link">
+						<a href={ homepage } target="_blank" rel="noreferrer noopener">
+							{ __( 'Learn more', 'amp' ) }
+						</a>
+					</p>
+				)
+			}
 		</Selectable>
 	);
 }
@@ -100,7 +104,7 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 ThemeCard.propTypes = {
 	description: PropTypes.string.isRequired,
 	ElementName: PropTypes.string,
-	homepage: PropTypes.string.isRequired,
+	homepage: PropTypes.string,
 	screenshotUrl: PropTypes.string,
 	slug: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,

--- a/assets/src/components/theme-card/index.js
+++ b/assets/src/components/theme-card/index.js
@@ -53,7 +53,7 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 						screenshotUrl ? (
 							<img
 								src={ screenshotUrl }
-								alt={ name }
+								alt={ name || slug }
 								height="2165"
 								width="1000"
 								loading="lazy"
@@ -78,7 +78,7 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 						} }
 					/>
 					<h4 className="theme-card__title">
-						{ decodeEntities( name ) }
+						{ decodeEntities( name || slug ) }
 					</h4>
 
 				</div>
@@ -87,7 +87,6 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 					description && (
 						<p className="theme-card__description">
 							{ decodeEntities( description ) }
-
 						</p>
 					)
 				}
@@ -111,7 +110,7 @@ ThemeCard.propTypes = {
 	homepage: PropTypes.string,
 	screenshotUrl: PropTypes.string,
 	slug: PropTypes.string.isRequired,
-	name: PropTypes.string.isRequired,
+	name: PropTypes.string,
 	disabled: PropTypes.bool,
 	style: PropTypes.object,
 };

--- a/assets/src/components/theme-card/index.js
+++ b/assets/src/components/theme-card/index.js
@@ -83,10 +83,14 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 
 				</div>
 
-				<p className="theme-card__description">
-					{ decodeEntities( description ) }
+				{
+					description && (
+						<p className="theme-card__description">
+							{ decodeEntities( description ) }
 
-				</p>
+						</p>
+					)
+				}
 			</label>
 			{
 				homepage && (
@@ -102,7 +106,7 @@ export function ThemeCard( { description, ElementName = 'li', homepage, screensh
 }
 
 ThemeCard.propTypes = {
-	description: PropTypes.string.isRequired,
+	description: PropTypes.string,
 	ElementName: PropTypes.string,
 	homepage: PropTypes.string,
 	screenshotUrl: PropTypes.string,

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -133,7 +133,7 @@ final class ReaderThemes {
 		$themes = array_filter(
 			$themes,
 			static function( $theme ) {
-				return is_array( $theme ) && ! empty( $theme );
+				return is_array( $theme ) && ! empty( $theme['slug'] );
 			}
 		);
 


### PR DESCRIPTION
## Summary

Remove the `required` field for `homepage` and omit the Learn More link when not provided.

Before | After
-------|------
<img width="881" alt="Screen Shot 2020-08-10 at 10 11 29" src="https://user-images.githubusercontent.com/134745/89810908-aa295e00-daf2-11ea-8203-eec471809037.png"> | <img width="869" alt="Screen Shot 2020-08-10 at 10 13 11" src="https://user-images.githubusercontent.com/134745/89810917-ac8bb800-daf2-11ea-9c84-eede1790e655.png">

Also do the same for the theme `name` and `description`. The only required fields needing to be added now are:

```php
add_filter( 'amp_reader_themes', function ( $reader_themes ) {
	array_unshift(
		$reader_themes,
		[ 'slug' => 'veinteveinte' ]
	);
	return $reader_themes;
} );
```

Result:

![image](https://user-images.githubusercontent.com/134745/89811702-e27d6c00-daf3-11ea-86bc-420686196e36.png)

This will facilitate users who make quick child themes who may not want or need to supply all fields.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
