### PR TITLE
Surface exceptions and end failed responses with a 500

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PHPSTORM_META {
+
+	override( \AmpProject\AmpWP\Services::get(), map( [
+		'admin.analytics_menu'             => \AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu::class,
+		'admin.google_fonts'               => \AmpProject\AmpWP\Admin\GoogleFonts::class,
+		'admin.onboarding_menu'            => \AmpProject\AmpWP\Admin\OnboardingWizardSubmenu::class,
+		'admin.onboarding_wizard'          => \AmpProject\AmpWP\Admin\OnboardingWizardSubmenuPage::class,
+		'admin.options_menu'               => \AmpProject\AmpWP\Admin\OptionsMenu::class,
+		'admin.polyfills'                  => \AmpProject\AmpWP\Admin\Polyfills::class,
+		'amp_slug_customization_watcher'   => \AmpProject\AmpWP\AmpSlugCustomizationWatcher::class,
+		'css_transient_cache.ajax_handler' => \AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction::class,
+		'css_transient_cache.monitor'      => \AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching::class,
+		'dev_tools.user_access'            => \AmpProject\AmpWP\Admin\DevToolsUserAccess::class,
+		'error_page'                       => \AmpProject\AmpWP\ErrorPage::class,
+		'extra_theme_and_plugin_headers'   => \AmpProject\AmpWP\ExtraThemeAndPluginHeaders::class,
+		'mobile_redirection'               => \AmpProject\AmpWP\MobileRedirection::class,
+		'obsolete_block_attribute_remover' => \AmpProject\AmpWP\ObsoleteBlockAttributeRemover::class,
+		'plugin_activation_notice'         => \AmpProject\AmpWP\Admin\PluginActivationNotice::class,
+		'plugin_registry'                  => \AmpProject\AmpWP\PluginRegistry::class,
+		'plugin_suppression'               => \AmpProject\AmpWP\PluginSuppression::class,
+		'reader_theme_loader'              => \AmpProject\AmpWP\ReaderThemeLoader::class,
+		'rest.options_controller'          => \AmpProject\AmpWP\OptionsRESTController::class,
+		'server_timing'                    => \AmpProject\AmpWP\Instrumentation\ServerTiming::class,
+		'site_health_integration'          => \AmpProject\AmpWP\Admin\SiteHealth::class,
+		'validated_url_stylesheet_gc'      => \AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection::class,
+	] ) );
+}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\Amp;
+use AmpProject\AmpWP\ErrorPage;
 use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
@@ -1842,7 +1843,10 @@ class AMP_Theme_Support {
 			$title   = __( 'Failed to prepare AMP response', 'amp' );
 			$message = __( 'A server error occurred while trying to prepare the AMP response.', 'amp' );
 
-			return Services::get( 'error_page' )
+			/** @var ErrorPage $error_page */
+			$error_page = Services::get( 'error_page' );
+
+			$error_page
 				->with_title( $title )
 				->with_message( $message )
 				->with_exception( $exception )

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1840,8 +1840,8 @@ class AMP_Theme_Support {
 		try {
 			$response = self::prepare_response( $response );
 		} catch ( Exception $exception ) {
-			$title   = __( 'Failed to prepare AMP response', 'amp' );
-			$message = __( 'A server error occurred while trying to prepare the AMP response.', 'amp' );
+			$title   = __( 'Failed to prepare AMP page', 'amp' );
+			$message = __( 'A PHP error occurred while trying to prepare the AMP response. This may not be caused by the AMP plugin but by some other active plugin or the current theme. You will need to review the error details to determine the source of the error.', 'amp' );
 
 			/** @var ErrorPage $error_page */
 			$error_page = Services::get( 'error_page' );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1846,12 +1846,28 @@ class AMP_Theme_Support {
 			/** @var ErrorPage $error_page */
 			$error_page = Services::get( 'error_page' );
 
-			$response = $error_page
+			$error_page
 				->with_title( $title )
 				->with_message( $message )
 				->with_exception( $exception )
-				->with_response_code( 500 )
-				->render();
+				->with_response_code( 500 );
+
+			// Add link to non-AMP version if not canonical.
+			if ( ! amp_is_canonical() ) {
+				$non_amp_url = amp_remove_endpoint( amp_get_current_url() );
+
+				// Prevent user from being redirected back to AMP version.
+				if ( true === AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
+					$non_amp_url = add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, $non_amp_url );
+				}
+
+				$error_page->with_back_link(
+					$non_amp_url,
+					__( 'Go to non-AMP version', 'amp' )
+				);
+			}
+
+			$response = $error_page->render();
 		}
 
 		/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -11,6 +11,7 @@ use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
 use AmpProject\AmpWP\ConfigurationArgument;
+use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Transformer;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
@@ -1834,7 +1835,20 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_output_buffering( $response ) {
 		self::$is_output_buffering = false;
-		$response                  = self::prepare_response( $response );
+
+		try {
+			$response = self::prepare_response( $response );
+		} catch ( Exception $exception ) {
+			$title   = __( 'Failed to prepare AMP response', 'amp' );
+			$message = __( 'A server error occurred while trying to prepare the AMP response.', 'amp' );
+
+			return Services::get( 'error_page' )
+				->with_title( $title )
+				->with_message( $message )
+				->with_exception( $exception )
+				->with_response_code( 500 )
+				->render();
+		}
 
 		/**
 		 * Fires when server timings should be sent.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1846,7 +1846,7 @@ class AMP_Theme_Support {
 			/** @var ErrorPage $error_page */
 			$error_page = Services::get( 'error_page' );
 
-			$error_page
+			$response = $error_page
 				->with_title( $title )
 				->with_message( $message )
 				->with_exception( $exception )

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -7,21 +7,10 @@
 
 namespace AmpProject\AmpWP;
 
-use AmpProject\AmpWP\Admin\AnalyticsOptionsSubmenu;
-use AmpProject\AmpWP\Admin\DevToolsUserAccess;
-use AmpProject\AmpWP\Admin\GoogleFonts;
-use AmpProject\AmpWP\Admin\OnboardingWizardSubmenu;
-use AmpProject\AmpWP\Admin\OnboardingWizardSubmenuPage;
-use AmpProject\AmpWP\Admin\OptionsMenu;
-use AmpProject\AmpWP\Admin\PluginActivationNotice;
-use AmpProject\AmpWP\Admin\Polyfills;
-use AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction;
-use AmpProject\AmpWP\Admin\SiteHealth;
-use AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching;
-use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
+use AmpProject\AmpWP\Admin;
+use AmpProject\AmpWP\BackgroundTask;
 use AmpProject\AmpWP\Infrastructure\ServiceBasedPlugin;
-use AmpProject\AmpWP\Instrumentation\ServerTiming;
-use AmpProject\AmpWP\Instrumentation\StopWatch;
+use AmpProject\AmpWP\Instrumentation;
 
 use function is_user_logged_in;
 
@@ -68,27 +57,28 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	 */
 	protected function get_service_classes() {
 		return [
+			'admin.analytics_menu'             => Admin\AnalyticsOptionsSubmenu::class,
+			'admin.google_fonts'               => Admin\GoogleFonts::class,
+			'admin.onboarding_menu'            => Admin\OnboardingWizardSubmenu::class,
+			'admin.onboarding_wizard'          => Admin\OnboardingWizardSubmenuPage::class,
+			'admin.options_menu'               => Admin\OptionsMenu::class,
+			'admin.polyfills'                  => Admin\Polyfills::class,
+			'amp_slug_customization_watcher'   => AmpSlugCustomizationWatcher::class,
+			'css_transient_cache.ajax_handler' => Admin\ReenableCssTransientCachingAjaxAction::class,
+			'css_transient_cache.monitor'      => BackgroundTask\MonitorCssTransientCaching::class,
+			'dev_tools.user_access'            => Admin\DevToolsUserAccess::class,
+			'error_page'                       => ErrorPage::class,
 			'extra_theme_and_plugin_headers'   => ExtraThemeAndPluginHeaders::class,
-			'dev_tools.user_access'            => DevToolsUserAccess::class,
-			'css_transient_cache.monitor'      => MonitorCssTransientCaching::class,
-			'css_transient_cache.ajax_handler' => ReenableCssTransientCachingAjaxAction::class,
-			'site_health_integration'          => SiteHealth::class,
-			'plugin_activation_notice'         => PluginActivationNotice::class,
+			'mobile_redirection'               => MobileRedirection::class,
+			'obsolete_block_attribute_remover' => ObsoleteBlockAttributeRemover::class,
+			'plugin_activation_notice'         => Admin\PluginActivationNotice::class,
 			'plugin_registry'                  => PluginRegistry::class,
 			'plugin_suppression'               => PluginSuppression::class,
-			'mobile_redirection'               => MobileRedirection::class,
-			'admin.google_fonts'               => GoogleFonts::class,
-			'admin.options_menu'               => OptionsMenu::class,
-			'admin.onboarding_menu'            => OnboardingWizardSubmenu::class,
-			'admin.onboarding_wizard'          => OnboardingWizardSubmenuPage::class,
 			'reader_theme_loader'              => ReaderThemeLoader::class,
-			'amp_slug_customization_watcher'   => AmpSlugCustomizationWatcher::class,
 			'rest.options_controller'          => OptionsRESTController::class,
-			'server_timing'                    => ServerTiming::class,
-			'obsolete_block_attribute_remover' => ObsoleteBlockAttributeRemover::class,
-			'admin.polyfills'                  => Polyfills::class,
-			'validated_url_stylesheet_gc'      => ValidatedUrlStylesheetDataGarbageCollection::class,
-			'admin.analytics_menu'             => AnalyticsOptionsSubmenu::class,
+			'server_timing'                    => Instrumentation\ServerTiming::class,
+			'site_health_integration'          => Admin\SiteHealth::class,
+			'validated_url_stylesheet_gc'      => BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection::class,
 		];
 	}
 

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -113,7 +113,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	 */
 	protected function get_arguments() {
 		return [
-			ServerTiming::class => [
+			Instrumentation\ServerTiming::class => [
 				// Wrapped in a closure so it is lazily evaluated. Otherwise,
 				// is_user_logged_in() breaks because it's used too early.
 				'verbose' => static function () {
@@ -144,7 +144,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	protected function get_shared_instances() {
 		return [
 			PluginRegistry::class,
-			StopWatch::class,
+			Instrumentation\StopWatch::class,
 		];
 	}
 

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -159,9 +159,12 @@ final class ErrorPage implements Service {
 	 * @return string HTML output.
 	 */
 	private function get_html( $styles, $text_direction ) {
-		$no_robots = function_exists( 'wp_no_robots' )
-			? wp_no_robots()
-			: '';
+		$no_robots = '';
+		if ( function_exists( 'wp_no_robots' ) ) {
+			ob_start();
+			wp_no_robots();
+			$no_robots = ob_get_clean();
+		}
 
 		return <<<HTML
 <!DOCTYPE html>

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -86,7 +86,7 @@ final class ErrorPage implements Service {
 	/**
 	 * Set the response_code of the error page.
 	 *
-	 * @param string $response_code Response code to use.
+	 * @param int $response_code Response code to use.
 	 * @return self
 	 */
 	public function with_response_code( $response_code ) {

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -176,16 +176,34 @@ final class ErrorPage implements Service {
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width">
 		{$no_robots}
-		<title>{$this->title}</title>
+		<title>{$this->render_title()}</title>
 		{$styles}
 	</head>
 	<body id="error-page">
-		<h1>{$this->title}</h1>
-		<p>{$this->message}</p>
+		<h1>{$this->render_title()}</h1>
+		<p>{$this->render_message()}</p>
 		{$this->render_exception()}
 	</body>
 </html>
 HTML;
+	}
+
+	/**
+	 * Render title.
+	 *
+	 * @return string HTML-escaped title.
+	 */
+	private function render_title() {
+		return esc_html( $this->title );
+	}
+
+	/**
+	 * Render message.
+	 *
+	 * @return string KSES-sanitized message.
+	 */
+	private function render_message() {
+		return wp_kses_post( $this->message );
 	}
 
 	/**
@@ -207,10 +225,10 @@ HTML;
 			|| ! defined( 'WP_DEBUG_DISPLAY' )
 			|| ! WP_DEBUG_DISPLAY
 		) {
-			return sprintf(
-				'<p><em>%s<br>%s</em></p>',
-				__( 'The exact details of the error are hidden for security reasons.', 'amp' ),
-				__( 'To learn more about this error, enable the WordPress debugging display (by setting both WP_DEBUG and WP_DEBUG_DISPLAY to true), or look into the PHP error log.', 'amp' )
+			return wpautop(
+				wp_kses_post(
+					__( 'The exact details of the error are hidden for security reasons. To learn more about this error, enable the WordPress debugging display (by setting both <code>WP_DEBUG</code> and <code>WP_DEBUG_DISPLAY</code> to <code>true</code>), or look into the PHP error log. Learn more about <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a>.', 'amp' )
+				)
 			);
 		}
 

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class ExtraThemeAndPluginHeaders.
+ * Class ErrorPage.
  *
  * @package AmpProject\AmpWP
  */
@@ -16,6 +16,7 @@ use Exception;
  * The actual wp_die() function cannot be used within the AMP response
  * preparation code, as its 'exit' argument is only usable from WP 5.1 onwards.
  *
+ * @see wp_die()
  * @package AmpProject\AmpWP
  * @since   2.0.1
  * @internal
@@ -35,6 +36,20 @@ final class ErrorPage implements Service {
 	 * @var string
 	 */
 	private $message = '';
+
+	/**
+	 * Back link URL.
+	 *
+	 * @var string
+	 */
+	private $link_url = '';
+
+	/**
+	 * Back link text.
+	 *
+	 * @var string
+	 */
+	private $link_text = '';
 
 	/**
 	 * Exception of the error page.
@@ -69,6 +84,19 @@ final class ErrorPage implements Service {
 	 */
 	public function with_message( $message ) {
 		$this->message = $message;
+		return $this;
+	}
+
+	/**
+	 * Set the message of the error page.
+	 *
+	 * @param string $link_url  Link URL.
+	 * @param string $link_text Link text.
+	 * @return self
+	 */
+	public function with_back_link( $link_url, $link_text ) {
+		$this->link_url  = $link_url;
+		$this->link_text = $link_text;
 		return $this;
 	}
 
@@ -183,6 +211,7 @@ final class ErrorPage implements Service {
 		<h1>{$this->render_title()}</h1>
 		<p>{$this->render_message()}</p>
 		{$this->render_exception()}
+		{$this->render_back_link()}
 	</body>
 </html>
 HTML;
@@ -238,6 +267,22 @@ HTML;
 			$this->exception->getCode(),
 			get_class( $this->exception ),
 			str_replace( "\n", '<br>', $this->exception->getTraceAsString() )
+		);
+	}
+
+	/**
+	 * Render back link.
+	 *
+	 * @return string Back link.
+	 */
+	private function render_back_link() {
+		if ( empty( $this->link_text ) || empty( $this->link_url ) ) {
+			return '';
+		}
+		return sprintf(
+			'<p><a href="%s" class="button button-large">%s</a></p>',
+			esc_url( $this->link_url ),
+			esc_html( $this->link_text )
 		);
 	}
 

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Class ExtraThemeAndPluginHeaders.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP;
+
+use AmpProject\AmpWP\Infrastructure\Service;
+use Exception;
+
+/**
+ * Produces an error page similar to wp_die().
+ *
+ * The actual wp_die() function cannot be used within the AMP response
+ * preparation code, as its 'exit' argument is only usable from WP 5.1 onwards.
+ *
+ * @package AmpProject\AmpWP
+ * @since   2.0.1
+ * @internal
+ */
+final class ErrorPage implements Service {
+
+	/**
+	 * Title of the error page.
+	 *
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * Message of the error page.
+	 *
+	 * @var string
+	 */
+	private $message = '';
+
+	/**
+	 * Exception of the error page.
+	 *
+	 * @var Exception
+	 */
+	private $exception;
+
+	/**
+	 * Response code of the error page.
+	 *
+	 * @var int
+	 */
+	private $response_code = 500;
+
+	/**
+	 * Set the title of the error page.
+	 *
+	 * @param string $title Title to use.
+	 * @return self
+	 */
+	public function with_title( $title ) {
+		$this->title = $title;
+		return $this;
+	}
+
+	/**
+	 * Set the message of the error page.
+	 *
+	 * @param string $message Message to use.
+	 * @return self
+	 */
+	public function with_message( $message ) {
+		$this->message = $message;
+		return $this;
+	}
+
+	/**
+	 * Set the exception of the error page.
+	 *
+	 * @param Exception $exception Exception to use.
+	 * @return self
+	 */
+	public function with_exception( Exception $exception ) {
+		$this->exception = $exception;
+		return $this;
+	}
+
+	/**
+	 * Set the response_code of the error page.
+	 *
+	 * @param string $response_code Response code to use.
+	 * @return self
+	 */
+	public function with_response_code( $response_code ) {
+		$this->response_code = $response_code;
+		return $this;
+	}
+
+	/**
+	 * Render the error page.
+	 *
+	 * This first sets the required headers and then returns the HTML to send as
+	 * output.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		$this->send_to_error_log();
+
+		$this->set_headers();
+
+		$text_direction = function_exists( 'is_rtl' ) && is_rtl()
+			? 'rtl'
+			: 'ltr';
+
+		$styles = $this->get_styles( $text_direction );
+		$html   = $this->get_html( $styles, $text_direction );
+
+		return $html;
+	}
+
+	/**
+	 * Send the exception that was caught to the error log.
+	 */
+	private function send_to_error_log(  ) {
+		error_log(
+			sprintf(
+				"%s - %s (%s) [%s]\n%s",
+				$this->message,
+				$this->exception->getMessage(),
+				$this->exception->getCode(),
+				get_class( $this->exception ),
+				$this->exception->getTraceAsString()
+			)
+		);
+	}
+
+	/**
+	 * Sets the required headers.
+	 *
+	 * This will only adapt the headers if they haven't yet been sent.
+	 */
+	private function set_headers() {
+		if ( ! headers_sent() ) {
+			// Define the content type for the error page.
+			header( 'Content-Type: text/html; charset=utf-8' );
+
+			// Mark the page as a server failure so it won't get indexed.
+			status_header( $this->response_code );
+
+			// Let the browser know this result shouldn't get cached.
+			nocache_headers();
+		}
+	}
+
+	/**
+	 * Get the HTML output for the error page.
+	 *
+	 * @param string $styles         CSS styles to use.
+	 * @param string $text_direction Text direction. Can be 'ltr' or 'rtl'.
+	 * @return string HTML output.
+	 */
+	private function get_html( $styles, $text_direction ) {
+		$no_robots = function_exists( 'wp_no_robots' )
+			? wp_no_robots()
+			: '';
+
+		return <<<HTML
+<!DOCTYPE html>
+<html dir="{$text_direction}">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta name="viewport" content="width=device-width">
+		{$no_robots}
+		<title>{$this->title}</title>
+		{$styles}
+	</head>
+	<body id="error-page">
+		<h1>{$this->title}</h1>
+		<p>{$this->message}</p>
+		{$this->render_exception()}
+	</body>
+</html>
+HTML;
+	}
+
+	/**
+	 * Render the exception of the error page.
+	 *
+	 * The exception details are only rendered if both WP_DEBUG and
+	 * WP_DEBUG_DISPLAY are true.
+	 *
+	 * @return string HTML describing the exception that was thrown.
+	 */
+	private function render_exception() {
+		if ( null === $this->exception ) {
+			return '';
+		}
+
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return '';
+		}
+
+		if ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) {
+			return '';
+		}
+
+		return sprintf(
+			'<code><strong>%s</strong> (%s) [<em>%s</em>]<br><br><small>%s</small></code>',
+			$this->exception->getMessage(),
+			$this->exception->getCode(),
+			get_class( $this->exception ),
+			str_replace( "\n", '<br>', $this->exception->getTraceAsString() )
+		);
+	}
+
+	/**
+	 * Get the CSS styles to use for the error page.
+	 *
+	 * @param string $text_direction Text direction. Can be 'ltr' or 'rtl'.
+	 * @return string CSS styles to use.
+	 */
+	private function get_styles( $text_direction ) {
+		$rtl_font_tweak = 'rtl' === $text_direction
+			? 'body { font-family: Tahoma, Arial; }'
+			: '';
+
+		return <<<STYLES
+<style type="text/css">
+	html {
+		background: #f1f1f1;
+	}
+	body {
+		background: #fff;
+		color: #444;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		margin: 2em auto;
+		padding: 1em 2em;
+		max-width: 700px;
+		-webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+	}
+	h1 {
+		border-bottom: 1px solid #dadada;
+		clear: both;
+		color: #666;
+		font-size: 24px;
+		margin: 30px 0 0 0;
+		padding: 0;
+		padding-bottom: 7px;
+	}
+	#error-page {
+		margin-top: 50px;
+	}
+	#error-page p,
+	#error-page .wp-die-message {
+		font-size: 14px;
+		line-height: 1.5;
+		margin: 25px 0 20px;
+	}
+	#error-page code {
+		font-family: Consolas, Monaco, monospace;
+	}
+	ul li {
+		margin-bottom: 10px;
+		font-size: 14px ;
+	}
+	a {
+		color: #0073aa;
+	}
+	a:hover,
+	a:active {
+		color: #006799;
+	}
+	a:focus {
+		color: #124964;
+		-webkit-box-shadow:
+			0 0 0 1px #5b9dd9,
+			0 0 2px 1px rgba(30, 140, 190, 0.8);
+		box-shadow:
+			0 0 0 1px #5b9dd9,
+			0 0 2px 1px rgba(30, 140, 190, 0.8);
+		outline: none;
+	}
+	.button {
+		background: #f7f7f7;
+		border: 1px solid #ccc;
+		color: #555;
+		display: inline-block;
+		text-decoration: none;
+		font-size: 13px;
+		line-height: 2;
+		height: 28px;
+		margin: 0;
+		padding: 0 10px 1px;
+		cursor: pointer;
+		-webkit-border-radius: 3px;
+		-webkit-appearance: none;
+		border-radius: 3px;
+		white-space: nowrap;
+		-webkit-box-sizing: border-box;
+		-moz-box-sizing:    border-box;
+		box-sizing:         border-box;
+
+		-webkit-box-shadow: 0 1px 0 #ccc;
+		box-shadow: 0 1px 0 #ccc;
+		vertical-align: top;
+	}
+
+	.button.button-large {
+		height: 30px;
+		line-height: 2.15384615;
+		padding: 0 12px 2px;
+	}
+
+	.button:hover,
+	.button:focus {
+		background: #fafafa;
+		border-color: #999;
+		color: #23282d;
+	}
+
+	.button:focus {
+		border-color: #5b9dd9;
+		-webkit-box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+		box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+		outline: none;
+	}
+
+	.button:active {
+		background: #eee;
+		border-color: #999;
+		-webkit-box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
+		box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
+	}
+
+	{$rtl_font_tweak}
+</style>
+STYLES;
+	}
+}

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -121,6 +121,12 @@ final class ErrorPage implements Service {
 	 * Send the exception that was caught to the error log.
 	 */
 	private function send_to_error_log() {
+		// Don't send to error log if fatal errors are not to be reported.
+		$error_level = error_reporting(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting,WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+		if ( ! (bool) ( $error_level & E_ERROR ) ) {
+			return;
+		}
+
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
 				"%s - %s (%s) [%s]\n%s",

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -201,12 +201,17 @@ HTML;
 			return '';
 		}
 
-		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-			return '';
-		}
-
-		if ( ! defined( 'WP_DEBUG_DISPLAY' ) || ! WP_DEBUG_DISPLAY ) {
-			return '';
+		if (
+			! defined( 'WP_DEBUG' )
+			|| ! WP_DEBUG
+			|| ! defined( 'WP_DEBUG_DISPLAY' )
+			|| ! WP_DEBUG_DISPLAY
+		) {
+			return sprintf(
+				'<p><em>%s<br>%s</em></p>',
+				__( 'The exact details of the error are hidden for security reasons.', 'amp' ),
+				__( 'To learn more about this error, enable the WordPress debugging display (by setting both WP_DEBUG and WP_DEBUG_DISPLAY to true), or look into the PHP error log.', 'amp' )
+			);
 		}
 
 		return sprintf(

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -215,7 +215,7 @@ HTML;
 		}
 
 		return sprintf(
-			'<code><strong>%s</strong> (%s) [<em>%s</em>]<br><br><small>%s</small></code>',
+			'<pre class="exception"><strong>%s</strong> (%s) [<em>%s</em>]<br><br><small>%s</small></pre>',
 			$this->exception->getMessage(),
 			$this->exception->getCode(),
 			get_class( $this->exception ),
@@ -225,6 +225,8 @@ HTML;
 
 	/**
 	 * Get the CSS styles to use for the error page.
+	 *
+	 * @see _default_wp_die_handler() Where styles are adapted from.
 	 *
 	 * @param string $text_direction Text direction. Can be 'ltr' or 'rtl'.
 	 * @return string CSS styles to use.
@@ -267,8 +269,9 @@ HTML;
 		line-height: 1.5;
 		margin: 25px 0 20px;
 	}
-	#error-page code {
+	#error-page .exception {
 		font-family: Consolas, Monaco, monospace;
+		overflow-x: auto;
 	}
 	ul li {
 		margin-bottom: 10px;

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -159,12 +159,9 @@ final class ErrorPage implements Service {
 	 * @return string HTML output.
 	 */
 	private function get_html( $styles, $text_direction ) {
-		$no_robots = '';
-		if ( function_exists( 'wp_no_robots' ) ) {
-			ob_start();
-			wp_no_robots();
-			$no_robots = ob_get_clean();
-		}
+		$no_robots = get_option( 'blog_public' )
+			? "<meta name='robots' content='noindex,follow' />\n"
+			: "<meta name='robots' content='noindex,nofollow' />\n";
 
 		return <<<HTML
 <!DOCTYPE html>

--- a/src/ErrorPage.php
+++ b/src/ErrorPage.php
@@ -120,8 +120,8 @@ final class ErrorPage implements Service {
 	/**
 	 * Send the exception that was caught to the error log.
 	 */
-	private function send_to_error_log(  ) {
-		error_log(
+	private function send_to_error_log() {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
 				"%s - %s (%s) [%s]\n%s",
 				$this->message,

--- a/tests/php/src/ErrorPageTest.php
+++ b/tests/php/src/ErrorPageTest.php
@@ -28,11 +28,11 @@ final class ErrorPageTest extends WP_UnitTestCase {
 		// Verify that error log was properly populated.
 		$this->assertRegExp(
 			'/^\[[^\]]*\] Error Page Message - FAILURE \(42\) \[RuntimeException\].*/',
-			stream_get_contents($capture)
+			stream_get_contents( $capture )
 		);
 
 		// Reset error log back to initial settings.
-		ini_set('error_log', $backup);
+		ini_set( 'error_log', $backup );
 
 		// Test HTML output.
 		$this->assertStringContains( '<title>Error Page Title</title>', $output );

--- a/tests/php/src/ErrorPageTest.php
+++ b/tests/php/src/ErrorPageTest.php
@@ -13,7 +13,7 @@ final class ErrorPageTest extends WP_UnitTestCase {
 	public function test_error_page_output() {
 		// Set up temporary capture of error log to test error log output.
 		$capture = tmpfile();
-		$backup  = ini_set(
+		$backup  = ini_set( // phpcs:ignore WordPress.PHP.IniSet.Risky
 			'error_log',
 			stream_get_meta_data( $capture )['uri']
 		);
@@ -32,7 +32,7 @@ final class ErrorPageTest extends WP_UnitTestCase {
 		);
 
 		// Reset error log back to initial settings.
-		ini_set( 'error_log', $backup );
+		ini_set( 'error_log', $backup ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 
 		// Test HTML output.
 		$this->assertStringContains( '<title>Error Page Title</title>', $output );

--- a/tests/php/src/ErrorPageTest.php
+++ b/tests/php/src/ErrorPageTest.php
@@ -23,6 +23,7 @@ final class ErrorPageTest extends WP_UnitTestCase {
 			->with_message( 'Error Page Message' )
 			->with_exception( new RuntimeException( 'FAILURE', 42 ) )
 			->with_response_code( 123 )
+			->with_back_link( 'https://back.example.com', 'Go Back' )
 			->render();
 
 		// Verify that error log was properly populated.
@@ -43,5 +44,8 @@ final class ErrorPageTest extends WP_UnitTestCase {
 		$this->assertStringContains( '<meta name="viewport"', $output );
 		$this->assertStringContains( '<body id="error-page">', $output );
 		$this->assertStringContains( '<style type="text/css">', $output );
+		$this->assertStringContains( 'button button-large', $output );
+		$this->assertStringContains( 'https://back.example.com', $output );
+		$this->assertStringContains( 'Go Back', $output );
 	}
 }

--- a/tests/php/src/ErrorPageTest.php
+++ b/tests/php/src/ErrorPageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests;
+
+use AmpProject\AmpWP\ErrorPage;
+use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
+use RuntimeException;
+use WP_UnitTestCase;
+
+final class ErrorPageTest extends WP_UnitTestCase {
+	use AssertContainsCompatibility;
+
+	public function test_error_page_output() {
+		// Set up temporary capture of error log to test error log output.
+		$capture = tmpfile();
+		$backup  = ini_set(
+			'error_log',
+			stream_get_meta_data( $capture )['uri']
+		);
+
+		$output = ( new ErrorPage() )
+			->with_title( 'Error Page Title' )
+			->with_message( 'Error Page Message' )
+			->with_exception( new RuntimeException( 'FAILURE', 42 ) )
+			->with_response_code( 123 )
+			->render();
+
+		// Verify that error log was properly populated.
+		$this->assertRegExp(
+			'/^\[[^\]]*\] Error Page Message - FAILURE \(42\) \[RuntimeException\].*/',
+			stream_get_contents($capture)
+		);
+
+		// Reset error log back to initial settings.
+		ini_set('error_log', $backup);
+
+		// Test HTML output.
+		$this->assertStringContains( '<title>Error Page Title</title>', $output );
+		$this->assertStringContains( '<h1>Error Page Title</h1>', $output );
+		$this->assertStringContains( '<p>Error Page Message</p>', $output );
+		$this->assertStringContains( '<strong>FAILURE</strong> (42) [<em>RuntimeException</em>]', $output );
+		$this->assertStringContains( '<!DOCTYPE html>', $output );
+		$this->assertStringContains( '<meta name="viewport"', $output );
+		$this->assertStringContains( '<body id="error-page">', $output );
+		$this->assertStringContains( '<style type="text/css">', $output );
+	}
+}

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2183,14 +2183,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Verify that error log was properly populated.
 		$this->assertRegExp(
-			'/^\[[^\]]*\] A server error occurred while trying to prepare the AMP response. - FAILURE \(42\) \[RuntimeException\].*/',
+			'/^\[[^\]]*\] A PHP error occurred while trying to prepare the AMP response\..*- FAILURE \(42\) \[RuntimeException\].*/',
 			stream_get_contents( $capture )
 		);
 
 		// Reset error log back to initial settings.
 		ini_set( 'error_log', $backup ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 
-		$this->assertStringContains( 'Failed to prepare AMP response', $output );
+		$this->assertStringContains( 'Failed to prepare AMP page', $output );
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2120,20 +2120,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Returns the "Server-Timing" headers.
-	 *
-	 * @return array Server-Timing headers.
-	 */
-	private function get_server_timing_headers() {
-		return array_filter(
-			AMP_HTTP::$headers_sent,
-			static function( $header ) {
-				return 'Server-Timing' === $header['name'];
-			}
-		);
-	}
-
-	/**
 	 * Test prepare_response for responses that do not trigger standard template actions.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2156,7 +2156,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_prepare_response_throwing_exception() {
 		// Set up temporary capture of error log to test error log output.
 		$capture = tmpfile();
-		$backup  = ini_set(
+		$backup  = ini_set( // phpcs:ignore WordPress.PHP.IniSet.Risky
 			'error_log',
 			stream_get_meta_data( $capture )['uri']
 		);
@@ -2169,6 +2169,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 
 		if ( ! function_exists( 'newrelic_disable_autorum' ) ) {
+
 			/**
 			 * Define newrelic_disable_autorum to allow passing line.
 			 */
@@ -2183,11 +2184,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Verify that error log was properly populated.
 		$this->assertRegExp(
 			'/^\[[^\]]*\] A server error occurred while trying to prepare the AMP response. - FAILURE \(42\) \[RuntimeException\].*/',
-			stream_get_contents($capture)
+			stream_get_contents( $capture )
 		);
 
 		// Reset error log back to initial settings.
-		ini_set( 'error_log', $backup );
+		ini_set( 'error_log', $backup ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 
 		$this->assertStringContains( 'Failed to prepare AMP response', $output );
 	}

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2178,16 +2178,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		}
 
 		wp();
-		$original_html = $this->get_original_html();
-		AMP_Theme_Support::start_output_buffering();
-		echo $original_html;
-		$output = ob_get_clean();
+		$output = AMP_Theme_Support::finish_output_buffering( $this->get_original_html() );
 
 		// Verify that error log was properly populated.
-		//$this->assertRegExp(
-		//	'/^\[[^\]]*\] A server error occurred while trying to prepare the AMP response. - FAILURE \(42\) \[RuntimeException\].*/',
-		//	stream_get_contents($capture)
-		//);
+		$this->assertRegExp(
+			'/^\[[^\]]*\] A server error occurred while trying to prepare the AMP response. - FAILURE \(42\) \[RuntimeException\].*/',
+			stream_get_contents($capture)
+		);
 
 		// Reset error log back to initial settings.
 		ini_set( 'error_log', $backup );


### PR DESCRIPTION
## Summary

This PR catches exceptions during the `AMP_Theme_Support::prepare_resonse()` call and displays them similar to what `wp_die()` does.

If `WP_DEBUG` & `WP_DEBUG_DISPLAY` are `true`, it also displays details about the exception together with a backtrace.

It also sends these exceptions to the error log if `error_reporting()` indicates that `E_ERROR`s should be reported.

### Error displayed on the frontpage with full details

![Image 2020-09-02 at 9 14 14 PM](https://user-images.githubusercontent.com/83631/92040160-a1851a00-ed76-11ea-872f-acf18fb0240b.png)

### Error displayed on the frontpage with restricted output

![Image 2020-09-02 at 11 59 37 PM](https://user-images.githubusercontent.com/83631/92041370-6388f580-ed78-11ea-9052-8f0e97fdb836.png)

### Log entry

![Image 2020-09-02 at 9 17 15 PM](https://user-images.githubusercontent.com/83631/92040209-b5c91700-ed76-11ea-9b27-1e0506e844c5.png)

TODO:
- [x] Add tests.
- [x] ~Only populate error log when `WP_DEBUG_LOG` is not `false` or missing (?) - I think this is taken care of automatically by WP?~ Check if fatal errors should be logged
- [x] ~Do we need an exit after the rendering or can we just let the request fizzle out?~

Fixes #5315

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
