### PR TITLE
Fix layout of mobile version switcher in core themes

### DIFF
--- a/assets/css/src/amp-mobile-version-switcher.css
+++ b/assets/css/src/amp-mobile-version-switcher.css
@@ -1,6 +1,12 @@
+#amp-mobile-version-switcher {
+	position: absolute;
+	width: 100%;
+	left: 0;
+	z-index: 100;
+}
+
 #amp-mobile-version-switcher > a {
 	display: block;
-	width: 100%;
 	padding: 15px 0;
 	font-size: 16px;
 	font-weight: 600;

--- a/assets/css/src/amp-mobile-version-switcher.css
+++ b/assets/css/src/amp-mobile-version-switcher.css
@@ -8,10 +8,18 @@
 #amp-mobile-version-switcher > a {
 	display: block;
 	padding: 15px 0;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 16px;
 	font-weight: 600;
 	color: #eaeaea;
 	text-align: center;
+	text-decoration: none;
 	background-color: #444;
 	border: 0;
+}
+
+#amp-mobile-version-switcher > a:hover,
+#amp-mobile-version-switcher > a:focus,
+#amp-mobile-version-switcher > a:active {
+	text-decoration: underline;
 }

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -415,7 +415,7 @@ final class MobileRedirection implements Service, Registerable {
 		if ( ! apply_filters( 'amp_mobile_version_switcher_styles_used', true ) ) {
 			return;
 		}
-		$source = file_get_contents( __DIR__ . '/../assets/css/amp-mobile-version-switcher' . ( is_rtl() ? '-rtl' : '' ) . '.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		$source =  file_get_contents( AMP__DIR__ . '/assets/css/amp-mobile-version-switcher' . ( is_rtl() ? '-rtl' : '' ) . '.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		printf( '<style>%s</style>', $source ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -415,7 +415,7 @@ final class MobileRedirection implements Service, Registerable {
 		if ( ! apply_filters( 'amp_mobile_version_switcher_styles_used', true ) ) {
 			return;
 		}
-		$source =  file_get_contents( AMP__DIR__ . '/assets/css/amp-mobile-version-switcher' . ( is_rtl() ? '-rtl' : '' ) . '.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		$source = file_get_contents( AMP__DIR__ . '/assets/css/amp-mobile-version-switcher' . ( is_rtl() ? '-rtl' : '' ) . '.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		printf( '<style>%s</style>', $source ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 

--- a/templates/style.php
+++ b/templates/style.php
@@ -161,8 +161,7 @@ blockquote p:last-child {
 .amp-wp-tax-tag,
 .amp-wp-comments-link,
 .amp-wp-footer p,
-.back-to-top,
-#amp-mobile-version-switcher {
+.back-to-top {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5251

This PR ensures that the mobile version switcher link is visible and compatible with all supported core themes. However, when viewed in a 1366x1024 viewport, in Twenty Fifteen the link overlaps the left section of the page and in Twenty Fourteen the link extends beyond the content of the page:

Twenty Fifteen:

![image](https://user-images.githubusercontent.com/16200219/90866832-f93d8180-e383-11ea-8216-027d40edeae2.png)

Twenty Fourteen:
![image](https://user-images.githubusercontent.com/16200219/90866855-fe9acc00-e383-11ea-9847-e28200e08186.png)


I think it's fine in either case, but just wanted to make those abnormalities known.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
