### PR TITLE
Prevent wp_print_service_workers() from happening at wp_print_footer_scripts in legacy Reader mode

### DIFF
--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -259,14 +259,6 @@ class AMP_Service_Worker {
 			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
 		} else {
 			add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
-			add_filter(
-				'amp_post_template_data',
-				static function ( $data ) {
-					$data['amp_component_scripts']['amp-install-serviceworker'] = true;
-
-					return $data;
-				}
-			);
 		}
 	}
 

--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -243,27 +243,31 @@ class AMP_Service_Worker {
 	 * Add hooks to install the service worker from AMP page.
 	 */
 	public static function add_install_hooks() {
-		if ( ! amp_is_legacy() && amp_is_request() ) {
-			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
+		if ( ! amp_is_request() ) {
+			return;
+		}
 
-			// Prevent validation error due to the script that installs the service worker on non-AMP pages.
-			foreach ( [ 'wp_print_scripts', 'wp_print_footer_scripts' ] as $action ) {
-				$priority = has_action( $action, 'wp_print_service_workers' );
-				if ( false !== $priority ) {
-					remove_action( $action, 'wp_print_service_workers', $priority );
-				}
+		// Prevent validation error due to the script that installs the service worker on non-AMP pages.
+		foreach ( [ 'wp_print_scripts', 'wp_print_footer_scripts' ] as $action ) {
+			$priority = has_action( $action, 'wp_print_service_workers' );
+			if ( false !== $priority ) {
+				remove_action( $action, 'wp_print_service_workers', $priority );
 			}
 		}
 
-		// Reader mode integration.
-		add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
-		add_filter(
-			'amp_post_template_data',
-			static function ( $data ) {
-				$data['amp_component_scripts']['amp-install-serviceworker'] = true;
-				return $data;
-			}
-		);
+		if ( ! amp_is_legacy() ) {
+			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
+		} else {
+			add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
+			add_filter(
+				'amp_post_template_data',
+				static function ( $data ) {
+					$data['amp_component_scripts']['amp-install-serviceworker'] = true;
+
+					return $data;
+				}
+			);
+		}
 	}
 
 	/**

--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -255,11 +255,8 @@ class AMP_Service_Worker {
 			}
 		}
 
-		if ( ! amp_is_legacy() ) {
-			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
-		} else {
-			add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
-		}
+		add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
+		add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -197,8 +197,9 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 
+		$this->assertFalse( amp_is_request() );
 		AMP_Service_Worker::add_install_hooks();
-		$this->assertSame( 10, has_action( 'amp_post_template_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
+		$this->assertFalse( has_action( 'amp_post_template_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
 		$this->assertFalse( has_action( 'wp_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );


### PR DESCRIPTION
## Summary

In order to facilitate the admin bar is shown on the legacy AMP template, the `wp_print_footer_scripts()` function is added to be called at `amp_post_template_footer`:

https://github.com/ampproject/amp-wp/blob/3a6243c96fddf3de6f0c71e6a7ba628d16c8bcd2/includes/amp-post-template-functions.php#L28-L30

This has an unintended side effect, however: the existing logic in `AMP_Service_Worker::add_install_hooks()` is failing to remove `wp_print_service_workers()` from happening at `wp_print_footer_scripts` since that action wasn't previously expected to happen in Reader mode. This PR ensures that the PWA plugin's scripts are never output on an AMP page.

Before | After
-------|------
<img width="1072" alt="Screen Shot 2020-08-25 at 13 46 09" src="https://user-images.githubusercontent.com/134745/91226605-1eaaf200-e6da-11ea-936c-3f2f69864cc8.png"> | <img width="1070" alt="Screen Shot 2020-08-25 at 13 45 39" src="https://user-images.githubusercontent.com/134745/91226600-1ce12e80-e6da-11ea-80c7-5363325930d2.png">


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
