### PR TITLE
Update Pinterest embed URL regex

### DIFF
--- a/includes/embeds/class-amp-pinterest-embed-handler.php
+++ b/includes/embeds/class-amp-pinterest-embed-handler.php
@@ -12,7 +12,7 @@
  */
 class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 
-	const URL_PATTERN = '#https?://(www\.)?pinterest\.com/pin/.*#i';
+	const URL_PATTERN = '#https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/([^/]+)(/[^/]+)?#i';
 
 	/**
 	 * Default width.

--- a/includes/embeds/class-amp-pinterest-embed-handler.php
+++ b/includes/embeds/class-amp-pinterest-embed-handler.php
@@ -12,7 +12,7 @@
  */
 class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 
-	const URL_PATTERN = '#https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/([^/]+)(/[^/]+)?#i';
+	const URL_PATTERN = '#https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.[a-z.]+/pin/[^/]+/?#i';
 
 	/**
 	 * Default width.

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -8,23 +8,23 @@ class AMP_Pinterest_Embed_Handler_Test extends WP_UnitTestCase {
 
 	public function get_conversion_data() {
 		return [
-			'no_embed'         => [
+			'no_embed'                     => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
-			'simple_url_https' => [
+			'simple_url_https'             => [
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_http'  => [
+			'simple_url_http'              => [
 				'http://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="http://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_without_subdomain'  => [
+			'simple_url_without_subdomain' => [
 				'https://pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_with_regional_tld'  => [
+			'simple_url_with_regional_tld' => [
 				'https://pinterest.de/pin/8092474319950168/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.de/pin/8092474319950168/"></amp-pinterest></p>' . PHP_EOL,
 			],

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -28,6 +28,10 @@ class AMP_Pinterest_Embed_Handler_Test extends WP_UnitTestCase {
 				'https://pinterest.de/pin/8092474319950168/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.de/pin/8092474319950168/"></amp-pinterest></p>' . PHP_EOL,
 			],
+			'simple_url_with_regional_subdomain' => [
+				'https://de.pinterest.com/pin/8092474319950168' . PHP_EOL,
+				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://de.pinterest.com/pin/8092474319950168"></amp-pinterest></p>' . PHP_EOL,
+			],
 		];
 	}
 

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -8,23 +8,23 @@ class AMP_Pinterest_Embed_Handler_Test extends WP_UnitTestCase {
 
 	public function get_conversion_data() {
 		return [
-			'no_embed'                     => [
+			'no_embed'                           => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
-			'simple_url_https'             => [
+			'simple_url_https'                   => [
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_http'              => [
+			'simple_url_http'                    => [
 				'http://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="http://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_without_subdomain' => [
+			'simple_url_without_subdomain'       => [
 				'https://pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
-			'simple_url_with_regional_tld' => [
+			'simple_url_with_regional_tld'       => [
 				'https://pinterest.de/pin/8092474319950168/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.de/pin/8092474319950168/"></amp-pinterest></p>' . PHP_EOL,
 			],

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -20,6 +20,14 @@ class AMP_Pinterest_Embed_Handler_Test extends WP_UnitTestCase {
 				'http://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="http://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
 			],
+			'simple_url_without_subdomain'  => [
+				'https://pinterest.com/pin/606156431067611861/' . PHP_EOL,
+				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
+			],
+			'simple_url_with_regional_tld'  => [
+				'https://pinterest.de/pin/8092474319950168/' . PHP_EOL,
+				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://pinterest.de/pin/8092474319950168/"></amp-pinterest></p>' . PHP_EOL,
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5291

Updates the Pinterest embed URL regex to include regional TLDs and subdomains. Regex adapted from the [Pinterest embed shortcode handler](https://github.com/Automattic/jetpack/blob/bf05b72ce2c12b4cb61391120fa23a0187bb4cf3/modules/shortcodes/pinterest.php#L15-L22) from Jetpack. 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
