### PR TITLE
Amend amp_get_current_url() to return null if the home URL cannot be parsed in CLI environment

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -603,14 +603,10 @@ function amp_get_slug() {
  *
  * @since 1.0
  *
- * @return string|null Current URL, or null if in a WP CLI context and the home URL could not be parsed.
+ * @return string Current URL.
  */
 function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );
-
-	if ( defined( 'WP_CLI' ) && WP_CLI && ! is_array( $parsed_url ) ) {
-		return null;
-	}
 
 	if ( ! is_array( $parsed_url ) ) {
 		$parsed_url = [];
@@ -619,6 +615,7 @@ function amp_get_current_url() {
 			$parsed_url['host'] = 'localhost';
 		}
 	}
+
 	if ( empty( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -609,11 +609,9 @@ function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );
 
 	if ( ! is_array( $parsed_url ) ) {
-		$parsed_url = [];
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			$parsed_url['host'] = 'localhost';
-		}
+		$parsed_url = [
+			'host' => 'localhost',
+		];
 	}
 
 	if ( empty( $parsed_url['scheme'] ) ) {

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -614,6 +614,10 @@ function amp_get_current_url() {
 
 	if ( ! is_array( $parsed_url ) ) {
 		$parsed_url = [];
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$parsed_url['host'] = 'localhost';
+		}
 	}
 	if ( empty( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -607,6 +607,11 @@ function amp_get_slug() {
  */
 function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );
+
+	if ( defined( 'WP_CLI' ) && WP_CLI && ! is_array( $parsed_url ) ) {
+		return null;
+	}
+
 	if ( ! is_array( $parsed_url ) ) {
 		$parsed_url = [];
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -609,16 +609,14 @@ function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );
 
 	if ( ! is_array( $parsed_url ) ) {
-		$parsed_url = [
-			'host' => 'localhost',
-		];
+		$parsed_url = [];
 	}
 
 	if ( empty( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}
 	if ( ! isset( $parsed_url['host'] ) ) {
-		$parsed_url['host'] = wp_unslash( $_SERVER['HTTP_HOST'] );
+		$parsed_url['host'] = isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : 'localhost';
 	}
 
 	$current_url = $parsed_url['scheme'] . '://';

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -603,7 +603,7 @@ function amp_get_slug() {
  *
  * @since 1.0
  *
- * @return string Current URL.
+ * @return string|null Current URL, or null if in a WP CLI context and the home URL could not be parsed.
  */
 function amp_get_current_url() {
 	$parsed_url = wp_parse_url( home_url() );

--- a/tests/e2e/specs/amp-onboarding/template-mode.js
+++ b/tests/e2e/specs/amp-onboarding/template-mode.js
@@ -88,12 +88,12 @@ describe( 'Stepper item modifications', () => {
 describe( 'Template mode recommendations with non-reader-theme active', () => {
 	beforeEach( async () => {
 		await cleanUpSettings();
-		await installTheme( 'neve' );
-		await activateTheme( 'neve' );
+		await installTheme( 'astra' );
+		await activateTheme( 'astra' );
 	} );
 
 	afterEach( async () => {
-		await deleteTheme( 'neve', 'twentytwenty' );
+		await deleteTheme( 'astra', 'twentytwenty' );
 	} );
 
 	it( 'makes correct recommendations when user is not technical and the current theme is not a reader theme', async () => {

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -390,9 +390,18 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 					amp_get_current_url()
 				);
 			},
+
+			'default_to_localhost'         => function () {
+				unset( $_SERVER['HTTP_HOST'] );
+				$this->set_home_url_with_filter( ':' );
+				$this->assertEquals(
+					'http://localhost/',
+					amp_get_current_url()
+				);
+			},
 		];
 		return array_map(
-			function ( $assertion ) {
+			static function ( $assertion ) {
 				return [ $assertion ];
 			},
 			$assertions

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -392,7 +392,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			},
 
 			'default_to_localhost'        => function () {
-				unset( $_SERVER['HTTP_HOST'] );
+				unset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
 				$this->set_home_url_with_filter( ':' );
 				$this->assertEquals(
 					'http://localhost/',

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -391,7 +391,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				);
 			},
 
-			'default_to_localhost'         => function () {
+			'default_to_localhost'        => function () {
 				unset( $_SERVER['HTTP_HOST'] );
 				$this->set_home_url_with_filter( ':' );
 				$this->assertEquals(


### PR DESCRIPTION
## Summary

Amends `amp_get_current_url()` to return `null` if `home_url()` returns an invalid URL which cannot be parsed when in a WP CLI environment.

<!-- Please reference the issue this PR addresses. -->
Fixes #5051.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
