### PR TITLE
Update button text used in the locked post dialog when editing a validated URL post

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -162,6 +162,7 @@ class AMP_Validated_URL_Post_Type {
 			self::POST_TYPE_SLUG,
 			[
 				'labels'       => [
+					'all_items'          => __( 'All Validated URLs', 'amp' ),
 					'name'               => _x( 'AMP Validated URLs', 'post type general name', 'amp' ),
 					'menu_name'          => __( 'Validated URLs', 'amp' ),
 					'singular_name'      => __( 'Validated URL', 'amp' ),
@@ -199,7 +200,7 @@ class AMP_Validated_URL_Post_Type {
 		);
 
 		if ( $show_in_menu ) {
-			add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_new_invalid_url_count' ] );
+			add_action( 'admin_menu', [ __CLASS__, 'update_validated_url_menu_item' ] );
 		}
 
 		// Rename the top-level menu from "Validated URLs" to "AMP DevTools" when the user does not have access to the AMP settings screen.
@@ -469,11 +470,12 @@ class AMP_Validated_URL_Post_Type {
 	}
 
 	/**
-	 * Add count of how many validation error posts there are to the admin menu.
+	 * Update the "Validated URLs" menu item label and append a count of how many validation error posts there are
+	 * next to it.
 	 *
 	 * @global array $submenu
 	 */
-	public static function add_admin_menu_new_invalid_url_count() {
+	public static function update_validated_url_menu_item() {
 		global $submenu;
 
 		$post_type_menu_slug = 'edit.php?post_type=' . self::POST_TYPE_SLUG;
@@ -483,14 +485,17 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
-		$new_validation_error_urls = static::get_validation_error_urls_count();
-		if ( 0 === $new_validation_error_urls ) {
-			return;
-		}
-
 		foreach ( $submenu[ $parent_menu_slug ] as &$submenu_item ) {
 			if ( $post_type_menu_slug === $submenu_item[2] ) {
-				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="new-validation-error-urls-count">' . esc_html( number_format_i18n( $new_validation_error_urls ) ) . '</span></span>';
+				// Use the `menu_name` label as the submenu label instead of the `all_items` label.
+				$menu_name_label = get_post_type_object( self::POST_TYPE_SLUG )->labels->menu_name;
+				$submenu_item[0] = $menu_name_label;
+
+				// Display the count of new validation errors next to the label, if there are any.
+				$new_validation_error_url_count = self::get_validation_error_urls_count();
+				if ( 0 < $new_validation_error_url_count ) {
+					$submenu_item[0] .= ' <span class="awaiting-mod"><span class="new-validation-error-urls-count">' . esc_html( number_format_i18n( $new_validation_error_url_count ) ) . '</span></span>';
+				}
 				break;
 			}
 		}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -65,7 +65,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Options_Manager::OPTION_NAME, $amp_post_type->show_in_menu );
 		$this->assertTrue( $amp_post_type->show_in_admin_bar );
 		$this->assertNotContains( AMP_Validated_URL_Post_Type::REMAINING_ERRORS, wp_removable_query_args() );
-		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_new_invalid_url_count' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'update_validated_url_menu_item' ] ) );
 
 		// Make sure that add_admin_hooks() gets called.
 		set_current_screen( 'index.php' );
@@ -121,18 +121,18 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_admin_menu_new_invalid_url_count.
+	 * Test update_validated_url_menu_item.
 	 *
-	 * @covers \AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count()
+	 * @covers \AMP_Validated_URL_Post_Type::update_validated_url_menu_item()
 	 */
-	public function test_add_admin_menu_new_invalid_url_count() {
+	public function test_update_validated_url_menu_item() {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $submenu;
 
 		$original_submenu = $submenu;
 
 		AMP_Validation_Manager::init(); // Register the post type and taxonomy.
-		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
+		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 
 		$submenu[ AMP_Options_Manager::OPTION_NAME ] = [
 			0 => [
@@ -148,10 +148,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 				3 => 'AMP Analytics Options',
 			],
 			2 => [
-				0 => 'Invalid Pages',
-				1 => 'edit_posts',
+				0 => 'All Validated URLs',
+				1 => 'amp_validate',
 				2 => 'edit.php?post_type=amp_validated_url',
-				3 => 'Invalid AMP Pages (URLs)',
+				3 => 'AMP Validated URLs',
 			],
 		];
 
@@ -165,9 +165,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
 
-		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
+		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 
-		$this->assertStringContains( '<span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+		$this->assertSame( 'Validated URLs <span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 
 		$submenu = $original_submenu;
 	}


### PR DESCRIPTION
## Summary

This PR updates the button text used to navigate the user away from the locked post when another user is editing the same Validated URL post.

Before | After
---|---
![image](https://user-images.githubusercontent.com/16200219/92516952-76327d00-f205-11ea-9c28-29ed57f40f4f.png) | ![image](https://user-images.githubusercontent.com/16200219/92516906-6450da00-f205-11ea-8adb-a143f264259c.png)

Do note that this also requires manually overriding the submenu label text as well; when the `all_items` label is set for the post type, WordPress uses that as the menu label instead of the `menu_name` label. Without overriding the submenu label, it would look like this in the admin menu:

![image](https://user-images.githubusercontent.com/16200219/92517300-f6f17900-f205-11ea-9b70-79202be9fa5d.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
