### PR TITLE
Hide Customizer panel collapse button label and improve positioning of AMP toggle

### DIFF
--- a/assets/css/src/amp-customizer-legacy.css
+++ b/assets/css/src/amp-customizer-legacy.css
@@ -1,12 +1,16 @@
 /* This stylesheet only applies to Legacy Reader mode */
 
-.amp-toggle {
+.devices-wrapper {
 	position: relative;
+}
+
+.amp-toggle {
+	position: absolute;
 	display: inline-block;
 	width: 30px;
 	height: 15px;
 	top: 15px;
-	left: 130px;
+	left: -47px;
 }
 
 .amp-toggle input,
@@ -115,9 +119,22 @@
 	z-index: 0;
 }
 
+.wp-core-ui .wp-full-overlay .collapse-sidebar {
+
+	/* Add same padding to right as left since label now hidden. */
+	padding: 9px 10px;
+}
+
 #customize-footer-actions .collapse-sidebar-label {
-	font-size: 11px;
-	margin-left: -3px;
+
+	/* This is moved to a tooltip in amp-customize-controls-legacy.js */
+	display: none;
+}
+
+.wp-full-overlay-footer .devices {
+
+	/* Remove box-shadow because not needed to cause long "Hide Controls" text to fade since it is hidden altogether. */
+	box-shadow: none;
 }
 
 .devices-wrapper .preview-desktop {

--- a/assets/src/customizer/amp-customize-controls-legacy.js
+++ b/assets/src/customizer/amp-customize-controls-legacy.js
@@ -2,6 +2,11 @@
 
 /* eslint no-magic-numbers: [ "error", { "ignore": [ 0, 1, 250] } ] */
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 window.ampCustomizeControls = ( function( api, $ ) {
 	'use strict';
 
@@ -287,7 +292,20 @@ window.ampCustomizeControls = ( function( api, $ ) {
 		} );
 
 		// Adding checkbox toggle before device selection.
-		$( '.devices-wrapper' ).before( ampToggleContainer );
+		$( '.devices-wrapper' ).prepend( ampToggleContainer );
+
+		// Update tooltip for Customizer collapse button based on whether the pane is shown.
+		const collapseSidebarButton = $( '.collapse-sidebar.button' );
+		const collapseSidebarLabel = collapseSidebarButton.find( '> .collapse-sidebar-label' );
+		const updateCollapseSidebarTooltip = () => {
+			if ( api.state( 'paneVisible' ).get() ) {
+				collapseSidebarButton.prop( 'title', collapseSidebarLabel.text() );
+			} else {
+				collapseSidebarButton.prop( 'title', __( 'Show Controls', 'amp' ) );
+			}
+		};
+		updateCollapseSidebarTooltip();
+		api.state( 'paneVisible' ).bind( updateCollapseSidebarTooltip );
 
 		// User clicked link within tooltip, go to linked post in preview.
 		tooltipLink.on( 'click', function( event ) {


### PR DESCRIPTION
## Summary

Fixes #5252

* Hide the "Collapse Controls" label for the button that hides (and shows) the Customizer pane. Move this text into a tooltip for that button instead.
* Inject the AMP toggle inside the preview devices container and position absolutely from inside so that it will be consistently positioned on the right.

On a 1680px-wide display:

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/91409951-08488780-e7fb-11ea-81e2-5a3eaff7ad08.png) | ![after](https://user-images.githubusercontent.com/134745/91409906-f961d500-e7fa-11ea-8859-13a3b0a2585b.png)

When more than 3 devices are being previewed:

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/91410296-8dcc3780-e7fb-11ea-8f2e-bb96e66ddf5c.png) | ![after](https://user-images.githubusercontent.com/134745/91410297-8e64ce00-e7fb-11ea-9295-b9a38e926d4d.png)


On a 3360px-wide display:

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/91410053-26ae8300-e7fb-11ea-88ac-96bf98534f5b.png) | ![after](https://user-images.githubusercontent.com/134745/91410068-2ca46400-e7fb-11ea-9bc4-717d1d03e58a.png)

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
