### PR TITLE
Ensure amp_is_available() returns false when accessing Database Repair screen

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -409,7 +409,7 @@ function amp_is_available() {
 	global $pagenow, $wp_query;
 
 	// Short-circuit for admin requests or requests to non-frontend pages.
-	if ( is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ], true ) ) {
+	if ( is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/google/site-kit-wp/issues/2003. See AMP [support topic](https://wordpress.org/support/topic/amp-debug-error-notice-amp_is_available-was-called-incorrectly/).

Given this plugin being activate:

```php
<?php
/**
 * Plugin Name: Simulate _doing_it_wrong(amp_is_available) for maint/repair.php screen
 */

add_filter(
	'style_loader_tag',
	function ( $s ) {
		amp_is_available();
		return $s;
	}
);
```

Currently when going to `/wp-admin/maint/repair.php`, a PHP notice is raised for `amp_is_available()` being called incorrectly. This page is like other faux-admin pages (on which `is_admin()` doesn't return `true`. So it needs to be included in the list of such faux-admin pages, alongside `wp-login.php`, `wp-signup.php`, and `wp-activate.php`.

With this PR checked out, no notice is raised.

Note that the `WP_REPAIRING` constant could also be looked for in `amp_is_available()`, but since we're already looking at `$pagenow` I decided against it.

Aside: In all my years of using WordPress, I never before have encountered this Database Repair screen!

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
