### PR TITLE
Prevent catastrophic backtracing when purging obsolete data-amp attributes

### DIFF
--- a/src/ObsoleteBlockAttributeRemover.php
+++ b/src/ObsoleteBlockAttributeRemover.php
@@ -93,7 +93,7 @@ final class ObsoleteBlockAttributeRemover implements Service, Registerable, Dela
 	public function filter_rest_prepare_post( WP_REST_Response $response ) {
 		if ( isset( $response->data['content']['raw'] ) ) {
 			$response->data['content']['raw'] = preg_replace_callback(
-				'#(?P<block_comment><!--\s*+wp:\w+.*?-->\s*+)(?P<start_tag><[a-z][a-z0-9_:-]*+\s[^>]*+>)#s',
+				'#(?P<block_comment>(?><!--\s*+wp:\w+.*?-->)\s*+)(?P<start_tag><[a-z][a-z0-9_:-]*+\s[^>]*+>)#s',
 				function ( $matches ) {
 					return $matches['block_comment'] . preg_replace( $this->get_obsolete_attribute_pattern(), '', $matches['start_tag'] );
 				},

--- a/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
+++ b/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
@@ -86,14 +86,14 @@ final class ObsoleteBlockAttributeRemoverTest extends WP_UnitTestCase {
 				',
 				0, // Expect props.
 			],
-			'huge_post' => [
+			'huge_post'                 => [
 				'
 				<!-- wp:paragraph -->'
 				. str_repeat( 'a', 111101 ) .
 				'<!-- /wp:paragraph -->
 				',
 				0, // Expect props.
-			]
+			],
 		];
 	}
 

--- a/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
+++ b/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
@@ -86,6 +86,14 @@ final class ObsoleteBlockAttributeRemoverTest extends WP_UnitTestCase {
 				',
 				0, // Expect props.
 			],
+			'huge_post' => [
+				'
+				<!-- wp:paragraph -->'
+				. str_repeat( 'a', 111101 ) .
+				'<!-- /wp:paragraph -->
+				',
+				0, // Expect props.
+			]
 		];
 	}
 
@@ -116,6 +124,8 @@ final class ObsoleteBlockAttributeRemoverTest extends WP_UnitTestCase {
 		);
 
 		$filtered_response = $this->instance->filter_rest_prepare_post( clone $response );
+		$this->assertNotNull( $filtered_response );
+
 		if ( $expected_prop_count > 0 ) {
 			$this->assertNotEquals( $response->data['content']['raw'], $filtered_response->data['content']['raw'] );
 		} else {


### PR DESCRIPTION
## Summary

Prevents `ObsoleteBlockAttributeRemover::filter_rest_prepare_post()` from returning `null` by preventing a catastrophic backtracing error from occuring when attempting to replace obsolete `data-amp` attributes in the post content.

The pattern used to find the the beginning of the HTML comment (`<!--\s*+wp:\w+.*?-->`) is wrapped in an atomic group to prevent any later backtracing that may occur while the regex is executing.

<!-- Please reference the issue this PR addresses. -->
Fixes #5308

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
