### PR TITLE
Print amp-default.css via amp_post_template_css action instead of in style.php template

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1044,6 +1044,14 @@ function amp_register_default_scripts( $wp_scripts ) {
  */
 function amp_register_default_styles( WP_Styles $styles ) {
 	$styles->add(
+		'amp-default',
+		amp_get_asset_url( 'css/amp-default.css' ),
+		[],
+		AMP__VERSION
+	);
+	$styles->add_data( 'amp-default', 'rtl', 'replace' );
+
+	$styles->add(
 		'amp-icons',
 		amp_get_asset_url( 'css/amp-icons.css' ),
 		[ 'dashicons' ],

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -18,7 +18,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_head', 'wp_generator' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' );
-	add_action( 'amp_post_template_css', 'amp_post_template_add_default_styles', 0 );
+	add_action( 'amp_post_template_head', 'amp_post_template_add_default_styles' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
@@ -95,7 +95,7 @@ function amp_post_template_add_block_styles() {
  * @internal
  */
 function amp_post_template_add_default_styles() {
-	echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions, WordPress.Security.EscapeOutput.OutputNotEscaped
+	wp_print_styles( 'amp-default' );
 }
 
 /**

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -18,6 +18,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_head', 'wp_generator' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' );
+	add_action( 'amp_post_template_css', 'amp_post_template_add_default_styles', 0 );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
@@ -88,6 +89,16 @@ function amp_post_template_add_block_styles() {
 }
 
 /**
+ * Print default styles.
+ *
+ * @since 2.0.1
+ * @internal
+ */
+function amp_post_template_add_default_styles() {
+	echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions, WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+/**
  * Print styles.
  *
  * @internal
@@ -95,8 +106,6 @@ function amp_post_template_add_block_styles() {
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_styles( $amp_template ) {
-	echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-
 	$stylesheets = $amp_template->get( 'post_amp_stylesheets' );
 	if ( ! empty( $stylesheets ) ) {
 		echo '/* Inline stylesheets */' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -95,6 +95,8 @@ function amp_post_template_add_block_styles() {
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_styles( $amp_template ) {
+	echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
 	$stylesheets = $amp_template->get( 'post_amp_stylesheets' );
 	if ( ! empty( $stylesheets ) ) {
 		echo '/* Inline stylesheets */' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2295,8 +2295,7 @@ class AMP_Theme_Support {
 	 */
 	public static function enqueue_assets() {
 		// Enqueue default styles expected by sanitizer.
-		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), [], AMP__VERSION );
-		wp_styles()->add_data( 'amp-default', 'rtl', 'replace' );
+		wp_enqueue_style( 'amp-default' );
 	}
 
 	/**

--- a/templates/style.php
+++ b/templates/style.php
@@ -94,8 +94,6 @@ $alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 	margin: 0 auto;
 }
 
-<?php echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions ?>
-
 /* Template Styles */
 
 .amp-wp-content,


### PR DESCRIPTION
## Summary

Fixes https://wordpress.org/support/topic/no-photos-showing-since-update-2-0/

When a theme has customized their `style.php` template so that it does not include the manual inclusion of `amp-default.css`, the result is changes to that stylesheet will not be included. So if someone has a Gallery block that is showing as a slideshow, it won't render properly if this CSS from `amp-default.css` is not added to the page:

https://github.com/ampproject/amp-wp/blob/f44c07f606713ee78e6e4ce0d437749c5821c8f8/assets/css/src/amp-default.css#L76-L79

If the theme does not intentionally include `amp-default.css` like so:

https://github.com/ampproject/amp-wp/blob/f44c07f606713ee78e6e4ce0d437749c5821c8f8/templates/style.php#L97

Then they won't get such rules.

We can avoid this from happening in the future by printing `amp-default.css` via the `amp_post_template_css` action, rather than manually printing it in the `style.php`.

This workaround code also does the trick:

```php
add_action( 'amp_post_template_css', function () {
	echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
} );
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
