### PR TITLE
Fix typos in deprecation comments

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -826,7 +826,7 @@ function amp_is_post_supported( $post ) {
  *
  * @since 0.1
  * @since 0.6 Returns false when post has meta to disable AMP.
- * @since 2.0 Renamed to AMP-prefixed version, amp_is_endpoint().
+ * @since 2.0 Renamed to AMP-prefixed version, amp_is_post_supported().
  * @deprecated Use amp_is_post_supported() instead.
  *
  * @param WP_Post $post Post.
@@ -895,8 +895,8 @@ function amp_is_request() {
  * var is present, or else in standard mode if just the template is available.
  *
  * @since 0.1
- * @since 2.0 Renamed to AMP-prefixed version, amp_is_endpoint().
- * @deprecated Use amp_is_endpoint() instead.
+ * @since 2.0 Renamed to AMP-prefixed version, amp_is_request().
+ * @deprecated Use amp_is_request() instead.
  *
  * @return bool Whether it is the AMP endpoint.
  */


### PR DESCRIPTION
## Summary

Fix deprecation comments typos as a follow-up to https://github.com/ampproject/amp-wp/pull/5218.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
