### PR TITLE
Add extra "AMP" header for themes to indicate their support for AMP

### DIFF
--- a/assets/src/components/reader-theme-carousel/style.css
+++ b/assets/src/components/reader-theme-carousel/style.css
@@ -18,16 +18,16 @@
 .choose-reader-theme__unavailable .choose-reader-theme__grid {
 	display: grid;
 	gap: 1rem;
-	grid-template-columns: repeat(4, 1fr);
+	grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .amp-carousel__page {
 	display: grid;
 	gap: 60px;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .reader-theme-selection .theme-card {
 	margin: 0 auto;
-	max-width: 300px;
+	width: 275px;
 }

--- a/assets/src/components/reader-theme-selection/style.css
+++ b/assets/src/components/reader-theme-selection/style.css
@@ -8,11 +8,11 @@
 	grid-gap: 40px;
 
 	@media screen and (min-width: 600px) {
-		grid-template-columns: repeat(2, 1fr);
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
 	@media screen and (min-width: 1100px) {
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat(3, minmax(0, 1fr));
 	}
 }
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -261,7 +261,7 @@ class AMP_Theme_Support {
 	 * Get the theme support args.
 	 *
 	 * This avoids having to repeatedly call `get_theme_support()`, check the args, shift an item off the array, and so on.
-	 * Note that if the theme's `style.css` has `AMP: true` or `AMP: theme-support`, then this function will return the same
+	 * Note that if the theme's `style.css` has the `AMP` header with a value that when converted to a boolean evaluates to `true`, then this function will return the same
 	 * as if the theme had done `add_theme_support('amp')`.
 	 *
 	 * @since 1.0

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -270,13 +270,8 @@ class AMP_Theme_Support {
 	 */
 	public static function get_theme_support_args() {
 		if ( ! current_theme_supports( self::SLUG ) ) {
-			if (
-				in_array(
-					strtolower( wp_get_theme()->get( ExtraThemeAndPluginHeaders::AMP_HEADER ) ),
-					ExtraThemeAndPluginHeaders::AMP_THEME_SUPPORT_VALUES,
-					true
-				)
-			) {
+			$theme_header = wp_get_theme()->get( ExtraThemeAndPluginHeaders::AMP_HEADER );
+			if ( rest_sanitize_boolean( $theme_header ) && ExtraThemeAndPluginHeaders::AMP_HEADER_LEGACY !== $theme_header ) {
 				return [
 					self::PAIRED_FLAG => true,
 				];

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\Amp;
+use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
@@ -260,6 +261,8 @@ class AMP_Theme_Support {
 	 * Get the theme support args.
 	 *
 	 * This avoids having to repeatedly call `get_theme_support()`, check the args, shift an item off the array, and so on.
+	 * Note that if the theme's `style.css` has `AMP: true` or `AMP: theme-support`, then this function will return the same
+	 * as if the theme had done `add_theme_support('amp')`.
 	 *
 	 * @since 1.0
 	 *
@@ -267,6 +270,17 @@ class AMP_Theme_Support {
 	 */
 	public static function get_theme_support_args() {
 		if ( ! current_theme_supports( self::SLUG ) ) {
+			if (
+				in_array(
+					strtolower( wp_get_theme()->get( ExtraThemeAndPluginHeaders::AMP_HEADER ) ),
+					ExtraThemeAndPluginHeaders::AMP_THEME_SUPPORT_VALUES,
+					true
+				)
+			) {
+				return [
+					self::PAIRED_FLAG => true,
+				];
+			}
 			return false;
 		}
 		$support = get_theme_support( self::SLUG );

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -134,12 +134,6 @@ final class ReaderThemes {
 			}
 		}
 
-		/*
-		 * Append the AMP Legacy theme details after filtering the default themes. This ensures the AMP Legacy theme
-		 * will always be available as a fallback if the chosen Reader theme becomes unavailable.
-		 */
-		$themes[] = $this->get_legacy_theme();
-
 		$themes = array_filter(
 			$themes,
 			static function( $theme ) {
@@ -149,11 +143,26 @@ final class ReaderThemes {
 
 		$themes = array_map(
 			function ( $theme ) {
+				$theme                 = $this->normalize_theme_data( $theme );
 				$theme['availability'] = $this->get_theme_availability( $theme );
 				return $theme;
 			},
 			$themes
 		);
+
+		// Sort themes alphabetically before AMP Legacy.
+		usort(
+			$themes,
+			static function ( $a, $b ) {
+				return strcmp( $a['name'], $b['name'] );
+			}
+		);
+
+		/*
+		 * Append the AMP Legacy theme details after filtering the default themes. This ensures the AMP Legacy theme
+		 * will always be available as a fallback if the chosen Reader theme becomes unavailable.
+		 */
+		$themes[] = $this->get_legacy_theme();
 
 		$this->themes = array_values( $themes );
 
@@ -270,7 +279,7 @@ final class ReaderThemes {
 			}
 
 			return [
-				'name'           => $theme->display( 'Name' ),
+				'name'           => $theme->display( 'Name' ) ?: $theme->get_stylesheet(),
 				'slug'           => $theme->get_stylesheet(),
 				'preview_url'    => null,
 				'screenshot_url' => $theme->get_screenshot() ?: '',

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -251,7 +251,7 @@ final class ReaderThemes {
 	}
 
 	/**
-	 * Get installed themes that are marked as being AMP-comaptible.
+	 * Get installed themes that are marked as being AMP-compatible.
 	 *
 	 * @return WP_Theme[] Themes.
 	 */

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -278,11 +278,23 @@ final class ReaderThemes {
 				return [];
 			}
 
+			$mobile_screenshot = null;
+			if ( file_exists( $theme->get_stylesheet_directory() . '/screenshot-mobile.png' ) ) {
+				$mobile_screenshot = $theme->get_stylesheet_directory_uri() . '/screenshot-mobile.png';
+			} elseif ( file_exists( $theme->get_stylesheet_directory() . '/screenshot-mobile.jpg' ) ) {
+				$mobile_screenshot = $theme->get_stylesheet_directory_uri() . '/screenshot-mobile.jpg';
+			} else {
+				$mobile_screenshot = $theme->get_screenshot();
+			}
+			if ( $mobile_screenshot ) {
+				$mobile_screenshot = add_query_arg( 'ver', $theme->get( 'Version' ), $mobile_screenshot );
+			}
+
 			return [
 				'name'           => $theme->display( 'Name' ) ?: $theme->get_stylesheet(),
 				'slug'           => $theme->get_stylesheet(),
 				'preview_url'    => null,
-				'screenshot_url' => $theme->get_screenshot() ?: '',
+				'screenshot_url' => $mobile_screenshot ?: '',
 				'homepage'       => $theme->display( 'ThemeURI' ),
 				'description'    => $theme->display( 'Description' ),
 				'requires'       => $theme->get( 'RequiresWP' ),

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -90,7 +90,7 @@ final class ReaderThemes {
 
 		$themes = $this->get_default_reader_themes();
 
-		// Also include themes that declare AMP-compatibility their style.css.
+		// Also include themes that declare AMP-compatibility in their style.css.
 		$default_reader_theme_slugs = wp_list_pluck( $themes, 'slug' );
 		foreach ( $this->get_compatible_installed_themes() as $compatible_installed_theme ) {
 			if ( ! in_array( $compatible_installed_theme->get_stylesheet(), $default_reader_theme_slugs, true ) ) {

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -250,7 +250,7 @@ final class ReaderThemes {
 		$compatible_themes = [];
 		foreach ( wp_get_themes() as $theme ) {
 			$value = $theme->get( ExtraThemeAndPluginHeaders::AMP_HEADER );
-			if ( $value && preg_match( '/^(true|theme[-_]?support|yes)$/i', $value ) ) {
+			if ( in_array( strtolower( $value ), ExtraThemeAndPluginHeaders::AMP_THEME_SUPPORT_VALUES, true ) ) {
 				$compatible_themes[] = $theme;
 			}
 		}

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -259,7 +259,7 @@ final class ReaderThemes {
 		$compatible_themes = [];
 		foreach ( wp_get_themes() as $theme ) {
 			$value = $theme->get( ExtraThemeAndPluginHeaders::AMP_HEADER );
-			if ( in_array( strtolower( $value ), ExtraThemeAndPluginHeaders::AMP_THEME_SUPPORT_VALUES, true ) ) {
+			if ( rest_sanitize_boolean( $value ) && ExtraThemeAndPluginHeaders::AMP_HEADER_LEGACY !== $value ) {
 				$compatible_themes[] = $theme;
 			}
 		}

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -273,7 +273,7 @@ final class ReaderThemes {
 				'name'           => $theme->display( 'Name' ),
 				'slug'           => $theme->get_stylesheet(),
 				'preview_url'    => null,
-				'screenshot_url' => $theme->get_screenshot(),
+				'screenshot_url' => $theme->get_screenshot() ?: '',
 				'homepage'       => $theme->display( 'ThemeURI' ),
 				'description'    => $theme->display( 'Description' ),
 				'requires'       => $theme->get( 'RequiresWP' ),

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -66,6 +66,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	 */
 	protected function get_service_classes() {
 		return [
+			'extra_theme_and_plugin_headers'   => ExtraThemeAndPluginHeaders::class,
 			'dev_tools.user_access'            => DevToolsUserAccess::class,
 			'css_transient_cache.monitor'      => MonitorCssTransientCaching::class,
 			'css_transient_cache.ajax_handler' => ReenableCssTransientCachingAjaxAction::class,

--- a/src/ExtraThemeAndPluginHeaders.php
+++ b/src/ExtraThemeAndPluginHeaders.php
@@ -27,16 +27,11 @@ final class ExtraThemeAndPluginHeaders implements Service, Registerable {
 	const AMP_HEADER = 'AMP';
 
 	/**
-	 * Values which indicate the theme has 'amp' theme support.
+	 * AMP header value indicating legacy template support.
 	 *
-	 * @var string[]
+	 * @var string
 	 */
-	const AMP_THEME_SUPPORT_VALUES = [
-		'theme-support',
-		'theme_support',
-		'true',
-		'yes',
-	];
+	const AMP_HEADER_LEGACY = 'legacy';
 
 	/**
 	 * Register the service with the system.

--- a/src/ExtraThemeAndPluginHeaders.php
+++ b/src/ExtraThemeAndPluginHeaders.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Class ExtraThemeAndPluginHeaders.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP;
+
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+
+/**
+ * Registers the 'AMP' extra header for themes and plugins.
+ *
+ * @package AmpProject\AmpWP
+ * @since 2.0
+ * @internal
+ */
+final class ExtraThemeAndPluginHeaders implements Service, Registerable {
+
+	/**
+	 * Header name.
+	 *
+	 * @var string
+	 */
+	const AMP_HEADER = 'AMP';
+
+	/**
+	 * Register the service with the system.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Filter must be added as soon as possible since once wp_get_themes() is called, the results are cached.
+		add_filter( 'extra_theme_headers', [ $this, 'filter_extra_headers' ] );
+
+		// Note that get_plugins() may have already been called, resulting in this returning stale data. See \WC_Helper::get_local_woo_plugins().
+		add_filter( 'extra_plugin_headers', [ $this, 'filter_extra_headers' ] );
+	}
+
+	/**
+	 * Add 'AMP' to the list of headers parsed from a theme's style.css or plugin's bootstrap file.
+	 *
+	 * For prior precedent here, WooCommerce adds a 'Woo' header.
+	 *
+	 * @see wc_enable_wc_plugin_headers()
+	 * @see \WC_Helper::get_local_woo_themes()
+	 *
+	 * @param string[] $headers Headers.
+	 * @return string[] Amended headers.
+	 */
+	public function filter_extra_headers( $headers ) {
+		$headers[] = self::AMP_HEADER;
+		return $headers;
+	}
+}

--- a/src/ExtraThemeAndPluginHeaders.php
+++ b/src/ExtraThemeAndPluginHeaders.php
@@ -46,9 +46,6 @@ final class ExtraThemeAndPluginHeaders implements Service, Registerable {
 	public function register() {
 		// Filter must be added as soon as possible since once wp_get_themes() is called, the results are cached.
 		add_filter( 'extra_theme_headers', [ $this, 'filter_extra_headers' ] );
-
-		// Note that get_plugins() may have already been called, resulting in this returning stale data. See \WC_Helper::get_local_woo_plugins().
-		add_filter( 'extra_plugin_headers', [ $this, 'filter_extra_headers' ] );
 	}
 
 	/**

--- a/src/ExtraThemeAndPluginHeaders.php
+++ b/src/ExtraThemeAndPluginHeaders.php
@@ -27,6 +27,18 @@ final class ExtraThemeAndPluginHeaders implements Service, Registerable {
 	const AMP_HEADER = 'AMP';
 
 	/**
+	 * Values which indicate the theme has 'amp' theme support.
+	 *
+	 * @var string[]
+	 */
+	const AMP_THEME_SUPPORT_VALUES = [
+		'theme-support',
+		'theme_support',
+		'true',
+		'yes',
+	];
+
+	/**
 	 * Register the service with the system.
 	 *
 	 * @return void

--- a/tests/php/data/themes/child-of-core/style.css
+++ b/tests/php/data/themes/child-of-core/style.css
@@ -1,4 +1,5 @@
-/**
+/*
 Theme Name: Child o' Twenty Seventeen
 Template: twentyseventeen
- */
+AMP: true
+*/

--- a/tests/php/data/themes/custom/style.css
+++ b/tests/php/data/themes/custom/style.css
@@ -1,4 +1,3 @@
 /*
 Theme Name: Custom
-AMP: theme-support
 */

--- a/tests/php/data/themes/custom/style.css
+++ b/tests/php/data/themes/custom/style.css
@@ -1,3 +1,4 @@
 /*
 Theme Name: Custom
+AMP: theme-support
 */

--- a/tests/php/data/themes/with-legacy/amp/meta-author.php
+++ b/tests/php/data/themes/with-legacy/amp/meta-author.php
@@ -1,0 +1,2 @@
+<?php
+echo 'Nobody!';

--- a/tests/php/data/themes/with-legacy/style.css
+++ b/tests/php/data/themes/with-legacy/style.css
@@ -1,0 +1,4 @@
+/*
+Theme Name: With Legacy Templates
+AMP: legacy
+*/

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -100,7 +100,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 
 		$available_theme_slugs = wp_list_pluck( $themes, 'slug' );
 		$this->assertContains( 'child-of-core', $available_theme_slugs );
-		$this->assertContains( 'custom', $available_theme_slugs );
+		$this->assertNotContains( 'custom', $available_theme_slugs );
 		$this->assertNotContains( 'with-legacy', $available_theme_slugs );
 	}
 

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -11,6 +11,7 @@ namespace AmpProject\AmpWP\Tests\Admin;
 use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AmpProject\AmpWP\Admin\ReaderThemes;
+use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
@@ -69,8 +70,13 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	 * @covers ReaderThemes::get_classic_mode
 	 */
 	public function test_get_themes() {
-		$themes = $this->reader_themes->get_themes();
+		register_theme_directory( __DIR__ . '/../../data/themes' );
+		delete_site_transient( 'theme_roots' );
 
+		$extra_theme_and_plugin_headers = new ExtraThemeAndPluginHeaders();
+		$extra_theme_and_plugin_headers->register();
+
+		$themes = $this->reader_themes->get_themes();
 		$this->assertEquals( 'legacy', end( $themes )['slug'] );
 
 		$keys = [
@@ -88,15 +94,14 @@ class ReaderThemesTest extends WP_UnitTestCase {
 			$this->assertEqualSets( $keys, array_keys( $theme ) );
 		}
 
-		// Verify that the Reader theme data can be retrieved from the list of installed themes.
-		register_theme_directory( __DIR__ . '/../../data/themes' );
-		delete_site_transient( 'theme_roots' );
-
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'child-of-core' );
 
 		$themes = ( new ReaderThemes() )->get_themes();
 
-		$this->assertContains( 'child-of-core', wp_list_pluck( $themes, 'slug' ) );
+		$available_theme_slugs = wp_list_pluck( $themes, 'slug' );
+		$this->assertContains( 'child-of-core', $available_theme_slugs );
+		$this->assertContains( 'custom', $available_theme_slugs );
+		$this->assertNotContains( 'with-legacy', $available_theme_slugs );
 	}
 
 	/**

--- a/tests/php/src/ExtraThemeAndPluginHeadersTest.php
+++ b/tests/php/src/ExtraThemeAndPluginHeadersTest.php
@@ -29,7 +29,6 @@ final class ExtraThemeAndPluginHeadersTest extends WP_UnitTestCase {
 	public function test_register() {
 		$this->instance->register();
 		$this->assertEquals( 10, has_action( 'extra_theme_headers', [ $this->instance, 'filter_extra_headers' ] ) );
-		$this->assertEquals( 10, has_action( 'extra_plugin_headers', [ $this->instance, 'filter_extra_headers' ] ) );
 	}
 
 	/** @covers ::filter_extra_headers() */

--- a/tests/php/src/ExtraThemeAndPluginHeadersTest.php
+++ b/tests/php/src/ExtraThemeAndPluginHeadersTest.php
@@ -18,7 +18,6 @@ final class ExtraThemeAndPluginHeadersTest extends WP_UnitTestCase {
 		$this->instance = new ExtraThemeAndPluginHeaders();
 	}
 
-	/** @covers ::__construct() */
 	public function test__construct() {
 		$this->assertInstanceOf( ExtraThemeAndPluginHeaders::class, $this->instance );
 		$this->assertInstanceOf( Service::class, $this->instance );

--- a/tests/php/src/ExtraThemeAndPluginHeadersTest.php
+++ b/tests/php/src/ExtraThemeAndPluginHeadersTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests;
+
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
+use WP_UnitTestCase;
+
+/** @coversDefaultClass \AmpProject\AmpWP\ExtraThemeAndPluginHeaders */
+final class ExtraThemeAndPluginHeadersTest extends WP_UnitTestCase {
+
+	/** @var ExtraThemeAndPluginHeaders */
+	private $instance;
+
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new ExtraThemeAndPluginHeaders();
+	}
+
+	/** @covers ::__construct() */
+	public function test__construct() {
+		$this->assertInstanceOf( ExtraThemeAndPluginHeaders::class, $this->instance );
+		$this->assertInstanceOf( Service::class, $this->instance );
+		$this->assertInstanceOf( Registerable::class, $this->instance );
+	}
+
+	/** @covers ::register() */
+	public function test_register() {
+		$this->instance->register();
+		$this->assertEquals( 10, has_action( 'extra_theme_headers', [ $this->instance, 'filter_extra_headers' ] ) );
+		$this->assertEquals( 10, has_action( 'extra_plugin_headers', [ $this->instance, 'filter_extra_headers' ] ) );
+	}
+
+	/** @covers ::filter_extra_headers() */
+	public function test_filter_extra_headers() {
+		$this->assertContains( ExtraThemeAndPluginHeaders::AMP_HEADER, $this->instance->filter_extra_headers( [ 'Woo' ] ) );
+	}
+}

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -57,7 +57,23 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 	 * @covers AMP_Reader_Theme_REST_Controller::get_items
 	 */
 	public function test_get_items() {
-		$this->assertEquals( 10, count( $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) )->data ) );
+		$data = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) )->data;
+
+		$this->assertArraySubset(
+			[
+				'twentytwenty',
+				'twentynineteen',
+				'twentyseventeen',
+				'twentysixteen',
+				'twentyfifteen',
+				'twentyfourteen',
+				'twentythirteen',
+				'twentytwelve',
+				'twentyeleven',
+				'legacy',
+			],
+			wp_list_pluck( $data, 'slug' )
+		);
 
 		$filter = static function() {
 			return [

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -59,21 +59,23 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 	public function test_get_items() {
 		$data = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) )->data;
 
-		$this->assertArraySubset(
-			[
-				'twentytwenty',
-				'twentynineteen',
-				'twentyseventeen',
-				'twentysixteen',
-				'twentyfifteen',
-				'twentyfourteen',
-				'twentythirteen',
-				'twentytwelve',
-				'twentyeleven',
-				'legacy',
-			],
-			wp_list_pluck( $data, 'slug' )
-		);
+		$actual_reader_themes   = wp_list_pluck( $data, 'slug' );
+		$expected_reader_themes = [
+			'twentytwenty',
+			'twentynineteen',
+			'twentyseventeen',
+			'twentysixteen',
+			'twentyfifteen',
+			'twentyfourteen',
+			'twentythirteen',
+			'twentytwelve',
+			'twentyeleven',
+			'legacy',
+		];
+
+		foreach ( $expected_reader_themes as $expected_reader_theme ) {
+			$this->assertContains( $expected_reader_theme, $actual_reader_themes );
+		}
 
 		$filter = static function() {
 			return [


### PR DESCRIPTION
## Summary

Fixes #5222

This registers an extra `AMP` header for themes (and plugins) to indicate their support for AMP. Now instead of having to add a plugin that registers a theme via the `amp_reader_themes` filter, a theme merely has to add the following AMP line to the theme's `style.css` metadata:

```
Theme Name: Foo
...
AMP: true
```

And the theme will be automatically included among the list of Reader themes. Additionally, when a theme has this then it will be treated as if the theme had done `add_theme_support('amp')`.

The intention is that themes with custom legacy Reader mode templates could also include:

```
Theme Name: Foo
...
AMP: legacy
```

In the future that could provide some indicator highlighting the AMP Legacy theme as being an option that should be considered.  It is not yet implemented with this PR, however.

Interestingly, I found that WooCommerce registers an extra theme header for `Woo`, though I can't see exactly how it is being 
used. See: 

https://github.com/woocommerce/woocommerce/blob/a887cd73690f3cbfd9e90687c0574e62c6a0f9c5/includes/wc-core-functions.php#L2145-L2169

~One piece to this which is not totally ideal yet is that just adding the `AMP` header will result in the theme's desktop `screenshot.png` being used in the theme card which prefers a mobile viewport. In this way using the `amp_reader_themes` filter is still superior, unless we also introduce a `Mobile Screenshot` theme header which includes a relative URL to the image file which should be used for the theme card. There is a related core ticket ([#26695](https://core.trac.wordpress.org/ticket/26695)) for adding support for multiple screenshots in themes, though it doesn't specifically mention mobile screenshots.~

If a theme has a `screenshot-mobile.png` or a `screenshot-mobile.jpg` in its root directory (alongside the existing `screenshot.png`) then it will be used by default as the Reader theme screenshot.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
