### PR TITLE
Wizard: Override reader mode selection and re-set page index before reaching done screen

### DIFF
--- a/assets/src/onboarding-wizard/components/navigation-context-provider.js
+++ b/assets/src/onboarding-wizard/components/navigation-context-provider.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useState, useContext, useEffect, useMemo } from '@wordpress/element';
+import { createContext, useState, useContext, useMemo } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -40,6 +40,7 @@ export function NavigationContextProvider( { children, pages } ) {
 	const currentPage = adaptedPages[ activePageIndex ];
 
 	const isLastPage = activePageIndex === adaptedPages.length - 1;
+
 	/**
 	 * Navigates back to the previous page.
 	 */

--- a/assets/src/onboarding-wizard/components/navigation-context-provider.js
+++ b/assets/src/onboarding-wizard/components/navigation-context-provider.js
@@ -25,7 +25,7 @@ export const Navigation = createContext();
 export function NavigationContextProvider( { children, pages } ) {
 	const [ activePageIndex, setActivePageIndex ] = useState( 0 );
 	const [ canGoForward, setCanGoForward ] = useState( true ); // Allow immediately moving forward on first page. @todo This may need to change in 2.1.
-	const { editedOptions, readerModeWasOverridden } = useContext( Options );
+	const { editedOptions } = useContext( Options );
 
 	const { theme_support: themeSupport } = editedOptions;
 
@@ -40,16 +40,6 @@ export function NavigationContextProvider( { children, pages } ) {
 	const currentPage = adaptedPages[ activePageIndex ];
 
 	const isLastPage = activePageIndex === adaptedPages.length - 1;
-
-	useEffect( () => {
-		if ( readerModeWasOverridden && 'done' === currentPage.slug ) {
-			// If reader mode is overridden, the Theme Selection page will be removed, and means `activePageIndex` will
-			// point to the Done page instead of Summary. To overcome this we decrement `activePageIndex` by 1 so that
-			// it points to the Summary page.
-			setActivePageIndex( activePageIndex - 1 );
-		}
-	}, [ currentPage.slug, activePageIndex, adaptedPages, readerModeWasOverridden ] );
-
 	/**
 	 * Navigates back to the previous page.
 	 */
@@ -81,6 +71,7 @@ export function NavigationContextProvider( { children, pages } ) {
 					moveBack,
 					moveForward,
 					pages: adaptedPages,
+					setActivePageIndex,
 					setCanGoForward,
 				}
 			}

--- a/assets/src/onboarding-wizard/components/template-mode-override-context-provider.js
+++ b/assets/src/onboarding-wizard/components/template-mode-override-context-provider.js
@@ -26,7 +26,7 @@ export const TemplateModeOverride = createContext();
  */
 export function TemplateModeOverrideContextProvider( { children } ) {
 	const { editedOptions, originalOptions, updateOptions, readerModeWasOverridden, setReaderModeWasOverridden } = useContext( Options );
-	const { currentPage: { slug: currentPageSlug } } = useContext( Navigation );
+	const { activePageIndex, currentPage: { slug: currentPageSlug }, setActivePageIndex } = useContext( Navigation );
 	const { selectedTheme, currentTheme } = useContext( ReaderThemes );
 	const { developerToolsOption, fetchingUser, originalDeveloperToolsOption } = useContext( User );
 	const [ respondedToDeveloperToolsOptionChange, setRespondedToDeveloperToolsOptionChange ] = useState( false );
@@ -61,10 +61,25 @@ export function TemplateModeOverrideContextProvider( { children } ) {
 	 */
 	useEffect( () => {
 		if ( 'summary' === currentPageSlug && 'reader' === themeSupport && selectedTheme.name === currentTheme.name ) {
-			updateOptions( { theme_support: 'transitional' } );
-			setReaderModeWasOverridden( true );
+			if ( ! readerModeWasOverridden ) {
+				updateOptions( { theme_support: 'transitional' } );
+				setReaderModeWasOverridden( true );
+				setActivePageIndex( activePageIndex - 1 );
+			} else {
+				setReaderModeWasOverridden( false );
+			}
 		}
-	}, [ selectedTheme.name, currentTheme.name, themeSupport, currentPageSlug, updateOptions, setReaderModeWasOverridden ] );
+	}, [
+		activePageIndex,
+		selectedTheme.name,
+		currentTheme.name,
+		themeSupport,
+		currentPageSlug,
+		readerModeWasOverridden,
+		updateOptions,
+		setReaderModeWasOverridden,
+		setActivePageIndex,
+	] );
 
 	/**
 	 * Unset theme support in current session if the user changes their answer on the technical screen.


### PR DESCRIPTION
## Summary

This fixes the bug described in #5351. Users whose reader theme selection had been overridden (due to choosing the reader theme that was also their main theme) were being kicked back a page every time they reached the "Done" screen. We originally implemented this to account for the removal of the "Theme Selection" screen when the mode was automatically switched to "Transitional," requiring the active page index to be reduced by one, but it seems like at some point some bit of logic was misplaced.

Another thing I noticed is that my options were being saved on the Review screen (because the "Done" screen was briefly reached).

I'm not sure how this bug started, but I would guess it's a side effect of something we did on the settings screen.

To fix it, I rearranged things a bit. Now:

1. When we reach the review screen, we check whether the reader mode should be overridden. 
2. If so, we immediately do the override and and re-set the active page index to one lower at the same time that the number of pages is reduced. 

<!-- Please reference the issue this PR addresses. -->
Fixes #5351

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
