### PR TITLE
Fix iframe height on done screen of onboarding wizard

### DIFF
--- a/assets/src/onboarding-wizard/pages/save/style.css
+++ b/assets/src/onboarding-wizard/pages/save/style.css
@@ -46,7 +46,7 @@
 }
 
 .done__preview-container .phone {
-	max-height: 610px;
+	height: auto;
 	padding-bottom: 2rem;
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes the height of the iframe on the done screen of the onboarding wizard.

Before|After
---|---
![image](https://user-images.githubusercontent.com/16200219/91370126-0d0e3b00-e7fd-11ea-8857-30f1b022d1f6.png) | ![image](https://user-images.githubusercontent.com/16200219/91370099-fb2c9800-e7fc-11ea-96b4-893121ce9afd.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
