### PR TITLE
Cache error index counts and URL count in "At a Glance" widget

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -502,7 +502,7 @@ class AMP_Validated_URL_Post_Type {
 	 */
 	protected static function get_validation_error_urls_count() {
 		$count = get_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
-		if ( false === $count ) {
+		if ( false !== $count ) {
 			// Handle case where integer stored in transient gets returned as string when persistent object cache is not
 			// used. This is due to wp_options.option_value being a string.
 			return (int) $count;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -959,7 +959,6 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
-		delete_transient( AMP_Validation_Error_Taxonomy::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 
 		return $post_id;
 	}
@@ -1973,7 +1972,6 @@ class AMP_Validated_URL_Post_Type {
 			}
 
 			delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
-			delete_transient( AMP_Validation_Error_Taxonomy::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 		}
 
 		$redirect = wp_get_referer();

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -957,6 +957,7 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
+		delete_transient( AMP_Validation_Error_Taxonomy::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 
 		return $post_id;
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -219,6 +219,7 @@ class AMP_Validated_URL_Post_Type {
 		$handle_delete = static function ( $post_id ) {
 			if ( static::POST_TYPE_SLUG === get_post_type( $post_id ) ) {
 				delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
+				delete_transient( AMP_Validation_Error_Taxonomy::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 			}
 		};
 		add_action( 'save_post_' . self::POST_TYPE_SLUG, $handle_delete );
@@ -1971,6 +1972,7 @@ class AMP_Validated_URL_Post_Type {
 			}
 
 			delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
+			delete_transient( AMP_Validation_Error_Taxonomy::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 		}
 
 		$redirect = wp_get_referer();

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2923,20 +2923,27 @@ class AMP_Validated_URL_Post_Type {
 	 * @return array Items.
 	 */
 	public static function filter_dashboard_glance_items( $items ) {
+		$count = get_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
 
-		$query = new WP_Query(
-			[
-				'post_type'              => self::POST_TYPE_SLUG,
-				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-				],
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			]
-		);
+		if ( false === $count ) {
 
-		if ( 0 !== $query->found_posts ) {
+			$query = new WP_Query(
+				[
+					'post_type'              => self::POST_TYPE_SLUG,
+					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [
+						AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
+						AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
+					],
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				]
+			);
+
+			$count = $query->found_posts;
+			set_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT, $count, DAY_IN_SECONDS );
+		}
+
+		if ( 0 !== $count ) {
 			$items[] = sprintf(
 				'<a class="amp-validation-errors" href="%s">%s</a>',
 				esc_url(
@@ -2959,10 +2966,10 @@ class AMP_Validated_URL_Post_Type {
 						_n(
 							'%s URL w/ new AMP errors',
 							'%s URLs w/ new AMP errors',
-							$query->found_posts,
+							$count,
 							'amp'
 						),
-						number_format_i18n( $query->found_posts )
+						number_format_i18n( $count )
 					)
 				)
 			);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -288,6 +288,8 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		add_action( 'created_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
+		add_action( 'edit_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
+		add_action( 'delete_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
 	}
 
 	/**
@@ -341,9 +343,6 @@ class AMP_Validation_Error_Taxonomy {
 				$deleted_count++;
 			}
 		}
-
-		delete_transient( self::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
-
 		return $deleted_count;
 	}
 
@@ -2874,7 +2873,6 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( $updated_count ) {
 			delete_transient( AMP_Validated_URL_Post_Type::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
-			delete_transient( self::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 		}
 
 		return $redirect_to;

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -288,7 +288,7 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		add_action( 'created_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
-		add_action( 'edit_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
+		add_action( 'edited_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
 		add_action( 'delete_' . self::TAXONOMY_SLUG, [ __CLASS__, 'clear_cached_counts' ] );
 	}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -639,7 +639,7 @@ class AMP_Validation_Error_Taxonomy {
 		$result = (int) $term_count;
 
 		$cached_counts[ $cache_key ] = $result;
-		set_transient( self::TRANSIENT_KEY_ERROR_INDEX_COUNTS, $cached_counts, HOUR_IN_SECONDS );
+		set_transient( self::TRANSIENT_KEY_ERROR_INDEX_COUNTS, $cached_counts, DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -206,7 +206,7 @@ class AMP_Validation_Error_Taxonomy {
 
 	/**
 	 * Key for the transient storing error index counts.
-	 * 
+	 *
 	 * @var string
 	 */
 	const TRANSIENT_KEY_ERROR_INDEX_COUNTS = 'amp_error_index_counts';
@@ -2874,6 +2874,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( $updated_count ) {
 			delete_transient( AMP_Validated_URL_Post_Type::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
+			delete_transient( self::TRANSIENT_KEY_ERROR_INDEX_COUNTS );
 		}
 
 		return $redirect_to;

--- a/tests/e2e/specs/amp-onboarding/template-mode.js
+++ b/tests/e2e/specs/amp-onboarding/template-mode.js
@@ -93,7 +93,7 @@ describe( 'Template mode recommendations with non-reader-theme active', () => {
 	} );
 
 	afterEach( async () => {
-		await deleteTheme( 'neve', 'twentytwenty' );
+		await deleteTheme( 'hestia', 'twentytwenty' );
 	} );
 
 	it( 'makes correct recommendations when user is not technical and the current theme is not a reader theme', async () => {

--- a/tests/e2e/specs/amp-onboarding/template-mode.js
+++ b/tests/e2e/specs/amp-onboarding/template-mode.js
@@ -88,8 +88,8 @@ describe( 'Stepper item modifications', () => {
 describe( 'Template mode recommendations with non-reader-theme active', () => {
 	beforeEach( async () => {
 		await cleanUpSettings();
-		await installTheme( 'neve' );
-		await activateTheme( 'neve' );
+		await installTheme( 'hestia' );
+		await activateTheme( 'hestia' );
 	} );
 
 	afterEach( async () => {

--- a/tests/e2e/specs/amp-onboarding/template-mode.js
+++ b/tests/e2e/specs/amp-onboarding/template-mode.js
@@ -88,12 +88,12 @@ describe( 'Stepper item modifications', () => {
 describe( 'Template mode recommendations with non-reader-theme active', () => {
 	beforeEach( async () => {
 		await cleanUpSettings();
-		await installTheme( 'astra' );
-		await activateTheme( 'astra' );
+		await installTheme( 'neve' );
+		await activateTheme( 'neve' );
 	} );
 
 	afterEach( async () => {
-		await deleteTheme( 'astra', 'twentytwenty' );
+		await deleteTheme( 'neve', 'twentytwenty' );
 	} );
 
 	it( 'makes correct recommendations when user is not technical and the current theme is not a reader theme', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5271

This PR adds transient-based caching to the `get_validation_error_count` function. The transient data is an associative array with the JSON-encoded `get_validation_error_count` used as the key. The transient data is deleted when terms are created, deleted, or updated.

Additionally, this PR caches the validated URL count shown in the "At a Glance" admin dashboard widget using the transient used to show the count in the sidebar.


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
