### PR TITLE
Remove instances of @return annotation in hook documentation

### DIFF
--- a/docs/templates/hook.mustache
+++ b/docs/templates/hook.mustache
@@ -20,12 +20,6 @@
 {{/ arguments }}
 
 {{/ has_arguments }}
-{{# has_return_value }}
-### Return value
-
-`{{ get_return_value_types }}`{{# has_return_value_description }} - {{ get_return_value_description }}{{/ has_return_value_description }}
-
-{{/ has_return_value }}
 ### Source
 
 :link: [{{ get_file_path }}:{{ line }}]({{{ get_github_link }}})

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2155,7 +2155,6 @@ class AMP_Theme_Support {
 		 * @since 1.5.0
 		 *
 		 * @param bool $enable_optimizer Whether the generated HTML output should be run through the AMP Optimizer or not.
-		 * @return bool Filtered value of whether the generated HTML output should be run through the AMP Optimizer or not.
 		 */
 		$enable_optimizer = apply_filters( 'amp_enable_optimizer', $enable_optimizer );
 
@@ -2275,7 +2274,6 @@ class AMP_Theme_Support {
 		 * @since 1.5.0
 		 *
 		 * @param bool $enable_ssr Whether the AMP Optimizer should use server-side rendering or not.
-		 * @return bool Filtered value of whether the AMP Optimizer should use server-side rendering or not.
 		 */
 		$enable_ssr = apply_filters( 'amp_enable_ssr', $enable_ssr );
 
@@ -2299,7 +2297,6 @@ class AMP_Theme_Support {
 		 * @since 1.5.0
 		 *
 		 * @param array $configuration Associative array of configuration data.
-		 * @return array Filtered associative array of configuration data.
 		 */
 		$configuration = apply_filters(
 			'amp_optimizer_config',


### PR DESCRIPTION
## Summary

As @westonruter pointed out in https://github.com/ampproject/amp-wp/pull/5333#discussion_r483288534, the WordPress documentation states that [`@return` should not be used](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters:~:text=Note%20that%20%40return%20is%20not%20used,hooks%20always%20return%20their%20first%20parameter.) for hook documentation. This PR removes all instances of those annotations and removes the markup used to document what a hook returns.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
