### PR TITLE
Only add_admin_menu_new_invalid_url_count when post type is show_in_menu

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -198,6 +198,10 @@ class AMP_Validated_URL_Post_Type {
 			]
 		);
 
+		if ( $show_in_menu ) {
+			add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_new_invalid_url_count' ] );
+		}
+
 		// Rename the top-level menu from "Validated URLs" to "AMP DevTools" when the user does not have access to the AMP settings screen.
 		if ( $show_in_menu && ! current_user_can( 'manage_options' ) ) {
 			add_action(
@@ -314,7 +318,6 @@ class AMP_Validated_URL_Post_Type {
 		add_action( 'admin_notices', [ __CLASS__, 'print_admin_notice' ] );
 		add_action( 'admin_action_' . self::VALIDATE_ACTION, [ __CLASS__, 'handle_validate_request' ] );
 		add_action( 'post_action_' . self::UPDATE_POST_TERM_STATUS_ACTION, [ __CLASS__, 'handle_validation_error_status_update' ] );
-		add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_new_invalid_url_count' ] );
 		add_filter( 'post_row_actions', [ __CLASS__, 'filter_post_row_actions' ], PHP_INT_MAX, 2 );
 		add_filter( sprintf( 'views_edit-%s', self::POST_TYPE_SLUG ), [ __CLASS__, 'filter_table_views' ] );
 		add_filter( 'bulk_post_updated_messages', [ __CLASS__, 'filter_bulk_post_updated_messages' ], 10, 2 );

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -65,6 +65,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Options_Manager::OPTION_NAME, $amp_post_type->show_in_menu );
 		$this->assertTrue( $amp_post_type->show_in_admin_bar );
 		$this->assertNotContains( AMP_Validated_URL_Post_Type::REMAINING_ERRORS, wp_removable_query_args() );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_new_invalid_url_count' ] ) );
 
 		// Make sure that add_admin_hooks() gets called.
 		set_current_screen( 'index.php' );
@@ -107,7 +108,6 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'print_admin_notice' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_action_' . AMP_Validated_URL_Post_Type::VALIDATE_ACTION, [ self::TESTED_CLASS, 'handle_validate_request' ] ) );
 		$this->assertEquals( 10, has_action( 'post_action_' . AMP_Validated_URL_Post_Type::UPDATE_POST_TERM_STATUS_ACTION, [ self::TESTED_CLASS, 'handle_validation_error_status_update' ] ) );
-		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_new_invalid_url_count' ] ) );
 
 		$post = self::factory()->post->create_and_get( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertEquals( '', apply_filters( 'post_date_column_status', 'publish', $post ) );


### PR DESCRIPTION
## Summary

As is being investigated in a [support topic](https://wordpress.org/support/topic/slow-admin-7/), the query initiated by `AMP_Validated_URL_Post_Type::get_validation_error_urls_count()` can take a long time to complete. (In reality, the output should be cached in a transient, but for the support topic in question this doesn't seem to be happening. See also #5271.) This method is called in `AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count()` to add the unmoderated count next to “Validated URLs”, here 22:

![image](https://user-images.githubusercontent.com/134745/92207754-9d243400-ee3e-11ea-8b5c-7c7a2807cb4a.png)

I thought that by turning off AMP Developer Tools that this query would be bypassed entirely. However, I see that is not the case. This is because the method first gets the count, then aborts if it is zero, or else it then it loops over the menu items until it finds the right one to inject it into. What is missing is we should not be invoking `add_admin_menu_new_invalid_url_count` in the first place if the post type is not set to `$show_in_menu`. This PR implements that change.

With all transients deleted and accessing the post list table and developer tools turned off, queries being made by the AMP plugin:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/92208155-7ca8a980-ee3f-11ea-9709-9ee56db0b8db.png) | ![image](https://user-images.githubusercontent.com/134745/92208180-8e8a4c80-ee3f-11ea-9e38-d3e8f0ef7843.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
