### PR TITLE
Replace focus selector with a common class selector when used in a descendant combinator

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1531,7 +1531,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$parsed         = null;
 		$cache_key      = null;
 		$cached         = true;
-		$cache_group    = 'amp-parsed-stylesheet-v30'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group    = 'amp-parsed-stylesheet-v31'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 		$use_transients = $this->should_use_transient_caching();
 
 		$cache_impacting_options = array_merge(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -3105,7 +3105,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 							$replacement = '.menu-item-has-children' . $replacement;
 						}
 
-						return $matches['combinator'] . $replacement;
+						// Ensure preceding combinator is preserved.
+						if ( ! empty( $matches['combinator'] ) ) {
+							$replacement = $matches['combinator'] . $replacement;
+						}
+
+						return $replacement;
 					},
 					$selector,
 					-1,

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -3190,7 +3190,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				(array) $class_names
 			)
 		);
-		return "/(?<combinator>(?<![>+~])\s+)?\.(?<class>{$class_pattern})(?=$|[^a-zA-Z0-9_-])/";
+		return "/(?<combinator>(?<![>+~\s])\s+)?\.(?<class>{$class_pattern})(?=$|[^a-zA-Z0-9_-])/";
 	}
 
 	/**

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -984,8 +984,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 			'focus_selector_after_whitespace_combinator' => [
 				'<nav class="main-navigation focused"><ul><li class="menu-item-has-children"><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
-				'.main-navigation ul li:hover > ul, .main-navigation ul    .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
-				'.main-navigation ul li:hover > ul,.main-navigation ul .menu-item-has-children:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+				'.main-navigation ul li:hover > ul, .main-navigation ul    .focus > ul { left: 100% } .focus > ul { right: auto } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul li:hover > ul,.main-navigation ul    .menu-item-has-children:focus-within > ul{left:100%}.menu-item-has-children:focus-within > ul{right:auto}nav.focused{outline:solid 1px red}',
 			],
 			'focus_selector_after_child_combinator' => [
 				'<nav class="main-navigation focused"><ul><li><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -984,13 +984,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 			'focus_selector_after_whitespace_combinator' => [
 				'<nav class="main-navigation focused"><ul><li class="menu-item-has-children"><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
-				'.main-navigation ul li:hover > ul, .main-navigation ul .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul li:hover > ul, .main-navigation ul    .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
 				'.main-navigation ul li:hover > ul,.main-navigation ul .menu-item-has-children:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
 			],
 			'focus_selector_after_child_combinator' => [
 				'<nav class="main-navigation focused"><ul><li><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
-				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul > .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
-				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul > :focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul    >    .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul    >    :focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
 			],
 			'style_attribute_selector' => [
 				'<figure class="wp-block-pullquote" style="border-color:#ce3a0d">',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -982,6 +982,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul li.focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
 				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul li:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
 			],
+			'focus_selector_after_whitespace_combinator' => [
+				'<nav class="main-navigation focused"><ul><li class="menu-item-has-children"><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
+				'.main-navigation ul li:hover > ul, .main-navigation ul .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul li:hover > ul,.main-navigation ul .menu-item-has-children:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+			],
+			'focus_selector_after_child_combinator' => [
+				'<nav class="main-navigation focused"><ul><li><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
+				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul > .focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul > :focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+			],
 			'style_attribute_selector' => [
 				'<figure class="wp-block-pullquote" style="border-color:#ce3a0d">',
 				'.wp-block-pullquote:not(.is-style-solid-color)[style*="border-color"] { border: 2px solid; }',

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1364,7 +1364,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			'latest_posts' => [
 				'<!-- wp:latest-posts {"postsToShow":1} /-->',
 				sprintf(
-					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}--><ul class="wp-block-latest-posts wp-block-latest-posts__list"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}-->',
+					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}--><ul class="%6$s"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}-->',
 					$is_gutenberg ? 'plugin' : 'core',
 					$is_gutenberg ? 'gutenberg' : 'wp-includes',
 					$latest_posts_block->render_callback,
@@ -1373,7 +1373,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 						? preg_replace( ':.*gutenberg/:', '', $reflection_function->getFileName() )
 						: preg_replace( ':.*wp-includes/:', '', $reflection_function->getFileName() )
 					),
-					$reflection_function->getStartLine()
+					$reflection_function->getStartLine(),
+					( defined( 'GUTENBERG_VERSION' ) && GUTENBERG_VERSION && version_compare( GUTENBERG_VERSION, '8.8.0', '>=' ) )
+						? 'wp-block-latest-posts__list wp-block-latest-posts'
+						: 'wp-block-latest-posts wp-block-latest-posts__list'
 				),
 				[
 					'element' => 'ul',
@@ -1431,13 +1434,6 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 				get_permalink( $post ),
 			],
 			$expected
-		);
-
-		// Temporary patch to support running unit tests in Gutenberg<5.7.0.
-		$rendered_block = str_replace(
-			'class="wp-block-latest-posts"',
-			'class="wp-block-latest-posts wp-block-latest-posts__list"',
-			$rendered_block
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5246

In #3586 the CSS sanitizer was enhanced to convert `.focus` class selectors to `:focus-within` pseudo-class selectors. One unforeseen issue that was not detected was when the `.focus` selector is used as a selector next to a descendant combinator. For example:

```css
foo .focus > ul
```
would be converted to:

```css
foo :focus-within > ul
```

The problem with the above CSS rule is that the pseudo-class selector is now being applied to `foo`, the ancestor of `.focus`, and not a child of `foo`. A basic selector ([type](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors), [class](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors), [ID](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors) or [attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)) is needed to fill the gap when the `.focus` selector is replaced.

After looking through all the JS logic in the core themes that use `focus` class, it can be seen that the `.menu-item-has-children` is a primary class selector used to target the element which needs to be focused. This means it would be a viable replacement for the `.focus` selector in cases where the selector cannot be simply replaced. So:

```css
foo :focus-within > ul
```

would become:

```css
foo .menu-item-has-children:focus-within > ul
```

which is what this PR does. Do note that this will only happen when the `.focus` class is as a selector next to a descendant combinator.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
