### PR TITLE
Ensure non-AMP link in paired browsing does not redirect to AMP version

### DIFF
--- a/assets/src/admin/paired-browsing/app.js
+++ b/assets/src/admin/paired-browsing/app.js
@@ -8,7 +8,7 @@ import { addQueryArgs, hasQueryArg, removeQueryArgs } from '@wordpress/url';
 import './app.css';
 
 const { app, history } = window;
-const { ampSlug, noampQueryVar, ampPairedBrowsingQueryVar, documentTitlePrefix } = app;
+const { ampSlug, noampQueryVar, noampMobile, ampPairedBrowsingQueryVar, documentTitlePrefix } = app;
 
 class PairedBrowsingApp {
 	/**
@@ -194,7 +194,7 @@ class PairedBrowsingApp {
 		return addQueryArgs(
 			url,
 			{
-				[ ampSlug ]: '',
+				[ ampSlug ]: '1',
 			},
 		);
 	}
@@ -271,7 +271,7 @@ class PairedBrowsingApp {
 			}
 
 			// Update the AMP link above the iframe used for exiting paired browsing.
-			this.ampLink.href = this.ampIframe.contentWindow.location.href;
+			this.ampLink.href = removeQueryArgs( this.ampIframe.contentWindow.location.href, noampQueryVar );
 
 			this.ampPageHasErrors = false;
 			oppositeWindow = this.nonAmpIframe.contentWindow;
@@ -283,7 +283,10 @@ class PairedBrowsingApp {
 			}
 
 			// Update the non-AMP link above the iframe used for exiting paired browsing.
-			this.nonAmpLink.href = this.nonAmpIframe.contentWindow.location.href;
+			this.nonAmpLink.href = addQueryArgs(
+				this.nonAmpIframe.contentWindow.location.href,
+				{ [ noampQueryVar ]: noampMobile },
+			);
 
 			oppositeWindow = this.ampIframe.contentWindow;
 		}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2428,6 +2428,7 @@ class AMP_Theme_Support {
 				'ampSlug'                   => amp_get_slug(),
 				'ampPairedBrowsingQueryVar' => self::PAIRED_BROWSING_QUERY_VAR,
 				'noampQueryVar'             => QueryVar::NOAMP,
+				'noampMobile'               => QueryVar::NOAMP_MOBILE,
 				'documentTitlePrefix'       => __( 'AMP Paired Browsing:', 'amp' ),
 			]
 		);

--- a/includes/templates/amp-paired-browsing.php
+++ b/includes/templates/amp-paired-browsing.php
@@ -5,8 +5,11 @@
  * @package AMP
  */
 
-$url     = remove_query_arg( AMP_Theme_Support::PAIRED_BROWSING_QUERY_VAR );
-$amp_url = add_query_arg( amp_get_slug(), '1', $url );
+use AmpProject\AmpWP\QueryVar;
+
+$url         = remove_query_arg( [ AMP_Theme_Support::PAIRED_BROWSING_QUERY_VAR, QueryVar::NOAMP ] );
+$non_amp_url = add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, $url );
+$amp_url     = add_query_arg( amp_get_slug(), '1', $url );
 ?>
 
 <!DOCTYPE html>
@@ -23,7 +26,7 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 		<section>
 			<nav id="header">
 				<ul>
-					<li class="iframe-label non-amp"><a id="non-amp-link" class="exit-link" title="<?php esc_attr_e( 'Exit paired browsing onto the non-AMP version.', 'amp' ); ?>" href="<?php echo esc_url( $url ); ?>"><?php esc_html_e( 'Non-AMP', 'amp' ); ?><span class="dashicons dashicons-migrate"></span></a></li>
+					<li class="iframe-label non-amp"><a id="non-amp-link" class="exit-link" title="<?php esc_attr_e( 'Exit paired browsing onto the non-AMP version.', 'amp' ); ?>" href="<?php echo esc_url( $non_amp_url ); ?>"><?php esc_html_e( 'Non-AMP', 'amp' ); ?><span class="dashicons dashicons-migrate"></span></a></li>
 					<li class="iframe-label amp"><a id="amp-link" class="exit-link" title="<?php esc_attr_e( 'Exit paired browsing onto the AMP version.', 'amp' ); ?>" href="<?php echo esc_url( $amp_url ); ?>"><?php esc_html_e( 'AMP', 'amp' ); ?><span class="dashicons dashicons-migrate"></span></a></li>
 				</ul>
 			</nav>
@@ -60,7 +63,7 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 			<div id="non-amp">
 				<iframe
 					name="paired-browsing-non-amp"
-					src="<?php echo esc_url( $url ); ?>"
+					src="<?php echo esc_url( $non_amp_url ); ?>"
 					sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-modals"
 					title="<?php esc_attr__( 'Non-AMP version', 'amp' ); ?>"
 				></iframe>


### PR DESCRIPTION
## Summary

I have have a plugin active that includes “Chrome” among the user agents to do mobile redirection:

```php
<?php
/**
 * Plugin Name: AMP Include Chrome as Mobile Redirection Device
 */

add_filter( 'amp_mobile_user_agents', function( $user_agents ) {
	$user_agents[] = '/chrome/i';
	return $user_agents;
} );
```

When I opened paired browsing, the non-AMP link pointed to `https://wordpressdev.lndo.site/` so that when I accessed it I then got unexpectedly redirected to `https://wordpressdev.lndo.site/?amp=1`. This PR makes sure that the non-AMP link always gets `noamp=mobile` added to it.

Granted this is not going to be a common scenario, but it's a good hardening that will make the user experience more consistent.

<img width="852" alt="Screen Shot 2020-08-10 at 12 17 03" src="https://user-images.githubusercontent.com/134745/89823934-25950a80-db07-11ea-8c8f-d0de1da8666e.png">


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
