### PR TITLE
Settings screen: allow showing success notice multiple times

### DIFF
--- a/assets/src/components/amp-notice/index.js
+++ b/assets/src/components/amp-notice/index.js
@@ -75,17 +75,19 @@ function getNoticeIcon( type ) {
  * @param {string} props.size The notice size.
  * @param {string} props.type The notice type.
  */
-export function AMPNotice( { children, className, size = NOTICE_SIZE_LARGE, type = NOTICE_TYPE_INFO } ) {
+export function AMPNotice( { children, className, size = NOTICE_SIZE_LARGE, type = NOTICE_TYPE_INFO, ...props } ) {
 	const noticeIcon = getNoticeIcon( type );
 
 	return (
-		<div className={
-			classnames(
-				className,
-				'amp-notice',
-				`amp-notice--${ type }`,
-				`amp-notice--${ size }`,
-			) }
+		<div
+			className={
+				classnames(
+					className,
+					'amp-notice',
+					`amp-notice--${ type }`,
+					`amp-notice--${ size }`,
+				) }
+			{ ...props }
 		>
 			<div className="amp-notice__icon">
 				{ noticeIcon }

--- a/assets/src/components/options-context-provider/index.js
+++ b/assets/src/components/options-context-provider/index.js
@@ -162,6 +162,7 @@ export function OptionsContextProvider( { children, optionsRestPath, populateDef
 			return;
 		}
 
+		setUpdates( {} );
 		setDidSaveOptions( true );
 		setSavingOptions( false );
 	}, [ delaySave, hasErrorBoundary, optionsRestPath, setAsyncError, originalOptions, setError, updates ] );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -122,25 +122,36 @@ function scrollFocusedSectionIntoView( focusedSectionId ) {
 function Root() {
 	const [ focusedSection, setFocusedSection ] = useState( global.location.hash.replace( /^#/, '' ) );
 
-	const { didSaveOptions, fetchingOptions, saveOptions } = useContext( Options );
+	const { didSaveOptions, fetchingOptions, hasOptionsChanges, saveOptions } = useContext( Options );
 	const { error } = useContext( ErrorContext );
 	const { downloadingTheme } = useContext( ReaderThemes );
-	const [ saved, setSaved ] = useState( false );
-
-	// Show the success notice after options have saved.
-	useEffect( () => {
-		if ( didSaveOptions ) {
-			setSaved( true );
-		}
-	}, [ didSaveOptions ] );
+	const [ savedNoticeClass, setSavedNoticeClass ] = useState( '' );
 
 	/**
-	 * Shows a saved notice on success.
+	 * Show the success notice after options have saved.
 	 */
 	useEffect( () => {
-		if ( saved && ! downloadingTheme ) {
+		if ( didSaveOptions && ! downloadingTheme ) {
+			setSavedNoticeClass( 'visible' );
+		}
+	}, [ didSaveOptions, downloadingTheme ] );
+
+	/**
+	 * If the success notice is showing and updates have been made, hide the notice.
+	 */
+	useEffect( () => {
+		if ( 'visible' === savedNoticeClass && hasOptionsChanges ) {
+			setSavedNoticeClass( 'dismissed' );
+		}
+	}, [ savedNoticeClass, hasOptionsChanges ] );
+
+	/**
+	 * Hide the success notice after several seconds.
+	 */
+	useEffect( () => {
+		if ( 'visible' === savedNoticeClass ) {
 			const timeout = setTimeout( () => {
-				setSaved( false );
+				setSavedNoticeClass( 'dismissed' );
 			}, 9000 );
 
 			return () => {
@@ -149,7 +160,7 @@ function Root() {
 		}
 
 		return () => undefined;
-	}, [ downloadingTheme, saved ] );
+	}, [ savedNoticeClass ] );
 
 	/**
 	 * Scroll to the focused element on load or when it changes.
@@ -242,13 +253,11 @@ function Root() {
 			</form>
 			<UnsavedChangesWarning excludeUserContext={ true } />
 			{ error && <ErrorNotice errorMessage={ error.message || __( 'An error occurred. You might be offline or logged out.', 'amp' ) } /> }
-			{ saved && (
-				<AMPNotice className={ `amp-save-success-notice` } type={ NOTICE_TYPE_SUCCESS }>
-					<p>
-						{ __( 'Settings saved', 'amp' ) }
-					</p>
-				</AMPNotice>
-			) }
+			<AMPNotice className={ `amp-save-success-notice ${ savedNoticeClass }` } type={ NOTICE_TYPE_SUCCESS }>
+				<p>
+					{ __( 'Settings saved', 'amp' ) }
+				</p>
+			</AMPNotice>
 		</>
 	);
 }

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -127,16 +127,21 @@ function Root() {
 	const { downloadingTheme } = useContext( ReaderThemes );
 	const [ saved, setSaved ] = useState( false );
 
+	// Show the success notice after options have saved.
+	useEffect( () => {
+		if ( didSaveOptions ) {
+			setSaved( true );
+		}
+	}, [ didSaveOptions ] );
+
 	/**
 	 * Shows a saved notice on success.
 	 */
 	useEffect( () => {
-		if ( true === didSaveOptions && ! downloadingTheme ) {
-			setSaved( true );
-
-			const timeout = setTimeout( () => [
-				setSaved( false ),
-			], 9000 );
+		if ( saved && ! downloadingTheme ) {
+			const timeout = setTimeout( () => {
+				setSaved( false );
+			}, 9000 );
 
 			return () => {
 				clearTimeout( timeout );
@@ -144,7 +149,7 @@ function Root() {
 		}
 
 		return () => undefined;
-	}, [ didSaveOptions, downloadingTheme ] );
+	}, [ downloadingTheme, saved ] );
 
 	/**
 	 * Scroll to the focused element on load or when it changes.

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -253,7 +253,11 @@ function Root() {
 			</form>
 			<UnsavedChangesWarning excludeUserContext={ true } />
 			{ error && <ErrorNotice errorMessage={ error.message || __( 'An error occurred. You might be offline or logged out.', 'amp' ) } /> }
-			<AMPNotice className={ `amp-save-success-notice ${ savedNoticeClass }` } type={ NOTICE_TYPE_SUCCESS }>
+			<AMPNotice
+				className={ `amp-save-success-notice ${ savedNoticeClass }` }
+				type={ NOTICE_TYPE_SUCCESS }
+				aria-hidden={ 'visible' !== savedNoticeClass }
+			>
 				<p>
 					{ __( 'Settings saved', 'amp' ) }
 				</p>

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -308,22 +308,32 @@ li.error-kept {
 	}
 }
 
-@keyframes fadeOut {
+@keyframes slideOut {
 
 	from {
-		opacity: 1;
+		transform: translate3d(0, 0, 0);
 	}
 
 	to {
-		opacity: 0;
+		transform: translate3d(300px, 0, 0);
 	}
 }
 
+.amp .amp-save-success-notice.amp-notice:not(.dismissed):not(.visible) {
+	transform: translate3d(300px, 0, 0);
+}
 
-.amp .amp-save-success-notice.amp-notice {
-	animation: slideIn, fadeOut;
-	animation-delay: 0s, 8s;
-	animation-duration: 0.5s, 0.5s;
+.amp .amp-save-success-notice.amp-notice.visible {
+	animation: slideIn;
+	animation-delay: 0s;
+	animation-duration: 0.5s;
+	animation-fill-mode: both;
+}
+
+.amp .amp-save-success-notice.amp-notice.dismissed {
+	animation: slideOut;
+	animation-delay: 0s;
+	animation-duration: 0.5s;
 	animation-fill-mode: both;
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5264 

This fixes a bug on the settings screen preventing the save success notice from showing multiple times within a pageload. 
The success notice was being triggered within an effect hook that sets the `saved` state to true when the `didSaveOptions` variable from the options context provider becomes true. Within the effect hook, a callback was set using `setTimeout` to set `saved` to false after nine seconds, causing the notice to disappear. The options context provider sets `didSaveOptions` back to false, however, after save success. This was causing the effect hook's unmount callback to run, clearing the timeout early. 

To fix this, I moved the `didSaveOptions` effect into its own `useEffect` hook. This way, when it changes back to false almost immediately, `clearTimeout` won't be called.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
