### PR TITLE
Reduce top/bottom padding in wizard nav bar

### DIFF
--- a/assets/src/onboarding-wizard/components/nav/style.css
+++ b/assets/src/onboarding-wizard/components/nav/style.css
@@ -24,7 +24,7 @@
 	width: 100%;
 
 	@media screen and (min-width: 783px) {
-		padding: 40px 90px;
+		padding: 30px 90px;
 	}
 }
 


### PR DESCRIPTION
## Summary

This reduces the padding in the wizard navbar above the 783px width. It was previously 40px; now it's 30px.

| Before | After |
|-------|------|
|![before](https://user-images.githubusercontent.com/9020968/90287496-9ad14a00-de3d-11ea-8b8c-7c9c3212215b.png)|![after](https://user-images.githubusercontent.com/9020968/90287515-a3c21b80-de3d-11ea-9ce1-422b16a3cb0e.png)|



<!-- Please reference the issue this PR addresses. -->
Fixes #5234 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
