### PR TITLE
Ensure post_publish_timestamp in AMP_Post_Template is UTC for human_time_diff()

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -275,7 +275,7 @@ class AMP_Post_Template {
 	 */
 	private function build_post_data() {
 		$post_title              = get_the_title( $this->post );
-		$post_publish_timestamp  = get_the_date( 'U', $this->post );
+		$post_publish_timestamp  = $this->build_post_publish_timestamp();
 		$post_modified_timestamp = get_post_modified_time( 'U', false, $this->post );
 		$post_author             = get_userdata( $this->post->post_author );
 
@@ -292,6 +292,28 @@ class AMP_Post_Template {
 
 		$this->build_post_featured_image();
 		$this->build_post_comments_data();
+	}
+
+	/**
+	 * Build post publish timestamp.
+	 *
+	 * We can't use `get_the_date( 'U' )` because it always returns the non-GMT value.
+	 *
+	 * @return int Post publish UTC timestamp.
+	 */
+	private function build_post_publish_timestamp() {
+		$format    = 'U';
+		$timestamp = (int) get_post_time( $format, true, $this->post, true );
+
+		/** This filter is documented in wp-includes/general-template.php. */
+		$filtered_timestamp = apply_filters( 'get_the_date', $timestamp, $format, $this->post );
+
+		// Guard against a plugin poorly filtering get_the_date to be something other than a Unix timestamp.
+		if ( is_int( $filtered_timestamp ) ) {
+			$timestamp = $filtered_timestamp;
+		}
+
+		return $timestamp;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As reported in a [support forum topic](https://wordpress.org/support/topic/incorrect-time-stamp/), the relative publish time displayed on the legacy post template is incorrect when the timezone is not UTC.

For example, on my site I have the timezone set to `America/Los_Angeles`. Nevertheless, when I publish my post and I immediately view the legacy AMP post template, I see "7 hours ago". This is because my timezone is UTC-7. The problem is that the `post_publish_timestamp` was being populated with `get_the_date( 'U', $this->post )` which returns a _non-GMT_ “Unix timestamp” (which AFAIK doesn't even make sense, since this value should be timezone-independent). Nevertheless, since `get_the_date( 'U', $this->post )` is getting the blog's timezone offset, it then fails to render the right result in the template:

https://github.com/ampproject/amp-wp/blob/5191d35b5df6f18c4d7785c15cc7ad4730d7f8a4/templates/meta-time.php#L25-L31

Here `time()` is the Unix timestamp of seconds since January 1, 1970 00:00:00 UTC. But `$post_publish_timestamp` is actually 7 hours before that on my install.

The fix is to not call `get_the_date()` directly, but to call the underlying `get_post_time()` which _does_ allow you to specifically request the GMT time.

Since previously `get_the_date()` was used, I figured it would be good to continue applying `get_the_date` filters so that they wouldn't break if sites were using them.

Before | After
-------|-----
![image](https://user-images.githubusercontent.com/134745/92195134-1e6cce00-ee21-11ea-8b7b-e90e80e3f127.png) | ![image](https://user-images.githubusercontent.com/134745/92195170-33e1f800-ee21-11ea-9264-beb25eb4a640.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
