### PR TITLE
Ensure robots meta tag is added to AMP legacy template

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -11,6 +11,7 @@
  * @internal
  */
 function amp_post_template_init_hooks() {
+	add_action( 'amp_post_template_head', 'noindex' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_title' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_canonical' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_fonts' );


### PR DESCRIPTION
## Summary

Props @ernee for the discovery.

It turns out that the robots meta tag is not currently being printed on the AMP legacy post templates when Search Engine Visibility is set to discourage indexing:

![image](https://user-images.githubusercontent.com/134745/92279989-4d308600-eead-11ea-8c51-5a4319db0eaa.png)

I don't believe this is resulting in such AMP pages being indexed currently, however, since the canonical URLs _would_ still have the `robots` meta tag. It doesn't appear that this tag has ever been output on legacy AMP pages.  Nevertheless, for completeness the same robots directive should be included on the AMP page.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/92280333-00997a80-eeae-11ea-87c3-2a81e88c153e.png) | ![image](https://user-images.githubusercontent.com/134745/92280214-caf49180-eead-11ea-90a5-8b98df87f917.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
