### PR TITLE
Remove unused REMOVED_SOURCES constant

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -198,13 +198,6 @@ class AMP_Validation_Error_Taxonomy {
 	const SOURCES_INVALID_OUTPUT = 'sources_with_invalid_output';
 
 	/**
-	 * The key for removed sources.
-	 *
-	 * @var string
-	 */
-	const REMOVED_SOURCES = 'removed_sources';
-
-	/**
 	 * The key for the error status.
 	 *
 	 * @var string


### PR DESCRIPTION
## Summary

Removes the unused `REMOVED_SOURCES` constant from the `AMP_Validation_Error_Taxonomy` class.

A quick look through commit history revealed that it had never been in use.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
