### PR TITLE
Add missing internal tags on deprecated code

### DIFF
--- a/includes/amp-frontend-actions.php
+++ b/includes/amp-frontend-actions.php
@@ -22,7 +22,7 @@ _deprecated_file(
 /**
  * Add amphtml link to frontend.
  *
- * @deprecated
+ * @deprecated Use amp_add_amphtml_link() instead.
  *
  * @since 0.2
  * @since 1.0 Deprecated

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -771,7 +771,7 @@ function amp_add_amphtml_link() {
 		 *     } );
 		 *
 		 * @since 0.2
-		 * @deprecated
+		 * @deprecated Remove amp_add_amphtml_link() call on wp_head action instead.
 		 */
 		false === apply_filters_deprecated(
 			'amp_frontend_show_canonical',

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -10,7 +10,8 @@
  *
  * Class AMP_Autoloader
  *
- * @deprecated Uses Composer autoloading instead.
+ * @deprecated Use Composer autoloading instead.
+ * @internal
  */
 class AMP_Autoloader {
 	/**

--- a/includes/class-amp-comment-walker.php
+++ b/includes/class-amp-comment-walker.php
@@ -16,6 +16,7 @@ _deprecated_file( __FILE__, '1.1', null, sprintf( esc_html__( '%1$s functionalit
  * Walker to wrap comments in mustache tags for amp-template.
  *
  * @deprecated 1.1.0 This functionality was moved to AMP_Comments_Sanitizer
+ * @internal
  */
 class AMP_Comment_Walker extends Walker_Comment {
 

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -105,6 +105,7 @@ class AMP_HTTP {
 	 * @since 1.0
 	 *
 	 * @deprecated Use the `ServerTiming` service or its associated actions instead.
+	 * @internal
 	 *
 	 * @param string $name        Name.
 	 * @param float  $duration    Duration. If negative, will be added to microtime( true ). Optional.

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -26,6 +26,7 @@ class AMP_Post_Type_Support {
 	 * Get post types that plugin supports out of the box (which cannot be disabled).
 	 *
 	 * @deprecated
+	 * @internal
 	 * @codeCoverageIgnore
 	 * @return string[] Post types.
 	 */

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -11,6 +11,7 @@
  * @since 0.2
  * @codeCoverageIgnore
  * @deprecated As of 0.6 since autoloading is now employed.
+ * @internal
  */
 function amp_load_classes() {
 	_deprecated_function( __FUNCTION__, '0.6' );
@@ -166,7 +167,7 @@ function amp_render_post( $post ) {
 	 * This action is not triggered when 'amp' theme support is present. Instead, you should use 'template_redirect' action and check if `amp_is_request()`.
 	 *
 	 * @since 0.2
-	 * @deprecated
+	 * @deprecated Check amp_is_request() on the template_redirect action instead.
 	 *
 	 * @param int $post_id Post ID.
 	 */
@@ -186,6 +187,7 @@ function amp_render_post( $post ) {
  *
  * @codeCoverageIgnore
  * @deprecated Scripts are now automatically added.
+ * @internal
  * @see amp_register_default_scripts()
  * @see amp_filter_script_loader_tag()
  * @param AMP_Post_Template $amp_template Template.
@@ -209,6 +211,7 @@ function amp_post_template_add_scripts( $amp_template ) {
  *
  * @codeCoverageIgnore
  * @deprecated Boilerplate is now automatically added via the ampproject/optimizer library.
+ * @internal
  * @since 0.3
  * @see amp_get_boilerplate_code()
  */
@@ -222,6 +225,7 @@ function amp_post_template_add_boilerplate_css() {
  *
  * @codeCoverageIgnore
  * @deprecated Since 0.7
+ * @internal
  */
 function amp_post_template_add_schemaorg_metadata() {
 	_deprecated_function( __FUNCTION__, '0.7', 'amp_print_schemaorg_metadata' );
@@ -236,6 +240,7 @@ function amp_post_template_add_schemaorg_metadata() {
  * @since 0.6
  * @codeCoverageIgnore
  * @deprecated Since 1.5.0, as admin class bootstrapping is moved to amp_bootstrap_admin().
+ * @internal
  */
 function amp_post_meta_box() {
 	_deprecated_function( __FUNCTION__, '1.5.0' );
@@ -247,6 +252,7 @@ function amp_post_meta_box() {
  * @since 1.0
  * @codeCoverageIgnore
  * @deprecated Since 1.5.0, as admin class bootstrapping is moved to amp_bootstrap_admin().
+ * @internal
  */
 function amp_admin_pointer() {
 	_deprecated_function( __FUNCTION__, '1.5.0' );
@@ -257,6 +263,7 @@ function amp_admin_pointer() {
  *
  * @since 1.3
  * @deprecated 1.5.0 Warning moved to Site Health.
+ * @internal
  * @see AmpProject\AmpWP\Admin\SiteHealth::xdebug_extension()
  */
 function _amp_xdebug_admin_notice() {

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -20,6 +20,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Only handling single videos. Playlists are handled elsewhere.
 	 *
 	 * @deprecated No longer used.
+	 * @internal
 	 * @var string
 	 */
 	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|watch[/\#?])|youtu\.be/).*#i';

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -177,6 +177,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @since 0.4
 	 * @codeCoverageIgnore
 	 * @deprecated As of 1.0, use get_stylesheets().
+	 * @internal
 	 *
 	 * @return array[][] Mapping of CSS selectors to arrays of properties.
 	 */

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -10,6 +10,7 @@
  *
  * @codeCoverageIgnore
  * @deprecated 1.5 Reader mode now sanitizes its entire template through the standard post-processor.
+ * @internal
  */
 class AMP_Content {
 

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -22,6 +22,7 @@ class AMP_DOM_Utils {
 	 *
 	 * @since 1.2.1
 	 * @deprecated Use AmpProject\Dom\Document::AMP_BIND_DATA_ATTR_PREFIX instead.
+	 * @internal
 	 * @var string
 	 */
 	const AMP_BIND_DATA_ATTR_PREFIX = Document::AMP_BIND_DATA_ATTR_PREFIX;
@@ -114,6 +115,7 @@ class AMP_DOM_Utils {
 	 * @since 0.7
 	 * @codeCoverageIgnore
 	 * @deprecated This is handled automatically via AmpProject\Dom\Document.
+	 * @internal
 	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
 	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
 	 *
@@ -134,6 +136,7 @@ class AMP_DOM_Utils {
 	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
 	 * @codeCoverageIgnore
 	 * @deprecated This is handled automatically via AmpProject\Dom\Document.
+	 * @internal
 	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
 	 *
 	 * @param string $html HTML with amp-bind attributes converted.
@@ -286,11 +289,12 @@ class AMP_DOM_Utils {
 	}
 
 	/**
-	 * Forces HTML element closing tags given a Dom\Document and optional DOMElement
+	 * Forces HTML element closing tags given a Dom\Document and optional DOMElement.
 	 *
 	 * @since 0.2
 	 * @codeCoverageIgnore
 	 * @deprecated
+	 * @internal
 	 *
 	 * @param Document   $dom  Represents HTML document on which to force closing tags.
 	 * @param DOMElement $node Represents HTML element to start closing tags on.

--- a/includes/widgets/class-amp-widget-archives.php
+++ b/includes/widgets/class-amp-widget-archives.php
@@ -13,6 +13,7 @@ _deprecated_file( __FILE__, '2.0.0' );
  * Class AMP_Widget_Archives
  *
  * @deprecated As of 2.0 the AMP_Core_Block_Handler will sanitize the core widgets instead.
+ * @internal
  * @since 0.7.0
  * @package AMP
  */

--- a/includes/widgets/class-amp-widget-categories.php
+++ b/includes/widgets/class-amp-widget-categories.php
@@ -13,6 +13,7 @@ _deprecated_file( __FILE__, '2.0.0' );
  * Class AMP_Widget_Categories
  *
  * @deprecated As of 2.0 the AMP_Core_Block_Handler will sanitize the core widgets instead.
+ * @internal
  * @since 0.7.0
  * @package AMP
  */

--- a/includes/widgets/class-amp-widget-text.php
+++ b/includes/widgets/class-amp-widget-text.php
@@ -15,6 +15,7 @@ if ( class_exists( 'WP_Widget_Text' ) ) {
 	 *
 	 * @since 0.7.0
 	 * @deprecated As of 2.0 the AMP_Core_Block_Handler will sanitize the core widgets instead.
+	 * @internal
 	 * @package AMP
 	 */
 	class AMP_Widget_Text extends WP_Widget_Text {


### PR DESCRIPTION
## Summary

As we are now including the `@deprecated` pieces of code, it became apparent that we did not add `@internal` tags to these as needed.

This PR adds the `@internal` for some but not all of the deprecated elements, and improves some of the `@deprecated` description where it made sense.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
