### PR TITLE
Ensure get_default_reader_themes returns an array and sets the array as a class attribute, and handle failed themes_api in UI

### DIFF
--- a/assets/src/components/reader-theme-carousel/index.js
+++ b/assets/src/components/reader-theme-carousel/index.js
@@ -20,6 +20,7 @@ import { AMPNotice, NOTICE_TYPE_WARNING } from '../amp-notice';
 import { ThemeCard } from '../theme-card';
 import { Carousel, DEFAULT_MOBILE_BREAKPOINT } from '../carousel';
 import { useWindowWidth } from '../../utils/use-window-width';
+import { ThemesAPIError } from '../themes-api-error';
 
 /**
  * Component for selecting a reader theme.
@@ -36,7 +37,7 @@ export function ReaderThemeCarousel() {
 	 */
 
 	/** @type {Theme[]} themes */
-	const { currentTheme, fetchingThemes, selectedTheme, themes, themesAPIError } = useContext( ReaderThemes );
+	const { currentTheme, fetchingThemes, selectedTheme, themes } = useContext( ReaderThemes );
 	const [ includeUnavailableThemes, setIncludeUnavailableThemes ] = useState( false );
 
 	// Separate available themes (both installed and installable) from those that need to be installed manually.
@@ -165,15 +166,7 @@ export function ReaderThemeCarousel() {
 					</p>
 				</AMPNotice>
 			) }
-			{ themesAPIError && (
-				<AMPNotice type={ NOTICE_TYPE_WARNING }>
-					<p>
-						{
-							__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
-						}
-					</p>
-				</AMPNotice>
-			) }
+			<ThemesAPIError />
 			<div>
 				{
 					hasUnavailableThemes && (

--- a/assets/src/components/reader-theme-carousel/index.js
+++ b/assets/src/components/reader-theme-carousel/index.js
@@ -36,7 +36,7 @@ export function ReaderThemeCarousel() {
 	 */
 
 	/** @type {Theme[]} themes */
-	const { currentTheme, fetchingThemes, selectedTheme, themes } = useContext( ReaderThemes );
+	const { currentTheme, fetchingThemes, selectedTheme, themes, themesAPIError } = useContext( ReaderThemes );
 	const [ includeUnavailableThemes, setIncludeUnavailableThemes ] = useState( false );
 
 	// Separate available themes (both installed and installable) from those that need to be installed manually.
@@ -161,6 +161,15 @@ export function ReaderThemeCarousel() {
 								__( 'Your active theme “%s” is not available as a reader theme. If you wish to use it, Transitional mode may be the best option for you.', 'amp' ),
 								currentTheme.name,
 							)
+						}
+					</p>
+				</AMPNotice>
+			) }
+			{ themesAPIError && (
+				<AMPNotice type={ NOTICE_TYPE_WARNING }>
+					<p>
+						{
+							__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
 						}
 					</p>
 				</AMPNotice>

--- a/assets/src/components/reader-theme-selection/index.js
+++ b/assets/src/components/reader-theme-selection/index.js
@@ -18,12 +18,13 @@ import { Loading } from '../loading';
 import './style.css';
 import { ThemeCard } from '../theme-card';
 import { AMPNotice, NOTICE_TYPE_WARNING } from '../amp-notice';
+import { ThemesAPIError } from '../themes-api-error';
 
 /**
  * Component for selecting a reader theme.
  */
 export function ReaderThemeSelection() {
-	const { currentTheme, fetchingThemes, themes, themesAPIError } = useContext( ReaderThemes );
+	const { currentTheme, fetchingThemes, themes } = useContext( ReaderThemes );
 
 	// Separate available themes (both installed and installable) from those that need to be installed manually.
 	const { availableThemes, unavailableThemes } = useMemo(
@@ -66,15 +67,7 @@ export function ReaderThemeSelection() {
 					</p>
 				</AMPNotice>
 			) }
-			{ themesAPIError && (
-				<AMPNotice type={ NOTICE_TYPE_WARNING }>
-					<p>
-						{
-							__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
-						}
-					</p>
-				</AMPNotice>
-			) }
+			<ThemesAPIError />
 			<div>
 				{ 0 < availableThemes.length && (
 					<ul className="choose-reader-theme__grid">

--- a/assets/src/components/reader-theme-selection/index.js
+++ b/assets/src/components/reader-theme-selection/index.js
@@ -17,7 +17,7 @@ import { ReaderThemes } from '../reader-themes-context-provider';
 import { Loading } from '../loading';
 import './style.css';
 import { ThemeCard } from '../theme-card';
-import { AMPNotice, NOTICE_TYPE_WARNING } from '../amp-notice';
+import { AMPNotice } from '../amp-notice';
 import { ThemesAPIError } from '../themes-api-error';
 
 /**

--- a/assets/src/components/reader-theme-selection/index.js
+++ b/assets/src/components/reader-theme-selection/index.js
@@ -17,13 +17,13 @@ import { ReaderThemes } from '../reader-themes-context-provider';
 import { Loading } from '../loading';
 import './style.css';
 import { ThemeCard } from '../theme-card';
-import { AMPNotice } from '../amp-notice';
+import { AMPNotice, NOTICE_TYPE_WARNING } from '../amp-notice';
 
 /**
  * Component for selecting a reader theme.
  */
 export function ReaderThemeSelection() {
-	const { currentTheme, fetchingThemes, themes } = useContext( ReaderThemes );
+	const { currentTheme, fetchingThemes, themes, themesAPIError } = useContext( ReaderThemes );
 
 	// Separate available themes (both installed and installable) from those that need to be installed manually.
 	const { availableThemes, unavailableThemes } = useMemo(
@@ -62,6 +62,15 @@ export function ReaderThemeSelection() {
 								__( 'Your active theme “%s” is not available as a reader theme. If you wish to use it, Transitional mode may be the best option for you.', 'amp' ),
 								currentTheme.name,
 							)
+						}
+					</p>
+				</AMPNotice>
+			) }
+			{ themesAPIError && (
+				<AMPNotice type={ NOTICE_TYPE_WARNING }>
+					<p>
+						{
+							__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
 						}
 					</p>
 				</AMPNotice>

--- a/assets/src/components/reader-themes-context-provider/index.js
+++ b/assets/src/components/reader-themes-context-provider/index.js
@@ -41,6 +41,7 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 	const [ fetchingThemes, setFetchingThemes ] = useState( false );
 	const [ downloadingTheme, setDownloadingTheme ] = useState( false );
 	const [ downloadedTheme, setDownloadedTheme ] = useState( false );
+	const [ themesAPIError, setThemesAPIError ] = useState( null );
 
 	const { editedOptions, originalOptions, updateOptions, savingOptions } = useContext( Options );
 
@@ -178,7 +179,11 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 			setFetchingThemes( true );
 
 			try {
-				const fetchedThemes = await apiFetch( { path: readerThemesRestPath } );
+				const fetchedThemesResponse = await apiFetch( { path: readerThemesRestPath, parse: false } );
+
+				setThemesAPIError( fetchedThemesResponse.headers.get( 'X-AMP-Theme-API-Error' ) );
+
+				const fetchedThemes = await fetchedThemesResponse.json();
 
 				if ( hasUnmounted.current === true ) {
 					return;
@@ -228,6 +233,7 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 					fetchingThemes,
 					themes: filteredThemes,
 					selectedTheme: selectedTheme || {},
+					themesAPIError,
 				}
 			}
 		>

--- a/assets/src/components/themes-api-error/index.js
+++ b/assets/src/components/themes-api-error/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 
 /**

--- a/assets/src/components/themes-api-error/index.js
+++ b/assets/src/components/themes-api-error/index.js
@@ -24,7 +24,7 @@ export function ThemesAPIError() {
 		<AMPNotice type={ NOTICE_TYPE_WARNING }>
 			<p>
 				{
-					__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
+					themesAPIError
 				}
 			</p>
 		</AMPNotice>

--- a/assets/src/components/themes-api-error/index.js
+++ b/assets/src/components/themes-api-error/index.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { AMPNotice, NOTICE_TYPE_WARNING } from '../amp-notice';
+import { ReaderThemes } from '../reader-themes-context-provider';
+
+/**
+ * Notice showing a message when the WordPress.org themes API request has failed on the backend.
+ */
+export function ThemesAPIError() {
+	const { themesAPIError } = useContext( ReaderThemes );
+
+	if ( ! themesAPIError ) {
+		return null;
+	}
+
+	return (
+		<AMPNotice type={ NOTICE_TYPE_WARNING }>
+			<p>
+				{
+					__( 'There was an error fetching the default reader themes from WordPress.org. Please try again later. Contact your hosting provider if the issue persists.', 'amp' )
+				}
+			</p>
+		</AMPNotice>
+	);
+}

--- a/includes/options/class-amp-reader-theme-rest-controller.php
+++ b/includes/options/class-amp-reader-theme-rest-controller.php
@@ -73,7 +73,7 @@ final class AMP_Reader_Theme_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves all AMP plugin options specified in the endpoint schema.
+	 * Retrieves all available reader themes.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Response object.
@@ -81,6 +81,12 @@ final class AMP_Reader_Theme_REST_Controller extends WP_REST_Controller {
 	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$themes = $this->reader_themes->get_themes();
 
-		return rest_ensure_response( $themes );
+		$response = rest_ensure_response( $themes );
+
+		if ( is_wp_error( $this->reader_themes->get_themes_api_error() ) ) {
+			$response->header( 'X-AMP-Theme-API-Error', true );
+		}
+
+		return $response;
 	}
 }

--- a/includes/options/class-amp-reader-theme-rest-controller.php
+++ b/includes/options/class-amp-reader-theme-rest-controller.php
@@ -85,7 +85,7 @@ final class AMP_Reader_Theme_REST_Controller extends WP_REST_Controller {
 
 		$themes_api_error = $this->reader_themes->get_themes_api_error();
 		if ( is_wp_error( $themes_api_error ) ) {
-			$response->header( 'X-AMP-Theme-API-Error', current( $themes_api_error->get_error_messages() ) );
+			$response->header( 'X-AMP-Theme-API-Error', $themes_api_error->get_error_message() );
 		}
 
 		return $response;

--- a/includes/options/class-amp-reader-theme-rest-controller.php
+++ b/includes/options/class-amp-reader-theme-rest-controller.php
@@ -83,8 +83,9 @@ final class AMP_Reader_Theme_REST_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $themes );
 
-		if ( is_wp_error( $this->reader_themes->get_themes_api_error() ) ) {
-			$response->header( 'X-AMP-Theme-API-Error', true );
+		$themes_api_error = $this->reader_themes->get_themes_api_error();
+		if ( is_wp_error( $themes_api_error ) ) {
+			$response->header( 'X-AMP-Theme-API-Error', current( $themes_api_error->get_error_messages() ) );
 		}
 
 		return $response;

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -218,7 +218,12 @@ final class ReaderThemes {
 			 *
 			 * @see https://wordpress.org/support/topic/issue-during-activating-the-updated-plugins/#post-13383737
 			 */
-			if ( is_wp_error( $response ) || ! is_object( $response ) || ! is_array( $response->themes ) ) {
+			if (
+				is_wp_error( $response )
+				|| ! is_object( $response )
+				|| ! property_exists( $response, 'themes' )
+				|| ! is_array( $response->themes )
+			) {
 				$response = (object) [ 'themes' => [] ];
 			} else {
 				// Store the transient only if the response was valid.

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -242,10 +242,17 @@ final class ReaderThemes {
 				|| ! is_array( $response->themes )
 				|| is_wp_error( $response )
 			) {
+				if ( is_wp_error( $response ) ) {
+					$message = $response->get_error_message();
+				} else {
+					$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.', 'amp' );
+				}
+
 				$this->themes_api_error = new WP_Error(
 					'amp_themes_api_invalid_response',
-					__( 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.', 'amp' )
+					$message
 				);
+
 				return [];
 			}
 

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -242,10 +242,9 @@ final class ReaderThemes {
 				|| ! is_array( $response->themes )
 				|| is_wp_error( $response )
 			) {
-				if ( is_wp_error( $response ) ) {
-					$message = $response->get_error_message();
-				} else {
-					$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
+				$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
+				if ( is_wp_error( $response ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) ) {
+					$message .= ' ' . __( 'Error message:', 'amp' ) . ' ' . $response->get_error_message();
 				}
 
 				$this->themes_api_error = new WP_Error(

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -247,18 +247,18 @@ final class ReaderThemes {
 					__( 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.', 'amp' )
 				);
 				return [];
-			} else {
-				if ( empty( $response->themes ) ) {
-					$this->themes_api_error = new WP_Error(
-						'amp_themes_api_invalid_response',
-						__( 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.', 'amp' )
-					);
-					return [];
-				}
-
-				// Store the transient only if the response was valid.
-				set_transient( $cache_key, $response, DAY_IN_SECONDS );
 			}
+
+			if ( empty( $response->themes ) ) {
+				$this->themes_api_error = new WP_Error(
+					'amp_themes_api_invalid_response',
+					__( 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.', 'amp' )
+				);
+				return [];
+			}
+
+			// Store the transient only if the response was valid.
+			set_transient( $cache_key, $response, DAY_IN_SECONDS );
 		}
 
 		$supported_themes = array_diff(

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -237,10 +237,10 @@ final class ReaderThemes {
 			 * @see https://wordpress.org/support/topic/issue-during-activating-the-updated-plugins/#post-13383737
 			 */
 			if (
-				is_wp_error( $response )
-				|| ! is_object( $response )
+				! is_object( $response )
 				|| ! property_exists( $response, 'themes' )
 				|| ! is_array( $response->themes )
+				|| is_wp_error( $response )
 			) {
 				$this->themes_api_error = new WP_Error(
 					'amp_themes_api_invalid_response',

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -249,7 +249,7 @@ final class ReaderThemes {
 				|| ! is_array( $response->themes )
 			) {
 				return new WP_Error(
-					'amp_themes_api_invalid_Response',
+					'amp_themes_api_invalid_response',
 					__( 'The request for reader themes from the WordPress.org themes API resulted in an invalid response.', 'amp' )
 				);
 			} else {

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -243,8 +243,13 @@ final class ReaderThemes {
 				|| is_wp_error( $response )
 			) {
 				$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
-				if ( is_wp_error( $response ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) ) {
-					$message .= ' ' . __( 'Error message:', 'amp' ) . ' ' . $response->get_error_message();
+				if ( is_wp_error( $response ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
+					$message .= ' ' . __( 'Error:', 'amp' );
+					if ( $response->get_error_message() ) {
+						$message .= sprintf( ' %s (%s).', $response->get_error_message(), $response->get_error_code() );
+					} else {
+						$message .= ' ' . $response->get_error_code() . '.';
+					}
 				}
 
 				$this->themes_api_error = new WP_Error(

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -245,7 +245,7 @@ final class ReaderThemes {
 				if ( is_wp_error( $response ) ) {
 					$message = $response->get_error_message();
 				} else {
-					$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.', 'amp' );
+					$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
 				}
 
 				$this->themes_api_error = new WP_Error(

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -259,7 +259,7 @@ final class ReaderThemes {
 			if ( empty( $response->themes ) ) {
 				$this->themes_api_error = new WP_Error(
 					'amp_themes_api_empty_themes_array',
-					__( 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.', 'amp' )
+					__( 'The default reader themes cannot be displayed because a plugin appears to be overriding the themes response from WordPress.org.', 'amp' )
 				);
 				return [];
 			}

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -221,6 +221,7 @@ final class ReaderThemes {
 
 		$cache_key = 'amp_themes_wporg';
 		$response  = get_transient( $cache_key );
+
 		if ( ! $response ) {
 			require_once ABSPATH . 'wp-admin/includes/theme.php';
 
@@ -247,7 +248,10 @@ final class ReaderThemes {
 				|| ! property_exists( $response, 'themes' )
 				|| ! is_array( $response->themes )
 			) {
-				$response = (object) [ 'themes' => [] ];
+				return new WP_Error(
+					'amp_themes_api_invalid_Response',
+					__( 'The request for reader themes from the WordPress.org themes API resulted in an invalid response.', 'amp' )
+				);
 			} else {
 				// Store the transient only if the response was valid.
 				set_transient( $cache_key, $response, DAY_IN_SECONDS );

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -251,7 +251,7 @@ final class ReaderThemes {
 
 			if ( empty( $response->themes ) ) {
 				$this->themes_api_error = new WP_Error(
-					'amp_themes_api_invalid_response',
+					'amp_themes_api_empty_themes_array',
 					__( 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.', 'amp' )
 				);
 				return [];

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -242,7 +242,7 @@ final class ReaderThemes {
 				|| ! is_array( $response->themes )
 				|| is_wp_error( $response )
 			) {
-				$message = __( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
+				$message = __( 'The request for reader themes from WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', 'amp' );
 				if ( is_wp_error( $response ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
 					$message .= ' ' . __( 'Error:', 'amp' );
 					if ( $response->get_error_message() ) {

--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -221,7 +221,7 @@ final class ReaderThemes {
 
 		$cache_key = 'amp_themes_wporg';
 		$response  = get_transient( $cache_key );
-		if ( true || ! $response ) {
+		if ( ! $response ) {
 			require_once ABSPATH . 'wp-admin/includes/theme.php';
 
 			$response = themes_api(

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -13,6 +13,7 @@ use AMP_Theme_Support;
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
 use WP_UnitTestCase;
@@ -28,7 +29,7 @@ use WP_Error;
  */
 class ReaderThemesTest extends WP_UnitTestCase {
 
-	use ThemesApiRequestMocking, LoadsCoreThemes;
+	use AssertContainsCompatibility, ThemesApiRequestMocking, LoadsCoreThemes;
 
 	/**
 	 * Test instance.
@@ -180,10 +181,14 @@ class ReaderThemesTest extends WP_UnitTestCase {
 
 		$error = $this->reader_themes->get_themes_api_error();
 		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
-		$this->assertEquals(
-			'Test message',
+		$this->assertStringStartsWith(
+			'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
 			$error->get_error_message()
 		);
+		if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
+			$this->assertStringContains( 'Test message', $error->get_error_message() );
+			$this->assertStringContains( 'amp_test_error', $error->get_error_message() );
+		}
 	}
 
 	/**

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -133,7 +133,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 		$error = $this->reader_themes->get_themes_api_error();
 		$this->assertWPError( $error );
 		$this->assertEquals(
-			'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
+			'The request for reader themes from WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
 			$error->get_error_message()
 		);
 
@@ -182,7 +182,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 		$error = $this->reader_themes->get_themes_api_error();
 		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
 		$this->assertStringStartsWith(
-			'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
+			'The request for reader themes from WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
 			$error->get_error_message()
 		);
 		if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -110,7 +110,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_themes
 	 * @covers ::get_default_reader_themes
-	 *////
+	 */
 	public function test_themes_api_success() {
 		$this->reader_themes->get_themes();
 

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -128,9 +128,38 @@ class ReaderThemesTest extends WP_UnitTestCase {
 
 		$this->reader_themes->get_themes();
 
-		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
+		$error = $this->reader_themes->get_themes_api_error();
+		$this->assertWPError( $error );
+		$this->assertEquals(
+			'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.',
+			$error->get_error_message()
+		);
 
 		remove_filter( 'themes_api_result', '__return_null' );
+	}
+
+	/**
+	 * Test that a themes API response with an empty themes array results in a WP_Error.
+	 *
+	 * @covers ::get_themes
+	 * @covers ::get_default_reader_themes
+	 */
+	public function test_themes_api_empty_array() {
+		$filter_cb = static function() {
+			return (object) [ 'themes' => [] ];
+		};
+		add_filter( 'themes_api_result', $filter_cb );
+
+		$this->reader_themes->get_themes();
+
+		$error = $this->reader_themes->get_themes_api_error();
+		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
+		$this->assertEquals(
+			'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.',
+			$error->get_error_message()
+		);
+
+		remove_filter( 'themes_api_result', $filter_cb );
 	}
 
 	/**

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -132,7 +132,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 		$error = $this->reader_themes->get_themes_api_error();
 		$this->assertWPError( $error );
 		$this->assertEquals(
-			'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.',
+			'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.',
 			$error->get_error_message()
 		);
 
@@ -156,7 +156,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 		$error = $this->reader_themes->get_themes_api_error();
 		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
 		$this->assertEquals(
-			'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.',
+			'The default reader themes cannot be displayed because a plugin appears to be overriding the themes response from WordPress.org.',
 			$error->get_error_message()
 		);
 	}

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -48,6 +48,7 @@ class ReaderThemesTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Requires WordPress 5.0.' );
 		}
 
+		delete_transient( 'amp_themes_wporg' );
 		$this->add_reader_themes_request_filter();
 
 		switch_theme( 'twentytwenty' );
@@ -102,6 +103,22 @@ class ReaderThemesTest extends WP_UnitTestCase {
 		$this->assertContains( 'child-of-core', $available_theme_slugs );
 		$this->assertNotContains( 'custom', $available_theme_slugs );
 		$this->assertNotContains( 'with-legacy', $available_theme_slugs );
+	}
+
+	/**
+	 * Test that a themes API failure results in a WP_Error.
+	 *
+	 * @covers ::get_themes
+	 * @covers ::get_default_reader_themes
+	 */
+	public function test_themes_api_failure() {
+		add_filter( 'themes_api_result', '__return_null' );
+
+		$this->reader_themes->get_themes();
+
+		$this->assertWPError( $this->reader_themes->get_themes_api_error() );
+
+		remove_filter( 'themes_api_result', '__return_null' );
 	}
 
 	/**

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -106,6 +106,18 @@ class ReaderThemesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that themes API success does not result in a WP_Error.
+	 *
+	 * @covers ::get_themes
+	 * @covers ::get_default_reader_themes
+	 *////
+	public function test_themes_api_success() {
+		$this->reader_themes->get_themes();
+
+		$this->assertNull( $this->reader_themes->get_themes_api_error() );
+	}
+
+	/**
 	 * Test that a themes API failure results in a WP_Error.
 	 *
 	 * @covers ::get_themes

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -118,6 +118,11 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests REST response when themes_api contains an empty themes array.
+	 *
+	 * @covers ::get_items
+	 */
 	public function test_get_items_with_themes_api_empty_array() {
 		$filter_cb = static function() {
 			return (object) [ 'themes' => [] ];

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -13,7 +13,7 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
  *
  * @group reader-themes
  *
- * @coversDefaultClass \AmpProject\AmpWP\Admin\ReaderThemes
+ * @coversDefaultClass AMP_Reader_Theme_REST_Controller
  */
 class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 	/**

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -99,16 +99,21 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests REST response when themes_api fails.
+	 * Test the REST Response headers when themes_api was successful.
 	 *
 	 * @covers ::get_items
 	 */
-	public function test_get_items_with_themes_api_failure() {
+	public function test_get_items_header_with_themes_api_success() {
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$this->assertEquals( [], $response->get_headers() );
+	}
 
-		delete_transient( 'amp_themes_wporg' );
-		$this->controller = new AMP_Reader_Theme_REST_Controller( new ReaderThemes() );
+	/**
+	 * Tests the REST response headers when themes_api fails.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_header_with_themes_api_failure() {
 		add_filter( 'themes_api_result', '__return_null' );
 
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
@@ -119,11 +124,11 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests REST response when themes_api contains an empty themes array.
+	 * Tests the REST response headers when themes_api contains an empty themes array.
 	 *
 	 * @covers ::get_items
 	 */
-	public function test_get_items_with_themes_api_empty_array() {
+	public function test_get_items_header_with_themes_api_empty_array() {
 		$filter_cb = static function() {
 			return (object) [ 'themes' => [] ];
 		};

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -122,7 +122,7 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$this->assertEquals(
-			[ 'X-AMP-Theme-API-Error' => 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.' ],
+			[ 'X-AMP-Theme-API-Error' => 'The request for reader themes from WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.' ],
 			$response->get_headers()
 		);
 	}
@@ -165,7 +165,7 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$headers  = $response->get_headers();
 		$this->assertArrayHasKey( 'X-AMP-Theme-API-Error', $headers );
-		$this->assertStringStartsWith( 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', $headers['X-AMP-Theme-API-Error'] );
+		$this->assertStringStartsWith( 'The request for reader themes from WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.', $headers['X-AMP-Theme-API-Error'] );
 
 		if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
 			$this->assertStringContains( 'Test message', $headers['X-AMP-Theme-API-Error'] );

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -118,7 +118,7 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$this->assertEquals(
-			[ 'X-AMP-Theme-API-Error' => 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.' ],
+			[ 'X-AMP-Theme-API-Error' => 'The request for reader themes from the WordPress.org resulted in an invalid response. Check your Site Health to confirm that your site can communicate with WordPress.org. Otherwise, please try again later or contact your host.' ],
 			$response->get_headers()
 		);
 	}
@@ -136,7 +136,7 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$this->assertEquals(
-			[ 'X-AMP-Theme-API-Error' => 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.' ],
+			[ 'X-AMP-Theme-API-Error' => 'The default reader themes cannot be displayed because a plugin appears to be overriding the themes response from WordPress.org.' ],
 			$response->get_headers()
 		);
 

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -107,6 +107,7 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
 		$this->assertEquals( [], $response->get_headers() );
 
+		delete_transient( 'amp_themes_wporg' );
 		$this->controller = new AMP_Reader_Theme_REST_Controller( new ReaderThemes() );
 		add_filter( 'themes_api_result', '__return_null' );
 

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -141,4 +141,26 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 		);
 
 	}
+
+	/**
+	 * Test that an error is stored in state when themes_api returns an error.
+	 *
+	 * @covers ::get_themes
+	 * @covers ::get_default_reader_themes
+	 */
+	public function test_themes_api_remote_wp_error() {
+		$filter_cb = static function() {
+			return new WP_Error(
+				'amp_test_error',
+				'Test message'
+			);
+		};
+		add_filter( 'themes_api_result', $filter_cb );
+
+		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
+		$this->assertEquals(
+			[ 'X-AMP-Theme-API-Error' => 'Test message' ],
+			$response->get_headers()
+		);
+	}
 }

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -112,6 +112,23 @@ class Test_Reader_Theme_REST_Controller extends WP_UnitTestCase {
 		add_filter( 'themes_api_result', '__return_null' );
 
 		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
-		$this->assertEquals( [ 'X-AMP-Theme-API-Error' => true ], $response->get_headers() );
+		$this->assertEquals(
+			[ 'X-AMP-Theme-API-Error' => 'The request for reader themes from the WordPress.org resulted in an invalid response. Please try again later or contact your host.' ],
+			$response->get_headers()
+		);
+	}
+
+	public function test_get_items_with_themes_api_empty_array() {
+		$filter_cb = static function() {
+			return (object) [ 'themes' => [] ];
+		};
+		add_filter( 'themes_api_result', $filter_cb );
+
+		$response = $this->controller->get_items( new WP_REST_Request( 'GET', 'amp/v1' ) );
+		$this->assertEquals(
+			[ 'X-AMP-Theme-API-Error' => 'The default reader themes cannot be displayed because a plugin is overriding the themes from WordPress.org.' ],
+			$response->get_headers()
+		);
+
 	}
 }


### PR DESCRIPTION
## Summary

As the title describes, this makes a couple of small changes to the `ReaderThemes::get_default_reader_themes` method to ensure it (a) always returns an array regardless of the result of `themes_api` and (b) always sets that array as the `$default_reader_themes` class property. This latter point ensures `get_default_reader_themes` will never fully execute twice for a given instance.

This should solve https://wordpress.org/support/topic/issue-during-activating-the-updated-plugins/#post-13383737 

<!-- Please reference the issue this PR addresses. -->
Fixes #5367

## New addition to PR

I've also handled a failed_api response in the UI. Instead of letting `get_default_reader_themes` silently fail when `themes_api`'s response is invalid, it now returns an error. 

Where `get_default_reader_themes` is called, if the result is an error, that error is added to the `ReaderThemes` object state. When retrieving reader themes, the REST controller then checks for that error, and if there is an error, it sets a header on the response. In the JS app, we check for that header. If the header exists, we display a notice indicating that there is a problem.

### After
Settings screen: 
<img width="1065" alt="Screen Shot 2020-09-16 at 8 29 27 PM" src="https://user-images.githubusercontent.com/9020968/93408983-795be780-f85b-11ea-8028-7a2b29fe6db9.png">

Wizard:
<img width="932" alt="Screen Shot 2020-09-16 at 8 29 44 PM" src="https://user-images.githubusercontent.com/9020968/93408994-7e209b80-f85b-11ea-8bcc-32fdf8f6e3e4.png">


## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
