### PR TITLE
Call error_get_last() prior to calling sanitizers to ensure fatal error is not masked

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1931,6 +1931,7 @@ class AMP_Theme_Support {
 	 */
 	public static function prepare_response( $response, $args = [] ) {
 		global $content_width;
+		$last_error = error_get_last();
 
 		if ( isset( $args['validation_error_callback'] ) ) {
 			_doing_it_wrong( __METHOD__, 'Do not supply validation_error_callback arg.', '1.0' );
@@ -2098,11 +2099,10 @@ class AMP_Theme_Support {
 		if ( AMP_Validation_Manager::$is_validate_request ) {
 			status_header( 200 );
 			header( 'Content-Type: application/json; charset=utf-8' );
-			$data       = [
+			$data = [
 				'http_status_code' => $status_code,
 				'php_fatal_error'  => false,
 			];
-			$last_error = error_get_last();
 			if ( $last_error && in_array( $last_error['type'], [ E_ERROR, E_RECOVERABLE_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_PARSE ], true ) ) {
 				$data['php_fatal_error'] = $last_error;
 			}


### PR DESCRIPTION
## Summary

Given this plugin code:

```php
<?php
add_action( 'wp_footer', function () {
	throw new Exception( 'Bad!' );
} );

add_filter(
	'amp_to_amp_linking_element_excluded',
	function ( $excluded ) {
		trigger_error( 'Not good!' );
		return $excluded;
	}
);
```

I found that the notice being raised during sanitization was overriding the fatal error that was caused during output buffering. This PR fixes that problem by ensuring that `error_get_last()` is called before doing any post-processing to ensure it is captured.

Before | After
-------|-----
<img width="1167" alt="Screen Shot 2020-09-13 at 12 33 25" src="https://user-images.githubusercontent.com/134745/93026829-c15dde80-f5bd-11ea-99bb-ca83ad62d424.png"> | <img width="1167" alt="Screen Shot 2020-09-13 at 12 33 11" src="https://user-images.githubusercontent.com/134745/93026831-c458cf00-f5bd-11ea-9506-c14ceee0f7aa.png">


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
