### PR TITLE
Disable DevTools by default in reader mode; add amp_dev_tools_user_default_enabled filter

### DIFF
--- a/tests/php/test-class-dev-tools-user-access.php
+++ b/tests/php/test-class-dev-tools-user-access.php
@@ -51,6 +51,7 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers ::is_user_enabled
 	 */
 	public function test_is_user_enabled() {
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$admin_user  = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		$editor_user = self::factory()->user->create_and_get( [ 'role' => 'editor' ] );
 
@@ -201,6 +202,7 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers ::rest_get_dev_tools_enabled
 	 */
 	public function test_rest_get_dev_tools_enabled() {
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$user = self::factory()->user->create_and_get( [ 'role' => 'author' ] );
 
 		$this->assertFalse( $this->dev_tools_user_access->rest_get_dev_tools_enabled( [ 'id' => $user->ID ] ) );

--- a/tests/php/test-class-dev-tools-user-access.php
+++ b/tests/php/test-class-dev-tools-user-access.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\AmpWP\Admin\DevToolsUserAccess;
+use AmpProject\AmpWP\Option;
 
 /**
  * Tests for DevToolsUserAccess class.
@@ -71,7 +72,55 @@ class Test_DevToolsUserAccess extends WP_UnitTestCase {
 	 * @covers ::get_user_enabled
 	 */
 	public function test_get_user_enabled() {
-		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( self::factory()->user->create_and_get( [ 'role' => 'administrator' ] ) ) );
+		$admin_user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+
+		// Enabled by default in Transitional mode.
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+
+		// Enabled by default in Standard mode.
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user->ID ) );
+
+		// Disabled by default in Reader mode.
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user->ID ) );
+
+		// Check filter overriding default to be true in Reader mode, but then user forcing it off via user pref.
+		delete_user_meta( $admin_user->ID, DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
+		remove_all_filters( 'amp_dev_tools_user_default_enabled' );
+		add_filter(
+			'amp_dev_tools_user_default_enabled',
+			function ( $enabled, $user_id ) use ( $admin_user ) {
+				unset( $enabled );
+				$this->assertSame( $user_id, $admin_user->ID );
+				return true;
+			},
+			10,
+			2
+		);
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+		update_user_meta( $admin_user->ID, DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, 'false' );
+		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+
+		// Check filter overriding default to be false in Standard mode, but then user forcing it on via user pref.
+		delete_user_meta( $admin_user->ID, DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
+		remove_all_filters( 'amp_dev_tools_user_default_enabled' );
+		add_filter(
+			'amp_dev_tools_user_default_enabled',
+			function ( $enabled, $user_id ) use ( $admin_user ) {
+				unset( $enabled );
+				$this->assertSame( $user_id, $admin_user->ID );
+				return false;
+			},
+			10,
+			2
+		);
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
+		$this->assertFalse( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
+		update_user_meta( $admin_user->ID, DevToolsUserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, 'true' );
+		$this->assertTrue( $this->dev_tools_user_access->get_user_enabled( $admin_user ) );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -84,6 +84,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_hooks()
 	 */
 	public function test_add_admin_hooks() {
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validated_URL_Post_Type::add_admin_hooks();
 


### PR DESCRIPTION
## Summary

Fixes #5286

This PR disables AMP Developer Tools by default when Reader mode is active.

It also provides a `amp_dev_tools_user_default_enabled` filter to override the _default_ for whether DevTools is enabled (and user can override in user profile).

For example, to disable DevTools by default on a Standard mode site:

```php
add_filter( 'amp_dev_tools_user_default_enabled', '__return_false' );
```

Or to enable DevTools by default for users with emails on a certain domain:

```php
add_filter(
	'amp_dev_tools_user_default_enabled',
	function ( $enabled, $user_id ) {
		$user = new WP_User( $user_id );
		if ( false !== strpos( $user->user_email, '@example.com' ) ) {
			$enabled = true;
		}
		return $enabled;
	},
	10,
	2
);
```

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
