### PR TITLE
Ignore docs folder when code coverage is being processed 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,4 @@ comment: off
 ignore:
   - "/bin"
   - "/back-compat"
+  - "/docs"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
This PR ignores the `docs` folder when code coverage is run.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
