### PR TITLE
Guard against infinite recursion error when validating AMP pages using a Reader theme

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -35,4 +35,10 @@ namespace PHPSTORM_META {
 			'validated_url_stylesheet_gc'       => \AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection::class,
 		] )
 	);
+
+	// For the injector, the return type should be the same as what the provided FQCN represents.
+	override(
+		\AmpProject\AmpWP\Infrastructure\Injector::make(),
+		map( [ '' => '@' ] )
+	);
 }

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -71,12 +71,14 @@ class AMP_Template_Customizer {
 	 * @since 0.4
 	 * @access public
 	 *
-	 * @param WP_Customize_Manager $wp_customize Customizer instance.
+	 * @param WP_Customize_Manager $wp_customize        Customizer instance.
+	 * @param ReaderThemeLoader    $reader_theme_loader Reader theme loader.
 	 * @return AMP_Template_Customizer Instance.
 	 */
-	public static function init( WP_Customize_Manager $wp_customize ) {
-		$reader_theme_loader = Services::get( 'reader_theme_loader' );
-
+	public static function init( WP_Customize_Manager $wp_customize, ReaderThemeLoader $reader_theme_loader = null ) {
+		if ( null === $reader_theme_loader ) {
+			$reader_theme_loader = Services::get( 'reader_theme_loader' );
+		}
 		$self = new self( $wp_customize, $reader_theme_loader );
 
 		$is_reader_mode   = ( AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,10 @@ includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 services:
 	-
+		class: AmpProject\AmpWP\Tests\PhpStan\ServiceContainerDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
 		class: AmpProject\AmpWP\Tests\PhpStan\ServicesDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -160,6 +160,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			Instrumentation\StopWatch::class,
 			DevTools\CallbackReflection::class,
 			DevTools\FileReflection::class,
+			ReaderThemeLoader::class,
 		];
 	}
 

--- a/src/DevTools/FileReflection.php
+++ b/src/DevTools/FileReflection.php
@@ -178,9 +178,18 @@ final class FileReflection implements Service, Registerable {
 	 * }
 	 */
 	public function get_file_source( $file ) {
+		static $recursion_protection = false;
+
+		if ( $recursion_protection ) {
+			return [];
+		}
+
+		$recursion_protection = true;
+
 		$matches = [];
 
 		if ( $this->is_parent_theme_file( $file, $matches ) ) {
+			$recursion_protection = false;
 			return $this->get_file_source_array(
 				self::TYPE_THEME,
 				$this->get_template_slug(),
@@ -189,6 +198,7 @@ final class FileReflection implements Service, Registerable {
 		}
 
 		if ( $this->is_child_theme_file( $file, $matches ) ) {
+			$recursion_protection = false;
 			return $this->get_file_source_array(
 				self::TYPE_THEME,
 				$this->get_stylesheet_slug(),
@@ -197,6 +207,7 @@ final class FileReflection implements Service, Registerable {
 		}
 
 		if ( $this->is_plugin_file( $file, $matches ) ) {
+			$recursion_protection = false;
 			return $this->get_file_source_array(
 				self::TYPE_PLUGIN,
 				$matches['slug'],
@@ -205,6 +216,7 @@ final class FileReflection implements Service, Registerable {
 		}
 
 		if ( $this->is_mu_plugin_file( $file, $matches ) ) {
+			$recursion_protection = false;
 			return $this->get_file_source_array(
 				self::TYPE_MU_PLUGIN,
 				$matches['slug'],
@@ -213,6 +225,7 @@ final class FileReflection implements Service, Registerable {
 		}
 
 		if ( $this->is_core_file( $file, $matches ) ) {
+			$recursion_protection = false;
 			return $this->get_file_source_array(
 				self::TYPE_CORE,
 				$matches['slug'],
@@ -220,6 +233,7 @@ final class FileReflection implements Service, Registerable {
 			);
 		}
 
+		$recursion_protection = false;
 		return [];
 	}
 

--- a/src/DevTools/FileReflection.php
+++ b/src/DevTools/FileReflection.php
@@ -244,12 +244,9 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_template_directory() {
 		if ( null === $this->template_directory ) {
-			if ( $this->reader_theme_loader->is_theme_overridden() ) {
-				$template_directory = $this->reader_theme_loader->get_reader_theme()->get_template_directory();
-			} else {
-				$template_directory = get_template_directory();
-			}
-			$this->template_directory = wp_normalize_path( $template_directory );
+			$this->template_directory = wp_normalize_path(
+				get_template_directory()
+			);
 		}
 
 		return $this->template_directory;
@@ -262,11 +259,7 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_template_slug() {
 		if ( null === $this->template_slug ) {
-			if ( $this->reader_theme_loader->is_theme_overridden() ) {
-				$this->template_slug = $this->reader_theme_loader->get_reader_theme()->get_template();
-			} else {
-				$this->template_slug = get_template();
-			}
+			$this->template_slug = get_template();
 		}
 
 		return $this->template_slug;
@@ -279,12 +272,9 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_stylesheet_directory() {
 		if ( null === $this->stylesheet_directory ) {
-			if ( $this->reader_theme_loader->is_theme_overridden() ) {
-				$stylesheet_directory = $this->reader_theme_loader->get_reader_theme()->get_stylesheet_directory();
-			} else {
-				$stylesheet_directory = get_stylesheet_directory();
-			}
-			$this->stylesheet_directory = wp_normalize_path( $stylesheet_directory );
+			$this->stylesheet_directory = wp_normalize_path(
+				get_stylesheet_directory()
+			);
 		}
 
 		return $this->stylesheet_directory;
@@ -297,11 +287,7 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_stylesheet_slug() {
 		if ( null === $this->stylesheet_slug ) {
-			if ( $this->reader_theme_loader->is_theme_overridden() ) {
-				$this->stylesheet_slug = $this->reader_theme_loader->get_reader_theme()->get_stylesheet();
-			} else {
-				$this->stylesheet_slug = get_stylesheet();
-			}
+			$this->stylesheet_slug = get_stylesheet();
 		}
 		return $this->stylesheet_slug;
 	}

--- a/src/DevTools/FileReflection.php
+++ b/src/DevTools/FileReflection.php
@@ -10,7 +10,6 @@ namespace AmpProject\AmpWP\DevTools;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\PluginRegistry;
-use AmpProject\AmpWP\ReaderThemeLoader;
 
 /**
  * Reflect on a file to deduce its type of source (plugin, theme, core).
@@ -44,13 +43,6 @@ final class FileReflection implements Service, Registerable {
 	 * @var PluginRegistry
 	 */
 	private $plugin_registry;
-
-	/**
-	 * Reader theme loader instance to use.
-	 *
-	 * @var ReaderThemeLoader
-	 */
-	private $reader_theme_loader;
 
 	/**
 	 * Plugin file pattern to use.
@@ -136,12 +128,10 @@ final class FileReflection implements Service, Registerable {
 	/**
 	 * FileReflection constructor.
 	 *
-	 * @param PluginRegistry    $plugin_registry     Plugin registry to use.
-	 * @param ReaderThemeLoader $reader_theme_loader Reader theme loader to use.
+	 * @param PluginRegistry $plugin_registry Plugin registry to use.
 	 */
-	public function __construct( PluginRegistry $plugin_registry, ReaderThemeLoader $reader_theme_loader ) {
-		$this->plugin_registry     = $plugin_registry;
-		$this->reader_theme_loader = $reader_theme_loader;
+	public function __construct( PluginRegistry $plugin_registry ) {
+		$this->plugin_registry = $plugin_registry;
 	}
 
 	/**
@@ -289,6 +279,7 @@ final class FileReflection implements Service, Registerable {
 		if ( null === $this->stylesheet_slug ) {
 			$this->stylesheet_slug = get_stylesheet();
 		}
+
 		return $this->stylesheet_slug;
 	}
 

--- a/src/DevTools/FileReflection.php
+++ b/src/DevTools/FileReflection.php
@@ -10,6 +10,7 @@ namespace AmpProject\AmpWP\DevTools;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\PluginRegistry;
+use AmpProject\AmpWP\ReaderThemeLoader;
 
 /**
  * Reflect on a file to deduce its type of source (plugin, theme, core).
@@ -43,6 +44,13 @@ final class FileReflection implements Service, Registerable {
 	 * @var PluginRegistry
 	 */
 	private $plugin_registry;
+
+	/**
+	 * Reader theme loader instance to use.
+	 *
+	 * @var ReaderThemeLoader
+	 */
+	private $reader_theme_loader;
 
 	/**
 	 * Plugin file pattern to use.
@@ -130,8 +138,9 @@ final class FileReflection implements Service, Registerable {
 	 *
 	 * @param PluginRegistry $plugin_registry Plugin registry to use.
 	 */
-	public function __construct( PluginRegistry $plugin_registry ) {
-		$this->plugin_registry = $plugin_registry;
+	public function __construct( PluginRegistry $plugin_registry, ReaderThemeLoader $reader_theme_loader ) {
+		$this->plugin_registry     = $plugin_registry;
+		$this->reader_theme_loader = $reader_theme_loader;
 	}
 
 	/**
@@ -220,9 +229,12 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_template_directory() {
 		if ( null === $this->template_directory ) {
-			$this->template_directory = wp_normalize_path(
-				get_template_directory()
-			);
+			if ( $this->reader_theme_loader->is_theme_overridden() ) {
+				$template_directory = $this->reader_theme_loader->get_reader_theme()->get_template_directory();
+			} else {
+				$template_directory = get_template_directory();
+			}
+			$this->template_directory = wp_normalize_path( $template_directory );
 		}
 
 		return $this->template_directory;
@@ -235,7 +247,11 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_template_slug() {
 		if ( null === $this->template_slug ) {
-			$this->template_slug = get_template();
+			if ( $this->reader_theme_loader->is_theme_overridden() ) {
+				$this->template_slug = $this->reader_theme_loader->get_reader_theme()->get_template();
+			} else {
+				$this->template_slug = get_template();
+			}
 		}
 
 		return $this->template_slug;
@@ -248,9 +264,12 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_stylesheet_directory() {
 		if ( null === $this->stylesheet_directory ) {
-			$this->stylesheet_directory = wp_normalize_path(
-				get_stylesheet_directory()
-			);
+			if ( $this->reader_theme_loader->is_theme_overridden() ) {
+				$stylesheet_directory = $this->reader_theme_loader->get_reader_theme()->get_stylesheet_directory();
+			} else {
+				$stylesheet_directory = get_stylesheet_directory();
+			}
+			$this->stylesheet_directory = wp_normalize_path( $stylesheet_directory );
 		}
 
 		return $this->stylesheet_directory;
@@ -263,9 +282,12 @@ final class FileReflection implements Service, Registerable {
 	 */
 	private function get_stylesheet_slug() {
 		if ( null === $this->stylesheet_slug ) {
-			$this->stylesheet_slug = get_stylesheet();
+			if ( $this->reader_theme_loader->is_theme_overridden() ) {
+				$this->stylesheet_slug = $this->reader_theme_loader->get_reader_theme()->get_stylesheet();
+			} else {
+				$this->stylesheet_slug = get_stylesheet();
+			}
 		}
-
 		return $this->stylesheet_slug;
 	}
 

--- a/src/DevTools/FileReflection.php
+++ b/src/DevTools/FileReflection.php
@@ -136,7 +136,8 @@ final class FileReflection implements Service, Registerable {
 	/**
 	 * FileReflection constructor.
 	 *
-	 * @param PluginRegistry $plugin_registry Plugin registry to use.
+	 * @param PluginRegistry    $plugin_registry     Plugin registry to use.
+	 * @param ReaderThemeLoader $reader_theme_loader Reader theme loader to use.
 	 */
 	public function __construct( PluginRegistry $plugin_registry, ReaderThemeLoader $reader_theme_loader ) {
 		$this->plugin_registry     = $plugin_registry;

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -128,7 +128,12 @@ final class ReaderThemeLoader implements Service, Registerable {
 			return $prepared_themes;
 		}
 
-		$reader_theme = AMP_Options_Manager::get_option( Option::READER_THEME );
+		$reader_theme_obj = $this->get_reader_theme();
+		if ( ! $reader_theme_obj ) {
+			return $prepared_themes;
+		}
+		$reader_theme = $reader_theme_obj->get_stylesheet();
+
 		if ( isset( $prepared_themes[ $reader_theme ] ) ) {
 
 			// Make sure the AMP Reader theme appears right after the active theme in the list.
@@ -181,7 +186,11 @@ final class ReaderThemeLoader implements Service, Registerable {
 			return;
 		}
 
-		$reader_theme = AMP_Options_Manager::get_option( Option::READER_THEME );
+		$reader_theme = $this->get_reader_theme();
+		if ( ! $reader_theme instanceof WP_Theme ) {
+			return;
+		}
+
 		?>
 		<script>
 			(function( themeSingleTmpl ) {
@@ -249,7 +258,7 @@ final class ReaderThemeLoader implements Service, Registerable {
 				}
 			}) (
 				document.getElementById( 'tmpl-theme' ),
-				document.querySelector( <?php echo wp_json_encode( sprintf( '#%s-name > span', $reader_theme ) ); ?> )
+				document.querySelector( <?php echo wp_json_encode( sprintf( '#%s-name > span', $reader_theme->get_stylesheet() ) ); ?> )
 			);
 		</script>
 		<?php
@@ -264,6 +273,10 @@ final class ReaderThemeLoader implements Service, Registerable {
 	 * @return WP_Theme|null Theme if selected and no errors.
 	 */
 	public function get_reader_theme() {
+		if ( $this->reader_theme instanceof WP_Theme ) {
+			return $this->reader_theme;
+		}
+
 		$reader_theme_slug = AMP_Options_Manager::get_option( Option::READER_THEME );
 		if ( ! $reader_theme_slug ) {
 			return null;

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -129,7 +129,7 @@ final class ReaderThemeLoader implements Service, Registerable {
 		}
 
 		$reader_theme_obj = $this->get_reader_theme();
-		if ( ! $reader_theme_obj ) {
+		if ( ! $reader_theme_obj instanceof WP_Theme ) {
 			return $prepared_themes;
 		}
 		$reader_theme = $reader_theme_obj->get_stylesheet();

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -169,7 +169,7 @@ final class ReaderThemeLoader implements Service, Registerable {
 						'a' => [ 'href' => true ],
 					]
 				),
-				esc_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, admin_url( 'admin.php' ) ) )
+				esc_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, admin_url( 'admin.php' ) ) . '#reader-themes' )
 			);
 		}
 

--- a/src/Services.php
+++ b/src/Services.php
@@ -7,6 +7,7 @@
 
 namespace AmpProject\AmpWP;
 
+use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Infrastructure\ServiceContainer;
 
@@ -23,6 +24,27 @@ use AmpProject\AmpWP\Infrastructure\ServiceContainer;
 final class Services {
 
 	/**
+	 * Plugin object instance.
+	 *
+	 * @var AmpWpPlugin
+	 */
+	private static $plugin;
+
+	/**
+	 * Service container object instance.
+	 *
+	 * @var ServiceContainer
+	 */
+	private static $container;
+
+	/**
+	 * Dependency injector object instance.
+	 *
+	 * @var Injector
+	 */
+	private static $injector;
+
+	/**
 	 * Get a particular service out of the service container.
 	 *
 	 * @param string $service Service ID to retrieve.
@@ -33,17 +55,41 @@ final class Services {
 	}
 
 	/**
-	 * Get an instance of the service container.
+	 * Get an instance of the plugin.
 	 *
-	 * @return ServiceContainer
+	 * @return AmpWpPlugin Plugin object instance.
 	 */
-	public static function get_container() {
-		static $container = null;
-
-		if ( null === $container ) {
-			$container = AmpWpPluginFactory::create()->get_container();
+	public static function get_plugin() {
+		if ( null === self::$plugin ) {
+			self::$plugin = AmpWpPluginFactory::create();
 		}
 
-		return $container;
+		return self::$plugin;
+	}
+
+	/**
+	 * Get an instance of the service container.
+	 *
+	 * @return ServiceContainer Service container object instance.
+	 */
+	public static function get_container() {
+		if ( null === self::$container ) {
+			self::$container = self::get_plugin()->get_container();
+		}
+
+		return self::$container;
+	}
+
+	/**
+	 * Get an instance of the dependency injector.
+	 *
+	 * @return Injector Dependency injector object instance.
+	 */
+	public static function get_injector() {
+		if ( null === self::$injector ) {
+			self::$injector = self::get_container()->get( 'injector' );
+		}
+
+		return self::$injector;
 	}
 }

--- a/src/Services.php
+++ b/src/Services.php
@@ -8,6 +8,7 @@
 namespace AmpProject\AmpWP;
 
 use AmpProject\AmpWP\Infrastructure\Injector;
+use AmpProject\AmpWP\Infrastructure\Plugin;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Infrastructure\ServiceContainer;
 
@@ -26,7 +27,7 @@ final class Services {
 	/**
 	 * Plugin object instance.
 	 *
-	 * @var AmpWpPlugin
+	 * @var Plugin
 	 */
 	private static $plugin;
 
@@ -57,7 +58,7 @@ final class Services {
 	/**
 	 * Get an instance of the plugin.
 	 *
-	 * @return AmpWpPlugin Plugin object instance.
+	 * @return Plugin Plugin object instance.
 	 */
 	public static function get_plugin() {
 		if ( null === self::$plugin ) {

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests;
+
+use AmpProject\AmpWP\AmpWpPlugin;
+use AmpProject\AmpWP\Infrastructure\Injector;
+use AmpProject\AmpWP\Infrastructure\ServiceContainer;
+use WP_UnitTestCase;
+
+class DependencyInjectedTestCase extends WP_UnitTestCase {
+
+	/**
+	 * Plugin instance to test with.
+	 *
+	 * @var AmpWpPlugin
+	 */
+	protected $plugin;
+
+	/**
+	 * Service container instance to test with.
+	 *
+	 * @var ServiceContainer
+	 */
+	protected $container;
+
+	/**
+	 * Injector instance to test with.
+	 *
+	 * @var Injector
+	 */
+	protected $injector;
+
+	/**
+	 * Runs the routine before each test is executed.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->plugin = new AmpWpPlugin();
+		$this->plugin->register();
+
+		$this->container = $this->plugin->get_container();
+		$this->injector  = $this->container->get( 'injector' );
+	}
+}

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -5,9 +5,13 @@ namespace AmpProject\AmpWP\Tests;
 use AmpProject\AmpWP\AmpWpPlugin;
 use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\ServiceContainer;
+use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use WP_UnitTestCase;
 
 abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * Plugin instance to test with.
@@ -41,5 +45,11 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 
 		$this->container = $this->plugin->get_container();
 		$this->injector  = $this->container->get( 'injector' );
+
+		// The static Services helper has to be modified to use the same objects
+		// as the ones that are injected into the tests.
+		$this->set_private_property( Services::class, 'plugin', $this->plugin );
+		$this->set_private_property( Services::class, 'container', $this->container );
+		$this->set_private_property( Services::class, 'injector', $this->injector );
 	}
 }

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -7,7 +7,7 @@ use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\ServiceContainer;
 use WP_UnitTestCase;
 
-class DependencyInjectedTestCase extends WP_UnitTestCase {
+abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 
 	/**
 	 * Plugin instance to test with.

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -40,6 +40,8 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		// We're intentionally avoiding the AmpWpPluginFactory here as it uses a
+		// static instance, because its whole point is to allow reuse across consumers.
 		$this->plugin = new AmpWpPlugin();
 		$this->plugin->register();
 

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -35,7 +35,7 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 	protected $injector;
 
 	/**
-	 * Runs the routine before each test is executed.
+	 * Set up the service architecture before each test run.
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -53,5 +53,19 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 		$this->set_private_property( Services::class, 'plugin', $this->plugin );
 		$this->set_private_property( Services::class, 'container', $this->container );
 		$this->set_private_property( Services::class, 'injector', $this->injector );
+	}
+
+	/**
+	 * Clean up again after each test run.
+	 */
+	public function tearDown()
+	{
+		parent::tearDown();
+
+		// The static Services helper has to be modified to use the same objects
+		// as the ones that are injected into the tests.
+		$this->set_private_property( Services::class, 'plugin', null );
+		$this->set_private_property( Services::class, 'container', null );
+		$this->set_private_property( Services::class, 'injector', null );
 	}
 }

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -61,8 +61,6 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		// The static Services helper has to be modified to use the same objects
-		// as the ones that are injected into the tests.
 		$this->set_private_property( Services::class, 'plugin', null );
 		$this->set_private_property( Services::class, 'container', null );
 		$this->set_private_property( Services::class, 'injector', null );

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -58,8 +58,7 @@ abstract class DependencyInjectedTestCase extends WP_UnitTestCase {
 	/**
 	 * Clean up again after each test run.
 	 */
-	public function tearDown()
-	{
+	public function tearDown() {
 		parent::tearDown();
 
 		// The static Services helper has to be modified to use the same objects

--- a/tests/php/src/DevTools/CallbackReflectionTest.php
+++ b/tests/php/src/DevTools/CallbackReflectionTest.php
@@ -10,7 +10,7 @@ namespace AmpProject\AmpWP\Tests\DevTools;
 use AmpProject\AmpWP\DevTools\CallbackReflection;
 use AmpProject\AmpWP\DevTools\FileReflection;
 use AmpProject\AmpWP\PluginRegistry;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\ReaderThemeLoader;
 use ReflectionFunction;
 use ReflectionMethod;
 use WP_UnitTestCase;
@@ -39,8 +39,7 @@ class CallbackReflectionTest extends WP_UnitTestCase {
 
 		$this->register_core_themes();
 
-		$plugin_registry = new PluginRegistry();
-		$file_reflection = new FileReflection( $plugin_registry );
+		$file_reflection = new FileReflection( new PluginRegistry(), new ReaderThemeLoader() );
 		$file_reflection->register();
 		$this->callback_reflection = new CallbackReflection( $file_reflection );
 

--- a/tests/php/src/DevTools/CallbackReflectionTest.php
+++ b/tests/php/src/DevTools/CallbackReflectionTest.php
@@ -9,11 +9,9 @@ namespace AmpProject\AmpWP\Tests\DevTools;
 
 use AmpProject\AmpWP\DevTools\CallbackReflection;
 use AmpProject\AmpWP\DevTools\FileReflection;
-use AmpProject\AmpWP\PluginRegistry;
-use AmpProject\AmpWP\ReaderThemeLoader;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use ReflectionFunction;
 use ReflectionMethod;
-use WP_UnitTestCase;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 
 /**
@@ -23,7 +21,7 @@ use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
  *
  * @coversDefaultClass \AmpProject\AmpWP\DevTools\CallbackReflection
  */
-class CallbackReflectionTest extends WP_UnitTestCase {
+class CallbackReflectionTest extends DependencyInjectedTestCase {
 
 	use LoadsCoreThemes;
 
@@ -39,9 +37,7 @@ class CallbackReflectionTest extends WP_UnitTestCase {
 
 		$this->register_core_themes();
 
-		$file_reflection = new FileReflection( new PluginRegistry(), new ReaderThemeLoader() );
-		$file_reflection->register();
-		$this->callback_reflection = new CallbackReflection( $file_reflection );
+		$this->callback_reflection = $this->injector->make( CallbackReflection::class );
 
 		$theme_root = dirname( dirname( __DIR__ ) ) . '/data/themes';
 		add_filter(

--- a/tests/php/src/DevTools/ErrorPageTest.php
+++ b/tests/php/src/DevTools/ErrorPageTest.php
@@ -2,6 +2,7 @@
 
 namespace AmpProject\AmpWP\Tests\DevTools;
 
+use AmpProject\AmpWP\DevTools\ErrorPage;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use RuntimeException;
@@ -17,7 +18,7 @@ final class ErrorPageTest extends DependencyInjectedTestCase {
 			stream_get_meta_data( $capture )['uri']
 		);
 
-		$output = $this->container->get( 'dev_tools.error_page' )
+		$output = $this->injector->make( ErrorPage::class )
 			->with_title( 'Error Page Title' )
 			->with_message( 'Error Page Message' )
 			->with_exception( new RuntimeException( 'FAILURE', 42 ) )

--- a/tests/php/src/DevTools/ErrorPageTest.php
+++ b/tests/php/src/DevTools/ErrorPageTest.php
@@ -2,12 +2,11 @@
 
 namespace AmpProject\AmpWP\Tests\DevTools;
 
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use RuntimeException;
-use WP_UnitTestCase;
 
-final class ErrorPageTest extends WP_UnitTestCase {
+final class ErrorPageTest extends DependencyInjectedTestCase {
 	use AssertContainsCompatibility;
 
 	public function test_error_page_output() {
@@ -18,7 +17,7 @@ final class ErrorPageTest extends WP_UnitTestCase {
 			stream_get_meta_data( $capture )['uri']
 		);
 
-		$output = Services::get( 'dev_tools.error_page' )
+		$output = $this->container->get( 'dev_tools.error_page' )
 			->with_title( 'Error Page Title' )
 			->with_message( 'Error Page Message' )
 			->with_exception( new RuntimeException( 'FAILURE', 42 ) )

--- a/tests/php/src/DevTools/FileReflectionTest.php
+++ b/tests/php/src/DevTools/FileReflectionTest.php
@@ -8,8 +8,7 @@
 namespace AmpProject\AmpWP\Tests\DevTools;
 
 use AmpProject\AmpWP\DevTools\FileReflection;
-use AmpProject\AmpWP\Services;
-use WP_UnitTestCase;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 
 /**
  * Tests for FileReflection class.
@@ -18,7 +17,7 @@ use WP_UnitTestCase;
  *
  * @coversDefaultClass \AmpProject\AmpWP\DevTools\FileReflection
  */
-class FileReflectionTest extends WP_UnitTestCase {
+class FileReflectionTest extends DependencyInjectedTestCase {
 
 	/**
 	 * Test instance.
@@ -29,7 +28,7 @@ class FileReflectionTest extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->file_reflection = Services::get( 'injector' )->make( FileReflection::class );
+		$this->file_reflection = $this->injector->make( FileReflection::class );
 	}
 
 	/**

--- a/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
+++ b/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
@@ -70,6 +70,7 @@ class LikelyCulpritDetectorTest extends DependencyInjectedTestCase {
 
 		$previous_theme = get_stylesheet();
 		switch_theme( 'custom' );
+		require get_template_directory() . '/functions.php';
 
 		// Refresh internal reflection caches.
 		do_action( 'setup_theme' );

--- a/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
+++ b/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
@@ -47,7 +47,7 @@ class LikelyCulpritDetectorTest extends WP_UnitTestCase {
 	 * @covers ::analyze_backtrace
 	 */
 	public function test_analyze_backtrace() {
-		$source = [];
+		$source = null;
 
 		// We need to provide a way to trigger the culprit detection after the
 		// code has passed through a theme or plugin that is not seen as being
@@ -76,6 +76,8 @@ class LikelyCulpritDetectorTest extends WP_UnitTestCase {
 		do_action( 'setup_theme' );
 
 		do_action( 'trigger_action_to_execute' );
+
+		$this->assertInternalType( 'array', $source, 'Expected the action to be triggered.' );
 
 		$this->assertArrayHasKey( 'type', $source );
 		$this->assertArrayHasKey( 'name', $source );

--- a/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
+++ b/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
@@ -8,10 +8,9 @@
 namespace AmpProject\AmpWP\Tests\DevTools;
 
 use AmpProject\AmpWP\DevTools\LikelyCulpritDetector;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use RuntimeException;
-use WP_UnitTestCase;
 
 /**
  * Tests for LikelyCulpritDetector class.
@@ -20,7 +19,7 @@ use WP_UnitTestCase;
  *
  * @coversDefaultClass \AmpProject\AmpWP\DevTools\LikelyCulpritDetector
  */
-class LikelyCulpritDetectorTest extends WP_UnitTestCase {
+class LikelyCulpritDetectorTest extends DependencyInjectedTestCase {
 
 	use PrivateAccess;
 
@@ -34,7 +33,7 @@ class LikelyCulpritDetectorTest extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->likely_culprit_detector = Services::get( 'injector' )->make( LikelyCulpritDetector::class );
+		$this->likely_culprit_detector = $this->injector->make( LikelyCulpritDetector::class );
 	}
 
 	/**

--- a/tests/php/src/Helpers/PrivateAccess.php
+++ b/tests/php/src/Helpers/PrivateAccess.php
@@ -61,7 +61,10 @@ trait PrivateAccess {
 	private function set_private_property( $object, $property_name, $value ) {
 		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
 		$property->setAccessible( true );
-		$property->setValue( $object, $value );
+
+		// Note: In PHP 8, `ReflectionProperty::getValue()` now requires that an object be supplied if it's a
+		// non-static property.
+		$property->isStatic() ? $property->setValue( $value ) : $property->setValue( $object, $value );
 	}
 
 	/**
@@ -73,26 +76,11 @@ trait PrivateAccess {
 	 * @throws ReflectionException If the object could not be reflected upon.
 	 */
 	private function get_private_property( $object, $property_name ) {
-		$class    = new ReflectionClass( $object );
-		$property = $class->getProperty( $property_name );
-
+		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
 		$property->setAccessible( true );
 
 		// Note: In PHP 8, `ReflectionProperty::getValue()` now requires that an object be supplied if it's a
 		// non-static property.
 		return $property->isStatic() ? $property->getValue() : $property->getValue( $object );
-	}
-
-	/**
-	 * Get a static private property as if it was public.
-	 *
-	 * @param string $class         Class string to get the property of.
-	 * @param string $property_name Name of the property to get.
-	 * @return mixed Return value of the property.
-	 * @throws ReflectionException If the class could not be reflected upon.
-	 */
-	private function get_static_private_property( $class, $property_name ) {
-		$properties = ( new ReflectionClass( $class ) )->getStaticProperties();
-		return array_key_exists( $property_name, $properties ) ? $properties[ $property_name ] : null;
 	}
 }

--- a/tests/php/src/Instrumentation/ServerTimingTest.php
+++ b/tests/php/src/Instrumentation/ServerTimingTest.php
@@ -3,35 +3,18 @@
 namespace AmpProject\AmpWP\Tests\Instrumentation;
 
 use AMP_HTTP;
-use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Instrumentation\Event;
 use AmpProject\AmpWP\Instrumentation\EventWithDuration;
 use AmpProject\AmpWP\Instrumentation\ServerTiming;
 use AmpProject\AmpWP\QueryVar;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use WP_UnitTestCase;
 
-final class ServerTimingTest extends WP_UnitTestCase {
+final class ServerTimingTest extends DependencyInjectedTestCase {
 
 	use AssertContainsCompatibility;
 	use PrivateAccess;
-
-	/**
-	 * Injector instance to use.
-	 *
-	 * @var Injector
-	 */
-	private $injector;
-
-	/**
-	 * Set up the tests.
-	 */
-	public function setUp() {
-		$this->injector = Services::get( 'injector' );
-		parent::setUp();
-	}
 
 	/**
 	 * @covers \AmpProject\AmpWP\Instrumentation\ServerTiming::register()

--- a/tests/php/src/OptionsRESTControllerTest.php
+++ b/tests/php/src/OptionsRESTControllerTest.php
@@ -9,10 +9,9 @@ namespace AmpProject\AmpWP\Tests;
 
 use AMP_Options_Manager;
 use AmpProject\AmpWP\OptionsRESTController;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
 use WP_REST_Request;
-use WP_UnitTestCase;
 
 /**
  * Tests for OptionsRESTController.
@@ -21,7 +20,7 @@ use WP_UnitTestCase;
  *
  * @coversDefaultClass \AmpProject\AmpWP\OptionsRESTController
  */
-class OptionsRESTControllerTest extends WP_UnitTestCase {
+class OptionsRESTControllerTest extends DependencyInjectedTestCase {
 
 	use ThemesApiRequestMocking;
 
@@ -44,8 +43,7 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 
 		$this->add_reader_themes_request_filter();
 
-		$this->controller = Services::get( 'injector' )
-			->make( OptionsRESTController::class );
+		$this->controller = $this->injector->make( OptionsRESTController::class );
 	}
 
 	/**
@@ -89,7 +87,7 @@ class OptionsRESTControllerTest extends WP_UnitTestCase {
 			array_keys( $data )
 		);
 
-		$plugin_registry = Services::get( 'plugin_registry' );
+		$plugin_registry = $this->injector->make( PluginRegistry::class );
 
 		$this->assertEqualSets( array_keys( $plugin_registry->get_plugins( true ) ), array_keys( $data['suppressible_plugins'] ) );
 		$this->assertEquals( null, $data['preview_permalink'] );

--- a/tests/php/src/PhpStan/ServiceContainerDynamicReturnTypeExtension.php
+++ b/tests/php/src/PhpStan/ServiceContainerDynamicReturnTypeExtension.php
@@ -10,8 +10,8 @@ namespace AmpProject\AmpWP\Tests\PhpStan;
 use AmpProject\AmpWP\AmpWpPlugin;
 use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\Service;
-use AmpProject\AmpWP\Services;
-use PhpParser\Node\Expr\StaticCall;
+use AmpProject\AmpWP\Infrastructure\ServiceContainer;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
@@ -19,7 +19,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -31,32 +31,32 @@ use PHPStan\Type\Type;
  * phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations
  * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
  */
-final class ServicesDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension {
+final class ServiceContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension {
 
 	public function getClass(): string {
-		return Services::class;
+		return ServiceContainer::class;
 	}
 
-	public function isStaticMethodSupported(
+	public function isMethodSupported(
 		MethodReflection $methodReflection
 	): bool {
 		return in_array( $methodReflection->getName(), [ 'get' ], true );
 	}
 
-	public function getTypeFromStaticMethodCall(
+	public function getTypeFromMethodCall(
 		MethodReflection $methodReflection,
-		StaticCall $methodCall,
+		MethodCall $methodCall,
 		Scope $scope
 	): Type {
 		switch ( $methodReflection->getName() ) {
 			case 'get':
-				return $this->getGetTypeFromStaticMethodCall(
+				return $this->getGetTypeFromMethodCall(
 					$methodReflection,
 					$methodCall
 				);
 
 			case 'has':
-				return $this->getHasTypeFromStaticMethodCall(
+				return $this->getHasTypeFromMethodCall(
 					$methodReflection,
 					$methodCall
 				);
@@ -65,9 +65,9 @@ final class ServicesDynamicReturnTypeExtension implements DynamicStaticMethodRet
 		throw new ShouldNotHappenException();
 	}
 
-	private function getGetTypeFromStaticMethodCall(
+	private function getGetTypeFromMethodCall(
 		MethodReflection $methodReflection,
-		StaticCall $methodCall
+		MethodCall $methodCall
 	): Type {
 		$return_type = ParametersAcceptorSelector::selectSingle(
 			$methodReflection->getVariants()

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -398,6 +398,8 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	 * @covers AMP_Validated_URL_Post_Type::get_recent_validation_errors_by_source()
 	 */
 	public function test_sanitize_options() {
+		remove_all_filters( 'amp_options_updating' ); // @todo Figure out why this is needed to prevent duplicate PluginSuppression::sanitize_options() callbacks from being added.
+
 		$instance = $this->get_instance();
 		$instance->register();
 

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -2,11 +2,12 @@
 
 namespace AmpProject\AmpWP\Tests;
 
+use AmpProject\AmpWP\DevTools\FileReflection;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\PluginSuppression;
-use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\MockPluginEnvironment;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
@@ -19,10 +20,9 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
 use Exception;
 use WP_Block_Type_Registry;
-use WP_UnitTestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\PluginSuppression */
-final class PluginSuppressionTest extends WP_UnitTestCase {
+final class PluginSuppressionTest extends DependencyInjectedTestCase {
 
 	use PrivateAccess;
 	use AssertContainsCompatibility;
@@ -61,7 +61,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 			3
 		);
 
-		$plugin_suppression = Services::get( 'plugin_suppression' );
+		$plugin_suppression = $this->injector->make( PluginSuppression::class );
 		$plugin_registry    = $this->get_private_property( $plugin_suppression, 'plugin_registry' );
 		$this->set_private_property(
 			$plugin_registry,
@@ -74,7 +74,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 			$plugin_registry
 		);
 		$this->set_private_property(
-			Services::get( 'dev_tools.file_reflection' ),
+			$this->injector->make( FileReflection::class ),
 			'plugin_file_pattern',
 			null
 		);
@@ -97,7 +97,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 			WP_Block_Type_Registry::get_instance()->unregister( 'bad/bad-block' );
 		}
 		$this->reset_widgets();
-		$plugin_suppression = Services::get( 'plugin_suppression' );
+		$plugin_suppression = $this->injector->make( PluginSuppression::class );
 		$plugin_registry    = $this->get_private_property( $plugin_suppression, 'plugin_registry' );
 		$this->set_private_property(
 			$plugin_registry,
@@ -105,7 +105,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 			''
 		);
 		$this->set_private_property(
-			Services::get( 'dev_tools.file_reflection' ),
+			$this->injector->make( FileReflection::class ),
 			'plugin_file_pattern',
 			null
 		);
@@ -180,7 +180,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 */
 	private function get_bad_plugin_file_slugs() {
 		$plugin_file_slugs = array_map(
-			[ Services::get( 'plugin_registry' ), 'get_plugin_slug_from_file' ],
+			[ $this->injector->make( PluginRegistry::class ), 'get_plugin_slug_from_file' ],
 			$this->get_bad_plugin_files()
 		);
 
@@ -192,7 +192,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 	 * @return PluginSuppression
 	 */
 	private function get_instance( $register = false ) {
-		$instance = Services::get( 'plugin_suppression' );
+		$instance = $this->injector->make( PluginSuppression::class );
 		if ( $register ) {
 			$instance->register();
 		}
@@ -462,7 +462,7 @@ final class PluginSuppressionTest extends WP_UnitTestCase {
 			$this->assertEquals( wp_get_current_user()->user_nicename, $suppressed_plugin[ Option::SUPPRESSED_PLUGINS_USERNAME ] );
 			$this->assertArrayHasKey( Option::SUPPRESSED_PLUGINS_ERRORING_URLS, $suppressed_plugin );
 			$this->assertEquals( [ home_url( '/' ) ], $suppressed_plugin[ Option::SUPPRESSED_PLUGINS_ERRORING_URLS ] );
-			$this->assertEquals( Services::get( 'plugin_registry' )->get_plugin_from_slug( $slug )['data']['Version'], $suppressed_plugin[ Option::SUPPRESSED_PLUGINS_LAST_VERSION ] );
+			$this->assertEquals( $this->injector->make( PluginRegistry::class )->get_plugin_from_slug( $slug )['data']['Version'], $suppressed_plugin[ Option::SUPPRESSED_PLUGINS_LAST_VERSION ] );
 		}
 
 		// Stop suppressing only some plugins.

--- a/tests/php/src/ReaderThemeLoaderTest.php
+++ b/tests/php/src/ReaderThemeLoaderTest.php
@@ -5,7 +5,6 @@ namespace AmpProject\AmpWP\Tests;
 use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AmpProject\AmpWP\Admin\ReaderThemes;
-use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Option;
@@ -117,6 +116,15 @@ final class ReaderThemeLoaderTest extends WP_UnitTestCase {
 
 	/** @covers ::inject_theme_single_template_modifications() */
 	public function test_inject_theme_single_template_modifications() {
+		$active_theme_slug = 'twentytwenty';
+		$reader_theme_slug = 'twentynineteen';
+		if ( ! wp_get_theme( $active_theme_slug )->exists() || ! wp_get_theme( $reader_theme_slug )->exists() ) {
+			$this->markTestSkipped();
+		}
+		switch_theme( $active_theme_slug );
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		AMP_Options_Manager::update_option( Option::READER_THEME, $reader_theme_slug );
+
 		$output = get_echo( [ $this->instance, 'inject_theme_single_template_modifications' ] );
 		$this->assertStringContains( '<script>', $output );
 	}

--- a/tests/php/src/ReaderThemeLoaderTest.php
+++ b/tests/php/src/ReaderThemeLoaderTest.php
@@ -14,10 +14,9 @@ use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use WP_Customize_Manager;
 use WP_Customize_Panel;
 use WP_Theme;
-use WP_UnitTestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\ReaderThemeLoader */
-final class ReaderThemeLoaderTest extends WP_UnitTestCase {
+final class ReaderThemeLoaderTest extends DependencyInjectedTestCase {
 
 	use AssertContainsCompatibility, LoadsCoreThemes;
 
@@ -26,7 +25,8 @@ final class ReaderThemeLoaderTest extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->instance = new ReaderThemeLoader();
+		remove_all_filters( 'wp_prepare_themes_for_js' );
+		$this->instance = $this->injector->make( ReaderThemeLoader::class );
 
 		$this->register_core_themes();
 	}
@@ -97,12 +97,17 @@ final class ReaderThemeLoaderTest extends WP_UnitTestCase {
 		switch_theme( $active_theme_slug );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, $reader_theme_slug );
+		$this->assertEquals( $active_theme_slug, get_stylesheet() );
+		$this->assertEquals( $reader_theme_slug, $this->instance->get_reader_theme()->get_stylesheet() );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		$themes = $this->instance->filter_wp_prepare_themes_to_indicate_reader_theme( wp_prepare_themes_for_js() );
+		// Note that this is added via filter and not called directly because the filtered value is keyed by theme slug,
+		// but the return value of wp_prepare_themes_for_js() is keyed with numeric indices.
+		$this->instance->register(); // This adds a `wp_prepare_themes_for_js` filter.
+		$themes = wp_prepare_themes_for_js();
 		$this->assertEquals( $active_theme_slug, $themes[0]['id'] );
 		$this->assertStringNotContains( 'AMP', $themes[0]['description'] );
-		$this->assertArrayHasKey( 'delete', $themes[0]['actions'] );
+		$this->assertArrayHasKey( 'delete', $themes[0]['actions'], 'The delete key is expected even though the theme is active because the delete option is hidden via the JS template.' );
 		$this->assertStringNotContains( amp_get_slug() . '=', $themes[0]['actions']['customize'] );
 		$this->assertArrayNotHasKey( 'ampActiveReaderTheme', $themes[0] );
 		$this->assertArrayNotHasKey( 'ampReaderThemeNotice', $themes[0] );

--- a/tests/php/src/ReaderThemeLoaderTest.php
+++ b/tests/php/src/ReaderThemeLoaderTest.php
@@ -25,7 +25,6 @@ final class ReaderThemeLoaderTest extends DependencyInjectedTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		remove_all_filters( 'wp_prepare_themes_for_js' );
 		$this->instance = $this->injector->make( ReaderThemeLoader::class );
 
 		$this->register_core_themes();

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -266,7 +266,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_modals() {
 		$dom         = new Document();
-		$modal_roles = $this->get_static_private_property( 'AMP_Core_Theme_Sanitizer', 'modal_roles' );
+		$modal_roles = $this->get_private_property( 'AMP_Core_Theme_Sanitizer', 'modal_roles' );
 
 		$a = array_map(
 			static function ( $rule ) use ( $dom ) {

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -8,13 +8,13 @@
 use AmpProject\AmpWP\MobileRedirection;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 
 /**
  * Class AMP_Link_Sanitizer_Test
  */
-class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
+class AMP_Link_Sanitizer_Test extends DependencyInjectedTestCase {
 
 	use AssertContainsCompatibility;
 
@@ -247,7 +247,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test disabling mobile redirection if the URL is excluded.
 	 */
 	public function test_disable_mobile_redirect_for_excluded_url() {
-		$mobile_redirection = Services::get( 'mobile_redirection' );
+		$mobile_redirection = $this->injector->make( MobileRedirection::class );
 
 		AMP_Options_Manager::update_option( Option::MOBILE_REDIRECT, true );
 
@@ -269,7 +269,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test disabling mobile redirection if the link has the `noamphtml` relationship.
 	 */
 	public function test_disable_mobile_redirect_for_url_with_noamphtml_rel() {
-		$mobile_redirection = Services::get( 'mobile_redirection' );
+		$mobile_redirection = $this->injector->make( MobileRedirection::class );
 
 		AMP_Options_Manager::update_option( Option::MOBILE_REDIRECT, true );
 

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -7,7 +7,6 @@
 
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\ReaderThemeLoader;
-use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
@@ -160,7 +159,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentytwenty' );
 
-		$reader_theme_loader = Services::get( 'reader_theme_loader' );
+		$reader_theme_loader = $this->injector->make( ReaderThemeLoader::class );
 
 		$_GET[ amp_get_slug() ] = '1';
 		$reader_theme_loader->override_theme();
@@ -214,7 +213,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentytwenty' );
 
-		$reader_theme_loader = Services::get( 'reader_theme_loader' );
+		$reader_theme_loader = $this->injector->make( ReaderThemeLoader::class );
 
 		$reader_theme_loader->override_theme();
 		$this->assertFalse( $reader_theme_loader->is_theme_overridden() );

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -11,13 +11,14 @@ use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 
 /**
  * Class Test_AMP_Template_Customizer
  *
  * @covers AMP_Template_Customizer
  */
-class Test_AMP_Template_Customizer extends WP_UnitTestCase {
+class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 
 	use AssertContainsCompatibility;
 	use PrivateAccess;
@@ -413,7 +414,7 @@ class Test_AMP_Template_Customizer extends WP_UnitTestCase {
 		);
 
 		// Switch to Reader theme.
-		$reader_theme_loader    = Services::get( 'reader_theme_loader' );
+		$reader_theme_loader    = $this->injector->make( ReaderThemeLoader::class );
 		$_GET[ amp_get_slug() ] = '1';
 		$reader_theme_loader->override_theme();
 		$this->assertTrue( $reader_theme_loader->is_theme_overridden() );
@@ -422,7 +423,7 @@ class Test_AMP_Template_Customizer extends WP_UnitTestCase {
 		// Initialize Customizer.
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$wp_customize = $this->get_customize_manager();
-		$instance     = AMP_Template_Customizer::init( $wp_customize );
+		$instance     = AMP_Template_Customizer::init( $wp_customize, $reader_theme_loader );
 		add_theme_support( 'custom-background' );
 		$wp_customize->register_controls();
 		$wp_customize->nav_menus->customize_register();

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -82,7 +82,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_theme_support( 'custom-header' );
 		$_REQUEST                = []; // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
 		$_SERVER['QUERY_STRING'] = '';
-		unset( $_SERVER['REQUEST_URI'] );
+		$_SERVER['REQUEST_URI']  = '';
 		unset( $_SERVER['REQUEST_METHOD'] );
 		unset( $GLOBALS['content_width'] );
 		if ( isset( $GLOBALS['wp_customize'] ) ) {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -7,9 +7,10 @@
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSameWarning
 
+use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
@@ -23,7 +24,7 @@ use AmpProject\Dom\Document;
  * @covers AMP_Validation_Manager
  * @since 0.7
  */
-class Test_AMP_Validation_Manager extends WP_UnitTestCase {
+class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 	use AssertContainsCompatibility;
 	use HandleValidation;
@@ -490,7 +491,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$editor_user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
 
 		wp_set_current_user( $admin_user_id );
-		$service = Services::get( 'dev_tools.user_access' );
+		$service = $this->injector->make( UserAccess::class );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$_SERVER['REQUEST_METHOD'] = 'POST';
@@ -631,7 +632,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		// Make user preference is honored.
-		$service = Services::get( 'dev_tools.user_access' );
+		$service = $this->injector->make( UserAccess::class );
 		$service->set_user_enabled( wp_get_current_user()->ID, false );
 		$this->assertNull(
 			AMP_Validation_Manager::get_amp_validity_rest_field(
@@ -893,7 +894,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertStringContains( $expected_notice_non_accepted_errors, $output );
 
 		// Ensure not displayed when dev tools is disabled.
-		$service = Services::get( 'dev_tools.user_access' );
+		$service = $this->injector->make( UserAccess::class );
 		$service->set_user_enabled( wp_get_current_user()->ID, false );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertStringNotContains( 'notice notice-warning', $output );
@@ -2533,7 +2534,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertFalse( wp_script_is( $slug, 'enqueued' ) );
 
 		// Ensure not displayed when dev tools is disabled.
-		$service = Services::get( 'dev_tools.user_access' );
+		$service = $this->injector->make( UserAccess::class );
 		$this->set_capability();
 		$service->set_user_enabled( wp_get_current_user()->ID, false );
 		AMP_Validation_Manager::enqueue_block_validation();


### PR DESCRIPTION
## Summary

Fixes #5409

~This PR prevents `FileReflection` from causing infinite recursion when a Reader theme has been loaded. When the theme has been overridden with a Reader theme, the current theme is obtained via `ReaderThemeLoader` as opposed to using global functions that have filters.~

This PR adds recursion prevention to `\AmpProject\AmpWP\DevTools\FileReflection::get_file_source()`. When a Reader theme is loaded (via `ReaderThemeLoader`), hooks are added to override which theme is active. When validating an AMP page with such a Reader theme, applying those filters can cause infinite recursion since the `get_file_source` also needs to apply the same filters to determine where a callback is coming from.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
