### PR TITLE
Docs: Ensure the GitHub link to the source is formed correctly

### DIFF
--- a/docs/class/AMP_Base_Embed_Handler.md
+++ b/docs/class/AMP_Base_Embed_Handler.md
@@ -11,7 +11,7 @@ Class AMP_Base_Embed_Handler
 * [`match_element_attributes`](../method/AMP_Base_Embed_Handler/match_element_attributes.md) - Get regex pattern for matching HTML attributes from a given tag name.
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:15](../../includes/embeds/class-amp-base-embed-handler.php#L15-L112)
+:link: [includes/embeds/class-amp-base-embed-handler.php:15](/includes/embeds/class-amp-base-embed-handler.php#L15-L112)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/class/AMP_Base_Sanitizer.md
+++ b/docs/class/AMP_Base_Sanitizer.md
@@ -33,7 +33,7 @@ Class AMP_Base_Sanitizer
 * [`get_validate_response_data`](../method/AMP_Base_Sanitizer/get_validate_response_data.md) - Get data that is returned in validate responses.
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:16](../../includes/sanitizers/class-amp-base-sanitizer.php#L16-L796)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:16](/includes/sanitizers/class-amp-base-sanitizer.php#L16-L796)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_add_amphtml_link.md
+++ b/docs/function/amp_add_amphtml_link.md
@@ -10,7 +10,7 @@ If there are known validation errors for the current URL then do not output anyt
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:762](../../includes/amp-helper-functions.php#L762-L812)
+:link: [includes/amp-helper-functions.php:762](/includes/amp-helper-functions.php#L762-L812)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_add_post_template_actions.md
+++ b/docs/function/amp_add_post_template_actions.md
@@ -10,7 +10,7 @@ Add post template actions.
 
 ### Source
 
-:link: [includes/deprecated.php:90](../../includes/deprecated.php#L90-L94)
+:link: [includes/deprecated.php:90](/includes/deprecated.php#L90-L94)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_backcompat_use_v03_templates.md
+++ b/docs/function/amp_backcompat_use_v03_templates.md
@@ -13,7 +13,7 @@ If you want to use the template that shipped with v0.3 and earlier, you can use 
 
 ### Source
 
-:link: [back-compat/back-compat.php:20](../../back-compat/back-compat.php#L20-L24)
+:link: [back-compat/back-compat.php:20](/back-compat/back-compat.php#L20-L24)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_frontend_add_canonical.md
+++ b/docs/function/amp_frontend_add_canonical.md
@@ -10,7 +10,7 @@ Add amphtml link to frontend.
 
 ### Source
 
-:link: [includes/amp-frontend-actions.php:31](../../includes/amp-frontend-actions.php#L31-L34)
+:link: [includes/amp-frontend-actions.php:31](/includes/amp-frontend-actions.php#L31-L34)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_generate_script_hash.md
+++ b/docs/function/amp_generate_script_hash.md
@@ -18,7 +18,7 @@ The sha384 hash used by amp-script is represented not as hexadecimal but as base
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1937](../../includes/amp-helper-functions.php#L1937-L1948)
+:link: [includes/amp-helper-functions.php:1937](/includes/amp-helper-functions.php#L1937-L1948)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_get_permalink.md
+++ b/docs/function/amp_get_permalink.md
@@ -16,7 +16,7 @@ Retrieves the full AMP-specific permalink for the given post ID.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:665](../../includes/amp-helper-functions.php#L665-L734)
+:link: [includes/amp-helper-functions.php:665](/includes/amp-helper-functions.php#L665-L734)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_get_slug.md
+++ b/docs/function/amp_get_slug.md
@@ -14,7 +14,7 @@ The return value can be overridden by previously defining a AMP_QUERY_VAR consta
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:599](../../includes/amp-helper-functions.php#L599-L610)
+:link: [includes/amp-helper-functions.php:599](/includes/amp-helper-functions.php#L599-L610)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_available.md
+++ b/docs/function/amp_is_available.md
@@ -12,7 +12,7 @@ Determine whether AMP is available for the current URL.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:408](../../includes/amp-helper-functions.php#L408-L546)
+:link: [includes/amp-helper-functions.php:408](/includes/amp-helper-functions.php#L408-L546)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_canonical.md
+++ b/docs/function/amp_is_canonical.md
@@ -25,7 +25,7 @@ Themes can register support for this with `add_theme_support( AMP_Theme_Support:
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:366](../../includes/amp-helper-functions.php#L366-L368)
+:link: [includes/amp-helper-functions.php:366](/includes/amp-helper-functions.php#L366-L368)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_dev_mode.md
+++ b/docs/function/amp_is_dev_mode.md
@@ -14,7 +14,7 @@ When enabled, the &lt;html&gt; element will get the data-ampdevmode attribute an
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1404](../../includes/amp-helper-functions.php#L1404-L1427)
+:link: [includes/amp-helper-functions.php:1404](/includes/amp-helper-functions.php#L1404-L1427)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_legacy.md
+++ b/docs/function/amp_is_legacy.md
@@ -12,7 +12,7 @@ Determines whether the legacy AMP post templates are being used.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:376](../../includes/amp-helper-functions.php#L376-L387)
+:link: [includes/amp-helper-functions.php:376](/includes/amp-helper-functions.php#L376-L387)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_post_supported.md
+++ b/docs/function/amp_is_post_supported.md
@@ -16,7 +16,7 @@ Determine whether a given post supports AMP.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:823](../../includes/amp-helper-functions.php#L823-L825)
+:link: [includes/amp-helper-functions.php:823](/includes/amp-helper-functions.php#L823-L825)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_is_request.md
+++ b/docs/function/amp_is_request.md
@@ -14,7 +14,7 @@ This function cannot be called before the parse_query action because it needs to
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:856](../../includes/amp-helper-functions.php#L856-L889)
+:link: [includes/amp-helper-functions.php:856](/includes/amp-helper-functions.php#L856-L889)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_maybe_add_actions.md
+++ b/docs/function/amp_maybe_add_actions.md
@@ -16,7 +16,7 @@ If the request is for an AMP page and this is in &#039;canonical mode,&#039; red
 
 ### Source
 
-:link: [includes/deprecated.php:32](../../includes/deprecated.php#L32-L81)
+:link: [includes/deprecated.php:32](/includes/deprecated.php#L32-L81)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_prepare_render.md
+++ b/docs/function/amp_prepare_render.md
@@ -10,7 +10,7 @@ Add action to do post template rendering at template_redirect action.
 
 ### Source
 
-:link: [includes/deprecated.php:104](../../includes/deprecated.php#L104-L107)
+:link: [includes/deprecated.php:104](/includes/deprecated.php#L104-L107)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_remove_endpoint.md
+++ b/docs/function/amp_remove_endpoint.md
@@ -16,7 +16,7 @@ Remove the AMP endpoint (and query var) from a given URL.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:744](../../includes/amp-helper-functions.php#L744-L753)
+:link: [includes/amp-helper-functions.php:744](/includes/amp-helper-functions.php#L744-L753)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_render.md
+++ b/docs/function/amp_render.md
@@ -10,7 +10,7 @@ Render AMP for queried post.
 
 ### Source
 
-:link: [includes/deprecated.php:116](../../includes/deprecated.php#L116-L125)
+:link: [includes/deprecated.php:116](/includes/deprecated.php#L116-L125)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/amp_render_post.md
+++ b/docs/function/amp_render_post.md
@@ -14,7 +14,7 @@ Render AMP post template.
 
 ### Source
 
-:link: [includes/deprecated.php:137](../../includes/deprecated.php#L137-L183)
+:link: [includes/deprecated.php:137](/includes/deprecated.php#L137-L183)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/is_amp_endpoint.md
+++ b/docs/function/is_amp_endpoint.md
@@ -16,7 +16,7 @@ This function cannot be called before the parse_query action because it needs to
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:906](../../includes/amp-helper-functions.php#L906-L908)
+:link: [includes/amp-helper-functions.php:906](/includes/amp-helper-functions.php#L906-L908)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/function/post_supports_amp.md
+++ b/docs/function/post_supports_amp.md
@@ -18,7 +18,7 @@ Determine whether a given post supports AMP.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:838](../../includes/amp-helper-functions.php#L838-L840)
+:link: [includes/amp-helper-functions.php:838](/includes/amp-helper-functions.php#L838-L840)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_analytics_entries.md
+++ b/docs/hook/amp_analytics_entries.md
@@ -14,7 +14,7 @@ This filter allows you to easily insert any amp-analytics tags without needing m
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1242](../../includes/amp-helper-functions.php#L1242)
+:link: [includes/amp-helper-functions.php:1242](/includes/amp-helper-functions.php#L1242)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_comment_posted_message.md
+++ b/docs/hook/amp_comment_posted_message.md
@@ -8,7 +8,7 @@ Filters the message when comment submitted success message when
 
 ### Source
 
-:link: [includes/class-amp-http.php:486](../../includes/class-amp-http.php#L486)
+:link: [includes/class-amp-http.php:486](/includes/class-amp-http.php#L486)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_content_embed_handlers.md
+++ b/docs/hook/amp_content_embed_handlers.md
@@ -13,7 +13,7 @@ Filters the content embed handlers.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1364](../../includes/amp-helper-functions.php#L1364-L1390)
+:link: [includes/amp-helper-functions.php:1364](/includes/amp-helper-functions.php#L1364-L1390)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_content_max_width.md
+++ b/docs/hook/amp_content_max_width.md
@@ -12,7 +12,7 @@ Filters the content max width for Reader templates.
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:113](../../includes/templates/class-amp-post-template.php#L113)
+:link: [includes/templates/class-amp-post-template.php:113](/includes/templates/class-amp-post-template.php#L113)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_content_sanitizers.md
+++ b/docs/hook/amp_content_sanitizers.md
@@ -13,7 +13,7 @@ Filters the content sanitizers.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1551](../../includes/amp-helper-functions.php#L1551)
+:link: [includes/amp-helper-functions.php:1551](/includes/amp-helper-functions.php#L1551)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_css_transient_monitoring_sampling_range.md
+++ b/docs/hook/amp_css_transient_monitoring_sampling_range.md
@@ -12,7 +12,7 @@ Filters the sampling range to use for monitoring the transient caching of styles
 
 ### Source
 
-:link: [src/BackgroundTask/MonitorCssTransientCaching.php:268](../../src/BackgroundTask/MonitorCssTransientCaching.php#L268)
+:link: [src/BackgroundTask/MonitorCssTransientCaching.php:268](/src/BackgroundTask/MonitorCssTransientCaching.php#L268)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_css_transient_monitoring_threshold.md
+++ b/docs/hook/amp_css_transient_monitoring_threshold.md
@@ -12,7 +12,7 @@ Filters the threshold to use for disabling transient caching of stylesheets.
 
 ### Source
 
-:link: [src/BackgroundTask/MonitorCssTransientCaching.php:247](../../src/BackgroundTask/MonitorCssTransientCaching.php#L247)
+:link: [src/BackgroundTask/MonitorCssTransientCaching.php:247](/src/BackgroundTask/MonitorCssTransientCaching.php#L247)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_enqueue_preview_scripts.md
+++ b/docs/hook/amp_customizer_enqueue_preview_scripts.md
@@ -12,7 +12,7 @@ Fires when plugins should enqueue their own scripts for the AMP Customizer previ
 
 ### Source
 
-:link: [includes/admin/class-amp-template-customizer.php:702](../../includes/admin/class-amp-template-customizer.php#L702)
+:link: [includes/admin/class-amp-template-customizer.php:702](/includes/admin/class-amp-template-customizer.php#L702)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_enqueue_scripts.md
+++ b/docs/hook/amp_customizer_enqueue_scripts.md
@@ -14,7 +14,7 @@ In practice the `customize_controls_enqueue_scripts` hook should be used instead
 
 ### Source
 
-:link: [includes/admin/class-amp-template-customizer.php:611](../../includes/admin/class-amp-template-customizer.php#L611)
+:link: [includes/admin/class-amp-template-customizer.php:611](/includes/admin/class-amp-template-customizer.php#L611)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_get_settings.md
+++ b/docs/hook/amp_customizer_get_settings.md
@@ -12,7 +12,7 @@ Filters the AMP Customizer settings.
 
 ### Source
 
-:link: [includes/settings/class-amp-customizer-settings.php:43](../../includes/settings/class-amp-customizer-settings.php#L43)
+:link: [includes/settings/class-amp-customizer-settings.php:43](/includes/settings/class-amp-customizer-settings.php#L43)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_init.md
+++ b/docs/hook/amp_customizer_init.md
@@ -14,7 +14,7 @@ In practice the `customize_register` hook should be used instead.
 
 ### Source
 
-:link: [includes/admin/class-amp-template-customizer.php:104](../../includes/admin/class-amp-template-customizer.php#L104)
+:link: [includes/admin/class-amp-template-customizer.php:104](/includes/admin/class-amp-template-customizer.php#L104)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_is_enabled.md
+++ b/docs/hook/amp_customizer_is_enabled.md
@@ -12,7 +12,7 @@ Filter whether to enable the AMP default template design settings.
 
 ### Source
 
-:link: [includes/settings/class-amp-customizer-design-settings.php:58](../../includes/settings/class-amp-customizer-design-settings.php#L58)
+:link: [includes/settings/class-amp-customizer-design-settings.php:58](/includes/settings/class-amp-customizer-design-settings.php#L58)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_post_type.md
+++ b/docs/hook/amp_customizer_post_type.md
@@ -12,7 +12,7 @@ Filter the post type to retrieve the latest for use in the AMP template customiz
 
 ### Source
 
-:link: [includes/admin/functions.php:43](../../includes/admin/functions.php#L43)
+:link: [includes/admin/functions.php:43](/includes/admin/functions.php#L43)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_register_settings.md
+++ b/docs/hook/amp_customizer_register_settings.md
@@ -14,7 +14,7 @@ In practice the `customize_register` hook should be used instead.
 
 ### Source
 
-:link: [includes/admin/class-amp-template-customizer.php:295](../../includes/admin/class-amp-template-customizer.php#L295)
+:link: [includes/admin/class-amp-template-customizer.php:295](/includes/admin/class-amp-template-customizer.php#L295)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_customizer_register_ui.md
+++ b/docs/hook/amp_customizer_register_ui.md
@@ -14,7 +14,7 @@ In practice the `customize_register` hook should be used instead.
 
 ### Source
 
-:link: [includes/admin/class-amp-template-customizer.php:259](../../includes/admin/class-amp-template-customizer.php#L259)
+:link: [includes/admin/class-amp-template-customizer.php:259](/includes/admin/class-amp-template-customizer.php#L259)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_dev_mode_element_xpaths.md
+++ b/docs/hook/amp_dev_mode_element_xpaths.md
@@ -14,7 +14,7 @@ By supplying XPath queries to this filter, the data-ampdevmode attribute will au
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1564](../../includes/amp-helper-functions.php#L1564)
+:link: [includes/amp-helper-functions.php:1564](/includes/amp-helper-functions.php#L1564)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_dev_mode_enabled.md
+++ b/docs/hook/amp_dev_mode_enabled.md
@@ -14,7 +14,7 @@ When enabled, the data-ampdevmode attribute will be added to the document elemen
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1416](../../includes/amp-helper-functions.php#L1416-L1426)
+:link: [includes/amp-helper-functions.php:1416](/includes/amp-helper-functions.php#L1416-L1426)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_dev_tools_user_default_enabled.md
+++ b/docs/hook/amp_dev_tools_user_default_enabled.md
@@ -15,7 +15,7 @@ When Reader mode is active, Developer Tools is currently disabled by default.
 
 ### Source
 
-:link: [src/Admin/DevToolsUserAccess.php:93](../../src/Admin/DevToolsUserAccess.php#L93)
+:link: [src/Admin/DevToolsUserAccess.php:93](/src/Admin/DevToolsUserAccess.php#L93)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_enable_optimizer.md
+++ b/docs/hook/amp_enable_optimizer.md
@@ -10,13 +10,9 @@ Filter whether the generated HTML output should be run through the AMP Optimizer
 
 * `bool $enable_optimizer` - Whether the generated HTML output should be run through the AMP Optimizer or not.
 
-### Return value
-
-`bool` - Filtered value of whether the generated HTML output should be run through the AMP Optimizer or not.
-
 ### Source
 
-:link: [includes/class-amp-theme-support.php:2160](../../includes/class-amp-theme-support.php#L2160)
+:link: [includes/class-amp-theme-support.php:2159](/includes/class-amp-theme-support.php#L2159)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_enable_ssr.md
+++ b/docs/hook/amp_enable_ssr.md
@@ -10,13 +10,9 @@ Filter whether the AMP Optimizer should use server-side rendering or not.
 
 * `bool $enable_ssr` - Whether the AMP Optimizer should use server-side rendering or not.
 
-### Return value
-
-`bool` - Filtered value of whether the AMP Optimizer should use server-side rendering or not.
-
 ### Source
 
-:link: [includes/class-amp-theme-support.php:2280](../../includes/class-amp-theme-support.php#L2280)
+:link: [includes/class-amp-theme-support.php:2278](/includes/class-amp-theme-support.php#L2278)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_extract_image_dimensions_batch.md
+++ b/docs/hook/amp_extract_image_dimensions_batch.md
@@ -12,7 +12,7 @@ Filters the dimensions extracted from image URLs.
 
 ### Source
 
-:link: [includes/utils/class-amp-image-dimension-extractor.php:69](../../includes/utils/class-amp-image-dimension-extractor.php#L69)
+:link: [includes/utils/class-amp-image-dimension-extractor.php:69](/includes/utils/class-amp-image-dimension-extractor.php#L69)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_extract_image_dimensions_batch_callbacks_registered.md
+++ b/docs/hook/amp_extract_image_dimensions_batch_callbacks_registered.md
@@ -8,7 +8,7 @@ Fires after the amp_extract_image_dimensions_batch filter has been added to extr
 
 ### Source
 
-:link: [includes/utils/class-amp-image-dimension-extractor.php:150](../../includes/utils/class-amp-image-dimension-extractor.php#L150)
+:link: [includes/utils/class-amp-image-dimension-extractor.php:150](/includes/utils/class-amp-image-dimension-extractor.php#L150)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_extract_image_dimensions_get_user_agent.md
+++ b/docs/hook/amp_extract_image_dimensions_get_user_agent.md
@@ -12,7 +12,7 @@ Filters the user agent for onbtaining the image dimensions.
 
 ### Source
 
-:link: [includes/utils/class-amp-image-dimension-extractor.php:250](../../includes/utils/class-amp-image-dimension-extractor.php#L250)
+:link: [includes/utils/class-amp-image-dimension-extractor.php:250](/includes/utils/class-amp-image-dimension-extractor.php#L250)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_frontend_show_canonical.md
+++ b/docs/hook/amp_frontend_show_canonical.md
@@ -13,7 +13,7 @@ This is deprecated since the name was wrong and the use case is not clear. To re
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:779](../../includes/amp-helper-functions.php#L779-L792)
+:link: [includes/amp-helper-functions.php:779](/includes/amp-helper-functions.php#L779-L792)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_get_permalink.md
+++ b/docs/hook/amp_get_permalink.md
@@ -13,7 +13,7 @@ Filters AMP permalink.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:733](../../includes/amp-helper-functions.php#L733)
+:link: [includes/amp-helper-functions.php:733](/includes/amp-helper-functions.php#L733)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_init.md
+++ b/docs/hook/amp_init.md
@@ -8,7 +8,7 @@ Triggers on init when AMP plugin is active.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:110](../../includes/amp-helper-functions.php#L110)
+:link: [includes/amp-helper-functions.php:110](/includes/amp-helper-functions.php#L110)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_is_enabled.md
+++ b/docs/hook/amp_is_enabled.md
@@ -10,7 +10,7 @@ Useful if the plugin is network activated and you want to turn it off on select 
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:68](../../includes/amp-helper-functions.php#L68)
+:link: [includes/amp-helper-functions.php:68](/includes/amp-helper-functions.php#L68)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_mobile_client_side_redirection.md
+++ b/docs/hook/amp_mobile_client_side_redirection.md
@@ -16,7 +16,7 @@ If false, a server-side solution will be used instead (via PHP). It&#039;s impor
 
 ### Source
 
-:link: [src/MobileRedirection.php:267](../../src/MobileRedirection.php#L267)
+:link: [src/MobileRedirection.php:267](/src/MobileRedirection.php#L267)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_mobile_user_agents.md
+++ b/docs/hook/amp_mobile_user_agents.md
@@ -12,7 +12,7 @@ Filters the list of user agents used to determine if the user agent from the cur
 
 ### Source
 
-:link: [src/MobileRedirection.php:298](../../src/MobileRedirection.php#L298)
+:link: [src/MobileRedirection.php:298](/src/MobileRedirection.php#L298)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_mobile_version_switcher_link_text.md
+++ b/docs/hook/amp_mobile_version_switcher_link_text.md
@@ -14,7 +14,7 @@ Use the `amp_is_request()` function to determine whether you are filtering the t
 
 ### Source
 
-:link: [src/MobileRedirection.php:449](../../src/MobileRedirection.php#L449)
+:link: [src/MobileRedirection.php:449](/src/MobileRedirection.php#L449)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_mobile_version_switcher_styles_used.md
+++ b/docs/hook/amp_mobile_version_switcher_styles_used.md
@@ -12,7 +12,7 @@ Filters whether the default mobile version switcher styles are printed.
 
 ### Source
 
-:link: [src/MobileRedirection.php:415](../../src/MobileRedirection.php#L415)
+:link: [src/MobileRedirection.php:415](/src/MobileRedirection.php#L415)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_normalized_dimension_extractor_image_url.md
+++ b/docs/hook/amp_normalized_dimension_extractor_image_url.md
@@ -13,7 +13,7 @@ Apply filters on the normalized image URL for dimension extraction.
 
 ### Source
 
-:link: [includes/utils/class-amp-image-dimension-extractor.php:132](../../includes/utils/class-amp-image-dimension-extractor.php#L132)
+:link: [includes/utils/class-amp-image-dimension-extractor.php:132](/includes/utils/class-amp-image-dimension-extractor.php#L132)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_optimizer_config.md
+++ b/docs/hook/amp_optimizer_config.md
@@ -10,13 +10,9 @@ Filter the configuration to be used for the AMP Optimizer.
 
 * `array $configuration` - Associative array of configuration data.
 
-### Return value
-
-`array` - Filtered associative array of configuration data.
-
 ### Source
 
-:link: [includes/class-amp-theme-support.php:2304](../../includes/class-amp-theme-support.php#L2304-L2310)
+:link: [includes/class-amp-theme-support.php:2301](/includes/class-amp-theme-support.php#L2301-L2307)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_options_menu_is_enabled.md
+++ b/docs/hook/amp_options_menu_is_enabled.md
@@ -12,7 +12,7 @@ Filter whether to enable the AMP settings.
 
 ### Source
 
-:link: [src/Admin/OptionsMenu.php:78](../../src/Admin/OptionsMenu.php#L78)
+:link: [src/Admin/OptionsMenu.php:78](/src/Admin/OptionsMenu.php#L78)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_parsed_css_transient_caching_allowed.md
+++ b/docs/hook/amp_parsed_css_transient_caching_allowed.md
@@ -14,7 +14,7 @@ When this is filtered to be false, parsed CSS will not be stored in transients. 
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1604](../../includes/amp-helper-functions.php#L1604)
+:link: [includes/amp-helper-functions.php:1604](/includes/amp-helper-functions.php#L1604)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_plugin_update.md
+++ b/docs/hook/amp_plugin_update.md
@@ -12,7 +12,7 @@ Triggers when after amp_init when the plugin version has updated.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:172](../../includes/amp-helper-functions.php#L172)
+:link: [includes/amp-helper-functions.php:172](/includes/amp-helper-functions.php#L172)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_status_default_enabled.md
+++ b/docs/hook/amp_post_status_default_enabled.md
@@ -13,7 +13,7 @@ Filters whether default AMP status should be enabled or not.
 
 ### Source
 
-:link: [includes/class-amp-post-type-support.php:190](../../includes/class-amp-post-type-support.php#L190)
+:link: [includes/class-amp-post-type-support.php:190](/includes/class-amp-post-type-support.php#L190)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_analytics.md
+++ b/docs/hook/amp_post_template_analytics.md
@@ -15,7 +15,7 @@ This filter allows you to easily insert any amp-analytics tags without needing m
 
 ### Source
 
-:link: [includes/admin/functions.php:159](../../includes/admin/functions.php#L159)
+:link: [includes/admin/functions.php:159](/includes/admin/functions.php#L159)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_customizer_settings.md
+++ b/docs/hook/amp_post_template_customizer_settings.md
@@ -17,7 +17,7 @@ Inject your Customizer settings here to make them accessible via the getter in y
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:401](../../includes/templates/class-amp-post-template.php#L401)
+:link: [includes/templates/class-amp-post-template.php:423](/includes/templates/class-amp-post-template.php#L423)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_data.md
+++ b/docs/hook/amp_post_template_data.md
@@ -13,7 +13,7 @@ Filters AMP template data.
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:160](../../includes/templates/class-amp-post-template.php#L160)
+:link: [includes/templates/class-amp-post-template.php:160](/includes/templates/class-amp-post-template.php#L160)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_dir.md
+++ b/docs/hook/amp_post_template_dir.md
@@ -8,7 +8,7 @@ Filters the Reader template directory.
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:177](../../includes/templates/class-amp-post-template.php#L177)
+:link: [includes/templates/class-amp-post-template.php:177](/includes/templates/class-amp-post-template.php#L177)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_file.md
+++ b/docs/hook/amp_post_template_file.md
@@ -14,7 +14,7 @@ Filters the template file being loaded for a given template type.
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:443](../../includes/templates/class-amp-post-template.php#L443)
+:link: [includes/templates/class-amp-post-template.php:465](/includes/templates/class-amp-post-template.php#L465)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_include_{$template_type}.md
+++ b/docs/hook/amp_post_template_include_{$template_type}.md
@@ -12,7 +12,7 @@ Fires before including a template.
 
 ### Source
 
-:link: [includes/templates/class-amp-post-template.php:457](../../includes/templates/class-amp-post-template.php#L457)
+:link: [includes/templates/class-amp-post-template.php:479](/includes/templates/class-amp-post-template.php#L479)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_post_template_metadata.md
+++ b/docs/hook/amp_post_template_metadata.md
@@ -15,7 +15,7 @@ The &#039;post_template&#039; in the filter name here is due to this filter orig
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1805](../../includes/amp-helper-functions.php#L1805)
+:link: [includes/amp-helper-functions.php:1805](/includes/amp-helper-functions.php#L1805)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_pre_get_permalink.md
+++ b/docs/hook/amp_pre_get_permalink.md
@@ -15,7 +15,7 @@ Returning a non-false value in this filter will cause the `get_permalink()` to g
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:687](../../includes/amp-helper-functions.php#L687)
+:link: [includes/amp-helper-functions.php:687](/includes/amp-helper-functions.php#L687)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_pre_is_mobile.md
+++ b/docs/hook/amp_pre_is_mobile.md
@@ -12,7 +12,7 @@ Filters whether the current request is from a mobile device. This is provided as
 
 ### Source
 
-:link: [src/MobileRedirection.php:207](../../src/MobileRedirection.php#L207)
+:link: [src/MobileRedirection.php:207](/src/MobileRedirection.php#L207)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_print_analytics.md
+++ b/docs/hook/amp_print_analytics.md
@@ -14,7 +14,7 @@ This is useful for printing additional `amp-analytics` tags to the page without 
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1287](../../includes/amp-helper-functions.php#L1287)
+:link: [includes/amp-helper-functions.php:1287](/includes/amp-helper-functions.php#L1287)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_query_var.md
+++ b/docs/hook/amp_query_var.md
@@ -14,7 +14,7 @@ Warning: This filter may become deprecated.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:609](../../includes/amp-helper-functions.php#L609)
+:link: [includes/amp-helper-functions.php:609](/includes/amp-helper-functions.php#L609)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_reader_themes.md
+++ b/docs/hook/amp_reader_themes.md
@@ -12,7 +12,7 @@ Filters supported reader themes.
 
 ### Source
 
-:link: [src/Admin/ReaderThemes.php:119](../../src/Admin/ReaderThemes.php#L119)
+:link: [src/Admin/ReaderThemes.php:119](/src/Admin/ReaderThemes.php#L119)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_schemaorg_metadata.md
+++ b/docs/hook/amp_schemaorg_metadata.md
@@ -14,7 +14,7 @@ Check the the main query for the context for which metadata should be added.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1819](../../includes/amp-helper-functions.php#L1819)
+:link: [includes/amp-helper-functions.php:1819](/includes/amp-helper-functions.php#L1819)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_site_icon_url.md
+++ b/docs/hook/amp_site_icon_url.md
@@ -14,7 +14,7 @@ Previously, this only filtered the Site Icon, as that was the only possible sche
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1732](../../includes/amp-helper-functions.php#L1732)
+:link: [includes/amp-helper-functions.php:1732](/includes/amp-helper-functions.php#L1732)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_skip_post.md
+++ b/docs/hook/amp_skip_post.md
@@ -14,7 +14,7 @@ Filters whether to skip the post from AMP.
 
 ### Source
 
-:link: [includes/class-amp-post-type-support.php:140](../../includes/class-amp-post-type-support.php#L140)
+:link: [includes/class-amp-post-type-support.php:140](/includes/class-amp-post-type-support.php#L140)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_supportable_post_types.md
+++ b/docs/hook/amp_supportable_post_types.md
@@ -14,7 +14,7 @@ By default the list includes those which are public.
 
 ### Source
 
-:link: [includes/class-amp-post-type-support.php:63](../../includes/class-amp-post-type-support.php#L63)
+:link: [includes/class-amp-post-type-support.php:63](/includes/class-amp-post-type-support.php#L63)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_supportable_templates.md
+++ b/docs/hook/amp_supportable_templates.md
@@ -14,7 +14,7 @@ Each array item should have a key that corresponds to a template conditional fun
 
 ### Source
 
-:link: [includes/class-amp-theme-support.php:903](../../includes/class-amp-theme-support.php#L903)
+:link: [includes/class-amp-theme-support.php:903](/includes/class-amp-theme-support.php#L903)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_to_amp_excluded_urls.md
+++ b/docs/hook/amp_to_amp_excluded_urls.md
@@ -14,7 +14,7 @@ This only applies when the amp_to_amp_linking_enabled filter returns true, which
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1534](../../includes/amp-helper-functions.php#L1534)
+:link: [includes/amp-helper-functions.php:1534](/includes/amp-helper-functions.php#L1534)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_to_amp_linking_element_excluded.md
+++ b/docs/hook/amp_to_amp_linking_element_excluded.md
@@ -17,7 +17,7 @@ The element may be either a link (`a` or `area`) or a `form`.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-link-sanitizer.php:182](../../includes/sanitizers/class-amp-link-sanitizer.php#L182)
+:link: [includes/sanitizers/class-amp-link-sanitizer.php:182](/includes/sanitizers/class-amp-link-sanitizer.php#L182)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_to_amp_linking_enabled.md
+++ b/docs/hook/amp_to_amp_linking_enabled.md
@@ -12,7 +12,7 @@ Filters whether AMP-to-AMP linking should be enabled.
 
 ### Source
 
-:link: [includes/amp-helper-functions.php:1468](../../includes/amp-helper-functions.php#L1468-L1471)
+:link: [includes/amp-helper-functions.php:1468](/includes/amp-helper-functions.php#L1468-L1471)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_validation_error.md
+++ b/docs/hook/amp_validation_error.md
@@ -15,7 +15,7 @@ This allows plugins to add amend additional properties which can help with more 
 
 ### Source
 
-:link: [includes/validation/class-amp-validation-manager.php:848](../../includes/validation/class-amp-validation-manager.php#L848)
+:link: [includes/validation/class-amp-validation-manager.php:848](/includes/validation/class-amp-validation-manager.php#L848)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_validation_error_default_sanitized.md
+++ b/docs/hook/amp_validation_error_default_sanitized.md
@@ -15,7 +15,7 @@ This only applies to validation errors that have not been encountered before. To
 
 ### Source
 
-:link: [includes/validation/class-amp-validation-manager.php:339](../../includes/validation/class-amp-validation-manager.php#L339)
+:link: [includes/validation/class-amp-validation-manager.php:339](/includes/validation/class-amp-validation-manager.php#L339)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_validation_error_sanitized.md
+++ b/docs/hook/amp_validation_error_sanitized.md
@@ -16,7 +16,7 @@ Returning true this indicates that the validation error is acceptable and should
 
 ### Source
 
-:link: [includes/validation/class-amp-validation-error-taxonomy.php:511](../../includes/validation/class-amp-validation-error-taxonomy.php#L511)
+:link: [includes/validation/class-amp-validation-error-taxonomy.php:511](/includes/validation/class-amp-validation-error-taxonomy.php#L511)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_validation_error_source_file_editor_url_template.md
+++ b/docs/hook/amp_validation_error_source_file_editor_url_template.md
@@ -17,7 +17,7 @@ Users of IDEs that support opening files in via web protocols can use this filte
 
 ### Source
 
-:link: [includes/validation/class-amp-validation-error-taxonomy.php:2280](../../includes/validation/class-amp-validation-error-taxonomy.php#L2280)
+:link: [includes/validation/class-amp-validation-error-taxonomy.php:2280](/includes/validation/class-amp-validation-error-taxonomy.php#L2280)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/amp_validation_error_source_file_path.md
+++ b/docs/hook/amp_validation_error_source_file_path.md
@@ -15,7 +15,7 @@ This is useful to map the file path from inside of a Docker container or VM to t
 
 ### Source
 
-:link: [includes/validation/class-amp-validation-error-taxonomy.php:2316](../../includes/validation/class-amp-validation-error-taxonomy.php#L2316)
+:link: [includes/validation/class-amp-validation-error-taxonomy.php:2316](/includes/validation/class-amp-validation-error-taxonomy.php#L2316)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/hook/pre_amp_render_post.md
+++ b/docs/hook/pre_amp_render_post.md
@@ -16,7 +16,7 @@ This action is not triggered when &#039;amp&#039; theme support is present. Inst
 
 ### Source
 
-:link: [includes/deprecated.php:174](../../includes/deprecated.php#L174)
+:link: [includes/deprecated.php:174](/includes/deprecated.php#L174)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Embed_Handler/__construct.md
+++ b/docs/method/AMP_Base_Embed_Handler/__construct.md
@@ -12,7 +12,7 @@ Constructor.
 
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:59](../../includes/embeds/class-amp-base-embed-handler.php#L59-L67)
+:link: [includes/embeds/class-amp-base-embed-handler.php:59](/includes/embeds/class-amp-base-embed-handler.php#L59-L67)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Embed_Handler/get_scripts.md
+++ b/docs/method/AMP_Base_Embed_Handler/get_scripts.md
@@ -14,7 +14,7 @@ This is normally no longer needed because the validating sanitizer will automati
 
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:79](../../includes/embeds/class-amp-base-embed-handler.php#L79-L81)
+:link: [includes/embeds/class-amp-base-embed-handler.php:79](/includes/embeds/class-amp-base-embed-handler.php#L79-L81)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Embed_Handler/match_element_attributes.md
+++ b/docs/method/AMP_Base_Embed_Handler/match_element_attributes.md
@@ -18,7 +18,7 @@ Get regex pattern for matching HTML attributes from a given tag name.
 
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:93](../../includes/embeds/class-amp-base-embed-handler.php#L93-L111)
+:link: [includes/embeds/class-amp-base-embed-handler.php:93](/includes/embeds/class-amp-base-embed-handler.php#L93-L111)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Embed_Handler/register_embed.md
+++ b/docs/method/AMP_Base_Embed_Handler/register_embed.md
@@ -8,7 +8,7 @@ Registers embed.
 
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:47](../../includes/embeds/class-amp-base-embed-handler.php#L47)
+:link: [includes/embeds/class-amp-base-embed-handler.php:47](/includes/embeds/class-amp-base-embed-handler.php#L47)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Embed_Handler/unregister_embed.md
+++ b/docs/method/AMP_Base_Embed_Handler/unregister_embed.md
@@ -8,7 +8,7 @@ Unregisters embed.
 
 ### Source
 
-:link: [includes/embeds/class-amp-base-embed-handler.php:52](../../includes/embeds/class-amp-base-embed-handler.php#L52)
+:link: [includes/embeds/class-amp-base-embed-handler.php:52](/includes/embeds/class-amp-base-embed-handler.php#L52)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/__construct.md
+++ b/docs/method/AMP_Base_Sanitizer/__construct.md
@@ -13,7 +13,7 @@ AMP_Base_Sanitizer constructor.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:107](../../includes/sanitizers/class-amp-base-sanitizer.php#L107-L116)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:107](/includes/sanitizers/class-amp-base-sanitizer.php#L107-L116)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/add_buffering_hooks.md
+++ b/docs/method/AMP_Base_Sanitizer/add_buffering_hooks.md
@@ -14,7 +14,7 @@ Add actions and filters before the page is rendered so that the sanitizer can fi
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:132](../../includes/sanitizers/class-amp-base-sanitizer.php#L132)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:132](/includes/sanitizers/class-amp-base-sanitizer.php#L132)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/add_or_append_attribute.md
+++ b/docs/method/AMP_Base_Sanitizer/add_or_append_attribute.md
@@ -17,7 +17,7 @@ Adds key and value to list of attributes, or if the key already exists in the ar
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:378](../../includes/sanitizers/class-amp-base-sanitizer.php#L378-L384)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:378](/includes/sanitizers/class-amp-base-sanitizer.php#L378-L384)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/clean_up_after_attribute_removal.md
+++ b/docs/method/AMP_Base_Sanitizer/clean_up_after_attribute_removal.md
@@ -13,7 +13,7 @@ Cleans up artifacts after the removal of an attribute node.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:642](../../includes/sanitizers/class-amp-base-sanitizer.php#L642-L657)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:642](/includes/sanitizers/class-amp-base-sanitizer.php#L642-L657)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/filter_attachment_layout_attributes.md
+++ b/docs/method/AMP_Base_Sanitizer/filter_attachment_layout_attributes.md
@@ -18,7 +18,7 @@ Set attributes to node&#039;s parent element according to layout.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:708](../../includes/sanitizers/class-amp-base-sanitizer.php#L708-L734)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:708](/includes/sanitizers/class-amp-base-sanitizer.php#L708-L734)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/filter_data_amp_attributes.md
+++ b/docs/method/AMP_Base_Sanitizer/filter_data_amp_attributes.md
@@ -17,7 +17,7 @@ Set AMP attributes.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:690](../../includes/sanitizers/class-amp-base-sanitizer.php#L690-L698)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:690](/includes/sanitizers/class-amp-base-sanitizer.php#L690-L698)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_body_node.md
+++ b/docs/method/AMP_Base_Sanitizer/get_body_node.md
@@ -14,7 +14,7 @@ Get HTML body as DOMElement from Dom\Document received by the constructor.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:213](../../includes/sanitizers/class-amp-base-sanitizer.php#L213-L216)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:213](/includes/sanitizers/class-amp-base-sanitizer.php#L213-L216)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_data_amp_attributes.md
+++ b/docs/method/AMP_Base_Sanitizer/get_data_amp_attributes.md
@@ -16,7 +16,7 @@ Get data-amp-* values from the parent node &#039;figure&#039; added by editor bl
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:665](../../includes/sanitizers/class-amp-base-sanitizer.php#L665-L681)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:665](/includes/sanitizers/class-amp-base-sanitizer.php#L665-L681)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_scripts.md
+++ b/docs/method/AMP_Base_Sanitizer/get_scripts.md
@@ -14,7 +14,7 @@ Array keys are AMP element names and array values are their respective Javascrip
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:170](../../includes/sanitizers/class-amp-base-sanitizer.php#L170-L172)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:170](/includes/sanitizers/class-amp-base-sanitizer.php#L170-L172)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_selector_conversion_mapping.md
+++ b/docs/method/AMP_Base_Sanitizer/get_selector_conversion_mapping.md
@@ -12,7 +12,7 @@ Get mapping of HTML selectors to the AMP component selectors which they may be c
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:139](../../includes/sanitizers/class-amp-base-sanitizer.php#L139-L141)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:139](/includes/sanitizers/class-amp-base-sanitizer.php#L139-L141)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_stylesheets.md
+++ b/docs/method/AMP_Base_Sanitizer/get_stylesheets.md
@@ -12,7 +12,7 @@ Get stylesheets.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:194](../../includes/sanitizers/class-amp-base-sanitizer.php#L194-L204)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:194](/includes/sanitizers/class-amp-base-sanitizer.php#L194-L204)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/get_validate_response_data.md
+++ b/docs/method/AMP_Base_Sanitizer/get_validate_response_data.md
@@ -14,7 +14,7 @@ The array returned is merged with the overall validate response data.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:793](../../includes/sanitizers/class-amp-base-sanitizer.php#L793-L795)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:793](/includes/sanitizers/class-amp-base-sanitizer.php#L793-L795)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/has_dev_mode_exemption.md
+++ b/docs/method/AMP_Base_Sanitizer/has_dev_mode_exemption.md
@@ -18,7 +18,7 @@ Check whether a node is exempt from validation during dev mode.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:436](../../includes/sanitizers/class-amp-base-sanitizer.php#L436-L439)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:436](/includes/sanitizers/class-amp-base-sanitizer.php#L436-L439)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/init.md
+++ b/docs/method/AMP_Base_Sanitizer/init.md
@@ -14,7 +14,7 @@ After the sanitizers are instantiated but before calling sanitize on each of the
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:151](../../includes/sanitizers/class-amp-base-sanitizer.php#L151)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:151](/includes/sanitizers/class-amp-base-sanitizer.php#L151)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/is_document_in_dev_mode.md
+++ b/docs/method/AMP_Base_Sanitizer/is_document_in_dev_mode.md
@@ -14,7 +14,7 @@ Check whether the document of a given node is in dev mode.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:421](../../includes/sanitizers/class-amp-base-sanitizer.php#L421-L424)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:421](/includes/sanitizers/class-amp-base-sanitizer.php#L421-L424)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/is_empty_attribute_value.md
+++ b/docs/method/AMP_Base_Sanitizer/is_empty_attribute_value.md
@@ -16,7 +16,7 @@ Determine if an attribute value is empty.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:261](../../includes/sanitizers/class-amp-base-sanitizer.php#L261-L263)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:261](/includes/sanitizers/class-amp-base-sanitizer.php#L261-L263)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/is_exempt_from_validation.md
+++ b/docs/method/AMP_Base_Sanitizer/is_exempt_from_validation.md
@@ -18,7 +18,7 @@ Check whether a certain node should be exempt from validation.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:449](../../includes/sanitizers/class-amp-base-sanitizer.php#L449-L452)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:449](/includes/sanitizers/class-amp-base-sanitizer.php#L449-L452)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/maybe_enforce_https_src.md
+++ b/docs/method/AMP_Base_Sanitizer/maybe_enforce_https_src.md
@@ -19,7 +19,7 @@ If not required, the implementing class may want to try and force https instead.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:395](../../includes/sanitizers/class-amp-base-sanitizer.php#L395-L410)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:395](/includes/sanitizers/class-amp-base-sanitizer.php#L395-L410)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/parse_style_string.md
+++ b/docs/method/AMP_Base_Sanitizer/parse_style_string.md
@@ -16,7 +16,7 @@ Parse a style string into an associative array of style attributes.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:742](../../includes/sanitizers/class-amp-base-sanitizer.php#L742-L756)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:742](/includes/sanitizers/class-amp-base-sanitizer.php#L742-L756)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/prepare_validation_error.md
+++ b/docs/method/AMP_Base_Sanitizer/prepare_validation_error.md
@@ -17,7 +17,7 @@ Prepare validation error.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:566](../../includes/sanitizers/class-amp-base-sanitizer.php#L566-L632)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:566](/includes/sanitizers/class-amp-base-sanitizer.php#L566-L632)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/reassemble_style_string.md
+++ b/docs/method/AMP_Base_Sanitizer/reassemble_style_string.md
@@ -16,7 +16,7 @@ Reassemble a style string that can be used in a &#039;style&#039; attribute.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:764](../../includes/sanitizers/class-amp-base-sanitizer.php#L764-L783)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:764](/includes/sanitizers/class-amp-base-sanitizer.php#L764-L783)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/remove_invalid_attribute.md
+++ b/docs/method/AMP_Base_Sanitizer/remove_invalid_attribute.md
@@ -21,7 +21,7 @@ Also, calls the mutation callback for it. This tracks all the attributes that we
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:504](../../includes/sanitizers/class-amp-base-sanitizer.php#L504-L532)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:504](/includes/sanitizers/class-amp-base-sanitizer.php#L504-L532)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/remove_invalid_child.md
+++ b/docs/method/AMP_Base_Sanitizer/remove_invalid_child.md
@@ -19,7 +19,7 @@ Also, calls the mutation callback for it. This tracks all the nodes that were re
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:466](../../includes/sanitizers/class-amp-base-sanitizer.php#L466-L488)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:466](/includes/sanitizers/class-amp-base-sanitizer.php#L466-L488)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/sanitize.md
+++ b/docs/method/AMP_Base_Sanitizer/sanitize.md
@@ -8,7 +8,7 @@ Sanitize the HTML contained in the DOMDocument received by the constructor
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:156](../../includes/sanitizers/class-amp-base-sanitizer.php#L156)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:156](/includes/sanitizers/class-amp-base-sanitizer.php#L156)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/sanitize_dimension.md
+++ b/docs/method/AMP_Base_Sanitizer/sanitize_dimension.md
@@ -17,7 +17,7 @@ Sanitizes a CSS dimension specifier while being sensitive to dimension context.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:226](../../includes/sanitizers/class-amp-base-sanitizer.php#L226-L253)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:226](/includes/sanitizers/class-amp-base-sanitizer.php#L226-L253)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/set_layout.md
+++ b/docs/method/AMP_Base_Sanitizer/set_layout.md
@@ -16,7 +16,7 @@ Sets the layout, and possibly the &#039;height&#039; and &#039;width&#039; attri
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:283](../../includes/sanitizers/class-amp-base-sanitizer.php#L283-L357)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:283](/includes/sanitizers/class-amp-base-sanitizer.php#L283-L357)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/method/AMP_Base_Sanitizer/should_sanitize_validation_error.md
+++ b/docs/method/AMP_Base_Sanitizer/should_sanitize_validation_error.md
@@ -17,7 +17,7 @@ Check whether or not sanitization should occur in response to validation error.
 
 ### Source
 
-:link: [includes/sanitizers/class-amp-base-sanitizer.php:543](../../includes/sanitizers/class-amp-base-sanitizer.php#L543-L549)
+:link: [includes/sanitizers/class-amp-base-sanitizer.php:543](/includes/sanitizers/class-amp-base-sanitizer.php#L543-L549)
 
 <details>
 <summary>Show Code</summary>

--- a/docs/src/Model/HasCodeLinks.php
+++ b/docs/src/Model/HasCodeLinks.php
@@ -38,7 +38,7 @@ trait HasCodeLinks {
 	public function get_github_link() {
 		// TODO: Adapt based on which tag to use for documentation.
 		return sprintf(
-			'../../%s%s',
+			'/%s%s',
 			$this->get_file_path(),
 			$this->end_line === $this->line
 				? "#L{$this->line}"


### PR DESCRIPTION
## Summary

This PR updates how the the direct link to the source in the repository is formed. This should fix any broken links that may be found currently within the docs.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
