### PR TITLE
Avoid version lock-in for libs for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/common": "^1",
-    "ampproject/optimizer": "^1",
+    "ampproject/common": "*",
+    "ampproject/optimizer": "*",
     "cweagans/composer-patches": "1.6.7",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/lib/common/composer.json
+++ b/lib/common/composer.json
@@ -29,10 +29,6 @@
     "sort-packages": true
   },
   "extra": {
-    "branch-alias": {
-      "dev-master": "1.0.x-dev",
-      "dev-develop": "1.0.x-dev"
-    },
     "downloads": {
       "phpstan": {
         "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -8,7 +8,7 @@
     "ext-dom": "*",
     "ext-iconv": "*",
     "ext-libxml": "*",
-    "ampproject/common": "^1",
+    "ampproject/common": "*",
     "php-parallel-lint/php-parallel-lint": "^1.2"
   },
   "require-dev": {
@@ -30,10 +30,6 @@
     "sort-packages": true
   },
   "extra": {
-    "branch-alias": {
-      "dev-master": "1.0.x-dev",
-      "dev-develop": "1.0.x-dev"
-    },
     "downloads": {
       "phpstan": {
         "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",


### PR DESCRIPTION
## Summary

We were locking the version of `lib/common` and `lib/optimizer` to `^1` and using a branch alias to alias `dev-develop` to that.

However, this breaks with the process of releasing v2 of the plugin now, as the library as inferring their version from the git repository they are in, which is the one from the plugin at this point. See https://travis-ci.org/github/ampproject/amp-wp/jobs/718128057#L258

I first thought about fixing this via an adapted branch alias that makes the libs appear as if they were `v2.x` now. However, I decided against that because I fear it might lead to problems down the road when we do externalize the libraries and start with an initial version below 2.0. For developers that were pulling in the plugin via Composer, this would then look as if there's already a v2.x installed but the latest version in the new repository would be lower, so you'd stick with the old library instead of getting the updates.

Therefore, I'm trying to fix this by using the `*` requirement for now, basically ignoring whatever version information we might have. This might still lead to the same issue in some cases, but will work better in others by having the libs be versioning as whatever branch you're currently at.

We'll have to see now what Travis makes out of this, as I cannot easily test this upfront.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
