### PR TITLE
Add missing @internal tag to function in bootstrap file

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -169,6 +169,7 @@ if ( ! file_exists( AMP__DIR__ . '/vendor/autoload.php' ) || ! file_exists( AMP_
  * Displays an admin notice about why the plugin is unable to load.
  *
  * @since 1.1.2
+ * @internal
  * @global WP_Error $_amp_load_errors
  */
 function _amp_show_load_errors_admin_notice() {
@@ -220,6 +221,7 @@ if ( ! empty( $_amp_load_errors->errors ) ) {
  * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).
  *
  * @since 1.0
+ * @internal
  */
 function _amp_incorrect_plugin_slug_admin_notice() {
 	$actual_slug = basename( AMP__DIR__ );


### PR DESCRIPTION
## Summary

This adds missing @internal tags to the two functions in the plugin bootstrap file:
- `_amp_show_load_errors_admin_notice()`
- `_amp_incorrect_plugin_slug_admin_notice()`

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
