### PR TITLE
Accept removal of -moz-document at-rules in Twenty Nineteen

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -130,6 +130,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					],
 					'add_twentynineteen_masthead_styles' => [],
 					'adjust_twentynineteen_images'       => [],
+					'accept_remove_moz_document_at_rule' => [],
 				];
 
 			// Twenty Seventeen.
@@ -286,6 +287,27 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public static function get_acceptable_errors() {
 		_deprecated_function( __METHOD__, '1.5' );
 		return [];
+	}
+
+	/**
+	 * Accept the removal of `@-moz-document` at-rules.
+	 *
+	 * This is temporary with the hope that the at-rule will become allowed in AMP.
+	 *
+	 * @since 2.0.1
+	 * @link https://github.com/ampproject/amp-wp/issues/5302
+	 * @link https://github.com/ampproject/amphtml/issues/26406
+	 */
+	public static function accept_remove_moz_document_at_rule() {
+		AMP_Validation_Error_Taxonomy::accept_validation_errors(
+			[
+				AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE => [
+					[
+						'at_rule' => '-moz-document',
+					],
+				],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #5302.
Repurposes some logic removed in #4375.

Granted, this PR doesn't “fix” the visual disparities between AMP and non-AMP: it only suppresses the validation error from being reported. But since there is no alternative yet available as we wait for https://github.com/ampproject/amphtml/issues/26406, this seems like the best immediate course of action.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
