### PR TITLE
In editor, make "Review issues" link open in a new tab

### DIFF
--- a/assets/src/block-validation/helpers/index.js
+++ b/assets/src/block-validation/helpers/index.js
@@ -231,7 +231,10 @@ export const maybeDisplayNotice = () => {
 		options.actions = [
 			{
 				label: __( 'Review issues', 'amp' ),
-				url: reviewLink,
+				className: 'components-button components-notice__action is-link',
+				onClick: () => {
+					window.open( reviewLink, '_blank' );
+				},
 			},
 		];
 	}

--- a/assets/src/block-validation/helpers/index.js
+++ b/assets/src/block-validation/helpers/index.js
@@ -231,7 +231,7 @@ export const maybeDisplayNotice = () => {
 		options.actions = [
 			{
 				label: __( 'Review issues', 'amp' ),
-				className: 'components-button components-notice__action is-link',
+				className: 'is-link',
 				onClick: () => {
 					window.open( reviewLink, '_blank' );
 				},

--- a/tests/php/src/ReaderThemeLoaderTest.php
+++ b/tests/php/src/ReaderThemeLoaderTest.php
@@ -201,6 +201,8 @@ final class ReaderThemeLoaderTest extends WP_UnitTestCase {
 	/** @covers ::disable_widgets() */
 	public function test_disable_widgets() {
 		remove_all_filters( 'sidebars_widgets' );
+		remove_filter( 'customize_loaded_components', 'gutenberg_remove_widgets_panel' ); // Added in Gutenberg v8.9.0.
+
 		$this->assertNotEmpty( wp_get_sidebars_widgets() );
 		$this->assertContains( 'widgets', apply_filters( 'customize_loaded_components', [ 'widgets' ] ) );
 

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -77,6 +77,10 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		$categories_block = '<!-- wp:categories {"displayAsDropdown":true,"showHierarchy":true,"showPostCounts":true} /-->';
 		$archives_block   = '<!-- wp:archives {"displayAsDropdown":true,"showPostCounts":true} /-->';
 
+		if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '8.9.0', '==' ) ) {
+			$this->markTestSkipped( 'See https://github.com/WordPress/gutenberg/pull/25026' );
+		}
+
 		$handler->register_embed();
 		$rendered = do_blocks( $categories_block );
 		$this->assertStringContains( '<select', $rendered );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
This relates to #5304, but I'm not sure it fixes it. 

In the editor, various incarnations of this notice display when there are AMP validation issues at the post's URL:

<img width="852" alt="Screen Shot 2020-09-02 at 12 45 47 PM" src="https://user-images.githubusercontent.com/9020968/92018465-cf3c7580-ed1a-11ea-9749-4c779af3ddf1.png">

Previously, this would open in the same tab. Now this will open in a new tab. 

Unfortunately, what we are able to do with that link is very limited, so I didn't add the usual icon to visually indicate it would open in a new tab. There _is_ an `__unstableHTML` parameter we can add to the notice options to allow HTML strings to be passed into the notice, but the inline documentation for notices [states very emphatically](https://github.com/WordPress/gutenberg/blob/b12aab0364ed2d91e3cf914b3a7590de030574bd/packages/notices/src/store/selectors.js#L31) not to use it. 

For similar reasons, we have to use an onClick handler instead of href with a target attribute to open the link in a new tab. 


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
