### PR TITLE
Fix enabling AMP-to-AMP linking when mobile redirection is active

### DIFF
--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -49,6 +49,10 @@ final class MobileRedirection implements Service, Registerable {
 
 		if ( AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
 			add_action( 'template_redirect', [ $this, 'redirect' ], PHP_INT_MAX );
+
+			// Enable AMP-to-AMP linking by default to avoid redirecting to AMP version when navigating.
+			// A low priority is used so that sites can continue overriding this if they have done so.
+			add_filter( 'amp_to_amp_linking_enabled', '__return_true', 0 );
 		}
 	}
 
@@ -141,10 +145,6 @@ final class MobileRedirection implements Service, Registerable {
 			if ( ! $js && $this->is_redirection_disabled_via_cookie() ) {
 				$this->set_mobile_redirection_disabled_cookie( false );
 			}
-
-			// Enable AMP-to-AMP linking by default to avoid redirecting to AMP version when navigating.
-			// A low priority is used so that sites can continue overriding this if they have done so.
-			add_filter( 'amp_to_amp_linking_enabled', '__return_true', 0 );
 
 			add_filter( 'amp_to_amp_linking_element_excluded', [ $this, 'filter_amp_to_amp_linking_element_excluded' ], 100, 2 );
 			add_filter( 'amp_to_amp_linking_element_query_vars', [ $this, 'filter_amp_to_amp_linking_element_query_vars' ], 10, 2 );

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -42,9 +42,20 @@ final class MobileRedirectionTest extends WP_UnitTestCase {
 	public function test_register() {
 		AMP_Options_Manager::update_option( Option::MOBILE_REDIRECT, true );
 		$this->instance->register();
-		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
-		$this->assertEquals( 10, has_filter( 'amp_options_updating', [ $this->instance, 'sanitize_options' ] ) );
-		$this->assertEquals( PHP_INT_MAX, has_action( 'template_redirect', [ $this->instance, 'redirect' ] ) );
+		$this->assertSame( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
+		$this->assertSame( 10, has_filter( 'amp_options_updating', [ $this->instance, 'sanitize_options' ] ) );
+		$this->assertSame( PHP_INT_MAX, has_action( 'template_redirect', [ $this->instance, 'redirect' ] ) );
+		$this->assertSame( 0, has_filter( 'amp_to_amp_linking_enabled', '__return_true' ) );
+	}
+
+	/** @covers ::register() */
+	public function test_register_not_enabled() {
+		AMP_Options_Manager::update_option( Option::MOBILE_REDIRECT, false );
+		$this->instance->register();
+		$this->assertSame( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
+		$this->assertSame( 10, has_filter( 'amp_options_updating', [ $this->instance, 'sanitize_options' ] ) );
+		$this->assertFalse( has_action( 'template_redirect', [ $this->instance, 'redirect' ] ) );
+		$this->assertFalse( has_filter( 'amp_to_amp_linking_enabled', '__return_true' ) );
 	}
 
 	/** @covers ::filter_default_options() */

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -77,7 +77,15 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		$categories_block = '<!-- wp:categories {"displayAsDropdown":true,"showHierarchy":true,"showPostCounts":true} /-->';
 		$archives_block   = '<!-- wp:archives {"displayAsDropdown":true,"showPostCounts":true} /-->';
 
-		if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '8.9.0', '==' ) ) {
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&&
+			(
+				version_compare( GUTENBERG_VERSION, '8.9.0', '==' )
+				||
+				version_compare( GUTENBERG_VERSION, '8.9.1', '==' )
+			)
+		) {
 			$this->markTestSkipped( 'See https://github.com/WordPress/gutenberg/pull/25026' );
 		}
 


### PR DESCRIPTION
## Summary

I tried navigating around a site in Reader mode and I was surprised to notice the links did not have `?amp` on them! Somehow a regression happened where the `amp_to_amp_linking_enabled` filter was getting added too late after the sanitizers args had already been initialized, and so it wasn't getting applied. This regression appears to have been caused by me in eba8d5dbe2a1c4cb708bad14bc942a26f5ffda7a for #5203. This happened at 2.0.0-RC1 so it's not surprising that it was missed.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
