### PR TITLE
Only show fatal errors on Validated URL screen when WP_DEBUG_DISPLAY is enabled

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1742,10 +1742,6 @@ class AMP_Validated_URL_Post_Type {
 	 * @param WP_Post $post Post.
 	 */
 	private static function render_php_fatal_error_admin_notice( WP_Post $post ) {
-		if ( ! ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) ) {
-			return;
-		}
-
 		$error = get_post_meta( $post->ID, self::PHP_FATAL_ERROR_POST_META_KEY, true );
 		if ( empty( $error ) ) {
 			return;
@@ -1757,13 +1753,19 @@ class AMP_Validated_URL_Post_Type {
 		?>
 		<div class="notice notice-error">
 			<p><?php echo AMP_Validation_Manager::get_validate_url_error_message( 'fatal_error_during_validation' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
-			<blockquote>
-				<pre><?php echo esc_html( $error_data['message'] ); ?></pre>
-			</blockquote>
-			<p>
-				<?php esc_html_e( 'Location:', 'amp' ); ?>
-				<code><?php echo esc_html( sprintf( '%s:%d', $error_data['file'], $error_data['line'] ) ); ?></code>
-			</p>
+			<?php
+			if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
+				?>
+				<blockquote>
+					<pre><?php echo esc_html( $error_data['message'] ); ?></pre>
+				</blockquote>
+				<p>
+					<?php esc_html_e( 'Location:', 'amp' ); ?>
+					<code><?php echo esc_html( sprintf( '%s:%d', $error_data['file'], $error_data['line'] ) ); ?></code>
+				</p>
+				<?php
+			}
+			?>
 		</div>
 		<?php
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1742,6 +1742,10 @@ class AMP_Validated_URL_Post_Type {
 	 * @param WP_Post $post Post.
 	 */
 	private static function render_php_fatal_error_admin_notice( WP_Post $post ) {
+		if ( ! ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) ) {
+			return;
+		}
+
 		$error = get_post_meta( $post->ID, self::PHP_FATAL_ERROR_POST_META_KEY, true );
 		if ( empty( $error ) ) {
 			return;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1753,9 +1753,7 @@ class AMP_Validated_URL_Post_Type {
 		?>
 		<div class="notice notice-error">
 			<p><?php echo AMP_Validation_Manager::get_validate_url_error_message( 'fatal_error_during_validation' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
-			<?php
-			if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
-				?>
+			<?php if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) : ?>
 				<blockquote>
 					<pre><?php echo esc_html( $error_data['message'] ); ?></pre>
 				</blockquote>
@@ -1763,9 +1761,7 @@ class AMP_Validated_URL_Post_Type {
 					<?php esc_html_e( 'Location:', 'amp' ); ?>
 					<code><?php echo esc_html( sprintf( '%s:%d', $error_data['file'], $error_data['line'] ) ); ?></code>
 				</p>
-				<?php
-			}
-			?>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2381,7 +2381,10 @@ class AMP_Validation_Manager {
 			case 'fatal_error_during_validation':
 				return $implode_non_empty_strings_with_spaces_and_sanitize(
 					[
-						esc_html__( 'A PHP fatal error occurred while validating the URL. This may indicate either a bug in theme/plugin code or it may be due to an issue in the AMP plugin itself. The error details appear below.', 'amp' ),
+						esc_html__( 'A PHP fatal error occurred while validating the URL. This may indicate either a bug in theme/plugin code or it may be due to an issue in the AMP plugin itself.', 'amp' ),
+						defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY
+							? esc_html__( 'The error details appear below.', 'amp' )
+							: $check_error_log,
 						$support_forum_message,
 					]
 				);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2384,7 +2384,8 @@ class AMP_Validation_Manager {
 						esc_html__( 'A PHP fatal error occurred while validating the URL. This may indicate either a bug in theme/plugin code or it may be due to an issue in the AMP plugin itself.', 'amp' ),
 						defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY
 							? esc_html__( 'The error details appear below.', 'amp' )
-							: $check_error_log,
+							/* translators: %s is WP_DEBUG_DISPLAY */
+							: $check_error_log . ' ' . wp_kses_post( sprintf( __( 'Alternatively, you may enable %s to show the error details below.', 'amp' ), '<code>WP_DEBUG_DISPLAY</code>' ) ),
 						$support_forum_message,
 					]
 				);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Amends #4542.

When `WP_DEBUG_DISPLAY` is off:

![image](https://user-images.githubusercontent.com/134745/90972532-afad7d80-e4ce-11ea-94bf-608dadd67a02.png)

When `WP_DEBUG_DISPLAY` is on:

<img width="1214" alt="Screen Shot 2020-08-22 at 23 19 07" src="https://user-images.githubusercontent.com/134745/90972478-2eee8180-e4ce-11ea-8e77-fcb0939eacb6.png">

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
