### PR TITLE
Remove checkbox column from error index since bulk actions removed

### DIFF
--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -272,6 +272,15 @@ tr.expanded.new + tr > td:first-of-type,
 	border-left: 4px solid #d54e21;
 }
 
+.wp-list-table th.column-error_code:first-child,
+.wp-list-table td.column-error_code:first-child {
+	border-left: 4px solid transparent;
+}
+
+.wp-list-table .new td.column-error_code:first-child {
+	border-left: 4px solid #d54e21;
+}
+
 .wp-list-table > tbody > tr > th,
 .wp-list-table > tbody > tr > td {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -840,21 +840,13 @@ class AMP_Validation_Error_Taxonomy {
 		);
 
 		// Remove bulk actions.
-		add_filter(
-			'bulk_actions-edit-' . self::TAXONOMY_SLUG,
-			static function( $bulk_actions ) {
-				unset( $bulk_actions['delete'] );
-				return $bulk_actions;
-			}
-		);
+		add_filter( 'bulk_actions-edit-' . self::TAXONOMY_SLUG, '__return_empty_array' );
 
 		// Override the columns displayed for the validation error terms.
 		add_filter(
 			'manage_edit-' . self::TAXONOMY_SLUG . '_columns',
-			static function( $old_columns ) {
-
+			static function() {
 				return [
-					'cb'               => $old_columns['cb'],
 					'error_code'       => esc_html__( 'Error', 'amp' ),
 					'status'           => sprintf(
 						'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -574,12 +574,10 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'load-edit-tags.php', [ self::TESTED_CLASS, 'handle_inline_edit_request' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts' ) );
 
-		$cb              = '<input type="checkbox" />';
-		$initial_columns = [ 'cb' => $cb ];
+		$initial_columns = [ 'cb' => '<input type="checkbox" />' ];
 		$this->assertEquals(
 			array_keys(
 				[
-					'cb'               => $cb,
 					'error_code'       => 'Error',
 					'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 					'details'          => 'Details<div class="tooltip dashicons dashicons-editor-help"><h3>Details tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',


### PR DESCRIPTION
## Summary

This fixes an issue that @amedina discovered where checkboxes are appearing on the Error Index even when there are no bulk actions. The bulk actions were removed in 93b08b2efb02551b72d207770d410f74dde453cb as part of #4382, but the bulk action checkboxes weren't also removed.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/91123464-ca5c2f80-e651-11ea-8f84-225e63d3e760.png) | ![image](https://user-images.githubusercontent.com/134745/91123599-2030d780-e652-11ea-8277-ed7db47ea1eb.png)


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
