### PR TITLE
Ensure AMP_QUERY_VAR is defined for plugins that expect it

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -235,7 +235,10 @@ function amp_init() {
  * @internal
  */
 function amp_after_setup_theme() {
-	amp_get_slug(); // Ensure AMP_QUERY_VAR is set.
+	// Ensure AMP_QUERY_VAR is set since some plugins still try reading it instead of using amp_get_slug().
+	if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+		define( 'AMP_QUERY_VAR', amp_get_slug() );
+	}
 
 	/** This filter is documented in includes/amp-helper-functions.php */
 	if ( false === apply_filters( 'amp_is_enabled', true ) ) {


### PR DESCRIPTION
## Summary

Fixes #5290

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/91610129-82792900-e92d-11ea-82d4-15e8faedbdbd.png) | ![image](https://user-images.githubusercontent.com/134745/91610197-a2a8e800-e92d-11ea-994c-1266f7f843e6.png)

Note if testing on a site that does not have `www` subdomain alias, you may actually see:

![image](https://user-images.githubusercontent.com/134745/91610459-1ba83f80-e92e-11ea-9b21-48d0b6e1e446.png)

This is a bug with the Calculated Fields Form plugin that I'll report to them separately.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
