### PR TITLE
Fix test_add_block_source_comments with latest_posts dataset when Gutenberg installed from source

### DIFF
--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1374,7 +1374,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 						: preg_replace( ':.*wp-includes/:', '', $reflection_function->getFileName() )
 					),
 					$reflection_function->getStartLine(),
-					( defined( 'GUTENBERG_VERSION' ) && GUTENBERG_VERSION && version_compare( GUTENBERG_VERSION, '8.8.0', '>=' ) )
+					( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' ) && GUTENBERG_VERSION && version_compare( GUTENBERG_VERSION, '8.8.0', '>=' ) )
 						? 'wp-block-latest-posts__list wp-block-latest-posts'
 						: 'wp-block-latest-posts wp-block-latest-posts__list'
 				),


### PR DESCRIPTION
## Summary

I noticed that `Test_AMP_Validation_Manager::test_add_block_source_comments()` was failing for me when I have Gutenberg source installed:

```
1) Test_AMP_Validation_Manager::test_add_block_source_comments with data set "latest_posts" ('<!-- wp:latest-posts {"postsT...} /-->', '<!--amp-source-stack {"block_...s"}-->', array('ul', array('core/latest-posts')))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":5,"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"plugin","name":"gutenberg","file":"build\/block-library\/blocks\/latest-posts.php","line":35,"function":"gutenberg_render_block_core_latest_posts"}--><ul class="wp-block-latest-posts wp-block-latest-posts__list"><li><a href="http://example.org/?p=5">Post title 0000019</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":5,"block_attrs":{"postsToShow":1},"type":"plugin","name":"gutenberg","file":"build\/block-library\/blocks\/latest-posts.php","line":35,"function":"gutenberg_render_block_core_latest_posts"}-->'
+'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":5,"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"plugin","name":"gutenberg","file":"build\/block-library\/blocks\/latest-posts.php","line":35,"function":"gutenberg_render_block_core_latest_posts"}--><ul class="wp-block-latest-posts__list wp-block-latest-posts"><li><a href="http://example.org/?p=5">Post title 0000019</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":5,"block_attrs":{"postsToShow":1},"type":"plugin","name":"gutenberg","file":"build\/block-library\/blocks\/latest-posts.php","line":35,"function":"gutenberg_render_block_core_latest_posts"}-->'

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1441
```

The fixes the issue by assuming that if `GUTENBERG_DEVELOPMENT_MODE` is defined that the user is running the current version of Gutenberg.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
