### PR TITLE
Eliminate regex used to determine if content from output buffer is a valid HTML document since done actions now used

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1941,7 +1941,7 @@ class AMP_Theme_Support {
 		 * Abort if the response was not HTML. To be post-processed as an AMP page, the output-buffered document must
 		 * have the HTML mime type and it must start with <html> followed by <head> tag (with whitespace, doctype, and comments optionally interspersed).
 		 */
-		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || ! preg_match( '#^(?:<!.*?>|\s+)*+<html.*?>(?:<!.*?>|\s+)*+<head\b(.*?)>#is', $response ) ) {
+		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) ) {
 			return $response;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1927,7 +1927,7 @@ class AMP_Theme_Support {
 		 * Abort if the response was not HTML. To be post-processed as an AMP page, the output-buffered document must
 		 * have the HTML mime type and it must start with <html> followed by <head> tag (with whitespace, doctype, and comments optionally interspersed).
 		 */
-		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || ! preg_match( '#^(?:<!.*?>|[^\S\s]+)*<html.*?>(?:<!.*?>|[^\S\s]+)*<head\b(.*?)>#is', $response ) ) {
+		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || ! preg_match( '#^(?:<!.*?>|\s+)*+<html.*?>(?:<!.*?>|\s+)*+<head\b(.*?)>#is', $response ) ) {
 			return $response;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1923,7 +1923,7 @@ class AMP_Theme_Support {
 			);
 		}
 
-		// Abort if an expected template was not rendered.
+		// Abort if an expected template was not rendered, in that template actions didn't fire and response type is not HTML.
 		$did_template_action = (
 			did_action( 'wp_head' )
 			||
@@ -1933,15 +1933,7 @@ class AMP_Theme_Support {
 			||
 			did_action( 'amp_post_template_footer' )
 		);
-		if ( ! $did_template_action ) {
-			return $response;
-		}
-
-		/*
-		 * Abort if the response was not HTML. To be post-processed as an AMP page, the output-buffered document must
-		 * have the HTML mime type and it must start with <html> followed by <head> tag (with whitespace, doctype, and comments optionally interspersed).
-		 */
-		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) ) {
+		if ( ! $did_template_action || Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) ) {
 			return $response;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1927,7 +1927,7 @@ class AMP_Theme_Support {
 		 * Abort if the response was not HTML. To be post-processed as an AMP page, the output-buffered document must
 		 * have the HTML mime type and it must start with <html> followed by <head> tag (with whitespace, doctype, and comments optionally interspersed).
 		 */
-		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || ! preg_match( '#^(?:<!.*?>|\s+)*<html.*?>(?:<!.*?>|\s+)*<head\b(.*?)>#is', $response ) ) {
+		if ( Attribute::TYPE_HTML !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || ! preg_match( '#^(?:<!.*?>|[^\S\s]+)*<html.*?>(?:<!.*?>|[^\S\s]+)*<head\b(.*?)>#is', $response ) ) {
 			return $response;
 		}
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2134,50 +2134,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test prepare_response for responses that may or may not be valid HTML.
-	 *
-	 * @covers AMP_Theme_Support::prepare_response()
-	 */
-	public function test_prepare_response_varying_html() {
-		wp();
-		add_filter( 'amp_validation_error_sanitized', '__return_true' );
-		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
-		AMP_Theme_Support::init();
-		AMP_Theme_Support::finish_init();
-
-		// Make sure that prepare_response saw that a template hook fired.
-		get_echo( 'wp_head' );
-
-		// JSON.
-		$input = '{"success":true}';
-		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
-
-		// Nothing, for redirect.
-		$input = '';
-		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
-
-		// HTML, but a fragment.
-		$input = '<ul><li>one</li><li>two</li><li>three</li></ul>';
-		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
-
-		// HTML, but still a fragment.
-		$input = '<html><header><h1>HellO!</h1></header></html>';
-		$this->assertEquals( $input, AMP_Theme_Support::prepare_response( $input ) );
-
-		// HTML, but very stripped down.
-		$input  = '<html><head></head>Hello</html>';
-		$output = AMP_Theme_Support::prepare_response( $input );
-		$this->assertStringContains( '<html amp', $output );
-		$this->assertStringContains( '<meta charset="utf-8">', $output );
-
-		// HTML with doctype, comments, and whitespace before head.
-		$input  = "   <!--\nHello world!\n-->\n\n<!DOCTYPE html>  <html\n\n>\n<head profile='http://www.acme.com/profiles/core'></head><body>Hello</body></html>";
-		$output = AMP_Theme_Support::prepare_response( $input );
-		$this->assertStringContains( '<html amp', $output );
-		$this->assertStringContains( '<meta charset="utf-8">', $output );
-	}
-
-	/**
 	 * Test prepare_response for responses that do not trigger standard template actions.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()


### PR DESCRIPTION
## Summary

Optimizes the number of steps that may be needed to determine if the content from the output buffer is a valid match.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
