### PR TITLE
Add link to analytics options in submenu and make all settings sections linkable

### DIFF
--- a/assets/src/components/amp-drawer/index.js
+++ b/assets/src/components/amp-drawer/index.js
@@ -34,6 +34,7 @@ export const HANDLE_TYPE_RIGHT = 'right';
  */
 export function AMPDrawer( { children = null, className, heading, handleType = HANDLE_TYPE_FULL_WIDTH, id, initialOpen = false, selected = false, hiddenTitle } ) {
 	const [ opened, setOpened ] = useState( initialOpen );
+	const [ resetting, setResetting ] = useState( false );
 
 	/**
 	 * Watch for changes to the panel body attributes and set opened state accordingly.
@@ -59,6 +60,23 @@ export function AMPDrawer( { children = null, className, heading, handleType = H
 		};
 	}, [ id, opened ] );
 
+	/**
+	 * Forces a rerender of the PanelBody when the initialOpen prop changes.
+	 */
+	useEffect( () => {
+		setResetting( true );
+
+		const timeout = setTimeout( () => {
+			setResetting( false );
+		}, 1 );
+
+		return () => {
+			if ( timeout ) {
+				clearTimeout( timeout );
+			}
+		};
+	}, [ initialOpen ] );
+
 	return (
 		<Selectable
 			id={ id }
@@ -77,23 +95,25 @@ export function AMPDrawer( { children = null, className, heading, handleType = H
 					{ heading }
 				</div>
 			) }
-			<PanelBody
-				title={ handleType === HANDLE_TYPE_RIGHT ? (
-					<span className="components-visually-hidden">
-						{ hiddenTitle }
-					</span>
-				) : (
-					<div className="amp-drawer__heading">
-						{ heading }
+			{ ! resetting && (
+				<PanelBody
+					title={ handleType === HANDLE_TYPE_RIGHT ? (
+						<span className="components-visually-hidden">
+							{ hiddenTitle }
+						</span>
+					) : (
+						<div className="amp-drawer__heading">
+							{ heading }
+						</div>
+					) }
+					className="amp-drawer__panel-body"
+					initialOpen={ initialOpen }
+				>
+					<div className="amp-drawer__panel-body-inner">
+						{ children }
 					</div>
-				) }
-				className="amp-drawer__panel-body"
-				initialOpen={ initialOpen }
-			>
-				<div className="amp-drawer__panel-body-inner">
-					{ children }
-				</div>
-			</PanelBody>
+				</PanelBody>
+			) }
 		</Selectable>
 	);
 }

--- a/assets/src/components/amp-drawer/index.js
+++ b/assets/src/components/amp-drawer/index.js
@@ -34,7 +34,7 @@ export const HANDLE_TYPE_RIGHT = 'right';
  */
 export function AMPDrawer( { children = null, className, heading, handleType = HANDLE_TYPE_FULL_WIDTH, id, initialOpen = false, selected = false, hiddenTitle } ) {
 	const [ opened, setOpened ] = useState( initialOpen );
-	const [ resetting, setResetting ] = useState( false );
+	const [ resetStatus, setResetStatus ] = useState( null );
 
 	/**
 	 * Watch for changes to the panel body attributes and set opened state accordingly.
@@ -60,22 +60,25 @@ export function AMPDrawer( { children = null, className, heading, handleType = H
 		};
 	}, [ id, opened ] );
 
+	// Force a rerender when initialOpen changes, only after the first render.
+	useEffect( () => {
+		if ( null === resetStatus ) {
+			setResetStatus( 'waiting' );
+			return;
+		}
+
+		setResetStatus( 'resetting' );
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ initialOpen ] );
+
 	/**
-	 * Forces a rerender of the PanelBody when the initialOpen prop changes.
+	 * After the `resetting` render, set status back to waiting.
 	 */
 	useEffect( () => {
-		setResetting( true );
-
-		const timeout = setTimeout( () => {
-			setResetting( false );
-		}, 1 );
-
-		return () => {
-			if ( timeout ) {
-				clearTimeout( timeout );
-			}
-		};
-	}, [ initialOpen ] );
+		if ( 'resetting' === resetStatus ) {
+			setResetStatus( 'waiting' );
+		}
+	}, [ resetStatus ] );
 
 	return (
 		<Selectable
@@ -95,7 +98,7 @@ export function AMPDrawer( { children = null, className, heading, handleType = H
 					{ heading }
 				</div>
 			) }
-			{ ! resetting && (
+			{ 'resetting' !== resetStatus && (
 				<PanelBody
 					title={ handleType === HANDLE_TYPE_RIGHT ? (
 						<span className="components-visually-hidden">

--- a/assets/src/components/carousel/index.js
+++ b/assets/src/components/carousel/index.js
@@ -205,6 +205,7 @@ function Style( { gutterWidth, itemWidth, namespace } ) {
 .${ namespace }__nav .components-button.is-primary svg {
 	display: block;
 	margin-left: 0;
+	margin-right: 0;
 }
 
 .${ namespace }__nav .components-button.is-primary svg path {

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -15,7 +15,6 @@ import { Button, TextControl, PanelRow, BaseControl } from '@wordpress/component
 /**
  * Internal dependencies
  */
-import { AMPDrawer } from '../components/amp-drawer';
 import { Options } from '../components/options-context-provider';
 import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
 
@@ -195,7 +194,7 @@ AnalyticsEntry.propTypes = {
 /**
  * Component handling addition and deletion of analytics entries.
  */
-function AnalyticsOptions() {
+export function Analytics() {
 	const { editedOptions, originalOptions, updateOptions } = useContext( Options );
 	const { analytics } = editedOptions;
 
@@ -274,23 +273,3 @@ function AnalyticsOptions() {
 	);
 }
 
-/**
- * Analytics section of the settings screen. Displays as a closed drawer on initial load.
- */
-export function Analytics() {
-	return (
-		<AMPDrawer
-			className="amp-analytics"
-			heading={ (
-				<h3>
-					{ __( 'Analytics', 'amp' ) }
-				</h3>
-			) }
-			hiddenTitle={ __( 'Analytics', 'amp' ) }
-			id="analytics-options-drawer"
-			initialOpen={ false }
-		>
-			<AnalyticsOptions />
-		</AMPDrawer>
-	);
-}

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -166,7 +166,7 @@ function Root() {
 				event.preventDefault();
 			}
 
-			// Ensure this runs after state upates.
+			// Ensure this runs after state updates.
 			const newFocusedSection = global.location.hash.replace( /^#/, '' );
 			setFocusedSection( newFocusedSection );
 		};

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -97,9 +97,11 @@ ErrorNotice.propTypes = {
  * Settings page application root.
  *
  * @param {Object} props Component props.
- * @param {string} props.section The initially focused section.
+ * @param {string} props.focusedSection The initially focused focusedSection.
  */
-function Root( { section } ) {
+function Root() {
+	const [ focusedSection, setFocusedSection ] = useState( global.location.hash.replace( /^#/, '' ) );
+
 	const { didSaveOptions, fetchingOptions, saveOptions } = useContext( Options );
 	const { error } = useContext( ErrorContext );
 	const { downloadingTheme } = useContext( ReaderThemes );
@@ -125,23 +127,31 @@ function Root( { section } ) {
 	}, [ didSaveOptions, downloadingTheme ] );
 
 	/**
-	 * Scrolls to the initially focused section after loading.
+	 * Scrolls to the initially focused focusedSection after loading.
 	 */
 	useEffect( () => {
 		if ( fetchingOptions ) {
 			return;
 		}
 
-		if ( ! section ) {
+		if ( ! focusedSection ) {
 			return;
 		}
 
-		const focusedSection = document.getElementById( section );
+		const focusedSectionElement = document.getElementById( focusedSection );
 
-		if ( focusedSection ) {
-			focusedSection.scrollIntoView();
+		if ( ! focusedSectionElement ) {
+			return;
 		}
-	}, [ fetchingOptions, section ] );
+
+		const firstInput = focusedSectionElement.querySelector( 'input, select, button:not(.components-panel__body-toggle)' );
+
+		if ( firstInput ) {
+			firstInput.focus( { behavior: 'smooth' } );
+		} else {
+			focusedSectionElement.scrollIntoView( { behavior: 'smooth' } );
+		}
+	}, [ fetchingOptions, focusedSection ] );
 
 	if ( false !== fetchingOptions ) {
 		return <Loading />;
@@ -168,7 +178,7 @@ function Root( { section } ) {
 					) }
 					hiddenTitle={ __( 'Supported templates', 'amp' ) }
 					id="supported-templates"
-					initialOpen={ 'supported-templates' === section }
+					initialOpen={ 'supported-templates' === focusedSection }
 				>
 					<SupportedTemplates />
 				</AMPDrawer>
@@ -180,7 +190,7 @@ function Root( { section } ) {
 					) }
 					hiddenTitle={ __( 'Plugin suppression', 'amp' ) }
 					id="plugin-suppression"
-					initialOpen={ 'plugin-suppression' === section }
+					initialOpen={ 'plugin-suppression' === focusedSection }
 				>
 					<PluginSuppression />
 				</AMPDrawer>
@@ -193,7 +203,7 @@ function Root( { section } ) {
 					) }
 					hiddenTitle={ __( 'Analytics', 'amp' ) }
 					id="analytics-options"
-					initialOpen={ 'analytics-options' === section }
+					initialOpen={ 'analytics-options' === focusedSection }
 				>
 					<Analytics />
 				</AMPDrawer>
@@ -212,7 +222,7 @@ function Root( { section } ) {
 	);
 }
 Root.propTypes = {
-	section: PropTypes.string,
+	focusedSection: PropTypes.string,
 };
 
 domReady( () => {
@@ -222,7 +232,7 @@ domReady( () => {
 		render( (
 			<ErrorContextProvider>
 				<Providers>
-					<Root section={ global.location.hash.replace( /^#/, '' ) } />
+					<Root />
 				</Providers>
 			</ErrorContextProvider>
 		), root );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -105,12 +105,11 @@ function scrollFocusedSectionIntoView( focusedSectionId ) {
 		return;
 	}
 
-	const firstInput = focusedSectionElement.querySelector( 'input, select, textarea, button:not(.components-panel__body-toggle)' );
+	const firstInput = focusedSectionElement.querySelector( 'input, select, textarea, button' );
 
+	focusedSectionElement.scrollIntoView( { behavior: 'smooth' } );
 	if ( firstInput ) {
 		firstInput.focus();
-	} else {
-		focusedSectionElement.scrollIntoView( { behavior: 'smooth' } );
 	}
 }
 
@@ -144,6 +143,9 @@ function Root() {
 		return () => undefined;
 	}, [ didSaveOptions, downloadingTheme ] );
 
+	/**
+	 * Scroll to the focused element on load or when it changes.
+	 */
 	useEffect( () => {
 		if ( fetchingOptions ) {
 			return;
@@ -185,7 +187,7 @@ function Root() {
 				event.preventDefault();
 				saveOptions();
 			} }>
-				<TemplateModes />
+				<TemplateModes focusReaderThemes={ 'reader-themes' === focusedSection } />
 				<h2 id="advanced-settings">
 					{ __( 'Advanced Settings', 'amp' ) }
 				</h2>

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -146,7 +146,7 @@ function Root() {
 
 	useEffect( () => {
 		if ( fetchingOptions ) {
-			return () => null;
+			return;
 		}
 
 		scrollFocusedSectionIntoView( focusedSection );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -99,15 +99,18 @@ ErrorNotice.propTypes = {
  * @param {string} focusedSectionId A section ID.
  */
 function scrollFocusedSectionIntoView( focusedSectionId ) {
-	const focusedSectionElement = document.getElementById( focusedSectionId );
+	if ( ! focusedSectionId ) {
+		return;
+	}
 
+	const focusedSectionElement = document.getElementById( focusedSectionId );
 	if ( ! focusedSectionElement ) {
 		return;
 	}
 
-	const firstInput = focusedSectionElement.querySelector( 'input, select, textarea, button' );
-
 	focusedSectionElement.scrollIntoView( { behavior: 'smooth' } );
+
+	const firstInput = focusedSectionElement.querySelector( 'input, select, textarea, button' );
 	if ( firstInput ) {
 		firstInput.focus();
 	}

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -194,7 +194,7 @@ function Root() {
 				<h2 id="advanced-settings">
 					{ __( 'Advanced Settings', 'amp' ) }
 				</h2>
-				<MobileRedirection />
+				<MobileRedirection id="mobile-redirection" />
 				<AMPDrawer
 
 					heading={ (

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -108,7 +108,7 @@ function scrollFocusedSectionIntoView( focusedSectionId ) {
 		return;
 	}
 
-	focusedSectionElement.scrollIntoView( { behavior: 'smooth' } );
+	focusedSectionElement.scrollIntoView();
 
 	const firstInput = focusedSectionElement.querySelector( 'input, select, textarea, button' );
 	if ( firstInput ) {

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -148,13 +148,8 @@ function Root() {
 		if ( fetchingOptions ) {
 			return () => null;
 		}
-		const timeout = setTimeout( () => {
-			scrollFocusedSectionIntoView( focusedSection );
-		} );
 
-		return () => {
-			clearTimeout( timeout );
-		};
+		scrollFocusedSectionIntoView( focusedSection );
 	}, [ fetchingOptions, focusedSection ] );
 
 	/**

--- a/assets/src/settings-page/mobile-redirection.js
+++ b/assets/src/settings-page/mobile-redirection.js
@@ -24,7 +24,7 @@ export function MobileRedirection() {
 	}
 
 	return (
-		<section className="mobile-redirection">
+		<section className="mobile-redirection" id="mobile-redirection">
 			<RedirectToggle direction="left" />
 		</section>
 	);

--- a/assets/src/settings-page/mobile-redirection.js
+++ b/assets/src/settings-page/mobile-redirection.js
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
@@ -12,8 +16,11 @@ import { Options } from '../components/options-context-provider';
 
 /**
  * Mobile redirection section of the settings page.
+ *
+ * @param {Object} props Component props.
+ * @param {string} props.id Unique HTML ID.
  */
-export function MobileRedirection() {
+export function MobileRedirection( { id } ) {
 	const { editedOptions } = useContext( Options );
 
 	const { theme_support: themeSupport } = editedOptions || {};
@@ -24,8 +31,11 @@ export function MobileRedirection() {
 	}
 
 	return (
-		<section className="mobile-redirection" id="mobile-redirection">
+		<section className="mobile-redirection" id={ id }>
 			<RedirectToggle direction="left" />
 		</section>
 	);
 }
+MobileRedirection.propTypes = {
+	id: PropTypes.string.isRequired,
+};

--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -19,7 +19,6 @@ import { SelectControl } from '@wordpress/components';
 import { Options } from '../components/options-context-provider';
 import { ConditionalDetails } from '../components/conditional-details';
 import { SiteSettings } from '../components/site-settings-provider';
-import { AMPDrawer } from '../components/amp-drawer';
 
 /**
  * Renders the formatted date for when a plugin was suppressed.
@@ -324,16 +323,7 @@ export function PluginSuppression() {
 	}
 
 	return (
-		<AMPDrawer
-			heading={ (
-				<h3>
-					{ __( 'Plugin Suppression', 'amp' ) }
-				</h3>
-			) }
-			hiddenTitle={ __( 'Plugin suppression', 'amp' ) }
-			id="plugin-suppression-drawer"
-			initialOpen={ false }
-		>
+		<>
 			<p>
 				{ __( 'When a plugin adds markup that is not allowed in AMP you may let the AMP plugin remove it, or you may suppress the plugin from running on AMP pages. The following list includes all active plugins on your site, with any of those detected to be generating invalid AMP markup appearing first.', 'amp' ) }
 			</p>
@@ -361,6 +351,6 @@ export function PluginSuppression() {
 					) ) }
 				</tbody>
 			</table>
-		</AMPDrawer>
+		</>
 	);
 }

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -1,3 +1,6 @@
+html {
+	scroll-behavior: smooth;
+}
 
 @media screen and (max-width: 400px) {
 

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -378,7 +378,7 @@ li.error-kept {
 	}
 }
 
-#plugin-suppression-drawer .amp-drawer__panel-body-inner,
+#plugin-suppression .amp-drawer__panel-body-inner,
 .amp-analytics .amp-drawer__panel-body-inner {
 	padding: 1.5rem 1.5rem 3rem;
 
@@ -387,21 +387,21 @@ li.error-kept {
 	}
 }
 
-#plugin-suppression-drawer .amp-drawer__panel-body-inner > p,
+#plugin-suppression .amp-drawer__panel-body-inner > p,
 .amp-analytics .amp-drawer__panel-body-inner p {
 	margin-top: 0;
 	font-size: 14px;
 }
 
-#analytics-options-drawer details > summary {
+#analytics-options details > summary {
 	font-size: 14px;
 }
 
-#analytics-options-drawer details > p {
+#analytics-options details > p {
 	margin-top: 1em;
 }
 
-#analytics-options-drawer .components-button:not(.components-panel__body-toggle) svg {
+#analytics-options .components-button:not(.components-panel__body-toggle) svg {
 	display: block;
 }
 

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -364,13 +364,13 @@ li.error-kept {
 	border-bottom-width: 1px;
 }
 
-#reader-themes-drawer {
+#reader-themes {
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 	border-top-width: 0;
 }
 
-#reader-themes-drawer .amp-drawer__heading {
+#reader-themes .amp-drawer__heading {
 	align-items: center;
 	display: flex;
 	padding-left: 1.5rem;

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -15,7 +15,6 @@ import { CheckboxControl } from '@wordpress/components';
  */
 import { SupportedTemplatesToggle } from '../components/supported-templates-toggle';
 import { Options } from '../components/options-context-provider';
-import { AMPDrawer } from '../components/amp-drawer';
 
 /**
  * Determine whether the supportable templates include the static front page.
@@ -276,24 +275,11 @@ export function SupportedTemplatesFieldset() {
  */
 export function SupportedTemplates() {
 	return (
-		<AMPDrawer
-
-			heading={ (
-				<h3>
-					{ __( 'Supported Templates', 'amp' ) }
-				</h3>
-			) }
-			hiddenTitle={ __( 'Supported templates', 'amp' ) }
-			id="supported-templates-drawer"
-			initialOpen={ false }
-		>
-
-			<div className="supported-templates">
-				<div className="supported-templates__fields">
-					<SupportedPostTypesFieldset />
-					<SupportedTemplatesFieldset />
-				</div>
+		<div className="supported-templates">
+			<div className="supported-templates__fields">
+				<SupportedPostTypesFieldset />
+				<SupportedTemplatesFieldset />
 			</div>
-		</AMPDrawer>
+		</div>
 	);
 }

--- a/assets/src/settings-page/template-modes.js
+++ b/assets/src/settings-page/template-modes.js
@@ -1,6 +1,11 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
+/**
+ * External dependencies
+ */
 import {
 	IS_CORE_THEME,
 	THEME_SUPPORT_ARGS,
@@ -91,8 +96,11 @@ function getReaderNotice( selected ) {
 
 /**
  * Template modes section of the settings page.
+ *
+ * @param {Object} props Component props.
+ * @param {boolean} props.focusReaderThemes Whether the reader themes drawer should be opened and focused.
  */
-export function TemplateModes() {
+export function TemplateModes( { focusReaderThemes } ) {
 	const { editedOptions } = useContext( Options );
 	const { selectedTheme } = useContext( ReaderThemes );
 
@@ -155,7 +163,7 @@ export function TemplateModes() {
 				<AMPDrawer
 					selected={ true }
 					heading={ (
-						<div className="reader-themes-drawer__heading">
+						<div className="reader-themes__heading">
 							<h3>
 								{ sprintf(
 									/* translators: placeholder is a theme name. */
@@ -166,8 +174,8 @@ export function TemplateModes() {
 						</div>
 					) }
 					hiddenTitle={ __( 'Show reader themes', 'amp' ) }
-					id="reader-themes-drawer"
-					initialOpen={ false }
+					id="reader-themes"
+					initialOpen={ focusReaderThemes }
 				>
 					<ReaderThemeCarousel />
 				</AMPDrawer>
@@ -175,3 +183,6 @@ export function TemplateModes() {
 		</section>
 	);
 }
+TemplateModes.propTypes = {
+	focusReaderThemes: PropTypes.bool.isRequired,
+};

--- a/assets/src/settings-page/template-modes.js
+++ b/assets/src/settings-page/template-modes.js
@@ -104,7 +104,7 @@ export function TemplateModes() {
 	);
 
 	return (
-		<section className="template-modes">
+		<section className="template-modes" id="template-modes">
 			<h2>
 				{ __( 'Template Mode', 'amp' ) }
 			</h2>

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -533,7 +533,7 @@ class AMP_Options_Manager {
 				/* translators: 1: slug of the Reader theme, 2: the URL for the reader theme selection UI */
 				__( 'The AMP Reader theme %1$s cannot be found. Your site is currently falling back to using the Legacy templates for AMP pages. Please <a href="%2$s">re-select</a> the desired Reader theme.', 'amp' ),
 				"<code>{$selected_theme}</code>",
-				esc_url( add_query_arg( 'page', self::OPTION_NAME, admin_url( 'admin.php' ) ) . '#reader-themes-drawer' )
+				esc_url( add_query_arg( 'page', self::OPTION_NAME, admin_url( 'admin.php' ) ) . '#reader-themes' )
 			);
 			?>
 			<div class="notice notice-warning">

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -51,23 +51,14 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 	 * Adds a submenu link to the AMP options submenu.
 	 */
 	public function add_submenu_link() {
-		global $submenu;
-
-		$old_menu = $submenu[ $this->parent_menu_slug ];
-
-		// The link should be the second menu item.
-		$new_menu = array_merge(
-			[ $old_menu[0] ],
-			[
-				[
-					__( 'AMP Analytics Options', 'amp' ),
-					'manage_options',
-					menu_page_url( $this->parent_menu_slug, false ) . '#analytics-options',
-				],
-			],
-			array_slice( $old_menu, 1 )
+		add_submenu_page(
+			$this->parent_menu_slug,
+			__( 'AMP Analytics Options', 'amp' ),
+			__( 'AMP Analytics Options', 'amp' ),
+			'manage_options',
+			$this->parent_menu_slug . '#analytics-options',
+			'__return_false',
+			1
 		);
-
-		$submenu[ $this->parent_menu_slug ] = array_values( $new_menu ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 }

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -7,7 +7,6 @@
 
 namespace AmpProject\AmpWP\Admin;
 
-use AMP_Options_Manager;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -59,7 +59,7 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 
 		// The link should be the second menu item.
 		$new_menu = array_merge(
-			[ $old_menu [0] ],
+			[ $old_menu[0] ],
 			[
 				[
 					__( 'AMP Analytics Options', 'amp' ),

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -53,8 +53,8 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 	public function add_submenu_link() {
 		add_submenu_page(
 			$this->parent_menu_slug,
-			__( 'AMP Analytics Options', 'amp' ),
-			__( 'AMP Analytics Options', 'amp' ),
+			__( 'Analytics', 'amp' ),
+			__( 'Analytics', 'amp' ),
 			'manage_options',
 			$this->parent_menu_slug . '#analytics-options',
 			'__return_false',

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class AnalyticsOptionsSubmenu
+ *
+ * @package AMP
+ */
+
+namespace AmpProject\AmpWP\Admin;
+
+use AMP_Options_Manager;
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+
+/**
+ * Class AnalyticsOptionsSubmenu
+ */
+final class AnalyticsOptionsSubmenu implements Service, Registerable {
+
+	/**
+	 * The parent menu slug.
+	 *
+	 * @var string
+	 */
+	private $parent_menu_slug;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param OptionsMenu $options_menu An instance of class handling the parent menu.
+	 */
+	public function __construct( OptionsMenu $options_menu ) {
+		$this->parent_menu_slug = $options_menu->get_menu_slug();
+	}
+
+	/**
+	 * Get the action to use for registering the service.
+	 *
+	 * @return string Registration action to use.
+	 */
+	public static function get_registration_action() {
+		return 'admin_init';
+	}
+
+	/**
+	 * Adds the submenu item and adds necessary hooks.
+	 */
+	public function register() {
+		add_action( 'admin_menu', [ $this, 'add_submenu_link' ], 99 );
+	}
+
+	/**
+	 * Adds a submenu link to the AMP options submenu.
+	 *
+	 * @return void
+	 */
+	public function add_submenu_link() {
+		global $submenu;
+
+		$old_menu = $submenu[ $this->parent_menu_slug ];
+
+		// The link should be the second menu item.
+		$new_menu = array_merge(
+			[ $old_menu [0] ],
+			[
+				[
+					__( 'AMP Analytics Options', 'amp' ),
+					'manage_options',
+					menu_page_url( $this->parent_menu_slug, false ) . '#analytics-options',
+				],
+			],
+			array_slice( $old_menu, 1 )
+		);
+
+		$submenu[ $this->parent_menu_slug ] = array_values( $new_menu ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+}

--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -25,7 +25,7 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 	/**
 	 * Class constructor.
 	 *
-	 * @param OptionsMenu $options_menu An instance of class handling the parent menu.
+	 * @param OptionsMenu $options_menu An instance of the class handling the parent menu.
 	 */
 	public function __construct( OptionsMenu $options_menu ) {
 		$this->parent_menu_slug = $options_menu->get_menu_slug();
@@ -41,7 +41,7 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 	}
 
 	/**
-	 * Adds the submenu item and adds necessary hooks.
+	 * Adds hooks.
 	 */
 	public function register() {
 		add_action( 'admin_menu', [ $this, 'add_submenu_link' ], 99 );
@@ -49,8 +49,6 @@ final class AnalyticsOptionsSubmenu implements Service, Registerable {
 
 	/**
 	 * Adds a submenu link to the AMP options submenu.
-	 *
-	 * @return void
 	 */
 	public function add_submenu_link() {
 		global $submenu;

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -110,12 +110,21 @@ class OptionsMenu implements Conditional, Service, Registerable {
 			[
 				'settings' => sprintf(
 					'<a href="%1$s">%2$s</a>',
-					esc_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, admin_url( 'admin.php' ) ) ),
+					esc_url( add_query_arg( 'page', $this->get_menu_slug(), admin_url( 'admin.php' ) ) ),
 					esc_html__( 'Settings', 'amp' )
 				),
 			],
 			$links
 		);
+	}
+
+	/**
+	 * Returns the slug for the settings page.
+	 *
+	 * @return string
+	 */
+	public function get_menu_slug() {
+		return AMP_Options_Manager::OPTION_NAME;
 	}
 
 	/**
@@ -130,17 +139,17 @@ class OptionsMenu implements Conditional, Service, Registerable {
 			esc_html__( 'AMP Settings', 'amp' ),
 			esc_html__( 'AMP', 'amp' ),
 			'manage_options',
-			AMP_Options_Manager::OPTION_NAME,
+			$this->get_menu_slug(),
 			[ $this, 'render_screen' ],
 			self::ICON_BASE64_SVG
 		);
 
 		add_submenu_page(
-			AMP_Options_Manager::OPTION_NAME,
+			$this->get_menu_slug(),
 			esc_html__( 'AMP Settings', 'amp' ),
 			esc_html__( 'Settings', 'amp' ),
 			'manage_options',
-			AMP_Options_Manager::OPTION_NAME
+			$this->get_menu_slug()
 		);
 	}
 
@@ -150,7 +159,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 	 * @return string
 	 */
 	public function screen_handle() {
-		return sprintf( 'toplevel_page_%s', AMP_Options_Manager::OPTION_NAME );
+		return sprintf( 'toplevel_page_%s', $this->get_menu_slug() );
 	}
 
 	/**
@@ -250,7 +259,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 		?>
 		<div class="wrap">
 			<form id="amp-settings" action="options.php" method="post">
-				<?php settings_fields( AMP_Options_Manager::OPTION_NAME ); ?>
+				<?php settings_fields( $this->get_menu_slug() ); ?>
 				<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 				<?php settings_errors(); ?>
 

--- a/src/Admin/Polyfills.php
+++ b/src/Admin/Polyfills.php
@@ -128,6 +128,10 @@ final class Polyfills implements Delayed, Service, Registerable {
 	 * @param WP_Styles $wp_styles The WP_Styles instance for the current page.
 	 */
 	public function register_shimmed_styles( $wp_styles ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.4', '<' ) ) {
+			$wp_styles->remove( 'wp-components' );
+		}
+
 		if ( ! isset( $wp_styles->registered['wp-components'] ) ) {
 			$wp_styles->add(
 				'wp-components',

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -7,6 +7,7 @@
 
 namespace AmpProject\AmpWP;
 
+use AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu;
 use AmpProject\AmpWP\Admin\DevToolsUserAccess;
 use AmpProject\AmpWP\Admin\GoogleFonts;
 use AmpProject\AmpWP\Admin\OnboardingWizardSubmenu;
@@ -21,6 +22,7 @@ use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
 use AmpProject\AmpWP\Infrastructure\ServiceBasedPlugin;
 use AmpProject\AmpWP\Instrumentation\ServerTiming;
 use AmpProject\AmpWP\Instrumentation\StopWatch;
+
 use function is_user_logged_in;
 
 /**
@@ -82,6 +84,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			'obsolete_block_attribute_remover' => ObsoleteBlockAttributeRemover::class,
 			'admin.polyfills'                  => Polyfills::class,
 			'validated_url_stylesheet_gc'      => ValidatedUrlStylesheetDataGarbageCollection::class,
+			'admin.analytics_menu'             => AnalyticsOptionsSubmenu::class,
 		];
 	}
 

--- a/tests/e2e/specs/admin/analytics-options.js
+++ b/tests/e2e/specs/admin/analytics-options.js
@@ -6,6 +6,7 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 describe( 'AMP analytics options', () => {
 	beforeEach( async () => {
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await page.addStyleTag( { content: 'html {scroll-behavior: auto !important;}' } );
 	} );
 
 	it( 'allows adding and deleting entries', async () => {

--- a/tests/e2e/specs/admin/analytics-options.js
+++ b/tests/e2e/specs/admin/analytics-options.js
@@ -9,7 +9,7 @@ describe( 'AMP analytics options', () => {
 	} );
 
 	it( 'allows adding and deleting entries', async () => {
-		await expect( page ).toClick( '#analytics-options-drawer .components-panel__body-toggle' );
+		await expect( page ).toClick( '#analytics-options .components-panel__body-toggle' );
 		await expect( page ).not.toMatchElement( '.amp-analytics-entry' );
 
 		// Add entry.

--- a/tests/e2e/specs/admin/anchor-linking.js
+++ b/tests/e2e/specs/admin/anchor-linking.js
@@ -1,0 +1,32 @@
+
+/**
+ * WordPress dependencies
+ */
+import { loginUser } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { visitAdminPageWithHash } from '../../utils/visit-admin-page-with-hash';
+
+describe( 'AMP settings page anchor linking', () => {
+	beforeEach( async () => {
+		await loginUser();
+	} );
+
+	it( 'jumps to supported templates section', async () => {
+		await visitAdminPageWithHash( 'admin.php', 'page=amp-options', 'supported-templates' );
+		await page.waitForSelector( '#supported-templates' );
+		await expect( page ).toMatchElement( '#supported-templates .amp-drawer__panel-body.is-opened' );
+	} );
+
+	it( 'has analytics link that links to an open analytics drawer', async () => {
+		await page.evaluate( () => {
+			document.querySelector( 'a[href$="#analytics-options"]' ).click();
+		} );
+
+		await page.waitForSelector( '#analytics-options' );
+		await expect( page ).toMatchElement( '#analytics-options .amp-drawer__panel-body.is-opened' );
+	} );
+} );
+

--- a/tests/e2e/specs/admin/reader-theme-carousel.js
+++ b/tests/e2e/specs/admin/reader-theme-carousel.js
@@ -6,6 +6,7 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 describe( 'AMP settings screen reader themes carousel', () => {
 	beforeEach( async () => {
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await page.addStyleTag( { content: 'html {scroll-behavior: auto !important;}' } );
 	} );
 
 	it( 'allows selection of carousel items', async () => {

--- a/tests/e2e/specs/admin/reader-theme-carousel.js
+++ b/tests/e2e/specs/admin/reader-theme-carousel.js
@@ -11,7 +11,7 @@ describe( 'AMP settings screen reader themes carousel', () => {
 
 	it( 'allows selection of carousel items', async () => {
 		await expect( page ).toClick( '#template-mode-reader' );
-		await expect( page ).toClick( '#reader-themes-drawer .components-panel__body-toggle' );
+		await expect( page ).toClick( '#reader-themes .components-panel__body-toggle' );
 
 		await expect( page ).toMatchElement( '.amp-carousel__carousel' );
 		await expect( page ).toMatchElement( '#theme-card__twentynineteen' );

--- a/tests/e2e/utils/visit-admin-page-with-hash.js
+++ b/tests/e2e/utils/visit-admin-page-with-hash.js
@@ -6,7 +6,7 @@ import { join } from 'path';
 /**
  * WordPress dependencies
  */
-import { isCurrentURL, loginUser, getPageError } from '@wordpress/e2e-test-utils';
+import { getPageError } from '@wordpress/e2e-test-utils';
 
 function createURLWithHash( WPPath, query = '', hash = '' ) {
 	const url = new URL( 'http://localhost:8890' );

--- a/tests/e2e/utils/visit-admin-page-with-hash.js
+++ b/tests/e2e/utils/visit-admin-page-with-hash.js
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { getPageError } from '@wordpress/e2e-test-utils';
 
 function createURLWithHash( WPPath, query = '', hash = '' ) {
-	const url = new URL( 'http://localhost:8890' );
+	const url = new URL( process.env.WP_BASE_URL );
 
 	url.pathname = join( url.pathname, WPPath );
 	url.search = query;
@@ -25,7 +25,7 @@ function createURLWithHash( WPPath, query = '', hash = '' ) {
  * @param {string} query String to be serialized as query portion of URL.
  * @param {string} hash URL hash.
  */
-export async function visitAdminPageWithHash( adminPath, query, hash = null ) {
+export async function visitAdminPageWithHash( adminPath, query, hash = '' ) {
 	await page.goto( createURLWithHash( join( 'wp-admin', adminPath ), query, hash ) );
 
 	const error = await getPageError();

--- a/tests/e2e/utils/visit-admin-page-with-hash.js
+++ b/tests/e2e/utils/visit-admin-page-with-hash.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { join } from 'path';
+
+/**
+ * WordPress dependencies
+ */
+import { isCurrentURL, loginUser, getPageError } from '@wordpress/e2e-test-utils';
+
+function createURLWithHash( WPPath, query = '', hash = '' ) {
+	const url = new URL( 'http://localhost:8890' );
+
+	url.pathname = join( url.pathname, WPPath );
+	url.search = query;
+	url.hash = hash;
+
+	return url.href;
+}
+
+/**
+ * Visits admin page with hash option; if user is not logged in then it logging in it first, then visits admin page.
+ *
+ * @param {string} adminPath String to be serialized as pathname.
+ * @param {string} query String to be serialized as query portion of URL.
+ * @param {string} hash URL hash.
+ */
+export async function visitAdminPageWithHash( adminPath, query, hash = null ) {
+	await page.goto( createURLWithHash( join( 'wp-admin', adminPath ), query, hash ) );
+
+	const error = await getPageError();
+	if ( error ) {
+		throw new Error( 'Unexpected error in page content: ' + error );
+	}
+}

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -85,12 +85,16 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 
 		$dev_tools_user_access = new DevToolsUserAccess();
 
-		$dev_tools_user_access->set_user_enabled( $test_user, true );
-		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+		$original_dev_tools_user_access = $dev_tools_user_access->get_user_enabled( $test_user );
 
 		$dev_tools_user_access->set_user_enabled( $test_user, true );
 		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
 
+		$dev_tools_user_access->set_user_enabled( $test_user, false );
+		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+
+		// Reset.
 		$submenu = $original_submenu;
+		$dev_tools_user_access->set_user_enabled( $test_user, $original_dev_tools_user_access );
 	}
 }

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -8,11 +8,11 @@
 namespace AmpProject\AmpWP\Tests\Admin;
 
 use AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu;
-use AmpProject\AmpWP\Admin\DevToolsUserAccess;
 use AmpProject\AmpWP\Admin\GoogleFonts;
 use AmpProject\AmpWP\Admin\OptionsMenu;
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Admin\RESTPreloader;
+use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use WP_UnitTestCase;
 
 /**
@@ -22,6 +22,8 @@ use WP_UnitTestCase;
  * @coversDefaultClass \AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu
  */
 class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of OptionsMenu class.
@@ -83,18 +85,8 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 		$this->options_menu_instance->add_menu_items();
 		$this->instance->add_submenu_link();
 
-		$dev_tools_user_access = new DevToolsUserAccess();
+		$this->assertContains( 'Analytics', wp_list_pluck( $submenu[ $this->options_menu_instance->get_menu_slug() ], 0 ) );
 
-		$original_dev_tools_user_access = $dev_tools_user_access->get_user_enabled( $test_user );
-
-		$dev_tools_user_access->set_user_enabled( $test_user, true );
-		$this->assertEquals( 'Analytics', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
-
-		$dev_tools_user_access->set_user_enabled( $test_user, false );
-		$this->assertEquals( 'Analytics', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
-
-		// Reset.
 		$submenu = $original_submenu;
-		$dev_tools_user_access->set_user_enabled( $test_user, $original_dev_tools_user_access );
 	}
 }

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -58,7 +58,7 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 	/**
 	 * Test register.
 	 *
-	 * @covers :register()
+	 * @covers ::register()
 	 */
 	public function test_register() {
 		$this->instance->register();

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for AnalyticsOptionsSubmenu.
+ *
+ * @package AmpProject\AmpWP\Tests
+ */
+
+namespace AmpProject\AmpWP\Tests\Admin;
+
+use AMP_Options_Manager;
+use AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu;
+use AmpProject\AmpWP\Admin\DevToolsUserAccess;
+use AmpProject\AmpWP\Admin\GoogleFonts;
+use AmpProject\AmpWP\Admin\OptionsMenu;
+use AmpProject\AmpWP\Admin\ReaderThemes;
+use AmpProject\AmpWP\Admin\RESTPreloader;
+use WP_UnitTestCase;
+
+/**
+ * Tests for AnalyticsOptionsSubmenu.
+ *
+ * @group options-menu
+ */
+class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance of OptionsMenu class.
+	 *
+	 * @var OptionsMenu.
+	 */
+	public $options_menu_instance;
+
+	/**
+	 * Instance of AnalyticsOptionsSubmenu
+	 *
+	 * @var AnalyticsOptionsSubmenu
+	 */
+	public $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->options_menu_instance = new OptionsMenu(
+			new GoogleFonts(),
+			new ReaderThemes(),
+			new RESTPreloader()
+		);
+		$this->instance              = new AnalyticsOptionsSubmenu( $this->options_menu_instance );
+	}
+
+	/**
+	 * Test register.
+	 *
+	 * @see AnalyticsOptionsSubmenu::register()
+	 */
+	public function test_register() {
+		$this->instance->register();
+		$this->assertEquals( 99, has_action( 'admin_menu', [ $this->instance, 'add_submenu_link' ] ) );
+	}
+
+	/**
+	 * Test add_submenu_link.
+	 *
+	 * @covers AnalyticsOptionsSubmenu::add_submenu_link()
+	 */
+	public function test_link_is_added() {
+		global $submenu;
+
+		$test_user = self::factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+		wp_set_current_user( $test_user );
+
+		$this->options_menu_instance->add_menu_items();
+		$this->instance->add_submenu_link();
+
+		$dev_tools_user_access = new DevToolsUserAccess();
+
+		$dev_tools_user_access->set_user_enabled( $test_user, true );
+		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+
+		$dev_tools_user_access->set_user_enabled( $test_user, true );
+		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+	}
+}

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -88,10 +88,10 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 		$original_dev_tools_user_access = $dev_tools_user_access->get_user_enabled( $test_user );
 
 		$dev_tools_user_access->set_user_enabled( $test_user, true );
-		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+		$this->assertEquals( 'Analytics', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
 
 		$dev_tools_user_access->set_user_enabled( $test_user, false );
-		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+		$this->assertEquals( 'Analytics', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
 
 		// Reset.
 		$submenu = $original_submenu;

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -71,6 +71,8 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 	public function test_link_is_added() {
 		global $submenu;
 
+		$original_submenu = $submenu;
+
 		$test_user = self::factory()->user->create(
 			[
 				'role' => 'administrator',
@@ -88,5 +90,7 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 
 		$dev_tools_user_access->set_user_enabled( $test_user, true );
 		$this->assertEquals( 'AMP Analytics Options', $submenu[ $this->options_menu_instance->get_menu_slug() ][1][0] );
+
+		$submenu = $original_submenu;
 	}
 }

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -7,7 +7,6 @@
 
 namespace AmpProject\AmpWP\Tests\Admin;
 
-use AMP_Options_Manager;
 use AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu;
 use AmpProject\AmpWP\Admin\DevToolsUserAccess;
 use AmpProject\AmpWP\Admin\GoogleFonts;
@@ -20,6 +19,7 @@ use WP_UnitTestCase;
  * Tests for AnalyticsOptionsSubmenu.
  *
  * @group options-menu
+ * @coversDefaultClass \AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu
  */
 class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 
@@ -56,7 +56,7 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 	/**
 	 * Test register.
 	 *
-	 * @see AnalyticsOptionsSubmenu::register()
+	 * @covers :register()
 	 */
 	public function test_register() {
 		$this->instance->register();
@@ -66,7 +66,7 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 	/**
 	 * Test add_submenu_link.
 	 *
-	 * @covers AnalyticsOptionsSubmenu::add_submenu_link()
+	 * @covers ::add_submenu_link()
 	 */
 	public function test_link_is_added() {
 		global $submenu;

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -85,7 +85,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
 		$this->assertCount( 2, $submenu['amp-options'] );
-		$this->assertEquals( 'amp-options', $submenu['amp-options'][0][2] );
+		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
 	}
 
 	/**

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,7 +84,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 4, $submenu['amp-options'] );
+		$this->assertCount( 2, $submenu['amp-options'] );
 		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
 	}
 

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,7 +84,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( version_compare( get_bloginfo( 'version' ), '5.2', '<' ) ? 2 : 4, $submenu['amp-options'] );
+		$this->assertCount( 2, $submenu['amp-options'] );
 		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
 	}
 

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -71,6 +71,9 @@ class OptionsMenuTest extends WP_UnitTestCase {
 	public function test_add_menu_items() {
 		global $_parent_pages, $submenu;
 
+		$original_submenu      = $submenu;
+		$original_parent_pages = $_parent_pages;
+
 		wp_set_current_user(
 			self::factory()->user->create(
 				[
@@ -84,8 +87,11 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 2, $submenu['amp-options'] );
-		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
+		$this->assertCount( 1, $submenu['amp-options'] );
+		$this->assertEquals( 'amp-options', $submenu['amp-options'][0][2] );
+
+		$submenu       = $original_submenu;
+		$_parent_pages = $original_parent_pages;
 	}
 
 	/**

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,7 +84,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 1, $submenu['amp-options'] );
+		$this->assertCount( 2, $submenu['amp-options'] );
 		$this->assertEquals( 'amp-options', $submenu['amp-options'][0][2] );
 	}
 

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,9 +84,8 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 2, $submenu['amp-options'] );
-		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
-		$this->assertEquals( 'amp-options', $submenu['amp-options'][1][2] );
+		$this->assertCount( 1, $submenu['amp-options'] );
+		$this->assertEquals( 'amp-options', $submenu['amp-options'][0][2] );
 	}
 
 	/**

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,7 +84,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 2, $submenu['amp-options'] );
+		$this->assertCount( version_compare( get_bloginfo( 'version' ), '5.2', '<' ) ? 2 : 4, $submenu['amp-options'] );
 		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
 	}
 

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -84,7 +84,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 		$this->assertEquals( 'amp-options', $_parent_pages['amp-options'] );
 
 		$this->assertArrayHasKey( 'amp-options', $submenu );
-		$this->assertCount( 2, $submenu['amp-options'] );
+		$this->assertCount( 4, $submenu['amp-options'] );
 		$this->assertEquals( 'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url', $submenu['amp-options'][0][2] );
 	}
 

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -127,9 +127,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_add_admin_menu_new_invalid_url_count() {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $submenu;
-		AMP_Validation_Manager::init(); // Register the post type and taxonomy.
 
-		unset( $submenu[ AMP_Options_Manager::OPTION_NAME ] );
+		$original_submenu = $submenu;
+
+		AMP_Validation_Manager::init(); // Register the post type and taxonomy.
 		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
 
 		$submenu[ AMP_Options_Manager::OPTION_NAME ] = [
@@ -166,6 +167,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
 
 		$this->assertStringContains( '<span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+
+		$submenu = $original_submenu;
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -998,7 +998,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_add_admin_menu_validation_error_item() {
 		global $submenu;
 
-		$submenu = [];
+		$original_submenu = $submenu;
+
 		AMP_Validation_Error_Taxonomy::register();
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
@@ -1010,6 +1011,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		];
 		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );
+
+		$submenu = $original_submenu;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5190  

In #5155 we removed the Analytics menu page and placed the analytics option on the settings screen. This restores that menu item with a link to the Analytics section of the menu page.

Additional changes:
- Passed the URL hash into the root settings screen component so that it can be used to scroll to sections after the UI loads
- Moved the drawers on the settings screen up to the root settings screen component so that all the handling of IDs/anchors can be in one file
- Created an `AnalyticsOptionsSubmenu` service class, which is a stripped-down version of the class that was removed in #5155. It inserts a link into the AMP admin menu in the second position. 
- Created a `get_menu_slug` method in the `OptionsMenu` class for consumption in `AnalyticsOptionsSubmenu`. 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
