### PR TITLE
Patch the PHP-CSS-Parser library to correctly validate the `turn` unit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     },
     "patches": {
       "sabberworm/php-css-parser": {
+        "Add additional validation for size unit <https://github.com/sabberworm/PHP-CSS-Parser/pull/193>": "patches/php-css-parser-pull-193.patch",
         "Validate name-start code points for identifier <https://github.com/sabberworm/PHP-CSS-Parser/pull/185>": "patches/php-css-parser-pull-185.patch",
         "Fix parsing CSS selectors which contain commas <https://github.com/westonruter/PHP-CSS-Parser/pull/1>": "patches/php-css-parser-commit-10a2501.patch"
       }

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d46e186da8fa0e68aae4ef50354b998",
+    "content-hash": "d1a85e21f2c175eaef58152407cc6756",
     "packages": [
         {
             "name": "ampproject/common",
-            "version": "dev-develop",
+            "version": "dev-fix/4604-parse-turn-unit",
             "dist": {
                 "type": "path",
                 "url": "lib/common",
-                "reference": "ce447047ea69ea2d06e54ac7607a749511cec51c"
+                "reference": "68d6534c512a0ebcd6b3fed94131d4b1738d929a"
             },
             "require": {
                 "ext-dom": "*",
@@ -24,7 +24,10 @@
             },
             "require-dev": {
                 "civicrm/composer-downloads-plugin": "^2.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
+                "phpcompatibility/phpcompatibility-wp": "2.1.0",
                 "roave/security-advisories": "dev-master",
+                "sirbrillig/phpcs-variable-analysis": "2.8.3",
                 "squizlabs/php_codesniffer": "^3"
             },
             "suggest": {
@@ -32,10 +35,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev",
-                    "dev-develop": "1.0.x-dev"
-                },
                 "downloads": {
                     "phpstan": {
                         "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
@@ -56,10 +55,10 @@
             },
             "scripts": {
                 "cbf": [
-                    "phpcbf --standard=PSR12 -n src tests"
+                    "phpcbf"
                 ],
                 "cs": [
-                    "if [ -z $TEST_SKIP_PHPCS ]; then phpcs --standard=PSR12 -s -n src tests; fi"
+                    "if [ -z $TEST_SKIP_PHPCS ]; then phpcs; fi"
                 ],
                 "lint": [
                     "if [ -z $TEST_SKIP_LINTING ]; then parallel-lint -j 10 --colors --exclude vendor .; fi"
@@ -82,20 +81,19 @@
             ],
             "description": "PHP library with common base functionality for AMP integrations.",
             "transport-options": {
-                "symlink": true,
-                "relative": true
+                "symlink": true
             }
         },
         {
             "name": "ampproject/optimizer",
-            "version": "dev-develop",
+            "version": "dev-fix/4604-parse-turn-unit",
             "dist": {
                 "type": "path",
                 "url": "lib/optimizer",
-                "reference": "f370dec309fc20ff93aaa67a495007e982105065"
+                "reference": "3c1c51d680d561801981294086d13be509327cc4"
             },
             "require": {
-                "ampproject/common": "^1",
+                "ampproject/common": "*",
                 "ext-dom": "*",
                 "ext-iconv": "*",
                 "ext-libxml": "*",
@@ -104,8 +102,11 @@
             },
             "require-dev": {
                 "civicrm/composer-downloads-plugin": "^2.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
                 "ext-zip": "*",
+                "phpcompatibility/phpcompatibility-wp": "2.1.0",
                 "roave/security-advisories": "dev-master",
+                "sirbrillig/phpcs-variable-analysis": "2.8.3",
                 "squizlabs/php_codesniffer": "^3"
             },
             "suggest": {
@@ -113,10 +114,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev",
-                    "dev-develop": "1.0.x-dev"
-                },
                 "downloads": {
                     "phpstan": {
                         "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
@@ -137,10 +134,10 @@
             },
             "scripts": {
                 "cbf": [
-                    "phpcbf --standard=PSR12 -n src tests"
+                    "phpcbf"
                 ],
                 "cs": [
-                    "if [ -z $TEST_SKIP_PHPCS ]; then phpcs --standard=PSR12 -s -n src tests; fi"
+                    "if [ -z $TEST_SKIP_PHPCS ]; then phpcs; fi"
                 ],
                 "lint": [
                     "if [ -z $TEST_SKIP_LINTING ]; then parallel-lint -j 10 --colors --exclude vendor .; fi"
@@ -170,8 +167,7 @@
             ],
             "description": "PHP library for optimizing AMP pages.",
             "transport-options": {
-                "symlink": true,
-                "relative": true
+                "symlink": true
             }
         },
         {
@@ -345,18 +341,19 @@
             },
             "require-dev": {
                 "codacy/coverage": "^1.4",
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.36"
             },
             "type": "library",
             "extra": {
                 "patches_applied": {
+                    "Add additional validation for size unit <https://github.com/sabberworm/PHP-CSS-Parser/pull/193>": "patches/php-css-parser-pull-193.patch",
                     "Validate name-start code points for identifier <https://github.com/sabberworm/PHP-CSS-Parser/pull/185>": "patches/php-css-parser-pull-185.patch",
                     "Fix parsing CSS selectors which contain commas <https://github.com/westonruter/PHP-CSS-Parser/pull/1>": "patches/php-css-parser-commit-10a2501.patch"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Sabberworm\\CSS\\": "lib/"
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "lib/Sabberworm/CSS/"
                 }
             },
             "license": [
@@ -681,16 +678,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.4.2",
+            "version": "v5.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "38b0963698ca5858658a5b09198062411f22932a"
+                "reference": "5b62027b3f3b9de4994da627898599460f054584"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/38b0963698ca5858658a5b09198062411f22932a",
-                "reference": "38b0963698ca5858658a5b09198062411f22932a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5b62027b3f3b9de4994da627898599460f054584",
+                "reference": "5b62027b3f3b9de4994da627898599460f054584",
                 "shasum": ""
             },
             "replace": {
@@ -717,7 +714,7 @@
                 "static analysis",
                 "wordpress"
             ],
-            "time": "2020-06-11T14:56:54+00:00"
+            "time": "2020-09-02T05:31:36+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1035,12 +1032,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9f386dba391018e90a5f1e51abeffc6bf27583db"
+                "reference": "34a7a7aa563809d603e12e34f0608d5f2da94f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9f386dba391018e90a5f1e51abeffc6bf27583db",
-                "reference": "9f386dba391018e90a5f1e51abeffc6bf27583db",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/34a7a7aa563809d603e12e34f0608d5f2da94f7f",
+                "reference": "34a7a7aa563809d603e12e34f0608d5f2da94f7f",
                 "shasum": ""
             },
             "conflict": {
@@ -1056,6 +1053,7 @@
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
+                "baserproject/basercms": ">=4,<=4.3.6",
                 "bolt/bolt": "<3.7.1",
                 "brightlocal/phpwhois": "<=4.2.5",
                 "buddypress/buddypress": "<5.1.2",
@@ -1073,6 +1071,7 @@
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "datadog/dd-trace": ">=0.30,<0.30.2",
                 "david-garcia/phpwhois": "<=4.3.1",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
                 "doctrine/annotations": ">=1,<1.2.7",
                 "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
                 "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
@@ -1094,11 +1093,12 @@
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
                 "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
-                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
                 "ezsystems/ezplatform-kernel": ">=1,<1.0.2.1",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
                 "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.2|>=6,<6.7.9.1|>=6.8,<6.13.6.3|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.7.1",
                 "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.1|>=2011,<2017.12.7.2|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.4.2",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
                 "ezyang/htmlpurifier": "<4.1.1",
                 "firebase/php-jwt": "<2",
@@ -1107,6 +1107,7 @@
                 "friendsofsymfony/oauth2-php": "<1.3",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "fuel/core": "<1.8.1",
                 "getgrav/grav": "<1.7-beta.8",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
@@ -1114,8 +1115,8 @@
                 "gregwar/rst": "<1.0.3",
                 "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
                 "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
-                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30",
-                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29|>=5.5,<=5.5.44|>=6,<6.18.34|>=7,<7.23.2",
                 "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
                 "illuminate/view": ">=7,<7.1.2",
                 "ivankristianto/phpwhois": "<=4.3",
@@ -1123,9 +1124,10 @@
                 "joomla/session": "<1.3.1",
                 "jsmitty12/phpwhois": "<5.1",
                 "kazist/phpwhois": "<=4.2.6",
+                "kitodo/presentation": "<3.1.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
-                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30|>=7,<7.1.2",
+                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.34|>=7,<7.23.2",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "league/commonmark": "<0.18.3",
                 "librenms/librenms": "<1.53",
@@ -1133,14 +1135,20 @@
                 "magento/magento1ce": "<1.9.4.3",
                 "magento/magento1ee": ">=1,<1.14.4.3",
                 "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+                "marcwillmann/turn": "<0.3.3",
+                "mittwald/typo3_forum": "<1.2.1",
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "nystudio107/craft-seomatic": "<3.3",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
-                "october/october": ">=1.0.319,<1.0.467",
+                "october/backend": ">=1.0.319,<1.0.467",
+                "october/cms": ">=1.0.319,<1.0.466",
+                "october/october": ">=1.0.319,<1.0.466",
+                "october/rain": ">=1.0.319,<1.0.468",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<19.4.6|>=20,<20.0.2",
                 "oro/crm": ">=1.7,<1.7.4",
                 "oro/platform": ">=1.7,<1.7.4",
                 "padraic/humbug_get_contents": "<1.1.2",
@@ -1148,6 +1156,7 @@
                 "paragonie/random_compat": "<2",
                 "paypal/merchant-sdk-php": "<3.12",
                 "pear/archive_tar": "<1.4.4",
+                "personnummer/personnummer": "<3.0.2",
                 "phpfastcache/phpfastcache": ">=5,<5.0.13",
                 "phpmailer/phpmailer": "<6.1.6",
                 "phpmussel/phpmussel": ">=1,<1.6",
@@ -1159,6 +1168,7 @@
                 "phpxmlrpc/extras": "<0.6.1",
                 "pimcore/pimcore": "<6.3",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/contactform": ">1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
                 "prestashop/ps_facetedsearch": "<3.4.1",
                 "privatebin/privatebin": "<1.2.2|>=1.3,<1.3.2",
@@ -1197,11 +1207,12 @@
                 "ssddanbrown/bookstack": "<0.29.2",
                 "stormpath/sdk": ">=0,<9.9.99",
                 "studio-42/elfinder": "<2.1.49",
+                "sulu/sulu": "<1.6.34|>=2,<2.0.10|>=2.1,<2.1.1",
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
                 "sylius/grid-bundle": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
-                "sylius/resource-bundle": "<1.3.13|>=1.4,<1.4.6|>=1.5,<1.5.1|>=1.6,<1.6.3",
+                "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
                 "sylius/sylius": "<1.3.16|>=1.4,<1.4.12|>=1.5,<1.5.9|>=1.6,<1.6.5",
                 "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
                 "symbiote/silverstripe-versionedfiles": "<=2.0.3",
@@ -1211,7 +1222,7 @@
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
-                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/mime": ">=4.3,<4.3.8",
                 "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
@@ -1226,7 +1237,7 @@
                 "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
@@ -1240,8 +1251,8 @@
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "twig/twig": "<1.38|>=2,<2.7",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.30|>=9,<9.5.17|>=10,<10.4.2",
-                "typo3/cms-core": ">=8,<8.7.30|>=9,<9.5.17|>=10,<10.4.2",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.30|>=9,<9.5.20|>=10,<10.4.6",
+                "typo3/cms-core": ">=8,<8.7.30|>=9,<9.5.20|>=10,<10.4.6",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
@@ -1252,7 +1263,7 @@
                 "willdurand/js-translation-bundle": "<2.1.1",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
-                "yiisoft/yii2": "<2.0.15",
+                "yiisoft/yii2": "<2.0.38",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<2.0.15",
                 "yiisoft/yii2-elasticsearch": "<2.0.5",
@@ -1314,7 +1325,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-16T05:17:29+00:00"
+            "time": "2020-09-15T19:01:50+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -1366,16 +1377,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -1413,7 +1424,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "togos/gitignore",

--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "ampproject/common",
-            "version": "dev-fix/4604-parse-turn-unit",
+            "version": "dev-develop",
             "dist": {
                 "type": "path",
                 "url": "lib/common",
-                "reference": "68d6534c512a0ebcd6b3fed94131d4b1738d929a"
+                "reference": "9ae4d10f085d41c46ae00ee0c32db2f96165a877"
             },
             "require": {
                 "ext-dom": "*",
@@ -81,16 +81,17 @@
             ],
             "description": "PHP library with common base functionality for AMP integrations.",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {
             "name": "ampproject/optimizer",
-            "version": "dev-fix/4604-parse-turn-unit",
+            "version": "dev-develop",
             "dist": {
                 "type": "path",
                 "url": "lib/optimizer",
-                "reference": "3c1c51d680d561801981294086d13be509327cc4"
+                "reference": "d4658dac3e58a9377314cb340f8cafe3b892d06f"
             },
             "require": {
                 "ampproject/common": "*",
@@ -167,7 +168,8 @@
             ],
             "description": "PHP library for optimizing AMP pages.",
             "transport-options": {
-                "symlink": true
+                "symlink": true,
+                "relative": true
             }
         },
         {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1561,7 +1561,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$parsed         = null;
 		$cache_key      = null;
 		$cached         = true;
-		$cache_group    = 'amp-parsed-stylesheet-v32'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group    = 'amp-parsed-stylesheet-v33'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 		$use_transients = $this->should_use_transient_caching();
 
 		$cache_impacting_options = array_merge(

--- a/patches/php-css-parser-pull-193.patch
+++ b/patches/php-css-parser-pull-193.patch
@@ -1,0 +1,415 @@
+From 2ab643b70569f703b560c9e1bfb4f25498f0dec4 Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Wed, 6 May 2020 15:41:19 -0400
+Subject: [PATCH 1/7] Change turns to turn
+
+---
+ lib/Sabberworm/CSS/Value/Size.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index 8490cc3..05f41ea 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -8,7 +8,7 @@ class Size extends PrimitiveValue {
+
+ 	const ABSOLUTE_SIZE_UNITS = 'px/cm/mm/mozmm/in/pt/pc/vh/vw/vmin/vmax/rem'; //vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
+ 	const RELATIVE_SIZE_UNITS = '%/em/ex/ch/fr';
+-	const NON_SIZE_UNITS = 'deg/grad/rad/s/ms/turns/Hz/kHz';
++	const NON_SIZE_UNITS = 'deg/grad/rad/s/ms/turn/Hz/kHz';
+
+ 	private static $SIZE_UNITS = null;
+
+--
+2.25.1
+
+
+From 1e0d5367444c4b5b62b12ea16737a26657ef4eac Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Mon, 11 May 2020 03:16:27 -0400
+Subject: [PATCH 2/7] Output correct size unit in lenient mode; fail if unit
+ not valid
+
+---
+ lib/Sabberworm/CSS/Value/Size.php   | 15 +++++++++++++--
+ tests/Sabberworm/CSS/ParserTest.php | 18 ++++++++++++++++++
+ 2 files changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index 05f41ea..26ce9aa 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -3,6 +3,7 @@
+ namespace Sabberworm\CSS\Value;
+
+ use Sabberworm\CSS\Parsing\ParserState;
++use Sabberworm\CSS\Parsing\UnexpectedTokenException;
+
+ class Size extends PrimitiveValue {
+
+@@ -38,11 +39,21 @@ class Size extends PrimitiveValue {
+
+ 		$sUnit = null;
+ 		$aSizeUnits = self::getSizeUnits();
+-		foreach($aSizeUnits as $iLength => &$aValues) {
++		$sUnit = strtolower($oParserState->parseIdentifier());
++		$oParserState->backtrack(strlen($sUnit));
++
++		foreach($aSizeUnits as $iLength => $aValues) {
++		    $iConsumeLength = $iLength;
+ 			$sKey = strtolower($oParserState->peek($iLength));
+ 			if(array_key_exists($sKey, $aValues)) {
++			    if ($sUnit !== $sKey) {
++                    if (!$oParserState->getSettings()->bLenientParsing) {
++                        throw new UnexpectedTokenException('Unit', $sUnit, 'identifier', $oParserState->currentLine());
++                    }
++                    $iConsumeLength = strlen($sUnit);
++                }
+ 				if (($sUnit = $aValues[$sKey]) !== null) {
+-					$oParserState->consume($iLength);
++					$oParserState->consume($iConsumeLength);
+ 					break;
+ 				}
+ 			}
+diff --git a/tests/Sabberworm/CSS/ParserTest.php b/tests/Sabberworm/CSS/ParserTest.php
+index 4a69019..e457f99 100644
+--- a/tests/Sabberworm/CSS/ParserTest.php
++++ b/tests/Sabberworm/CSS/ParserTest.php
+@@ -787,4 +787,22 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
+ 		$sExpected = "@import url(\"example.css\") only screen and (max-width: 600px);";
+ 		$this->assertSame($sExpected, $oDoc->render());
+ 	}
++
++    function testTurnUnitLenient() {
++        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
++        $sExpected = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turn);}";
++
++        $oParser = new Parser($sText);
++        $this->assertSame($sExpected, $oParser->parse()->render());
++    }
++
++    function testTurnUnitStrict() {
++        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
++
++        $oParser = new Parser($sText, Settings::create()->beStrict());
++
++        // Line 2 contains the invalid unit and so should be reported.
++        $this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
++        $oParser->parse();
++    }
+ }
+--
+2.25.1
+
+
+From 848e803b64cd1ced0059b83a37605e14732e568a Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Mon, 11 May 2020 11:50:58 -0400
+Subject: [PATCH 3/7] Fix parsing unit
+
+---
+ lib/Sabberworm/CSS/Value/Size.php | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index 26ce9aa..ef12898 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -37,20 +37,36 @@ class Size extends PrimitiveValue {
+ 			}
+ 		}
+
+-		$sUnit = null;
+-		$aSizeUnits = self::getSizeUnits();
+-		$sUnit = strtolower($oParserState->parseIdentifier());
+-		$oParserState->backtrack(strlen($sUnit));
++        $sParsedUnit = '';
++        $iOffset = 0;
++		while (true) {
++		    $sChar = $oParserState->peek(1, $iOffset);
++            $iPeek = ord($sChar);
++
++            // Ranges: a-z A-Z 0-9 %
++            if (($iPeek >= 97 && $iPeek <= 122) ||
++                ($iPeek >= 65 && $iPeek <= 90) ||
++                ($iPeek >= 48 && $iPeek <= 57) ||
++                ($iPeek === 37)) {
++                $sParsedUnit .= $sChar;
++                $iOffset++;
++            } else {
++                break;
++            }
++        }
++
++        $sUnit = null;
++        $aSizeUnits = self::getSizeUnits();
+
+ 		foreach($aSizeUnits as $iLength => $aValues) {
+ 		    $iConsumeLength = $iLength;
+ 			$sKey = strtolower($oParserState->peek($iLength));
+ 			if(array_key_exists($sKey, $aValues)) {
+-			    if ($sUnit !== $sKey) {
++			    if (strtolower($sParsedUnit) !== $sKey) {
+                     if (!$oParserState->getSettings()->bLenientParsing) {
+-                        throw new UnexpectedTokenException('Unit', $sUnit, 'identifier', $oParserState->currentLine());
++                        throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
+                     }
+-                    $iConsumeLength = strlen($sUnit);
++                    $iConsumeLength = strlen($sParsedUnit);
+                 }
+ 				if (($sUnit = $aValues[$sKey]) !== null) {
+ 					$oParserState->consume($iConsumeLength);
+--
+2.25.1
+
+
+From ca2d6e7dc88cca27f3e0192677baddd81f3c1c80 Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Mon, 11 May 2020 15:21:45 -0400
+Subject: [PATCH 4/7] Revert truncation of unit
+
+---
+ lib/Sabberworm/CSS/Value/Size.php   | 50 +++++++++++++----------------
+ tests/Sabberworm/CSS/ParserTest.php | 26 +++++++--------
+ 2 files changed, 36 insertions(+), 40 deletions(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index ef12898..e26a354 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -37,39 +37,35 @@ class Size extends PrimitiveValue {
+ 			}
+ 		}
+
+-        $sParsedUnit = '';
+-        $iOffset = 0;
++		$sParsedUnit = '';
++		$iOffset = 0;
+ 		while (true) {
+-		    $sChar = $oParserState->peek(1, $iOffset);
+-            $iPeek = ord($sChar);
+-
+-            // Ranges: a-z A-Z 0-9 %
+-            if (($iPeek >= 97 && $iPeek <= 122) ||
+-                ($iPeek >= 65 && $iPeek <= 90) ||
+-                ($iPeek >= 48 && $iPeek <= 57) ||
+-                ($iPeek === 37)) {
+-                $sParsedUnit .= $sChar;
+-                $iOffset++;
+-            } else {
+-                break;
+-            }
+-        }
+-
+-        $sUnit = null;
+-        $aSizeUnits = self::getSizeUnits();
++			$sChar = $oParserState->peek(1, $iOffset);
++			$iPeek = ord($sChar);
++
++			// Ranges: a-z A-Z 0-9 %
++			if (($iPeek >= 97 && $iPeek <= 122) ||
++				($iPeek >= 65 && $iPeek <= 90) ||
++				($iPeek >= 48 && $iPeek <= 57) ||
++				($iPeek === 37)) {
++				$sParsedUnit .= $sChar;
++				$iOffset++;
++			} else {
++				break;
++			}
++		}
++
++		$sUnit = null;
++		$aSizeUnits = self::getSizeUnits();
+
+ 		foreach($aSizeUnits as $iLength => $aValues) {
+-		    $iConsumeLength = $iLength;
+ 			$sKey = strtolower($oParserState->peek($iLength));
+ 			if(array_key_exists($sKey, $aValues)) {
+-			    if (strtolower($sParsedUnit) !== $sKey) {
+-                    if (!$oParserState->getSettings()->bLenientParsing) {
+-                        throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
+-                    }
+-                    $iConsumeLength = strlen($sParsedUnit);
+-                }
++				if (strtolower($sParsedUnit) !== $sKey) {
++					throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
++				}
+ 				if (($sUnit = $aValues[$sKey]) !== null) {
+-					$oParserState->consume($iConsumeLength);
++					$oParserState->consume($iLength);
+ 					break;
+ 				}
+ 			}
+diff --git a/tests/Sabberworm/CSS/ParserTest.php b/tests/Sabberworm/CSS/ParserTest.php
+index e457f99..6ef74bb 100644
+--- a/tests/Sabberworm/CSS/ParserTest.php
++++ b/tests/Sabberworm/CSS/ParserTest.php
+@@ -788,21 +788,21 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
+ 		$this->assertSame($sExpected, $oDoc->render());
+ 	}
+
+-    function testTurnUnitLenient() {
+-        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+-        $sExpected = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turn);}";
++	function testTurnUnitLenient() {
++		$sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
++		$sExpected = ".foo {transform: rotate(1turn);}\n.bar {}";
+
+-        $oParser = new Parser($sText);
+-        $this->assertSame($sExpected, $oParser->parse()->render());
+-    }
++		$oParser = new Parser($sText);
++		$this->assertSame($sExpected, $oParser->parse()->render());
++	}
+
+-    function testTurnUnitStrict() {
+-        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
++	function testTurnUnitStrict() {
++		$sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+
+-        $oParser = new Parser($sText, Settings::create()->beStrict());
++		$oParser = new Parser($sText, Settings::create()->beStrict());
+
+-        // Line 2 contains the invalid unit and so should be reported.
+-        $this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
+-        $oParser->parse();
+-    }
++		// Line 2 contains the invalid unit and so should be reported.
++		$this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
++		$oParser->parse();
++	}
+ }
+--
+2.25.1
+
+
+From d35c18f6924b2d26fac666a400ca5018beb61324 Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Mon, 11 May 2020 17:10:41 -0400
+Subject: [PATCH 5/7] Simplify logic for parsing size unit
+
+---
+ lib/Sabberworm/CSS/Value/Size.php | 24 ++++++------------------
+ 1 file changed, 6 insertions(+), 18 deletions(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index e26a354..9cfe890 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -37,27 +37,15 @@ class Size extends PrimitiveValue {
+ 			}
+ 		}
+
+-		$sParsedUnit = '';
+-		$iOffset = 0;
+-		while (true) {
+-			$sChar = $oParserState->peek(1, $iOffset);
+-			$iPeek = ord($sChar);
+-
+-			// Ranges: a-z A-Z 0-9 %
+-			if (($iPeek >= 97 && $iPeek <= 122) ||
+-				($iPeek >= 65 && $iPeek <= 90) ||
+-				($iPeek >= 48 && $iPeek <= 57) ||
+-				($iPeek === 37)) {
+-				$sParsedUnit .= $sChar;
+-				$iOffset++;
+-			} else {
+-				break;
+-			}
+-		}
+-
+ 		$sUnit = null;
++		$sParsedUnit = null;
+ 		$aSizeUnits = self::getSizeUnits();
+
++		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
++		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
++			$sParsedUnit = $matches[0];
++		}
++
+ 		foreach($aSizeUnits as $iLength => $aValues) {
+ 			$sKey = strtolower($oParserState->peek($iLength));
+ 			if(array_key_exists($sKey, $aValues)) {
+--
+2.25.1
+
+
+From b19d79be31b8b71300182f6c10a326386ec65d05 Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <pierregordon@protonmail.com>
+Date: Mon, 11 May 2020 17:53:50 -0400
+Subject: [PATCH 6/7] Refactor size unit parsing logic
+
+---
+ lib/Sabberworm/CSS/Value/Size.php | 23 +++++++++--------------
+ 1 file changed, 9 insertions(+), 14 deletions(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index 9cfe890..26e3eb1 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -38,26 +38,21 @@ class Size extends PrimitiveValue {
+ 		}
+
+ 		$sUnit = null;
+-		$sParsedUnit = null;
+ 		$aSizeUnits = self::getSizeUnits();
+-
+ 		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
++
+ 		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
+-			$sParsedUnit = $matches[0];
+-		}
++			$sUnit = strtolower($matches[0]);
++			$iUnitLength = strlen($sUnit);
+
+-		foreach($aSizeUnits as $iLength => $aValues) {
+-			$sKey = strtolower($oParserState->peek($iLength));
+-			if(array_key_exists($sKey, $aValues)) {
+-				if (strtolower($sParsedUnit) !== $sKey) {
+-					throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
+-				}
+-				if (($sUnit = $aValues[$sKey]) !== null) {
+-					$oParserState->consume($iLength);
+-					break;
+-				}
++			if (isset($aSizeUnits[$iUnitLength][$sUnit])) {
++				$sUnit = $aSizeUnits[$iUnitLength][$sUnit];
++				$oParserState->consume($iUnitLength);
++			} else {
++				throw new UnexpectedTokenException('Unit', $sUnit, 'identifier', $oParserState->currentLine());
+ 			}
+ 		}
++
+ 		return new Size(floatval($sSize), $sUnit, $bIsColorComponent, $oParserState->currentLine());
+ 	}
+
+--
+2.25.1
+
+
+From 9862b6087d0f5c8c8406d8e3033fde5352ad0c90 Mon Sep 17 00:00:00 2001
+From: Pierre Gordon <16200219+pierlon@users.noreply.github.com>
+Date: Mon, 11 May 2020 19:22:45 -0400
+Subject: [PATCH 7/7] Match percent symbol or alphanumeric text
+
+Co-authored-by: Weston Ruter <westonruter@google.com>
+---
+ lib/Sabberworm/CSS/Value/Size.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Sabberworm/CSS/Value/Size.php b/lib/Sabberworm/CSS/Value/Size.php
+index 26e3eb1..cd1a213 100644
+--- a/lib/Sabberworm/CSS/Value/Size.php
++++ b/lib/Sabberworm/CSS/Value/Size.php
+@@ -41,7 +41,7 @@ class Size extends PrimitiveValue {
+ 		$aSizeUnits = self::getSizeUnits();
+ 		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
+
+-		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
++		if ( preg_match( '/^(%|[a-zA-Z0-9]+)/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
+ 			$sUnit = strtolower($matches[0]);
+ 			$iUnitLength = strlen($sUnit);
+
+--
+2.25.1
+

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2107,7 +2107,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'denylisted_and_allowlisted_keyframe_properties' => [
 				'<style amp-keyframes>@keyframes anim1 { 50% { width: 50%; animation-timing-function: ease; opacity: 0.5; height:10%; offset-distance: 50%; visibility: visible; transform: rotate(0.5turn); -webkit-transform: rotate(0.5turn); color:red; } }</style>',
-				'<style amp-keyframes="">@keyframes anim1{50%{animation-timing-function:ease;opacity:.5;offset-distance:50%;visibility:visible;transform:rotate(.5 turn);-webkit-transform:rotate(.5 turn)}}</style>',
+				'<style amp-keyframes="">@keyframes anim1{50%{animation-timing-function:ease;opacity:.5;offset-distance:50%;visibility:visible;transform:rotate(.5turn);-webkit-transform:rotate(.5turn)}}</style>',
 				array_fill( 0, 3, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_PROPERTY ),
 			],
 
@@ -2115,6 +2115,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<style amp-keyframes>body { color:red; opacity:1; } @keyframes anim1 { 50% { opacity:0.5 !important; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); }</style>',
 				'<style amp-keyframes="">@keyframes anim1{50%{opacity:.5}}</style>',
 				[ AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_DECLARATION, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_IMPORTANT, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE ],
+			],
+
+			'style_amp_keyframes_turn_unit' => [
+				'<style amp-keyframes>@keyframes spin{ to { transform: rotate(1turn) } }</style>',
+				'<style amp-keyframes="">@keyframes spin{to{transform:rotate(1turn)}}</style>',
+				[],
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

Applies the changes from sabberworm/PHP-CSS-Parser#193 as a patch to be made to the PHP-CSS-Parser library.

<!-- Please reference the issue this PR addresses. -->
Fixes #4604

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
