### PR TITLE
Annotate AnalyticsOptionsSubmenu class as internal

### DIFF
--- a/src/Admin/AnalyticsOptionsSubmenu.php
+++ b/src/Admin/AnalyticsOptionsSubmenu.php
@@ -11,7 +11,10 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 
 /**
- * Class AnalyticsOptionsSubmenu
+ * Add a submenu link to the AMP options submenu.
+ *
+ * @since 2.0
+ * @internal
  */
 final class AnalyticsOptionsSubmenu implements Service, Registerable {
 


### PR DESCRIPTION
## Summary

The `AnalyticsOptionsSubmenu` class is missing the `@internal` docblock tag.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
