### PR TITLE
Settings screen: Add message for no suppressible plugins

### DIFF
--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -318,15 +318,29 @@ export function PluginSuppression() {
 		suppressible_plugins: suppressiblePlugins,
 	} = editedOptions;
 
+	const Description = () => (
+		<p>
+			{ __( 'When a plugin adds markup that is not allowed in AMP you may let the AMP plugin remove it, or you may suppress the plugin from running on AMP pages. The following list includes all active plugins on your site, with any of those detected to be generating invalid AMP markup appearing first.', 'amp' ) }
+		</p>
+	);
+
 	if ( ! suppressiblePlugins || 0 === Object.keys( suppressiblePlugins ).length ) {
-		return null;
+		return (
+			<>
+				<Description />
+				<p>
+					<em>
+						{ __( 'You have no suppressible plugins active.', 'amp' ) }
+					</em>
+
+				</p>
+			</>
+		);
 	}
 
 	return (
 		<>
-			<p>
-				{ __( 'When a plugin adds markup that is not allowed in AMP you may let the AMP plugin remove it, or you may suppress the plugin from running on AMP pages. The following list includes all active plugins on your site, with any of those detected to be generating invalid AMP markup appearing first.', 'amp' ) }
-			</p>
+			<Description />
 			<table id="suppressed-plugins-table" className="wp-list-table widefat fixed">
 				<thead>
 					<tr>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5310 

On the settings screen, when there were no suppressible plugins to show, the "Plugin Suppression" section was showing a blank space. This adds a message.

|Before|After|
|---|---|
|![site5650 test_wp-admin_admin php_page=amp-options (1)](https://user-images.githubusercontent.com/9020968/92418668-4e241a80-f12e-11ea-94af-f7f317f1b966.png)|![site5650 test_wp-admin_admin php_page=amp-options](https://user-images.githubusercontent.com/9020968/92418660-46647600-f12e-11ea-9b49-e77855ee2ccd.png)|




## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
