### PR TITLE
Tag internal PHP API surface and create index of what is publicly exposed

### DIFF
--- a/assets/src/classic-editor/amp-post-meta-box.js
+++ b/assets/src/classic-editor/amp-post-meta-box.js
@@ -23,7 +23,7 @@ window.ampPostMetaBox = ( function( $ ) {
 		data: {
 			canonical: false, // Overridden by amp_is_canonical().
 			previewLink: '',
-			enabled: true, // Overridden by post_supports_amp( $post ).
+			enabled: true, // Overridden by amp_is_post_supported( $post ).
 			canSupport: true, // Overridden by count( AMP_Post_Type_Support::get_support_errors( $post ) ) === 0.
 			statusInputName: '',
 			l10n: {

--- a/back-compat/back-compat.php
+++ b/back-compat/back-compat.php
@@ -6,12 +6,19 @@
  */
 
 /**
- * Adds hooks to use legacy templates.
+ * Add hooks to use legacy AMP post templates from before v0.4.
  *
  * If you want to use the template that shipped with v0.3 and earlier, you can use this to force that.
  * Note that this may not stick around forever, so use caution and `function_exists`.
+ *
+ * Note that the old legacy post templates from AMP plugin v0.3 should no longer be used. Update to using
+ * the current AMP legacy post templates or better yet switch to using a full Reader theme.
+ *
+ * @deprecated Use Reader themes instead of old legacy AMP post templates.
+ * @since 0.4
  */
 function amp_backcompat_use_v03_templates() {
+	_deprecated_function( __FUNCTION__, '2.0' );
 	add_filter( 'amp_customizer_is_enabled', '__return_false' );
 	add_filter( 'amp_post_template_dir', '_amp_backcompat_use_v03_templates_callback', 0 ); // Early in case there are other overrides.
 }
@@ -19,7 +26,8 @@ function amp_backcompat_use_v03_templates() {
 /**
  * Callback for getting the legacy templates directory.
  *
- * @access private
+ * @internal
+ * @deprecated
  *
  * @param string $templates Template directory.
  * @return string Legacy template directory.

--- a/back-compat/templates-v0-3/single.php
+++ b/back-compat/templates-v0-3/single.php
@@ -17,11 +17,17 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
-	<?php do_action( 'amp_post_template_head', $this ); ?>
+	<?php
+	/** This action is documented in templates/html-start.php */
+	do_action( 'amp_post_template_head', $this );
+	?>
 
 	<style amp-custom>
 	<?php $this->load_parts( [ 'style' ] ); ?>
-	<?php do_action( 'amp_post_template_css', $this ); ?>
+	<?php
+	/** This action is documented in templates/html-start.php */
+	do_action( 'amp_post_template_css', $this );
+	?>
 	</style>
 </head>
 <body>
@@ -29,10 +35,23 @@
 <div class="amp-wp-content">
 	<h1 class="amp-wp-title"><?php echo wp_kses_data( $this->get( 'post_title' ) ); ?></h1>
 	<ul class="amp-wp-meta">
-		<?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', [ 'meta-author', 'meta-time', 'meta-taxonomy' ] ) ); ?>
+		<?php
+		/**
+		 * Filters the template parts to load in the meta area of the AMP legacy post template from before v0.4.
+		 *
+		 * @since 0.2
+		 * @deprecated
+		 *
+		 * @param string[] Templates to load.
+		 */
+		$this->load_parts( apply_filters( 'amp_post_template_meta_parts', [ 'meta-author', 'meta-time', 'meta-taxonomy' ] ) );
+		?>
 	</ul>
 	<?php echo $this->get( 'post_amp_content' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </div>
-<?php do_action( 'amp_post_template_footer', $this ); ?>
+<?php
+/** This action is documented in templates/html-start.php */
+do_action( 'amp_post_template_footer', $this );
+?>
 </body>
 </html>

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -149,6 +149,8 @@ def GenerateHeaderPHP(out):
 	out.append(' * `mandatory_parent_denylist` in the amp_wp_build.py script.')
 	out.append(' *')
 	out.append(' * phpcs:ignoreFile')
+	out.append(' *')
+	out.append(' * @internal')
 	out.append(' */')
 	out.append('class AMP_Allowed_Tags_Generated {')
 	out.append('')

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * This script outputs an index of the public-facing PHP API from the src and includes directories.
+ *
+ * @codeCoverageIgnore
+ * @package AMP
+ */
+
+if ( ! defined( 'WP_CLI' ) ) {
+	fwrite( STDERR, sprintf( 'Invoke via WP-CLI: wp eval-file bin/%s', basename( __FILE__ ) ) );
+	exit( 1 );
+}
+if ( ! function_exists( 'WP_Parser\get_wp_files' ) || ! function_exists( 'WP_Parser\parse_files' ) ) {
+	WP_CLI::error( 'Install and activate the phpdoc-parser plugin.' );
+}
+
+error_reporting( 0 ); // phpcs:ignore -- Because of some phpdoc internal errors.
+
+chdir( __DIR__ . '/..' );
+$files = [];
+if ( empty( $files ) ) {
+	$directories = [
+		'src/',
+		'includes/',
+	];
+
+	$files = [];
+	foreach ( $directories as $directory ) {
+		$files = array_merge( $files, WP_Parser\get_wp_files( $directory ) );
+	}
+}
+
+$parsed = WP_Parser\parse_files( $files, __DIR__ );
+
+/**
+ * Is parsed entity internal?
+ *
+ * @param array $parsed Parsed entity.
+ * @return bool Whether internal (or deprecated)
+ * @throws Exception If lacking tags.
+ */
+function is_internal_doc( $parsed ) {
+	if ( isset( $parsed['doc']['description'] ) && preg_match( '/This (filter|action) is documented in/', $parsed['doc']['description'] ) ) {
+		return true;
+	}
+
+	if ( empty( $parsed['doc']['tags'] ) ) {
+		throw new Exception( "Missing tags for {$parsed['name']}." );
+	}
+
+	foreach ( $parsed['doc']['tags'] as $tag ) {
+		if ( 'internal' === $tag['name'] ) {
+			return true;
+		} elseif ( 'deprecated' === $tag['name'] ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Process function.
+ *
+ * @param array $parsed_function Parsed function.
+ * @param null  $class           Class name the function belongs to.
+ * @return array Entities.
+ */
+function process_function( $parsed_function, $class = null ) {
+	$entries = [];
+
+	if ( ! $class && ! is_internal_doc( $parsed_function ) ) {
+		$name = '';
+		if ( 'global' !== $parsed_function['namespace'] ) {
+			$name .= $parsed_function['namespace'] . '\\';
+		}
+		if ( $class ) {
+			$name .= "{$class}::";
+		}
+		$name .= $parsed_function['name'] . '()';
+
+		$entries[] = [
+			'type' => $class ? 'method' : 'function',
+			'name' => $name,
+		];
+	}
+
+	if ( isset( $parsed_function['hooks'] ) ) {
+		foreach ( $parsed_function['hooks'] as $parsed_hook ) {
+			$entries = array_merge( $entries, process_hook( $parsed_hook ) );
+		}
+	}
+
+	return $entries;
+}
+
+/**
+ * Process hook.
+ *
+ * @param array $parsed_hook Parsed hook.
+ * @return array Entities.
+ */
+function process_hook( $parsed_hook ) {
+	if ( is_internal_doc( $parsed_hook ) ) {
+		return [];
+	}
+	return [
+		wp_array_slice_assoc( $parsed_hook, [ 'name', 'type' ] ),
+	];
+}
+
+/**
+ * Process class.
+ *
+ * @param array $parsed_class Parsed class.
+ * @return array Entities.
+ */
+function process_class( $parsed_class ) {
+	$entries  = [];
+	$internal = is_internal_doc( $parsed_class );
+	if ( ! $internal ) {
+		$name = '';
+		if ( 'global' !== $parsed_class['namespace'] ) {
+			$name .= $parsed_class['namespace'] . '\\';
+		}
+		$name .= $parsed_class['name'];
+
+		$entries[] = [
+			'type' => 'class',
+			'name' => $name,
+		];
+	}
+	if ( isset( $parsed_class['methods'] ) ) {
+		foreach ( $parsed_class['methods'] as $parsed_method ) {
+			$entries = array_merge(
+				$entries,
+				process_function(
+					$parsed_method,
+					$parsed_class['name']
+				)
+			);
+		}
+	}
+	return $entries;
+}
+
+$entries = [];
+foreach ( $parsed as $parsed_file ) {
+	if ( isset( $parsed_file['classes'] ) ) {
+		foreach ( $parsed_file['classes'] as $parsed_class ) {
+			$entries = array_merge( $entries, process_class( $parsed_class ) );
+		}
+	}
+	if ( isset( $parsed_file['functions'] ) ) {
+		foreach ( $parsed_file['functions'] as $parsed_function ) {
+			$entries = array_merge( $entries, process_function( $parsed_function, null ) );
+		}
+	}
+}
+
+foreach ( $entries as $entry ) {
+	echo "{$entry['type']}\t{$entry['name']}\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -64,8 +64,8 @@ function is_internal_doc( $parsed ) {
 /**
  * Process function.
  *
- * @param array         $parsed_function Parsed function.
- * @param string|null  $class            Class name the function belongs to. Defaults to null.
+ * @param array        $parsed_function Parsed function.
+ * @param string|null  $class           Class name the function belongs to. Defaults to null.
  * @return array Entities.
  */
 function process_function( $parsed_function, $class = null ) {

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -64,8 +64,8 @@ function is_internal_doc( $parsed ) {
 /**
  * Process function.
  *
- * @param array $parsed_function Parsed function.
- * @param null  $class           Class name the function belongs to.
+ * @param array         $parsed_function Parsed function.
+ * @param string|null  $class            Class name the function belongs to. Defaults to null.
  * @return array Entities.
  */
 function process_function( $parsed_function, $class = null ) {

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -64,8 +64,8 @@ function is_internal_doc( $parsed ) {
 /**
  * Process function.
  *
- * @param array        $parsed_function Parsed function.
- * @param string|null  $class           Class name the function belongs to. Defaults to null.
+ * @param array       $parsed_function Parsed function.
+ * @param string|null $class           Class name the function belongs to. Defaults to null.
  * @return array Entities.
  */
 function process_function( $parsed_function, $class = null ) {

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -14,7 +14,7 @@ if ( ! function_exists( 'WP_Parser\get_wp_files' ) || ! function_exists( 'WP_Par
 	WP_CLI::error( 'Install and activate the phpdoc-parser plugin.' );
 }
 
-error_reporting( 0 ); // phpcs:ignore -- Because of some phpdoc internal errors.
+error_reporting( E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED ); // phpcs:ignore -- Because of some phpdoc internal errors.
 
 chdir( __DIR__ . '/..' );
 $files = [];

--- a/bin/create-phpdoc-index.php
+++ b/bin/create-phpdoc-index.php
@@ -22,6 +22,8 @@ if ( empty( $files ) ) {
 	$directories = [
 		'src/',
 		'includes/',
+		'templates/',
+		'back-compat/',
 	];
 
 	$files = [];
@@ -154,6 +156,11 @@ foreach ( $parsed as $parsed_file ) {
 	if ( isset( $parsed_file['functions'] ) ) {
 		foreach ( $parsed_file['functions'] as $parsed_function ) {
 			$entries = array_merge( $entries, process_function( $parsed_function, null ) );
+		}
+	}
+	if ( isset( $parsed_file['hooks'] ) ) {
+		foreach ( $parsed_file['hooks'] as $parsed_hook ) {
+			$entries = array_merge( $entries, process_hook( $parsed_hook, null ) );
 		}
 	}
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ comment: off
 
 ignore:
   - "/bin"
+  - "/back-compat"

--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -10,6 +10,7 @@
  * Class representing a single admin pointer.
  *
  * @since 1.2
+ * @internal
  */
 class AMP_Admin_Pointer {
 

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -10,6 +10,7 @@
  * Class managing admin pointers to enhance discoverability.
  *
  * @since 1.2
+ * @internal
  */
 class AMP_Admin_Pointers {
 

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -130,7 +130,7 @@ class AMP_Editor_Blocks {
 	 * @return string Content (unmodified).
 	 */
 	public function tally_content_requiring_amp_scripts( $content ) {
-		if ( ! is_amp_endpoint() ) {
+		if ( ! amp_is_request() ) {
 			$pattern = sprintf( '/<(%s)\b.*?>/s', implode( '|', $this->amp_blocks ) );
 			if ( preg_match_all( $pattern, $content, $matches ) ) {
 				$this->content_required_amp_scripts = array_merge(
@@ -146,7 +146,7 @@ class AMP_Editor_Blocks {
 	 * Print AMP scripts required for AMP components used in a non-AMP document (dirty AMP).
 	 */
 	public function print_dirty_amp_scripts() {
-		if ( ! is_amp_endpoint() && ! empty( $this->content_required_amp_scripts ) ) {
+		if ( ! amp_is_request() && ! empty( $this->content_required_amp_scripts ) ) {
 			wp_scripts()->do_items( $this->content_required_amp_scripts );
 		}
 	}

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Editor_Blocks
+ *
+ * @internal
  */
 class AMP_Editor_Blocks {
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -10,6 +10,7 @@
  * Post meta box class.
  *
  * @since 0.6
+ * @internal
  */
 class AMP_Post_Meta_Box {
 

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -645,7 +645,7 @@ class AMP_Template_Customizer {
 				wp_json_encode(
 					[
 						'available' => amp_is_available(),
-						'enabled'   => is_amp_endpoint(),
+						'enabled'   => amp_is_request(),
 					]
 				)
 			)

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -17,6 +17,7 @@ use AmpProject\AmpWP\Services;
  * {@see amp_customizer_editor_link()} as a submenu to the Appearance menu.
  *
  * @since 0.4
+ * @internal
  */
 class AMP_Template_Customizer {
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -9,6 +9,8 @@ use AmpProject\AmpWP\Option;
 
 /**
  * Sets up the AMP template editor for the Customizer.
+ *
+ * @internal
  */
 function amp_init_customizer() {
 
@@ -29,6 +31,7 @@ function amp_init_customizer() {
 /**
  * Get permalink for the first AMP-eligible post.
  *
+ * @internal
  * @return string|null URL on success, null if none found.
  */
 function amp_admin_get_preview_permalink() {
@@ -82,6 +85,7 @@ function amp_admin_get_preview_permalink() {
 /**
  * Provides a URL to the customizer.
  *
+ * @internal
  * @return string
  */
 function amp_get_customizer_url() {
@@ -107,6 +111,8 @@ function amp_get_customizer_url() {
 
 /**
  * Registers a submenu page to access the AMP template editor panel in the Customizer.
+ *
+ * @internal
  */
 function amp_add_customizer_link() {
 	$customizer_url = amp_get_customizer_url();
@@ -131,6 +137,7 @@ function amp_add_customizer_link() {
  *
  * @since 0.5
  * @see amp_get_analytics()
+ * @internal
  *
  * @param array $analytics Analytics.
  * @return array Analytics.
@@ -156,6 +163,8 @@ function amp_add_custom_analytics( $analytics = [] ) {
 
 /**
  * Bootstrap AMP Editor core blocks.
+ *
+ * @internal
  */
 function amp_editor_core_blocks() {
 	$editor_blocks = new AMP_Editor_Blocks();
@@ -166,6 +175,7 @@ function amp_editor_core_blocks() {
  * Bootstraps AMP admin classes.
  *
  * @since 1.5.0
+ * @internal
  */
 function amp_bootstrap_admin() {
 	$admin_pointers = new AMP_Admin_Pointers();
@@ -178,6 +188,7 @@ function amp_bootstrap_admin() {
 /**
  * Whether to activate the new onboarding feature.
  *
+ * @internal
  * @return bool
  */
 function amp_should_use_new_onboarding() {

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -416,7 +416,7 @@ function amp_is_available() {
 			return;
 		}
 		$message = sprintf(
-			/* translators: %1$s: amp_is_request(), %2$s: is_amp_endpoint(), %3$s: the current action, %4$s: the wp action, %5$s: the WP_Query class, %6$s: the amp_skip_post() function */
+			/* translators: %1$s: amp_is_available(), %2$s: amp_is_request(), %3$s: is_amp_endpoint, %4$s: the current action, %5$s: the wp action, %6$s: the WP_Query class, %7$s: the amp_skip_post() function */
 			__( '%1$s (or %2$s, formerly %3$s) was called too early and so it will not work properly. WordPress is currently doing the "%4$s" action. Calling this function before the "%5$s" action means it will not have access to %6$s and the queried object to determine if it is an AMP response, thus neither the "%7$s" filter nor the AMP enabled toggle will be considered.', 'amp' ),
 			'amp_is_available()',
 			'amp_is_request()',
@@ -1857,9 +1857,9 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 		return;
 	}
 
-	$is_amp_endpoint = amp_is_request();
+	$is_amp_request = amp_is_request();
 
-	if ( $is_amp_endpoint ) {
+	if ( $is_amp_request ) {
 		$href = amp_remove_endpoint( amp_get_current_url() );
 	} elseif ( is_singular() ) {
 		$href = amp_get_permalink( get_queried_object_id() ); // For sake of Reader mode.
@@ -1869,7 +1869,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 
 	$href = remove_query_arg( QueryVar::NOAMP, $href );
 
-	$icon = $is_amp_endpoint ? Icon::logo() : Icon::link();
+	$icon = $is_amp_request ? Icon::logo() : Icon::link();
 	$attr = [
 		'id'    => 'amp-admin-bar-item-status-icon',
 		'class' => 'ab-icon',
@@ -1887,14 +1887,14 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 		[
 			'parent' => 'amp',
 			'id'     => 'amp-view',
-			'title'  => esc_html( $is_amp_endpoint ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) ),
+			'title'  => esc_html( $is_amp_request ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) ),
 			'href'   => esc_url( $href ),
 		]
 	);
 
 	// Make sure the Customizer opens with AMP enabled.
 	$customize_node = $wp_admin_bar->get_node( 'customize' );
-	if ( $customize_node && $is_amp_endpoint && AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) {
+	if ( $customize_node && $is_amp_request && AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) {
 		$args = get_object_vars( $customize_node );
 		if ( amp_is_legacy() ) {
 			$args['href'] = add_query_arg( 'autofocus[panel]', AMP_Template_Customizer::PANEL_ID, $args['href'] );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -15,6 +15,7 @@ use AmpProject\AmpWP\QueryVar;
  * Handle activation of plugin.
  *
  * @since 0.2
+ * @internal
  *
  * @param bool $network_wide Whether the activation was done network-wide.
  */
@@ -31,6 +32,7 @@ function amp_activate( $network_wide = false ) {
  * Handle deactivation of plugin.
  *
  * @since 0.2
+ * @internal
  *
  * @param bool $network_wide Whether the activation was done network-wide.
  */
@@ -52,6 +54,7 @@ function amp_deactivate( $network_wide = false ) {
  * Bootstrap plugin.
  *
  * @since 1.5
+ * @internal
  */
 function amp_bootstrap_plugin() {
 	/**
@@ -95,6 +98,7 @@ function amp_bootstrap_plugin() {
  * Init AMP.
  *
  * @since 0.1
+ * @internal
  */
 function amp_init() {
 
@@ -228,6 +232,7 @@ function amp_init() {
  * the AMP setting to declare the post types support earlier than plugins/theme.
  *
  * @since 0.6
+ * @internal
  */
 function amp_after_setup_theme() {
 	amp_get_slug(); // Ensure AMP_QUERY_VAR is set.
@@ -257,6 +262,7 @@ function amp_after_setup_theme() {
  * This avoids issues when filtering the deprecated `query_string` hook.
  *
  * @since 0.3.3
+ * @internal
  *
  * @param array $query_vars Query vars.
  * @return array Query vars.
@@ -274,6 +280,7 @@ function amp_force_query_var_value( $query_vars ) {
  * Normally the front page would not get served if a query var is present other than preview, page, paged, and cpage.
  *
  * @since 0.6
+ * @internal
  * @see WP_Query::parse_query()
  * @link https://github.com/WordPress/wordpress-develop/blob/0baa8ae85c670d338e78e408f8d6e301c6410c86/src/wp-includes/class-wp-query.php#L951-L971
  *
@@ -380,6 +387,7 @@ function amp_is_legacy() {
  * Add frontend actions.
  *
  * @since 0.2
+ * @internal
  */
 function amp_add_frontend_actions() {
 	add_action( 'wp_head', 'amp_add_amphtml_link' );
@@ -543,6 +551,7 @@ function amp_is_available() {
  * And `amp_init_customizer()` will be able to recognize theme support by calling `amp_is_canonical()`.
  *
  * @since 0.4
+ * @internal
  */
 function _amp_bootstrap_customizer() {
 	add_action( 'after_setup_theme', 'amp_init_customizer', 12 );
@@ -554,6 +563,7 @@ function _amp_bootstrap_customizer() {
  * If post slug is updated the amp page with old post slug will be redirected to the updated url.
  *
  * @since 0.5
+ * @internal
  *
  * @param string $link New URL of the post.
  * @return string URL to be redirected.
@@ -602,6 +612,7 @@ function amp_get_slug() {
  * This is needed in particular due to subdirectory installs.
  *
  * @since 1.0
+ * @internal
  *
  * @return string Current URL.
  */
@@ -741,6 +752,7 @@ function amp_remove_endpoint( $url ) {
  * If there are known validation errors for the current URL then do not output anything.
  *
  * @since 1.0
+ * @internal
  */
 function amp_add_amphtml_link() {
 	/**
@@ -834,6 +846,8 @@ function is_amp_endpoint() {
 /**
  * Get AMP asset URL.
  *
+ * @internal
+ *
  * @param string $file Relative path to file in assets directory.
  * @return string URL.
  */
@@ -845,6 +859,7 @@ function amp_get_asset_url( $file ) {
  * Get AMP boilerplate code.
  *
  * @since 0.7
+ * @internal
  * @link https://www.ampproject.org/docs/reference/spec#boilerplate
  *
  * @return string Boilerplate code.
@@ -858,6 +873,7 @@ function amp_get_boilerplate_code() {
  * Get AMP boilerplate stylesheets.
  *
  * @since 1.3
+ * @internal
  * @link https://www.ampproject.org/docs/reference/spec#boilerplate
  *
  * @return string[] Stylesheets, where first is contained in style[amp-boilerplate] and the second in noscript>style[amp-boilerplate].
@@ -875,6 +891,7 @@ function amp_get_boilerplate_stylesheets() {
  * @since 0.6
  * @since 1.0 Add template mode.
  * @since 2.0 Add reader theme.
+ * @internal
  */
 function amp_add_generator_metadata() {
 	$content = sprintf( 'AMP Plugin v%s', AMP__VERSION );
@@ -892,6 +909,8 @@ function amp_add_generator_metadata() {
 
 /**
  * Register default scripts for AMP components.
+ *
+ * @internal
  *
  * @param WP_Scripts $wp_scripts Scripts.
  */
@@ -957,6 +976,7 @@ function amp_register_default_scripts( $wp_scripts ) {
  * Register default styles.
  *
  * @since 2.0
+ * @internal
  *
  * @param WP_Styles $styles Styles.
  */
@@ -981,6 +1001,7 @@ function amp_register_default_styles( WP_Styles $styles ) {
  * @see WP_Scripts::do_items()
  * @see AMP_Base_Embed_Handler::get_scripts()
  * @see AMP_Base_Sanitizer::get_scripts()
+ * @internal
  *
  * @param array $scripts Script handles mapped to URLs or true.
  * @return string HTML for scripts tags that have not yet been done.
@@ -1022,6 +1043,7 @@ function amp_render_scripts( $scripts ) {
  *
  * @link https://core.trac.wordpress.org/ticket/12009
  * @since 0.7
+ * @internal
  *
  * @param string $tag    The script tag.
  * @param string $handle The script handle.
@@ -1094,6 +1116,7 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
  * @link https://developers.google.com/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
  * @link https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests#cross-origin_requests_and_opaque_responses
  * @todo This should be proposed for WordPress core.
+ * @internal
  *
  * @param string $tag    Link tag HTML.
  * @param string $handle Dependency handle.
@@ -1125,6 +1148,7 @@ function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $han
  * Retrieve analytics data added in backend.
  *
  * @since 0.7
+ * @internal
  *
  * @param array $analytics Analytics entries.
  * @return array Analytics.
@@ -1165,6 +1189,7 @@ function amp_get_analytics( $analytics = [] ) {
  * Print analytics data.
  *
  * @since 0.7
+ * @internal
  *
  * @param array|string $analytics Analytics entries, or empty string when called via wp_footer action.
  */
@@ -1234,6 +1259,7 @@ function amp_print_analytics( $analytics ) {
  * Get content embed handlers.
  *
  * @since 0.7
+ * @internal
  *
  * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as embeds may apply
  *                      to non-post data (e.g. Text widget).
@@ -1332,6 +1358,7 @@ function amp_is_dev_mode() {
  *
  * @since 0.7
  * @since 1.1 Added AMP_Nav_Menu_Toggle_Sanitizer and AMP_Nav_Menu_Dropdown_Sanitizer.
+ * @internal
  *
  * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as sanitizers apply
  *                      to non-post data (e.g. Text widget).
@@ -1519,6 +1546,7 @@ function amp_get_content_sanitizers( $post = null ) {
  * Grabs featured image or the first attached image for the post.
  *
  * @since 0.7 This originally was located in the private method AMP_Post_Template::get_post_image_metadata().
+ * @internal
  *
  * @param WP_Post|int $post Post or post ID.
  * @return array|false $post_image_meta Post image metadata, or false if not found.
@@ -1584,6 +1612,7 @@ function amp_get_post_image_metadata( $post = null ) {
  *
  * @since 1.2.1
  * @link https://developers.google.com/search/docs/data-types/article#logo-guidelines
+ * @internal
  *
  * @return string Publisher logo image URL. WordPress logo if no site icon or custom logo defined, and no logo provided via 'amp_site_icon_url' filter.
  */
@@ -1642,6 +1671,7 @@ function amp_get_publisher_logo() {
  *
  * @since 0.7
  * @see AMP_Post_Template::build_post_data() Where the logic in this function originally existed.
+ * @internal
  *
  * @return array $metadata All schema.org metadata for the post.
  */
@@ -1724,6 +1754,7 @@ function amp_get_schemaorg_metadata() {
  * @since 0.7
  * @since 1.1 we pass `JSON_UNESCAPED_UNICODE` to `wp_json_encode`.
  * @see https://github.com/ampproject/amp-wp/issues/1969
+ * @internal
  */
 function amp_print_schemaorg_metadata() {
 	$metadata = amp_get_schemaorg_metadata();
@@ -1740,6 +1771,7 @@ function amp_print_schemaorg_metadata() {
  *
  * @see wp_kses()
  * @since 1.0
+ * @internal
  *
  * @param string $markup Markup to sanitize.
  * @return string HTML markup with tags allowed by amp-mustache.
@@ -1756,6 +1788,7 @@ function amp_wp_kses_mustache( $markup ) {
  * the `AMP_Validation_Manager::add_admin_bar_menu_items()` method.
  *
  * @see \AMP_Validation_Manager::add_admin_bar_menu_items()
+ * @internal
  *
  * @param WP_Admin_Bar $wp_admin_bar Admin bar.
  */

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -416,7 +416,7 @@ function amp_is_available() {
 			return;
 		}
 		$message = sprintf(
-			/* translators: %1$s: amp_is_available(), %2$s: amp_is_request(), %3$s: is_amp_endpoint, %4$s: the current action, %5$s: the wp action, %6$s: the WP_Query class, %7$s: the amp_skip_post() function */
+			/* translators: %1$s: amp_is_available(), %2$s: amp_is_request(), %3$s: is_amp_endpoint(), %4$s: the current action, %5$s: the wp action, %6$s: the WP_Query class, %7$s: the amp_skip_post() function */
 			__( '%1$s (or %2$s, formerly %3$s) was called too early and so it will not work properly. WordPress is currently doing the "%4$s" action. Calling this function before the "%5$s" action means it will not have access to %6$s and the queried object to determine if it is an AMP response, thus neither the "%7$s" filter nor the AMP enabled toggle will be considered.', 'amp' ),
 			'amp_is_available()',
 			'amp_is_request()',

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -753,16 +753,39 @@ function amp_remove_endpoint( $url ) {
  * If there are known validation errors for the current URL then do not output anything.
  *
  * @since 1.0
- * @internal
  */
 function amp_add_amphtml_link() {
-	/**
-	 * Filters whether to show the amphtml link on the frontend.
-	 *
-	 * @todo This filter's name is incorrect. It's not about adding a canonical link but adding the amphtml link.
-	 * @since 0.2
-	 */
-	if ( amp_is_canonical() || false === apply_filters( 'amp_frontend_show_canonical', true ) ) {
+	if (
+		amp_is_canonical()
+		||
+		/**
+		 * Filters whether to show the amphtml link on the frontend.
+		 *
+		 * This is deprecated since the name was wrong and the use case is not clear. To remove this from being printed,
+		 * instead of using the filter you can rather do:
+		 *
+		 *     add_action( 'template_redirect', static function () {
+		 *         remove_action( 'wp_head', 'amp_add_amphtml_link' );
+		 *     } );
+		 *
+		 * @since 0.2
+		 * @deprecated
+		 */
+		false === apply_filters_deprecated(
+			'amp_frontend_show_canonical',
+			[ true ],
+			'2.0',
+			'',
+			sprintf(
+				/* translators: 1: amphtml, 2: amp_add_amphtml_link(), 3: wp_head, 4: template_redirect */
+				esc_html__( 'Removal of %1$s link should be done by removing %2$s from the %3$s action at %4$s.', 'amp' ),
+				'amphtml',
+				__FUNCTION__ . '()',
+				'wp_head',
+				'template_redirect'
+			)
+		)
+	) {
 		return;
 	}
 

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -7,6 +7,8 @@
 
 /**
  * Register hooks.
+ *
+ * @internal
  */
 function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_title' );
@@ -31,6 +33,8 @@ function amp_post_template_init_hooks() {
 /**
  * Add title.
  *
+ * @internal
+ *
  * @param AMP_Post_Template $amp_template template.
  */
 function amp_post_template_add_title( $amp_template ) {
@@ -41,6 +45,8 @@ function amp_post_template_add_title( $amp_template ) {
 
 /**
  * Add canonical link.
+ *
+ * @internal
  *
  * @param AMP_Post_Template $amp_template Template.
  */
@@ -53,6 +59,8 @@ function amp_post_template_add_canonical( $amp_template ) {
 /**
  * Print fonts.
  *
+ * @internal
+ *
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_fonts( $amp_template ) {
@@ -64,6 +72,8 @@ function amp_post_template_add_fonts( $amp_template ) {
 
 /**
  * Add block styles for core blocks and third-party blocks.
+ *
+ * @internal
  *
  * @since 1.5.0
  */
@@ -79,6 +89,8 @@ function amp_post_template_add_block_styles() {
 
 /**
  * Print styles.
+ *
+ * @internal
  *
  * @param AMP_Post_Template $amp_template Template.
  */
@@ -102,6 +114,8 @@ function amp_post_template_add_styles( $amp_template ) {
 /**
  * Add analytics scripts.
  *
+ * @internal
+ *
  * @param array $data Data.
  * @return array Data.
  */
@@ -114,6 +128,8 @@ function amp_post_template_add_analytics_script( $data ) {
 
 /**
  * Print analytics data.
+ *
+ * @internal
  *
  * @since 0.3.2
  */

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_HTTP
+ *
+ * @internal
  */
 class AMP_HTTP {
 

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -10,6 +10,8 @@ use AmpProject\AmpWP\Option;
 
 /**
  * Class AMP_Post_Type_Support.
+ *
+ * @internal
  */
 class AMP_Post_Type_Support {
 

--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Service_Worker.
+ *
+ * @internal
  */
 class AMP_Service_Worker {
 

--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -243,7 +243,7 @@ class AMP_Service_Worker {
 	 * Add hooks to install the service worker from AMP page.
 	 */
 	public static function add_install_hooks() {
-		if ( ! amp_is_legacy() && is_amp_endpoint() ) {
+		if ( ! amp_is_legacy() && amp_is_request() ) {
 			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
 
 			// Prevent validation error due to the script that installs the service worker on non-AMP pages.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -510,7 +510,7 @@ class AMP_Theme_Support {
 	/**
 	 * Determine template availability of AMP for the given query.
 	 *
-	 * This is not intended to return whether AMP is available for a _specific_ post. For that, use `post_supports_amp()`.
+	 * This is not intended to return whether AMP is available for a _specific_ post. For that, use `amp_is_post_supported()`.
 	 *
 	 * @since 1.0
 	 * @global WP_Query $wp_query
@@ -756,7 +756,7 @@ class AMP_Theme_Support {
 			$matching_template['errors'][] = 'template_unsupported';
 		}
 
-		// For singular queries, post_supports_amp() is given the final say.
+		// For singular queries, amp_is_post_supported() is given the final say.
 		if ( $query->is_singular() || $query->is_posts_page ) {
 			/**
 			 * Queried object.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -322,7 +322,7 @@ class AMP_Theme_Support {
 			false !== get_query_var( amp_get_slug(), false )
 		);
 
-		if ( ! is_amp_endpoint() ) {
+		if ( ! amp_is_request() ) {
 			/*
 			 * Redirect to AMP-less URL if AMP is not available for this URL and yet the query var is present.
 			 * Temporary redirect is used for admin users because implied transitional mode and template support can be
@@ -415,7 +415,7 @@ class AMP_Theme_Support {
 			 * When in AMP transitional mode *with* theme support, then the proper AMP URL has the 'amp' URL param
 			 * and not the /amp/ endpoint. The URL param is now the exclusive way to mark AMP in transitional mode
 			 * when amp theme support present. This is important for plugins to be able to reliably call
-			 * is_amp_endpoint() before the parse_query action.
+			 * amp_is_request() before the parse_query action.
 			 */
 			$old_url = amp_get_current_url();
 			$new_url = add_query_arg( amp_get_slug(), '', amp_remove_endpoint( $old_url ) );
@@ -514,7 +514,7 @@ class AMP_Theme_Support {
 	 *
 	 * @since 1.0
 	 * @global WP_Query $wp_query
-	 * @see post_supports_amp()
+	 * @see amp_is_post_supported()
 	 *
 	 * @param WP_Query|WP_Post|null $query Query or queried post. If null then the global query will be used.
 	 * @return array {
@@ -2327,7 +2327,7 @@ class AMP_Theme_Support {
 		add_filter(
 			'script_loader_tag',
 			static function( $tag, $handle ) {
-				if ( is_amp_endpoint() && self::has_dependency( wp_scripts(), 'amp-paired-browsing-client', $handle ) ) {
+				if ( amp_is_request() && self::has_dependency( wp_scripts(), 'amp-paired-browsing-client', $handle ) ) {
 					$tag = preg_replace( '/(?<=<script)(?=\s|>)/i', ' ' . AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, $tag );
 				}
 				return $tag;

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -24,6 +24,8 @@ use AmpProject\Tag;
  * Class AMP_Theme_Support
  *
  * Callbacks for adding AMP-related things when theme support is added.
+ *
+ * @internal
  */
 class AMP_Theme_Support {
 

--- a/includes/cli/class-amp-cli-namespace.php
+++ b/includes/cli/class-amp-cli-namespace.php
@@ -13,6 +13,7 @@ use WP_CLI\Dispatcher\CommandNamespace;
  * Interacts with the AMP plugin.
  *
  * @since 1.3.0
+ * @internal
  */
 final class AMP_CLI_Namespace extends CommandNamespace {
 

--- a/includes/cli/class-amp-cli-validation-command.php
+++ b/includes/cli/class-amp-cli-validation-command.php
@@ -478,7 +478,7 @@ final class AMP_CLI_Validation_Command {
 
 		return array_filter(
 			$ids,
-			'post_supports_amp'
+			'amp_is_post_supported'
 		);
 	}
 

--- a/includes/cli/class-amp-cli-validation-command.php
+++ b/includes/cli/class-amp-cli-validation-command.php
@@ -15,6 +15,7 @@ use AmpProject\AmpWP\Option;
  *
  * @since 1.0
  * @since 1.3.0 Renamed subcommands.
+ * @internal
  */
 final class AMP_CLI_Validation_Command {
 

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -42,7 +42,7 @@ function amp_maybe_add_actions() {
 		return;
 	}
 
-	$is_amp_endpoint = is_amp_endpoint();
+	$is_amp_endpoint = amp_is_request();
 
 	/**
 	 * Queried post object.
@@ -50,7 +50,7 @@ function amp_maybe_add_actions() {
 	 * @var WP_Post $post
 	 */
 	$post = get_queried_object();
-	if ( ! post_supports_amp( $post ) ) {
+	if ( ! amp_is_post_supported( $post ) ) {
 		if ( $is_amp_endpoint ) {
 			/*
 			 * Temporary redirect is used for admin users because reader mode and AMP support can be enabled by user at any time,
@@ -146,7 +146,7 @@ function amp_render_post( $post ) {
 	$post_id = $post->ID;
 
 	/*
-	 * If amp_render_post is called directly outside of the standard endpoint, is_amp_endpoint() will return false,
+	 * If amp_render_post is called directly outside of the standard endpoint, amp_is_request() will return false,
 	 * which is not ideal for any code that expects to run in an AMP context.
 	 * Let's force the value to be true while we render AMP.
 	 */
@@ -163,7 +163,7 @@ function amp_render_post( $post ) {
 	/**
 	 * Fires before rendering a post in AMP.
 	 *
-	 * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `is_amp_endpoint()`.
+	 * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `amp_is_request()`.
 	 *
 	 * @since 0.2
 	 * @deprecated

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -166,6 +166,7 @@ function amp_render_post( $post ) {
 	 * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `is_amp_endpoint()`.
 	 *
 	 * @since 0.2
+	 * @deprecated
 	 *
 	 * @param int $post_id Post ID.
 	 */

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -42,7 +42,7 @@ function amp_maybe_add_actions() {
 		return;
 	}
 
-	$is_amp_endpoint = amp_is_request();
+	$is_amp_request = amp_is_request();
 
 	/**
 	 * Queried post object.
@@ -51,7 +51,7 @@ function amp_maybe_add_actions() {
 	 */
 	$post = get_queried_object();
 	if ( ! amp_is_post_supported( $post ) ) {
-		if ( $is_amp_endpoint ) {
+		if ( $is_amp_request ) {
 			/*
 			 * Temporary redirect is used for admin users because reader mode and AMP support can be enabled by user at any time,
 			 * so they will be able to make AMP available for this URL and see the change without wrestling with the redirect cache.
@@ -62,7 +62,7 @@ function amp_maybe_add_actions() {
 		return;
 	}
 
-	if ( $is_amp_endpoint ) {
+	if ( $is_amp_request ) {
 
 		// Prevent infinite URL space under /amp/ endpoint.
 		global $wp;

--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -9,6 +9,8 @@
 
 /**
  * Class AMP_Base_Embed_Handler
+ *
+ * @since 0.2
  */
 abstract class AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -12,6 +12,7 @@ use AmpProject\Dom\Document;
  * Class AMP_Core_Block_Handler
  *
  * @since 1.0
+ * @internal
  */
 class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-crowdsignal-embed-handler.php
+++ b/includes/embeds/class-amp-crowdsignal-embed-handler.php
@@ -10,6 +10,8 @@
 
 /**
  * Class AMP_Crowdsignal_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Crowdsignal_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-dailymotion-embed-handler.php
+++ b/includes/embeds/class-amp-dailymotion-embed-handler.php
@@ -9,6 +9,8 @@
  * Class AMP_DailyMotion_Embed_Handler
  *
  * Much of this class is borrowed from Jetpack embeds
+ *
+ * @internal
  */
 class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-facebook-embed-handler.php
+++ b/includes/embeds/class-amp-facebook-embed-handler.php
@@ -9,6 +9,8 @@ use AmpProject\Dom\Document;
 
 /**
  * Class AMP_Facebook_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-gallery-embed-handler.php
+++ b/includes/embeds/class-amp-gallery-embed-handler.php
@@ -13,6 +13,7 @@ use AmpProject\Tag;
  * Class AMP_Gallery_Embed_Handler
  *
  * @since 0.2
+ * @internal
  */
 class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-gfycat-embed-handler.php
+++ b/includes/embeds/class-amp-gfycat-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Gfycat_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Gfycat_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-imgur-embed-handler.php
+++ b/includes/embeds/class-amp-imgur-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Imgur_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-instagram-embed-handler.php
+++ b/includes/embeds/class-amp-instagram-embed-handler.php
@@ -11,6 +11,8 @@ use AmpProject\Dom\Document;
  * Class AMP_Instagram_Embed_Handler
  *
  * Much of this class is borrowed from Jetpack embeds
+ *
+ * @internal
  */
 class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	const SHORT_URL_HOST = 'instagr.am';

--- a/includes/embeds/class-amp-issuu-embed-handler.php
+++ b/includes/embeds/class-amp-issuu-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Issuu_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Issuu_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-meetup-embed-handler.php
+++ b/includes/embeds/class-amp-meetup-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Meetup_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Meetup_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-pinterest-embed-handler.php
+++ b/includes/embeds/class-amp-pinterest-embed-handler.php
@@ -7,6 +7,8 @@
 
 /**
  * Class AMP_Pinterest_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -12,6 +12,7 @@
  * Creates AMP-compatible markup for the WordPress 'playlist' shortcode.
  *
  * @package AMP
+ * @internal
  */
 class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-reddit-embed-handler.php
+++ b/includes/embeds/class-amp-reddit-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Reddit_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**

--- a/includes/embeds/class-amp-scribd-embed-handler.php
+++ b/includes/embeds/class-amp-scribd-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Scribd_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-soundcloud-embed-handler.php
+++ b/includes/embeds/class-amp-soundcloud-embed-handler.php
@@ -9,6 +9,7 @@
  * Class AMP_SoundCloud_Embed_Handler
  *
  * @since 0.5
+ * @internal
  */
 class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-tiktok-embed-handler.php
+++ b/includes/embeds/class-amp-tiktok-embed-handler.php
@@ -9,6 +9,8 @@ use AmpProject\Dom\Document;
 
 /**
  * Class AMP_TikTok_Embed_Handler
+ *
+ * @internal
  */
 class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-tumblr-embed-handler.php
+++ b/includes/embeds/class-amp-tumblr-embed-handler.php
@@ -8,6 +8,8 @@
 
 /**
  * Class AMP_Tumblr_Embed_Handler
+ *
+ * @internal
  */
 class AMP_Tumblr_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -10,7 +10,9 @@ use AmpProject\Dom\Document;
 /**
  * Class AMP_Twitter_Embed_Handler
  *
- *  Much of this class is borrowed from Jetpack embeds
+ * Much of this class is borrowed from Jetpack embeds
+ *
+ * @internal
  */
 class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-vimeo-embed-handler.php
+++ b/includes/embeds/class-amp-vimeo-embed-handler.php
@@ -9,6 +9,8 @@
  * Class AMP_Vimeo_Embed_Handler
  *
  * Much of this class is borrowed from Jetpack embeds
+ *
+ * @internal
  */
 class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-wordpress-tv-embed-handler.php
+++ b/includes/embeds/class-amp-wordpress-tv-embed-handler.php
@@ -10,6 +10,7 @@
  * Class AMP_WordPress_TV_Embed_Handler
  *
  * @since 1.4
+ * @internal
  */
 class AMP_WordPress_TV_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -9,6 +9,8 @@
  * Class AMP_YouTube_Embed_Handler
  *
  * Much of this class is borrowed from Jetpack embeds.
+ *
+ * @internal
  */
 class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -10,6 +10,8 @@ use AmpProject\AmpWP\Option;
 
 /**
  * Class AMP_Options_Manager
+ *
+ * @internal
  */
 class AMP_Options_Manager {
 

--- a/includes/options/class-amp-reader-theme-rest-controller.php
+++ b/includes/options/class-amp-reader-theme-rest-controller.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
  * AMP reader theme REST controller.
  *
  * @since 2.0
+ * @internal
  */
 final class AMP_Reader_Theme_REST_Controller extends WP_REST_Controller {
 

--- a/includes/sanitizers/class-amp-accessibility-sanitizer.php
+++ b/includes/sanitizers/class-amp-accessibility-sanitizer.php
@@ -12,6 +12,7 @@ use AmpProject\Role;
  * Sanitizes attributes required for AMP accessibility requirements.
  *
  * @since 1.5.3
+ * @internal
  */
 class AMP_Accessibility_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -10,6 +10,8 @@
  * `mandatory_parent_denylist` in the amp_wp_build.py script.
  *
  * phpcs:ignoreFile
+ *
+ * @internal
  */
 class AMP_Allowed_Tags_Generated {
 

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -11,6 +11,8 @@ use AmpProject\DevMode;
  * Class AMP_Audio_Sanitizer
  *
  * Converts <audio> tags to <amp-audio>
+ *
+ * @internal
  */
 class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -10,6 +10,8 @@ use AmpProject\Dom\Document;
 
 /**
  * Class AMP_Base_Sanitizer
+ *
+ * @since 0.2
  */
 abstract class AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -9,6 +9,8 @@
  * Class AMP_Block_Sanitizer
  *
  * Modifies elements created as blocks to match the blocks' AMP-specific configuration.
+ *
+ * @internal
  */
 class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -11,6 +11,8 @@ use AmpProject\Dom\Document;
  * Class AMP_Comments_Sanitizer
  *
  * Strips and corrects attributes in forms.
+ *
+ * @internal
  */
 class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -17,6 +17,7 @@ use AmpProject\Role;
  *
  * @see AMP_Validation_Error_Taxonomy::accept_core_theme_validation_errors()
  * @since 1.0
+ * @internal
  */
 class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-dev-mode-sanitizer.php
+++ b/includes/sanitizers/class-amp-dev-mode-sanitizer.php
@@ -12,6 +12,7 @@
  * Class AMP_Dev_Mode_Sanitizer
  *
  * @since 1.3
+ * @internal
  */
 final class AMP_Dev_Mode_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-embed-sanitizer.php
+++ b/includes/sanitizers/class-amp-embed-sanitizer.php
@@ -11,6 +11,8 @@ use AmpProject\Dom\Document;
  * Class AMP_Embed_Sanitizer
  *
  * Calls sanitize_raw_embeds method on embed handlers.
+ *
+ * @internal
  */
 class AMP_Embed_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -15,6 +15,7 @@ use AmpProject\Dom\Document;
  * Strips and corrects attributes in forms.
  *
  * @since 0.7
+ * @internal
  */
 class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -12,6 +12,8 @@ use AmpProject\Tag;
  * Class AMP_Gallery_Block_Sanitizer
  *
  * Modifies gallery block to match the block's AMP-specific configuration.
+ *
+ * @internal
  */
 class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -13,6 +13,8 @@ use AmpProject\Layout;
  * Class AMP_Iframe_Sanitizer
  *
  * Converts <iframe> tags to <amp-iframe>
+ *
+ * @internal
  */
 class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -14,6 +14,8 @@ use AmpProject\Tag;
  * Class AMP_Img_Sanitizer
  *
  * Converts <img> tags to <amp-img> or <amp-anim>
+ *
+ * @internal
  */
 class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -12,6 +12,7 @@ use AmpProject\Layout;
  * Class AMP_Layout_Sanitizer
  *
  * @since 1.5.0
+ * @internal
  */
 class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -23,6 +23,7 @@ use AmpProject\Tag;
  *
  * @link https://github.com/ampproject/amphtml/issues/12496
  * @since 1.4.0
+ * @internal
  */
 class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -20,6 +20,7 @@ use AmpProject\Tag;
  * Sanitizes meta tags found in the header.
  *
  * @since 1.5.0
+ * @internal
  */
 class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
@@ -13,6 +13,7 @@ use AmpProject\Dom\Document;
  * Handles state for navigation menu dropdown toggles, based on theme support.
  *
  * @since 1.1.0
+ * @internal
  */
 class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -13,6 +13,7 @@ use AmpProject\Dom\Document;
  * Handles state for navigation menu toggles, based on theme support.
  *
  * @since 1.1.0
+ * @internal
  */
 class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-o2-player-sanitizer.php
+++ b/includes/sanitizers/class-amp-o2-player-sanitizer.php
@@ -14,6 +14,7 @@ use AmpProject\Dom\Document;
  *
  * @since 1.0
  * @see https://www.ampproject.org/docs/reference/components/amp-o2-player
+ * @internal
  */
 class AMP_O2_Player_Sanitizer extends AMP_Base_Sanitizer {
 	/**

--- a/includes/sanitizers/class-amp-playbuzz-sanitizer.php
+++ b/includes/sanitizers/class-amp-playbuzz-sanitizer.php
@@ -11,6 +11,7 @@
  * Converts Playbuzz embed to <amp-playbuzz>
  *
  * @see https://www.playbuzz.com/
+ * @internal
  */
 class AMP_Playbuzz_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -9,6 +9,8 @@
  * Class AMP_Rule_Spec
  *
  * Set of constants used throughout the sanitizer.
+ *
+ * @internal
  */
 abstract class AMP_Rule_Spec {
 	/*

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -12,6 +12,7 @@ use AmpProject\DevMode;
  * Class AMP_Script_Sanitizer
  *
  * @since 1.0
+ * @internal
  */
 class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -33,6 +33,8 @@ use Sabberworm\CSS\CSSList\Document as CSSDocument;
  * Class AMP_Style_Sanitizer
  *
  * Collects inline styles and outputs them in the amp-custom stylesheet.
+ *
+ * @internal
  */
 class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -29,6 +29,8 @@ use AmpProject\Tag;
  *     - `ChildTagSpec`       - Places restrictions on the number and type of child tags.
  *     - `if_value_regex`     - if one attribute value matches, this places a restriction
  *                              on another attribute/value.
+ *
+ * @internal
  */
 class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -10,9 +10,10 @@ use AmpProject\DevMode;
 /**
  * Class AMP_Video_Sanitizer
  *
- * @since 0.2
- *
  * Converts <video> tags to <amp-video>
+ *
+ * @since 0.2
+ * @internal
  */
 class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -10,9 +10,10 @@ use AmpProject\Dom\Document;
 /**
  * Trait AMP_Noscript_Fallback
  *
- * @since 1.1
- *
  * Used for sanitizers that place <noscript> tags with the original nodes on error.
+ *
+ * @since 1.1
+ * @internal
  */
 trait AMP_Noscript_Fallback {
 

--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -9,6 +9,8 @@ use AmpProject\AmpWP\Option;
 
 /**
  * Class AMP_Customizer_Design_Settings
+ *
+ * @internal
  */
 class AMP_Customizer_Design_Settings {
 

--- a/includes/settings/class-amp-customizer-settings.php
+++ b/includes/settings/class-amp-customizer-settings.php
@@ -7,6 +7,8 @@
 
 /**
  * Class AMP_Customizer_Settings
+ *
+ * @internal
  */
 class AMP_Customizer_Settings {
 

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -11,6 +11,7 @@ use AmpProject\Dom\Document;
  * Class AMP_Content_Sanitizer
  *
  * @since 0.4.1
+ * @internal
  */
 class AMP_Content_Sanitizer {
 

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -128,6 +128,7 @@ class AMP_Content {
 		$content = $this->content;
 
 		// First, embeds + the_content filter.
+		/** This filter is documented in wp-includes/post-template.php */
 		$content = apply_filters( 'the_content', $content );
 		$this->unregister_embed_handlers( $this->embed_handlers );
 

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -9,6 +9,7 @@
  * Class AMP_Post_Template
  *
  * @since 0.2
+ * @internal
  */
 class AMP_Post_Template {
 

--- a/includes/templates/reader-template-loader.php
+++ b/includes/templates/reader-template-loader.php
@@ -21,7 +21,7 @@ setup_postdata( $post );
 /**
  * Fires before rendering a post in AMP.
  *
- * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `is_amp_endpoint()`.
+ * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `amp_is_request()`.
  *
  * @since 0.2
  *

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -12,6 +12,8 @@ use AmpProject\Tag;
  * Class AMP_DOM_Utils
  *
  * Functionality to simplify working with Dom\Documents and DOMElements.
+ *
+ * @internal
  */
 class AMP_DOM_Utils {
 

--- a/includes/utils/class-amp-html-utils.php
+++ b/includes/utils/class-amp-html-utils.php
@@ -7,6 +7,8 @@
 
 /**
  * Class with static HTML utility methods.
+ *
+ * @internal
  */
 class AMP_HTML_Utils {
 

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -7,6 +7,8 @@
 
 /**
  * Class with static methods to extract image dimensions.
+ *
+ * @internal
  */
 class AMP_Image_Dimension_Extractor {
 
@@ -56,6 +58,14 @@ class AMP_Image_Dimension_Extractor {
 		}
 
 		$extracted_dimensions = array_fill_keys( $normalized_urls, false );
+
+		/**
+		 * Filters the dimensions extracted from image URLs.
+		 *
+		 * @since 0.5.1
+		 *
+		 * @param array $extracted_dimensions Extracted dimensions, initially mapping images URLs to false.
+		 */
 		$extracted_dimensions = apply_filters( 'amp_extract_image_dimensions_batch', $extracted_dimensions );
 
 		// We need to return a map with the original (un-normalized URL) as we that to match nodes that need dimensions.
@@ -132,6 +142,11 @@ class AMP_Image_Dimension_Extractor {
 
 		add_filter( 'amp_extract_image_dimensions_batch', [ __CLASS__, 'extract_by_downloading_images' ], 999, 1 );
 
+		/**
+		 * Fires after the amp_extract_image_dimensions_batch filter has been added to extract by downloading images.
+		 *
+		 * @since 0.5.1
+		 */
 		do_action( 'amp_extract_image_dimensions_batch_callbacks_registered' );
 	}
 

--- a/includes/utils/class-amp-string-utils.php
+++ b/includes/utils/class-amp-string-utils.php
@@ -7,6 +7,8 @@
 
 /**
  * Class with static string utility methods.
+ *
+ * @internal
  */
 class AMP_String_Utils {
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -17,6 +17,7 @@ use AmpProject\AmpWP\Services;
  * Class AMP_Validated_URL_Post_Type
  *
  * @since 1.0
+ * @internal
  */
 class AMP_Validated_URL_Post_Type {
 

--- a/includes/validation/class-amp-validation-callback-wrapper.php
+++ b/includes/validation/class-amp-validation-callback-wrapper.php
@@ -9,6 +9,7 @@
  * Class AMP_Validation_Callback_Wrapper
  *
  * @since 1.2.1
+ * @internal
  */
 class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -14,6 +14,7 @@ use AmpProject\AmpWP\Services;
  * Class AMP_Validation_Error_Taxonomy
  *
  * @since 1.0
+ * @internal
  */
 class AMP_Validation_Error_Taxonomy {
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -19,6 +19,7 @@ use AmpProject\Dom\Document;
  * Class AMP_Validation_Manager
  *
  * @since 0.7
+ * @internal
  */
 class AMP_Validation_Manager {
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -283,7 +283,7 @@ class AMP_Validation_Manager {
 			&&
 			'trash' !== $post->post_status
 			&&
-			post_supports_amp( $post )
+			amp_is_post_supported( $post )
 		);
 	}
 
@@ -368,7 +368,7 @@ class AMP_Validation_Manager {
 			return;
 		}
 
-		$is_amp_endpoint = is_amp_endpoint();
+		$is_amp_endpoint = amp_is_request();
 
 		$current_url = amp_get_current_url();
 		$non_amp_url = amp_remove_endpoint( $current_url );

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -368,7 +368,7 @@ class AMP_Validation_Manager {
 			return;
 		}
 
-		$is_amp_endpoint = amp_is_request();
+		$is_amp_request = amp_is_request();
 
 		$current_url = amp_get_current_url();
 		$non_amp_url = amp_remove_endpoint( $current_url );
@@ -389,7 +389,7 @@ class AMP_Validation_Manager {
 		$validate_url = AMP_Validated_URL_Post_Type::get_recheck_url( AMP_Validated_URL_Post_Type::get_invalid_url_post( $amp_url ) ?: $amp_url );
 
 		// Construct the parent admin bar item.
-		if ( $is_amp_endpoint ) {
+		if ( $is_amp_request ) {
 			$icon = Icon::valid(); // This will get overridden in AMP_Validation_Manager::finalize_validation() if there are unaccepted errors.
 			$href = $validate_url;
 		} else {
@@ -427,18 +427,18 @@ class AMP_Validation_Manager {
 		$link_item = [
 			'parent' => 'amp',
 			'id'     => 'amp-view',
-			'href'   => esc_url( $is_amp_endpoint ? $non_amp_url : $amp_url ),
+			'href'   => esc_url( $is_amp_request ? $non_amp_url : $amp_url ),
 		];
 		if ( amp_is_canonical() ) {
 			$link_item['title'] = esc_html__( 'View with AMP disabled', 'amp' );
 		} else {
-			$link_item['title'] = esc_html( $is_amp_endpoint ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) );
+			$link_item['title'] = esc_html( $is_amp_request ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) );
 		}
 
 		// Add top-level menu item. Note that this will correctly merge/amend any existing AMP nav menu item added in amp_add_admin_bar_view_link().
 		$wp_admin_bar->add_node( $parent );
 
-		if ( $is_amp_endpoint ) {
+		if ( $is_amp_request ) {
 			$wp_admin_bar->add_node( $validate_item );
 			$wp_admin_bar->add_node( $link_item );
 		} else {

--- a/includes/widgets/class-amp-widget-archives.php
+++ b/includes/widgets/class-amp-widget-archives.php
@@ -36,7 +36,7 @@ class AMP_Widget_Archives extends WP_Widget_Archives {
 	 * @return void.
 	 */
 	public function widget( $args, $instance ) {
-		if ( ! is_amp_endpoint() ) {
+		if ( ! amp_is_request() ) {
 			parent::widget( $args, $instance );
 			return;
 		}

--- a/includes/widgets/class-amp-widget-categories.php
+++ b/includes/widgets/class-amp-widget-categories.php
@@ -34,7 +34,7 @@ class AMP_Widget_Categories extends WP_Widget_Categories {
 	 * @return void
 	 */
 	public function widget( $args, $instance ) {
-		if ( ! is_amp_endpoint() ) {
+		if ( ! amp_is_request() ) {
 			parent::widget( $args, $instance );
 			return;
 		}

--- a/includes/widgets/class-amp-widget-text.php
+++ b/includes/widgets/class-amp-widget-text.php
@@ -26,7 +26,7 @@ if ( class_exists( 'WP_Widget_Text' ) ) {
 		 * @return string $html The markup, unaltered.
 		 */
 		public function inject_video_max_width_style( $matches ) {
-			if ( is_amp_endpoint() ) {
+			if ( amp_is_request() ) {
 				return $matches[0];
 			}
 			return parent::inject_video_max_width_style( $matches );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
 			<exclude>
 				<directory suffix=".php">svn</directory>
 				<directory suffix=".php">node_modules</directory>
+				<directory suffix=".php">back-compat</directory>
 				<directory suffix=".php">bin</directory>
 				<directory suffix=".php">tests</directory>
 				<directory suffix=".php">vendor</directory>

--- a/src/Admin/DevToolsUserAccess.php
+++ b/src/Admin/DevToolsUserAccess.php
@@ -19,6 +19,7 @@ use WP_User;
  * Class DevToolsUserAccess
  *
  * @since 2.0
+ * @internal
  */
 final class DevToolsUserAccess implements Service, Registerable {
 

--- a/src/Admin/GoogleFonts.php
+++ b/src/Admin/GoogleFonts.php
@@ -21,6 +21,7 @@ use WP_Styles;
  * Enqueue Google Fonts stylesheet.
  *
  * @since 2.0
+ * @internal
  */
 final class GoogleFonts implements Conditional, Delayed, Service, Registerable {
 

--- a/src/Admin/OnboardingWizardSubmenu.php
+++ b/src/Admin/OnboardingWizardSubmenu.php
@@ -17,6 +17,7 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * AMP onboarding wizard submenu class.
  *
  * @since 2.0
+ * @internal
  */
 final class OnboardingWizardSubmenu implements Conditional, Delayed, Service, Registerable {
 	/**

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -22,6 +22,7 @@ use AmpProject\AmpWP\Services;
  * AMP setup wizard submenu page class.
  *
  * @since 2.0
+ * @internal
  */
 final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registerable, Service {
 	/**
@@ -138,6 +139,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 		add_filter( 'admin_footer_text', '__return_empty_string' );
 		remove_all_filters( 'update_footer' );
 
+		/** This action is documented in wp-admin/admin-header.php */
 		do_action( 'admin_head' );
 
 		// <head> tag was opened prior to this action and hasn't been closed.

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -17,6 +17,9 @@ use AmpProject\AmpWP\Option;
 
 /**
  * OptionsMenu class.
+ *
+ * @since 2.0
+ * @internal
  */
 class OptionsMenu implements Conditional, Service, Registerable {
 	/**

--- a/src/Admin/PluginActivationNotice.php
+++ b/src/Admin/PluginActivationNotice.php
@@ -21,6 +21,7 @@ use AmpProject\AmpWP\Option;
  * Class PluginActivationNotice
  *
  * @since 2.0
+ * @internal
  */
 final class PluginActivationNotice implements Delayed, Service, Registerable {
 

--- a/src/Admin/Polyfills.php
+++ b/src/Admin/Polyfills.php
@@ -19,6 +19,7 @@ use WP_Styles;
  * Registers assets that may not be available in the current site's version of core.
  *
  * @since 2.0
+ * @internal
  */
 final class Polyfills implements Delayed, Service, Registerable {
 

--- a/src/Admin/RESTPreloader.php
+++ b/src/Admin/RESTPreloader.php
@@ -13,6 +13,8 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * Preloads REST responses for client-side applications to prevent having to call fetch on page load.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class RESTPreloader implements Service {
 

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -18,6 +18,7 @@ use WP_Upgrader;
  * Handles reader themes.
  *
  * @since 2.0
+ * @internal
  */
 final class ReaderThemes {
 	/**

--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -16,6 +16,8 @@ use AmpProject\AmpWP\Option;
  * Base class to define a new AJAX action.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class ReenableCssTransientCachingAjaxAction implements Service, Registerable {
 

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -23,6 +23,7 @@ use AmpProject\AmpWP\Option;
  * Adds tests and debugging information for Site Health.
  *
  * @since 1.5.0
+ * @internal
  */
 final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 

--- a/src/AmpSlugCustomizationWatcher.php
+++ b/src/AmpSlugCustomizationWatcher.php
@@ -14,6 +14,7 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * Service for redirecting mobile users to the AMP version of a page.
  *
  * @package AmpProject\AmpWP
+ * @internal
  */
 final class AmpSlugCustomizationWatcher implements Service, Registerable {
 

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -29,6 +29,9 @@ use function is_user_logged_in;
  * In here we assemble our infrastructure, configure it for the specific use
  * case the plugin is meant to solve and then kick off the services so that they
  * can hook themselves into the WordPress lifecycle.
+ *
+ * @since 2.0
+ * @internal
  */
 final class AmpWpPlugin extends ServiceBasedPlugin {
 	/*

--- a/src/AmpWpPluginFactory.php
+++ b/src/AmpWpPluginFactory.php
@@ -18,6 +18,8 @@ use AmpProject\AmpWP\Infrastructure\Plugin;
  * To read more about why this is preferable to a Singleton,
  *
  * @see https://www.alainschlesser.com/singletons-shared-instances/
+ * @since 2.0
+ * @internal
  */
 final class AmpWpPluginFactory {
 

--- a/src/BackgroundTask/CronBasedBackgroundTask.php
+++ b/src/BackgroundTask/CronBasedBackgroundTask.php
@@ -17,6 +17,8 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * Abstract base class for using cron to execute a background task.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 abstract class CronBasedBackgroundTask implements Service, Registerable, Conditional, Deactivateable {
 

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -19,6 +19,8 @@ use Exception;
  * This checks whether there's excessive cycling of CSS cached stylesheets and disables transient caching if so.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 

--- a/src/BackgroundTask/ValidatedUrlStylesheetDataGarbageCollection.php
+++ b/src/BackgroundTask/ValidatedUrlStylesheetDataGarbageCollection.php
@@ -22,6 +22,7 @@ use AMP_Validated_URL_Post_Type;
  *
  * @link https://github.com/ampproject/amp-wp/issues/5132
  * @package AmpProject\AmpWP
+ * @internal
  */
 final class ValidatedUrlStylesheetDataGarbageCollection extends CronBasedBackgroundTask {
 

--- a/src/ConfigurationArgument.php
+++ b/src/ConfigurationArgument.php
@@ -11,6 +11,8 @@ namespace AmpProject\AmpWP;
  * Constants for the options that the AmpWP plugin supports.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 interface ConfigurationArgument {
 

--- a/src/Embed/HandlesGalleryEmbed.php
+++ b/src/Embed/HandlesGalleryEmbed.php
@@ -21,6 +21,7 @@ use DOMNodeList;
  * Contains logic related to both gallery shortcodes and blocks.
  *
  * @since 2.0
+ * @internal
  */
 trait HandlesGalleryEmbed {
 

--- a/src/Exception/AmpWpException.php
+++ b/src/Exception/AmpWpException.php
@@ -13,6 +13,9 @@ namespace AmpProject\AmpWP\Exception;
  *
  * This allows you to not only catch individual exceptions, but also catch "all
  * exceptions from the AmpWp plugin".
+ *
+ * @since 2.0
+ * @internal
  */
 interface AmpWpException {
 

--- a/src/Exception/FailedToMakeInstance.php
+++ b/src/Exception/FailedToMakeInstance.php
@@ -12,6 +12,9 @@ use RuntimeException;
 /**
  * Exception thrown when the injector couldn't instantiate a given class or
  * interface.
+ *
+ * @since 2.0
+ * @internal
  */
 final class FailedToMakeInstance
 	extends RuntimeException

--- a/src/Exception/InvalidEventProperties.php
+++ b/src/Exception/InvalidEventProperties.php
@@ -11,6 +11,9 @@ use InvalidArgumentException;
 
 /**
  * Exception thrown when an invalid properties are added to an Event.
+ *
+ * @since 2.0
+ * @internal
  */
 final class InvalidEventProperties
 	extends InvalidArgumentException

--- a/src/Exception/InvalidService.php
+++ b/src/Exception/InvalidService.php
@@ -11,6 +11,9 @@ use InvalidArgumentException;
 
 /**
  * Exception thrown when an invalid service was requested.
+ *
+ * @since 2.0
+ * @internal
  */
 final class InvalidService
 	extends InvalidArgumentException

--- a/src/Exception/InvalidStopwatchEvent.php
+++ b/src/Exception/InvalidStopwatchEvent.php
@@ -11,6 +11,9 @@ use InvalidArgumentException;
 
 /**
  * Exception thrown when an invalid stopwatch name was requested.
+ *
+ * @since 2.0
+ * @internal
  */
 final class InvalidStopwatchEvent
 	extends InvalidArgumentException

--- a/src/Icon.php
+++ b/src/Icon.php
@@ -11,6 +11,8 @@ namespace AmpProject\AmpWP;
  * Icons used to visually represent the state of a validation error.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class Icon {
 

--- a/src/Infrastructure/Activateable.php
+++ b/src/Infrastructure/Activateable.php
@@ -15,6 +15,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  *
  * This way, we can just add the simple interface marker and not worry about how
  * to wire up the code to reach that part during the static activation hook.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Activateable {
 

--- a/src/Infrastructure/Conditional.php
+++ b/src/Infrastructure/Conditional.php
@@ -16,6 +16,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  *
  * This allows for a more systematic and automated optimization of how the
  * different parts of the plugin are enabled or disabled.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Conditional {
 

--- a/src/Infrastructure/Deactivateable.php
+++ b/src/Infrastructure/Deactivateable.php
@@ -15,6 +15,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  *
  * This way, we can just add the simple interface marker and not worry about how
  * to wire up the code to reach that part during the static deactivation hook.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Deactivateable {
 

--- a/src/Infrastructure/Delayed.php
+++ b/src/Infrastructure/Delayed.php
@@ -16,6 +16,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  * This can be used to only register a given object after certain contextual
  * requirements are met, like registering a frontend rendering service only
  * after the loop has been set up.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Delayed {
 

--- a/src/Infrastructure/Injector.php
+++ b/src/Infrastructure/Injector.php
@@ -23,6 +23,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  * objects to "share" (always handing out the same instance) or not to share
  * (always returning a fresh new instance on each subsequent call). This
  * effectively gets rid of the dreaded Singletons.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Injector extends Service {
 

--- a/src/Infrastructure/Injector/FallbackInstantiator.php
+++ b/src/Infrastructure/Injector/FallbackInstantiator.php
@@ -11,6 +11,9 @@ use AmpProject\AmpWP\Infrastructure\Instantiator;
 
 /**
  * Fallback instantiator to use in case none was provided.
+ *
+ * @since 2.0
+ * @internal
  */
 final class FallbackInstantiator implements Instantiator {
 

--- a/src/Infrastructure/Injector/InjectionChain.php
+++ b/src/Infrastructure/Injector/InjectionChain.php
@@ -15,6 +15,9 @@ use LogicException;
  *
  * It is used to detect circular dependencies, and can also be dumped for
  * debugging information.
+ *
+ * @since 2.0
+ * @internal
  */
 final class InjectionChain {
 

--- a/src/Infrastructure/Injector/SimpleInjector.php
+++ b/src/Infrastructure/Injector/SimpleInjector.php
@@ -17,6 +17,9 @@ use ReflectionParameter;
 
 /**
  * A simplified implementation of a dependency injector.
+ *
+ * @since 2.0
+ * @internal
  */
 final class SimpleInjector implements Injector {
 

--- a/src/Infrastructure/Instantiator.php
+++ b/src/Infrastructure/Instantiator.php
@@ -12,6 +12,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  *
  * This way, a more elaborate mechanism can be plugged in, like using
  * ProxyManager to instantiate proxies instead of actual objects.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Instantiator {
 

--- a/src/Infrastructure/Plugin.php
+++ b/src/Infrastructure/Plugin.php
@@ -20,6 +20,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  * Additionally, we provide a means to get access to the plugin's container that
  * collects all the services it is made up of. This allows direct access to the
  * services to outside code if needed.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Plugin extends Activateable, Deactivateable, Registerable {
 

--- a/src/Infrastructure/Registerable.php
+++ b/src/Infrastructure/Registerable.php
@@ -18,6 +18,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  *
  * Registering such an object is the explicit act of making it known to the
  * overarching system.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Registerable {
 

--- a/src/Infrastructure/Service.php
+++ b/src/Infrastructure/Service.php
@@ -13,6 +13,9 @@ namespace AmpProject\AmpWP\Infrastructure;
  * Splitting the logic up into independent services makes the approach of
  * assembling a plugin more systematic and scalable and lowers the cognitive
  * load when the code base increases in size.
+ *
+ * @since 2.0
+ * @internal
  */
 interface Service {
 

--- a/src/Infrastructure/ServiceBasedPlugin.php
+++ b/src/Infrastructure/ServiceBasedPlugin.php
@@ -13,6 +13,9 @@ use AmpProject\AmpWP\Infrastructure\ServiceContainer\LazilyInstantiatedService;
 /**
  * This abstract base plugin provides all the boilerplate code for working with
  * the dependency injector and the service container.
+ *
+ * @since 2.0
+ * @internal
  */
 abstract class ServiceBasedPlugin implements Plugin {
 

--- a/src/Infrastructure/ServiceContainer.php
+++ b/src/Infrastructure/ServiceContainer.php
@@ -20,6 +20,8 @@ use Traversable;
  * be able to easily swap out the implementation for something else later on.
  *
  * @see https://www.php-fig.org/psr/psr-11/
+ * @since 2.0
+ * @internal
  */
 interface ServiceContainer extends Traversable, Countable, ArrayAccess {
 

--- a/src/Infrastructure/ServiceContainer/LazilyInstantiatedService.php
+++ b/src/Infrastructure/ServiceContainer/LazilyInstantiatedService.php
@@ -13,6 +13,9 @@ use AmpProject\AmpWP\Infrastructure\Service;
 /**
  * A service that only gets properly instantiated when it is actually being
  * retrieved from the container.
+ *
+ * @since 2.0
+ * @internal
  */
 final class LazilyInstantiatedService implements Service {
 

--- a/src/Infrastructure/ServiceContainer/SimpleServiceContainer.php
+++ b/src/Infrastructure/ServiceContainer/SimpleServiceContainer.php
@@ -17,6 +17,9 @@ use ArrayObject;
  *
  * We extend ArrayObject so we have default implementations for iterators and
  * array access.
+ *
+ * @since 2.0
+ * @internal
  */
 final class SimpleServiceContainer
 	extends ArrayObject

--- a/src/Instrumentation/Event.php
+++ b/src/Instrumentation/Event.php
@@ -13,6 +13,8 @@ use AmpProject\AmpWP\Exception\InvalidEventProperties;
  * A server-timing event.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 class Event {
 

--- a/src/Instrumentation/EventWithDuration.php
+++ b/src/Instrumentation/EventWithDuration.php
@@ -11,6 +11,8 @@ namespace AmpProject\AmpWP\Instrumentation;
  * A server-timing event with a duration.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 class EventWithDuration extends Event {
 

--- a/src/Instrumentation/ServerTiming.php
+++ b/src/Instrumentation/ServerTiming.php
@@ -16,6 +16,8 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * Collect Server-Timing metrics.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class ServerTiming implements Service, Registerable, Delayed {
 

--- a/src/Instrumentation/StopWatch.php
+++ b/src/Instrumentation/StopWatch.php
@@ -12,9 +12,9 @@ use AmpProject\AmpWP\Exception\InvalidStopwatchEvent;
 /**
  * Record the timing of multiple events.
  *
- * @internal
- *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class StopWatch {
 

--- a/src/Instrumentation/StopWatchEvent.php
+++ b/src/Instrumentation/StopWatchEvent.php
@@ -10,9 +10,9 @@ namespace AmpProject\AmpWP\Instrumentation;
 /**
  * Record the timing of a single event.
  *
- * @internal
- *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class StopWatchEvent {
 

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -109,7 +109,7 @@ final class MobileRedirection implements Service, Registerable {
 
 			// Now abort if it's not an AMP page and the user agent is not mobile, since there won't be any redirection
 			// to the AMP version and we don't need to show a footer link to go to the AMP version.
-			if ( ! $this->is_mobile_request() && ! is_amp_endpoint() ) {
+			if ( ! $this->is_mobile_request() && ! amp_is_request() ) {
 				return;
 			}
 		}
@@ -118,7 +118,7 @@ final class MobileRedirection implements Service, Registerable {
 		add_action( 'wp_head', [ $this, 'add_mobile_version_switcher_styles' ] );
 		add_action( 'amp_post_template_head', [ $this, 'add_mobile_version_switcher_styles' ] ); // For legacy Reader mode theme.
 
-		if ( ! is_amp_endpoint() ) {
+		if ( ! amp_is_request() ) {
 			add_action( 'wp_head', [ $this, 'add_mobile_alternative_link' ] );
 			if ( $js ) {
 				// Add mobile redirection script.
@@ -425,7 +425,7 @@ final class MobileRedirection implements Service, Registerable {
 	public function add_mobile_version_switcher_link() {
 		$should_redirect_via_js = $this->is_using_client_side_redirection();
 
-		$is_amp = is_amp_endpoint();
+		$is_amp = amp_is_request();
 		if ( $is_amp ) {
 			$rel  = [ Attribute::REL_NOAMPHTML, Attribute::REL_NOFOLLOW ];
 			$url  = add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, amp_remove_endpoint( amp_get_current_url() ) );
@@ -439,7 +439,7 @@ final class MobileRedirection implements Service, Registerable {
 		/**
 		 * Filters the text to be used in the mobile switcher link.
 		 *
-		 * Use the `is_amp_endpoint()` function to determine whether you are filtering the
+		 * Use the `amp_is_request()` function to determine whether you are filtering the
 		 * text for the link to go to the non-AMP version or the AMP version.
 		 *
 		 * @since 2.0

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -17,6 +17,8 @@ use AMP_Theme_Support;
  * Service for redirecting mobile users to the AMP version of a page.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class MobileRedirection implements Service, Registerable {
 

--- a/src/ObsoleteBlockAttributeRemover.php
+++ b/src/ObsoleteBlockAttributeRemover.php
@@ -34,6 +34,8 @@ use WP_REST_Response;
  * @link https://github.com/ampproject/amp-wp/pull/4775
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class ObsoleteBlockAttributeRemover implements Service, Registerable, Delayed {
 

--- a/src/Option.php
+++ b/src/Option.php
@@ -11,6 +11,8 @@ namespace AmpProject\AmpWP;
  * An interface to share knowledge about options stored in the AMP Options Manager.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 interface Option {
 

--- a/src/OptionsRESTController.php
+++ b/src/OptionsRESTController.php
@@ -26,6 +26,7 @@ use WP_REST_Server;
  * OptionsRESTController class.
  *
  * @since 2.0
+ * @internal
  */
 final class OptionsRESTController extends WP_REST_Controller implements Delayed, Service, Registerable {
 

--- a/src/PluginRegistry.php
+++ b/src/PluginRegistry.php
@@ -13,6 +13,8 @@ use AmpProject\AmpWP\Infrastructure\Service;
  * Suppress plugins from running by removing their hooks and nullifying their shortcodes, widgets, and blocks.
  *
  * @package AmpProject\AmpWP
+ * @internal
+ * @since 2.0
  */
 final class PluginRegistry implements Service {
 

--- a/src/PluginSuppression.php
+++ b/src/PluginSuppression.php
@@ -25,6 +25,8 @@ use WP_User;
  * Suppress plugins from running by removing their hooks and nullifying their shortcodes, widgets, and blocks.
  *
  * @package AmpProject\AmpWP
+ * @internal
+ * @since 2.0
  */
 final class PluginSuppression implements Service, Registerable {
 

--- a/src/PluginSuppression.php
+++ b/src/PluginSuppression.php
@@ -66,7 +66,7 @@ final class PluginSuppression implements Service, Registerable {
 			$min_priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 
 			// In Standard mode we _have_ to wait for the wp action because with the absence of a query parameter
-			// we have to rely on is_amp_endpoint() and the WP_Query to determine whether a plugin should be suppressed.
+			// we have to rely on amp_is_request() and the WP_Query to determine whether a plugin should be suppressed.
 			add_action( 'wp', [ $this, 'maybe_suppress_plugins' ], $min_priority );
 		}
 	}
@@ -103,7 +103,7 @@ final class PluginSuppression implements Service, Registerable {
 	 * @return bool Whether plugins are being suppressed.
 	 */
 	public function maybe_suppress_plugins() {
-		if ( is_amp_endpoint() ) {
+		if ( amp_is_request() ) {
 			return $this->suppress_plugins();
 		}
 		return false;

--- a/src/QueryVar.php
+++ b/src/QueryVar.php
@@ -11,6 +11,8 @@ namespace AmpProject\AmpWP;
  * An interface to capture URL query vars used in the plugin.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 interface QueryVar {
 

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -22,6 +22,8 @@ use WP_Customize_Manager;
  * service in order to determine whether or a Reader theme is loaded, and if so, what the previously-active theme was.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class ReaderThemeLoader implements Service, Registerable {
 

--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -21,6 +21,8 @@ use DateTimeInterface;
  * Caching uses WordPress transients.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class CachedRemoteGetRequest implements RemoteGetRequest {
 

--- a/src/RemoteRequest/CachedResponse.php
+++ b/src/RemoteRequest/CachedResponse.php
@@ -14,6 +14,8 @@ use DateTimeInterface;
  * Serializable object that represents a cached response together with its expiry time.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class CachedResponse {
 

--- a/src/RemoteRequest/WpHttpRemoteGetRequest.php
+++ b/src/RemoteRequest/WpHttpRemoteGetRequest.php
@@ -19,6 +19,8 @@ use WP_Http;
  * Remote request transport using the WordPress WP_Http abstraction layer.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class WpHttpRemoteGetRequest implements RemoteGetRequest {
 

--- a/src/Services.php
+++ b/src/Services.php
@@ -17,6 +17,8 @@ use AmpProject\AmpWP\Infrastructure\ServiceContainer;
  * Always prefer to use constructor injection instead.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class Services {
 

--- a/src/Transformer/AmpSchemaOrgMetadata.php
+++ b/src/Transformer/AmpSchemaOrgMetadata.php
@@ -18,6 +18,8 @@ use AmpProject\Tag;
  * Ensure there is a schema.org script in the document.
  *
  * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
  */
 final class AmpSchemaOrgMetadata implements Transformer {
 

--- a/src/Transformer/AmpSchemaOrgMetadataConfiguration.php
+++ b/src/Transformer/AmpSchemaOrgMetadataConfiguration.php
@@ -17,6 +17,8 @@ use AmpProject\Optimizer\Transformer\TransformedIdentifier;
  * @property array $metadata Associative array of metadata.
  *
  * @package ampproject/optimizer
+ * @since 2.0
+ * @internal
  */
 final class AmpSchemaOrgMetadataConfiguration extends BaseTransformerConfiguration {
 

--- a/templates/single.php
+++ b/templates/single.php
@@ -26,7 +26,15 @@ $this->load_parts( [ 'html-start' ] );
 <article class="amp-wp-article">
 	<header class="amp-wp-article-header">
 		<h1 class="amp-wp-title"><?php echo $this->get( 'post_title' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h1>
-		<?php $this->load_parts( apply_filters( 'amp_post_article_header_meta', [ 'meta-author', 'meta-time' ] ) ); ?>
+		<?php
+		/**
+		 * Filters the template parts loaded in the header area of the AMP legacy post template.
+		 *
+		 * @since 0.4
+		 * @param string[] Templates to load.
+		 */
+		$this->load_parts( apply_filters( 'amp_post_article_header_meta', [ 'meta-author', 'meta-time' ] ) );
+		?>
 	</header>
 
 	<?php $this->load_parts( [ 'featured-image' ] ); ?>
@@ -36,7 +44,15 @@ $this->load_parts( [ 'html-start' ] );
 	</div>
 
 	<footer class="amp-wp-article-footer">
-		<?php $this->load_parts( apply_filters( 'amp_post_article_footer_meta', [ 'meta-taxonomy', 'meta-comments-link' ] ) ); ?>
+		<?php
+		/**
+		 * Filters the template parts to load in the footer area of the AMP legacy post template.
+		 *
+		 * @since 0.4
+		 * @param string[] Templates to load.
+		 */
+		$this->load_parts( apply_filters( 'amp_post_article_footer_meta', [ 'meta-taxonomy', 'meta-comments-link' ] ) );
+		?>
 	</footer>
 </article>
 

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -154,7 +154,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		set_query_var( QueryVar::AMP, '1' );
 		$this->assertFalse( amp_is_canonical() );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->instance->redirect();
 		$this->assertEquals( 10, has_action( 'wp_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
 		$this->assertEquals( 10, has_action( 'amp_post_template_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
@@ -174,7 +174,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		add_filter( 'amp_pre_is_mobile', '__return_false' );
 
 		$this->go_to( add_query_arg( QueryVar::AMP, '1', '/' ) );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertFalse( $this->instance->is_mobile_request() );
 
 		$this->instance->redirect();
@@ -186,7 +186,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 
 		$this->go_to( '/' );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertTrue( amp_is_available() );
 		$this->instance->redirect();
 		$this->assertEquals( 10, has_action( 'wp_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
@@ -201,7 +201,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		add_filter( 'amp_pre_is_mobile', '__return_true' );
 
 		$this->go_to( '/' );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertTrue( amp_is_available() );
 		$redirected_url = null;
 		add_filter(
@@ -226,7 +226,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		add_filter( 'amp_pre_is_mobile', '__return_true' );
 
 		$this->go_to( '/' );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertTrue( amp_is_available() );
 		$_COOKIE[ MobileRedirection::DISABLED_STORAGE_KEY ] = '1';
 		$this->instance->redirect();
@@ -242,7 +242,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 
 		$this->go_to( add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, '/' ) );
 		$_GET[ QueryVar::NOAMP ] = QueryVar::NOAMP_MOBILE;
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertTrue( amp_is_available() );
 
 		$this->assertArrayNotHasKey( MobileRedirection::DISABLED_STORAGE_KEY, $_COOKIE );
@@ -262,7 +262,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		set_query_var( QueryVar::AMP, '1' );
 		$this->assertFalse( amp_is_canonical() );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$_COOKIE[ MobileRedirection::DISABLED_STORAGE_KEY ] = '1';
 		$this->instance->redirect();
 		$this->assertArrayNotHasKey( MobileRedirection::DISABLED_STORAGE_KEY, $_COOKIE );
@@ -465,7 +465,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		if ( $is_amp ) {
 			set_query_var( QueryVar::AMP, '1' );
 		}
-		$this->assertEquals( $is_amp, is_amp_endpoint() );
+		$this->assertEquals( $is_amp, amp_is_request() );
 		ob_start();
 		$this->instance->add_mobile_version_switcher_link();
 		$output = ob_get_clean();
@@ -476,7 +476,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		add_filter(
 			'amp_mobile_version_switcher_link_text',
 			function ( $link_text ) {
-				return $link_text . ' ' . ( is_amp_endpoint() ? '(non-AMP version)' : '(AMP version)' );
+				return $link_text . ' ' . ( amp_is_request() ? '(non-AMP version)' : '(AMP version)' );
 			}
 		);
 
@@ -484,7 +484,7 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 		ob_start();
 		$this->instance->add_mobile_version_switcher_link();
 		$output = ob_get_clean();
-		$this->assertStringContains( is_amp_endpoint() ? '(non-AMP version)' : '(AMP version)', $output );
+		$this->assertStringContains( amp_is_request() ? '(non-AMP version)' : '(AMP version)', $output );
 		$this->assertStringContains( '<script data-ampdevmode>', $output );
 		$this->assertStringContains( 'notApplicableMessage', $output );
 	}

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -271,7 +271,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$instance = $this->get_instance( true );
 		$this->go_to( $url );
 
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertFalse( $instance->maybe_suppress_plugins(), 'Expected no suppression since not an AMP endpoint.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
@@ -287,7 +287,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$instance = $this->get_instance( true );
 		$this->go_to( $url );
 
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->assertTrue( $instance->maybe_suppress_plugins(), 'Expected suppression since an AMP endpoint and there are suppressible plugins.' );
 		$this->assert_plugin_suppressed_state( true, $bad_plugin_file_slugs );
 	}
@@ -303,7 +303,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$instance = $this->get_instance( true );
 		$this->go_to( $url );
 
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->assertFalse( $instance->suppress_plugins(), 'Expected no suppression since no suppressible plugins.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
@@ -319,7 +319,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$this->go_to( $url );
 		AMP_Options_Manager::update_option( Option::SUPPRESSED_PLUGINS, [] );
 
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->assertFalse( $instance->suppress_plugins(), 'Expected no suppression since no plugins are being suppressed.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
@@ -345,7 +345,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 
 		$this->update_suppressed_plugins_option( array_fill_keys( $bad_plugin_file_slugs, true ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->assertTrue( $instance->suppress_plugins() );
 		$this->assert_plugin_suppressed_state( true, $bad_plugin_file_slugs );
 	}
@@ -374,7 +374,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 
 		$this->update_suppressed_plugins_option( array_fill_keys( $suppressed_slugs, true ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$this->assertTrue( $instance->suppress_plugins() );
 		$this->assert_plugin_suppressed_state( true, $suppressed_slugs );
 		$this->assert_plugin_suppressed_state( false, $unsuppressed_slugs );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -773,6 +773,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_transitional_mode_amphtml_urls
 	 * @covers ::amp_add_amphtml_link()
+	 * @expectedDeprecated amp_frontend_show_canonical
 	 *
 	 * @param callable $data_provider Provider.
 	 */

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1418,11 +1418,11 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test post_supports_amp().
+	 * Test amp_is_post_supported().
 	 *
 	 * @covers ::amp_is_post_supported()
 	 */
-	public function test_post_supports_amp() {
+	public function test_amp_is_post_supported() {
 		add_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
 
 		// Test disabled by default for page for posts and show on front.

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -674,6 +674,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_reader_mode_amphtml_urls
 	 * @covers ::amp_add_amphtml_link()
+	 * @expectedDeprecated amp_frontend_show_canonical
 	 *
 	 * @param callable $data_provider Provider.
 	 */

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -831,45 +831,45 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test amp_is_available() and is_amp_endpoint() functions.
+	 * Test amp_is_available() and amp_is_request() functions.
 	 *
 	 * @covers ::amp_is_available()
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 */
-	public function test_is_amp_endpoint() {
+	public function test_amp_is_request() {
 		$this->go_to( get_permalink( self::factory()->post->create() ) );
 		$this->assertTrue( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// Legacy query var.
 		set_query_var( amp_get_slug(), '' );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		unset( $GLOBALS['wp_query']->query_vars[ amp_get_slug() ] );
 		$this->assertTrue( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// Transitional theme support.
 		add_theme_support( AMP_Theme_Support::SLUG, [ 'template_dir' => './' ] );
 		$_GET['amp'] = '';
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		unset( $_GET['amp'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->assertTrue( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 
 		// Standard theme support.
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		// Special core pages.
 		$pages = [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ];
 		foreach ( $pages as $page ) {
 			$GLOBALS['pagenow'] = $page;
 			$this->assertFalse( amp_is_available() );
-			$this->assertFalse( is_amp_endpoint() );
+			$this->assertFalse( amp_is_request() );
 		}
 		unset( $GLOBALS['pagenow'] );
 
@@ -883,24 +883,24 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// A post shouldn't be an AMP endpoint, as it was unchecked in the UI via the options above.
 		$this->go_to( self::factory()->post->create() );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// The homepage shouldn't be an AMP endpoint, as it was also unchecked in the UI.
 		$this->go_to( home_url( '/' ) );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// When the user passes a flag to the WP-CLI command, it forces AMP validation no matter whether the user disabled AMP on any template.
 		AMP_Validation_Manager::$is_validate_request = true;
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 	}
 
 	/**
 	 * Test amp_is_available() function when availability is blocked due to validation errors.
 	 *
 	 * @covers ::amp_is_available()
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 */
 	public function test_amp_is_available_when_noamp_due_to_validation_errors() {
 		$post_id = self::factory()->post->create();
@@ -909,129 +909,129 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		$this->go_to( amp_get_permalink( $post_id ) );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		$this->go_to( add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_AVAILABLE, get_permalink( $post_id ) ) );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// Now go AMP-first.
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$this->go_to( add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_AVAILABLE, get_permalink( $post_id ) ) );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 	}
 
 	/**
-	 * Test is_amp_endpoint() function for post embeds and feeds.
+	 * Test amp_is_request() function for post embeds and feeds.
 	 *
 	 * @covers ::amp_is_available()
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * global WP_Query $wp_the_query
 	 */
-	public function test_is_amp_endpoint_for_post_embeds_and_feeds() {
+	public function test_amp_is_request_for_post_embeds_and_feeds() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$post_id = self::factory()->post->create_and_get()->ID;
 
 		$this->go_to( home_url( "?p=$post_id" ) );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		$this->go_to( home_url( "?p=$post_id&embed=1" ) );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		$this->go_to( home_url( '?feed=rss' ) );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		if ( class_exists( 'WP_Service_Workers' ) && defined( 'WP_Service_Workers::QUERY_VAR' ) && function_exists( 'pwa_add_error_template_query_var' ) ) {
 			$this->go_to( home_url( "?p=$post_id" ) );
 			global $wp_query;
 			$wp_query->set( WP_Service_Workers::QUERY_VAR, WP_Service_Workers::SCOPE_FRONT );
 			$this->assertFalse( amp_is_available() );
-			$this->assertFalse( is_amp_endpoint() );
+			$this->assertFalse( amp_is_request() );
 		}
 	}
 
 	/**
-	 * Test is_amp_endpoint() function before the parse_query action happens.
+	 * Test amp_is_request() function before the parse_query action happens.
 	 *
 	 * @covers ::amp_is_available()
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @expectedIncorrectUsage amp_is_available
 	 */
 	public function test_amp_is_available_before_parse_query_action() {
 		global $wp_actions;
 		unset( $wp_actions['parse_query'] );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$this->assertFalse( amp_is_available() );
 	}
 
 	/**
-	 * Test is_amp_endpoint() function when there is no WP_Query.
+	 * Test amp_is_request() function when there is no WP_Query.
 	 *
 	 * @covers ::amp_is_available()
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @expectedIncorrectUsage amp_is_available
 	 */
-	public function test_is_amp_endpoint_when_no_wp_query() {
+	public function test_amp_is_request_when_no_wp_query() {
 		global $wp_query;
 		$wp_query = null;
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 	}
 
 	/**
-	 * Test is_amp_endpoint() function before the wp action happens in Standard mode.
+	 * Test amp_is_request() function before the wp action happens in Standard mode.
 	 *
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @covers ::amp_is_available()
 	 * @expectedIncorrectUsage amp_is_available
 	 */
-	public function test_is_amp_endpoint_before_wp_action_for_standard_mode() {
+	public function test_amp_is_request_before_wp_action_for_standard_mode() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		global $wp_actions;
 		unset( $wp_actions['wp'] );
 		$this->assertTrue( AMP_Options_Manager::get_option( Option::ALL_TEMPLATES_SUPPORTED ) );
 		$this->assertTrue( amp_is_canonical() );
 		$this->assertTrue( amp_is_available(), 'Expected available even before wp action because AMP-First' );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		AMP_Options_Manager::update_option( Option::ALL_TEMPLATES_SUPPORTED, false );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 	}
 
 	/**
-	 * Test is_amp_endpoint() function before the wp action happens in Reader mode.
+	 * Test amp_is_request() function before the wp action happens in Reader mode.
 	 *
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @covers ::amp_is_available()
 	 * @expectedIncorrectUsage amp_is_available
 	 */
-	public function test_is_amp_endpoint_before_wp_action_for_reader_mode() {
+	public function test_amp_is_request_before_wp_action_for_reader_mode() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		$this->go_to( home_url( '/' ) );
 		global $wp_actions;
 		unset( $wp_actions['wp'] );
 		$this->assertFalse( amp_is_canonical() );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 	}
 
 	/**
-	 * Test is_amp_endpoint() function before the wp action happens in Transitional mode (with no AMP query var present).
+	 * Test amp_is_request() function before the wp action happens in Transitional mode (with no AMP query var present).
 	 *
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @covers ::amp_is_available()
 	 * @expectedIncorrectUsage amp_is_available
 	 */
-	public function test_is_amp_endpoint_before_wp_action_for_transitional_mode_with_query_var() {
+	public function test_amp_is_request_before_wp_action_for_transitional_mode_with_query_var() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		$this->go_to( add_query_arg( amp_get_slug(), '1', home_url( '/' ) ) );
 		global $wp_actions;
@@ -1039,11 +1039,11 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertTrue( AMP_Options_Manager::get_option( Option::ALL_TEMPLATES_SUPPORTED ) );
 		$this->assertFalse( amp_is_canonical() );
 		$this->assertTrue( amp_is_available() );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		AMP_Options_Manager::update_option( Option::ALL_TEMPLATES_SUPPORTED, false );
 		$this->assertFalse( amp_is_available() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 	}
 
 	/**
@@ -1420,7 +1420,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	/**
 	 * Test post_supports_amp().
 	 *
-	 * @covers ::post_supports_amp()
+	 * @covers ::amp_is_post_supported()
 	 */
 	public function test_post_supports_amp() {
 		add_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
@@ -1428,20 +1428,20 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// Test disabled by default for page for posts and show on front.
 		update_option( 'show_on_front', 'page' );
 		$post = self::factory()->post->create_and_get( [ 'post_type' => 'page' ] );
-		$this->assertTrue( post_supports_amp( $post ) );
+		$this->assertTrue( amp_is_post_supported( $post ) );
 		update_option( 'show_on_front', 'page' );
-		$this->assertTrue( post_supports_amp( $post ) );
+		$this->assertTrue( amp_is_post_supported( $post ) );
 		update_option( 'page_for_posts', $post->ID );
-		$this->assertFalse( post_supports_amp( $post ) );
+		$this->assertFalse( amp_is_post_supported( $post ) );
 		update_option( 'page_for_posts', '' );
 		update_option( 'page_on_front', $post->ID );
-		$this->assertFalse( post_supports_amp( $post ) );
+		$this->assertFalse( amp_is_post_supported( $post ) );
 		update_option( 'show_on_front', 'posts' );
-		$this->assertTrue( post_supports_amp( $post ) );
+		$this->assertTrue( amp_is_post_supported( $post ) );
 
 		// Test disabled by default for page templates.
 		update_post_meta( $post->ID, '_wp_page_template', 'foo.php' );
-		$this->assertFalse( post_supports_amp( $post ) );
+		$this->assertFalse( amp_is_post_supported( $post ) );
 
 		// Reset.
 		remove_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
@@ -1737,14 +1737,14 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Confirm that link is added to non-AMP version.
 		set_query_var( amp_get_slug(), '' );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		$admin_bar = new WP_Admin_Bar();
 		amp_add_admin_bar_view_link( $admin_bar );
 		$item = $admin_bar->get_node( 'amp' );
 		$this->assertInternalType( 'object', $item );
 		$this->assertEquals( esc_url( get_permalink( $post_id ) ), $item->href );
 		unset( $wp_query->query_vars[ amp_get_slug() ] );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 
 		// Confirm post opt-out works.
 		add_filter( 'amp_skip_post', '__return_true' );

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -37,20 +37,20 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Stored result of is_amp_endpoint() when calling amp_render_post().
+	 * Stored result of amp_is_request() when calling amp_render_post().
 	 *
 	 * @var bool
 	 */
 	protected $was_amp_endpoint;
 
 	/**
-	 * Test is_amp_endpoint.
+	 * Test amp_is_request.
 	 *
-	 * @covers ::is_amp_endpoint()
+	 * @covers ::amp_is_request()
 	 * @expectedDeprecated amp_render_post
 	 * @expectedDeprecated amp_add_post_template_actions
 	 */
-	public function test__is_amp_endpoint() {
+	public function test__amp_is_request() {
 		$user_id = self::factory()->user->create();
 		$post_id = self::factory()->post->create(
 			[
@@ -60,38 +60,38 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 
 		$this->go_to( get_permalink( $post_id ) );
 
-		$before_is_amp_endpoint = is_amp_endpoint();
+		$before_amp_is_request = amp_is_request();
 
-		add_action( 'pre_amp_render_post', [ $this, 'check_is_amp_endpoint' ] );
+		add_action( 'pre_amp_render_post', [ $this, 'check_amp_is_request' ] );
 		$this->was_amp_endpoint = false;
 
 		$output = get_echo( 'amp_render_post', [ $post_id ] );
 		$this->assertStringContains( '<html amp', $output );
 
-		$after_is_amp_endpoint = is_amp_endpoint();
+		$after_amp_is_request = amp_is_request();
 
-		$this->assertFalse( $before_is_amp_endpoint, 'is_amp_endpoint was not defaulting to false before amp_render_post' );
-		$this->assertTrue( $this->was_amp_endpoint, 'is_amp_endpoint was not forced to true during amp_render_post' );
-		$this->assertFalse( $after_is_amp_endpoint, 'is_amp_endpoint was not reset after amp_render_post' );
+		$this->assertFalse( $before_amp_is_request, 'amp_is_request was not defaulting to false before amp_render_post' );
+		$this->assertTrue( $this->was_amp_endpoint, 'amp_is_request was not forced to true during amp_render_post' );
+		$this->assertFalse( $after_amp_is_request, 'amp_is_request was not reset after amp_render_post' );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$this->go_to( get_permalink( $post_id ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		// Make is_admin() true, as requests for an admin page aren't for AMP endpoints.
 		set_current_screen( 'edit.php' );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		unset( $GLOBALS['current_screen'] );
 
 		$GLOBALS['wp_query']->is_feed = true;
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		$GLOBALS['wp_query']->is_feed = false;
 	}
 
 	/**
-	 * Store whether it currently is_amp_endpoint().
+	 * Store whether it currently amp_is_request().
 	 */
-	public function check_is_amp_endpoint() {
-		$this->was_amp_endpoint = is_amp_endpoint();
+	public function check_amp_is_request() {
+		$this->was_amp_endpoint = amp_is_request();
 	}
 }

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -202,7 +202,7 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'wp_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		AMP_Service_Worker::add_install_hooks();
 		$this->assertSame( 10, has_action( 'wp_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
 		$this->assertFalse( has_action( 'wp_print_scripts', [ 'AMP_Service_Worker', 'wp_print_service_workers' ] ) );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -214,14 +214,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test transitional mode singular, where not on endpoint that it causes amphtml link to be added.
 		remove_action( 'wp_head', 'amp_add_amphtml_link' );
 		$this->go_to( get_permalink( $post_id ) );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		AMP_Theme_Support::finish_init();
 		$this->assertEquals( 10, has_action( 'wp_head', 'amp_add_amphtml_link' ) );
 
 		// Test transitional mode homepage, where still not on endpoint that it causes amphtml link to be added.
 		remove_action( 'wp_head', 'amp_add_amphtml_link' );
 		$this->go_to( home_url() );
-		$this->assertFalse( is_amp_endpoint() );
+		$this->assertFalse( amp_is_request() );
 		AMP_Theme_Support::finish_init();
 		$this->assertEquals( 10, has_action( 'wp_head', 'amp_add_amphtml_link' ) );
 
@@ -235,7 +235,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		AMP_Theme_Support::finish_init();
 		$this->assertFalse( has_action( 'wp_head', 'amp_add_amphtml_link' ) );
 		$this->assertEquals( 10, has_filter( 'index_template_hierarchy', [ 'AMP_Theme_Support', 'filter_amp_template_hierarchy' ] ), 'Expected add_amp_template_filters to have been called since template_dir is not empty' );
@@ -246,7 +246,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		remove_theme_support( 'amp' );
 		$this->go_to( amp_get_permalink( $post_id ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		AMP_Theme_Support::finish_init();
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 
@@ -254,7 +254,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		add_theme_support( 'amp', [ 'foo' => 'bar' ] );
 		$this->go_to( amp_get_permalink( $post_id ) );
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 		AMP_Theme_Support::finish_init();
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 		$this->assertEquals( [ [ 'foo' => 'bar' ] ], get_theme_support( 'amp' ) );
@@ -285,9 +285,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$post          = self::factory()->post->create();
 		$requested_url = get_permalink( $post );
 		$this->assertEquals( AMP_Theme_Support::READER_MODE_SLUG, AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) );
-		$this->assertTrue( post_supports_amp( $post ) );
+		$this->assertTrue( amp_is_post_supported( $post ) );
 		add_filter( 'amp_skip_post', '__return_true' );
-		$this->assertFalse( post_supports_amp( $post ) );
+		$this->assertFalse( amp_is_post_supported( $post ) );
 
 		$redirected = false;
 		add_filter(
@@ -2013,7 +2013,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$wp_widget_factory->widgets = [];
 		wp_widgets_init();
 
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		add_action(
 			'wp_enqueue_scripts',
@@ -2187,7 +2187,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
-		$this->assertTrue( is_amp_endpoint() );
+		$this->assertTrue( amp_is_request() );
 
 		ob_start();
 		?>


### PR DESCRIPTION
## Summary

Fixes #5119

This PR adds the necessary `@internal` tags so that phpdoc output can successfully exclude the API surface we do not intend for developers to touch.

When a class has a `@internal` (or `@deprecated`) tag, then it is omitted from the index. If there is a method that does an action or applies a filter, those hooks will be included in the index unless they too have `@internal`. Hooks that have PhpDoc like “This filter is documented in…” are omitted. A couple filters that lacked phpdoc were supplied with it. The `@since` tag was also added in various places.

Functions are included in the index unless they have the `@internal` tag.

Two functions which lack prefixes have been renamed, with the old versions being soft-deprecated (having `@deprecated` tags but no `_deprecated_function()` calls):

* `is_amp_endpoint()` => `amp_is_request()`
* `post_supports_amp()` => `amp_is_post_supported()`

This PR also deprecates the `amp_frontend_show_canonical` filter and the old v0.3 legacy AMP post templates (loaded via the `amp_backcompat_use_v03_templates()` function).

The following table is derived from the following script:

```bash
wp eval-file bin/create-phpdoc-index.php
```

My hope is that the logic in the script can be easily ported for the actual generation of the HTML phpdoc.

Type | Name
-----|-----
action | `amp_customizer_enqueue_preview_scripts`
action | `amp_customizer_enqueue_scripts`
action | `amp_customizer_init`
action | `amp_customizer_register_settings`
action | `amp_customizer_register_ui`
action | `amp_extract_image_dimensions_batch_callbacks_registered`
action | `amp_init`
action | `amp_plugin_update`
action | `amp_post_template_body_open`
action | `amp_post_template_css`
action | `amp_post_template_footer`
action | `amp_post_template_head`
action | `amp_post_template_include_{$template_type}`
action | `amp_print_analytics`
action | `pre_amp_render_post`
class | `AMP_Base_Embed_Handler`
class | `AMP_Base_Sanitizer`
filter | `amp_analytics_entries`
filter | `amp_comment_posted_message`
filter | `amp_content_embed_handlers`
filter | `amp_content_max_width`
filter | `amp_content_sanitizers`
filter | `amp_css_transient_monitoring_sampling_range`
filter | `amp_css_transient_monitoring_threshold`
filter | `amp_customizer_get_settings`
filter | `amp_customizer_is_enabled`
filter | `amp_customizer_post_type`
filter | `amp_dev_mode_element_xpaths`
filter | `amp_dev_mode_enabled`
filter | `amp_enable_optimizer`
filter | `amp_enable_ssr`
filter | `amp_extract_image_dimensions_batch`
filter | `amp_extract_image_dimensions_get_user_agent`
filter | `amp_get_permalink`
filter | `amp_is_enabled`
filter | `amp_mobile_client_side_redirection`
filter | `amp_mobile_user_agents`
filter | `amp_mobile_version_switcher_link_text`
filter | `amp_mobile_version_switcher_styles_used`
filter | `amp_normalized_dimension_extractor_image_url`
filter | `amp_optimizer_config`
filter | `amp_options_menu_is_enabled`
filter | `amp_parsed_css_transient_caching_allowed`
filter | `amp_post_article_footer_meta`
filter | `amp_post_article_header_meta`
filter | `amp_post_status_default_enabled`
filter | `amp_post_template_analytics`
filter | `amp_post_template_customizer_settings`
filter | `amp_post_template_data`
filter | `amp_post_template_dir`
filter | `amp_post_template_file`
filter | `amp_post_template_metadata`
filter | `amp_pre_get_permalink`
filter | `amp_pre_is_mobile`
filter | `amp_query_var`
filter | `amp_reader_themes`
filter | `amp_schemaorg_metadata`
filter | `amp_site_icon_url`
filter | `amp_skip_post`
filter | `amp_supportable_post_types`
filter | `amp_supportable_templates`
filter | `amp_to_amp_excluded_urls`
filter | `amp_to_amp_linking_element_excluded`
filter | `amp_to_amp_linking_enabled`
filter | `amp_validation_error_default_sanitized`
filter | `amp_validation_error_sanitized`
filter | `amp_validation_error_source_file_editor_url_template`
filter | `amp_validation_error_source_file_path`
filter | `amp_validation_error`
function | `amp_add_amphtml_link()`
function | `amp_generate_script_hash()`
function | `amp_get_permalink()`
function | `amp_get_slug()`
function | `amp_is_available()`
function | `amp_is_canonical()`
function | `amp_is_dev_mode()`
function | `amp_is_legacy()`
function | `amp_is_post_supported()`
function | `amp_is_request()`
function | `amp_remove_endpoint()`

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
