### PR TITLE
Migrate lint jobs from Travis to GHA

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -5,18 +5,144 @@ on:
     branches:
       - develop
       # Include all release branches.
-      - '*.*'
+      - '[0-9]+.[0-9]+'
   pull_request:
     # Run workflow whenever a PR is opened, updated (synchronized), or marked ready for review.
     types: [opened, synchronize, ready_for_review]
 
 jobs:
+  lint-css:
+    name: 'Lint: CSS'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Configure npm cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.cache-name }}-
+            ${{ runner.os }}-npm-
+            ${{ runner.os }}-
+
+      - name: Install Node dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Detect coding standard violations (stylelint)
+        run: npm run lint:css
+
+#-----------------------------------------------------------------------------------------------------------------------
+
+  lint-js:
+    name: 'Lint: JS'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Configure npm cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.cache-name }}-
+            ${{ runner.os }}-npm-
+            ${{ runner.os }}-
+
+      - name: Install Node dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Validate package.json
+        run: npm run lint:pkg-json
+
+      - name: Detect coding standard violations (ESLint)
+        run: npm run lint:js:report
+        continue-on-error: true
+
+      - name: Annotate code linting results
+        uses: ataylorme/eslint-annotate-action@1.0.4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          report-json: 'lint-js-report.json'
+
+#-----------------------------------------------------------------------------------------------------------------------
+
+  lint-php:
+    name: 'Lint: PHP'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer, cs2pr
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Configure Composer cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+            ${{ runner.os }}-
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --optimize-autoloader  --no-suggest --no-progress --no-interaction
+
+      - name: Validate composer.json
+        run: composer --no-interaction validate --no-check-all
+
+      - name: Detect coding standard violations (PHPCS)
+        run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
+
+      - name: Normalize composer.json
+        # composer-normalize requires PHP 7.1+.
+        run: |
+          composer require --no-interaction --dev ergebnis/composer-normalize --ignore-platform-reqs
+          composer --no-interaction normalize --dry-run
+
+      - name: Static Analysis (PHPStan)
+        # phpstan requires PHP 7.1+.
+        run: |
+          vendor/bin/phpstan --version
+          vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
+        if: always()
+
+#-----------------------------------------------------------------------------------------------------------------------
 
   dev-zip:
     name: Build dev build ZIP and upload as GHA artifact
     # Only run if it is not a draft PR and the PR is not from a forked repository.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    needs:
+      - lint-css
+      - lint-js
+      - lint-php
     outputs:
       branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}
       git-sha-8: ${{ steps.retrieve-git-sha-8.outputs.sha8 }}
@@ -89,6 +215,10 @@ jobs:
     # Only run if it is not a draft PR and the PR is not from a forked repository.
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    needs:
+      - lint-css
+      - lint-js
+      - lint-php
     outputs:
       branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}
       git-sha-8: ${{ steps.retrieve-git-sha-8.outputs.sha8 }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,30 +66,6 @@ jobs:
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
       php: nightly
   include:
-    - stage: lint
-      name: Lint (PHP, JavaScript, and configuration files)
-      php: "7.4"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpsyntax
-      before_script:
-        - phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
-        - composer require --dev localheinz/composer-normalize --ignore-platform-reqs
-      script:
-        - source "$DEV_LIB_PATH/travis.script.sh"
-        - composer validate --no-check-all
-        - composer normalize --dry-run
-        - npm run lint
-        - npm run build:js
-      after_success:
-        - npx sizereport --config
-
-    - stage: analyze
-      name: Static analysis (PHP)
-      php: "7.4"
-      install:
-        - composer install
-      script:
-        - composer analyze
-
     - stage: test
       name: JavaScript unit tests
       php: "7.4"
@@ -118,27 +94,27 @@ jobs:
 
     - name: PHP unit tests (7.3, WordPress latest)
       php: "7.3"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests (7.1, WordPress latest)
       php: "7.1"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests (7.0, WordPress 5.1)
       php: "7.0"
-      env: WP_VERSION=5.1    DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=5.1    DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
-      env: WP_VERSION=5.0    DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=5.0    DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
 
     - name: PHP unit tests w/ external-http (5.6, WordPress 4.9)
       php: "5.6"
-      env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_SUITE=external-http
+      env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit                                PHPUNIT_EXTRA_SUITE=external-http
 
     - name: PHP unit tests (8.0, WordPress trunk)
       php: "nightly"

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "lint:css:fix": "npm run lint:css -- --fix",
     "lint:js": "wp-scripts lint-js",
     "lint:js:fix": "npm run lint:js -- --fix",
+    "lint:js:report": "npm run lint:js -- --output-file lint-js-report.json --format json .",
     "lint:php": "vendor/bin/phpcs",
     "lint:plugin-bootstrap": "vendor/bin/phpcs --runtime-set testVersion 5.2- amp.php",
     "lint:php:fix": "./bin/phpcbf.sh",


### PR DESCRIPTION
## Summary

This PR migrates the Travis jobs that lint the code to GHA jobs. In my (limited) testing so far the GHA jobs perform quicker than their Travis counterparts.

These new lint jobs will also annotate each changed file with their respective errors within the GitHub UI, which I believe can improve the code review process and DX.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
