### PR TITLE
Allow test in Test_AMP_Core_Block_Handler to run now that WordPress/gutenberg#25026 has been merged

### DIFF
--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -77,18 +77,6 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		$categories_block = '<!-- wp:categories {"displayAsDropdown":true,"showHierarchy":true,"showPostCounts":true} /-->';
 		$archives_block   = '<!-- wp:archives {"displayAsDropdown":true,"showPostCounts":true} /-->';
 
-		if (
-			defined( 'GUTENBERG_VERSION' )
-			&&
-			(
-				version_compare( GUTENBERG_VERSION, '8.9.0', '==' )
-				||
-				version_compare( GUTENBERG_VERSION, '8.9.1', '==' )
-			)
-		) {
-			$this->markTestSkipped( 'See https://github.com/WordPress/gutenberg/pull/25026' );
-		}
-
 		$handler->register_embed();
 		$rendered = do_blocks( $categories_block );
 		$this->assertStringContains( '<select', $rendered );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Now that WordPress/gutenberg#25026 has been merged, we can unmark `Test_AMP_Core_Block_Handler::test_register_and_unregister_embed` as being skipped when Gutenberg v8.9.0 or v8.9.1 is used.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
