### PR TITLE
Disable widgets-block-editor when Reader theme loaded

### DIFF
--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -361,6 +361,7 @@ final class ReaderThemeLoader implements Service, Registerable {
 				return array_diff( $components, [ 'widgets' ] );
 			}
 		);
+		remove_theme_support( 'widgets-block-editor' );
 	}
 
 	/**

--- a/tests/php/src/ReaderThemeLoaderTest.php
+++ b/tests/php/src/ReaderThemeLoaderTest.php
@@ -202,15 +202,18 @@ final class ReaderThemeLoaderTest extends WP_UnitTestCase {
 	public function test_disable_widgets() {
 		remove_all_filters( 'sidebars_widgets' );
 		remove_filter( 'customize_loaded_components', 'gutenberg_remove_widgets_panel' ); // Added in Gutenberg v8.9.0.
+		add_theme_support( 'widgets-block-editor' );
 
 		$this->assertNotEmpty( wp_get_sidebars_widgets() );
 		$this->assertContains( 'widgets', apply_filters( 'customize_loaded_components', [ 'widgets' ] ) );
+		$this->assertTrue( current_theme_supports( 'widgets-block-editor' ) );
 
 		$this->instance->disable_widgets();
 
 		$this->assertTrue( has_filter( 'sidebars_widgets' ) );
 		$this->assertEquals( [], wp_get_sidebars_widgets() );
 		$this->assertNotContains( 'widgets', apply_filters( 'customize_loaded_components', [ 'widgets' ] ) );
+		$this->assertFalse( current_theme_supports( 'widgets-block-editor' ) );
 	}
 
 	/** @covers ::customize_previewable_devices() */


### PR DESCRIPTION
## Summary

Fixes #5322

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/92273624-90382c80-eea0-11ea-9f80-6b13a818cb2c.png) | ![image](https://user-images.githubusercontent.com/134745/92273643-9928fe00-eea0-11ea-85cc-61dbe6f22b16.png)


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
