### PR TITLE
Reverse style traversal when turning sizes attribute into CSS

### DIFF
--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -995,7 +995,7 @@ final class ServerSideRendering implements Transformer
         $cssRules   = [];
         $cssRules[] = new CssRule($mainStyle[0], sprintf($mainStyle[1], $lastItem));
 
-        foreach ($sourceSizes as $sourceSize) {
+        foreach (array_reverse($sourceSizes) as $sourceSize) {
             $matches = [];
             if (preg_match(self::CSS_DIMENSION_WITH_MEDIA_CONDITION_REGEX_PATTERN, $sourceSize, $matches)) {
                 $mediaCondition = trim($matches['media_condition'], self::CSS_TRIM_CHARACTERS);

--- a/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
+++ b/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
@@ -217,6 +217,15 @@ final class ServerSideRenderingTest extends TestCase
                 [],
             ],
 
+            'sizes attribute order reversal' => [
+                $input('<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes="(min-width: 200px) 200px, (min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" width="400"></amp-img>'),
+                $expectWithoutBoilerplate(
+                    '<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes="(min-width: 200px) 200px, (min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" width="400" id="i-amp-0" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive"><i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer></amp-img>',
+                    '<style amp-custom>#i-amp-0{width:100vw}@media (min-width: 320px){#i-amp-0{width:320px}}@media (min-width: 200px){#i-amp-0{width:200px}}</style>'
+                ),
+                [],
+            ],
+
             'bad sizes attribute' => [
                 $input('<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes=",,," src="https://acme.org/image1.png" width="400"></amp-img>'),
                 $expectWithBoilerplate('<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes=",,,"  src="https://acme.org/image1.png" width="400"></amp-img>'),


### PR DESCRIPTION
## Summary

Reverse the order of style traversal when turning a `sizes` attribute into a media query.

This is a follow-up to https://github.com/ampproject/amp-wp/pull/4482/files/580709173d74122c2c8dd141db998d4b0aa966bc#r423086524 where @sebastianbenz detected a bug which has not been fixed up until now.

![image](https://user-images.githubusercontent.com/134745/91202427-ab43b900-e6b6-11ea-9239-23d1eac70f00.png)


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
