### PR TITLE
Restore original `onOpen` callback if not featured image modal

### DIFF
--- a/assets/src/block-editor/components/with-media-library-notice.js
+++ b/assets/src/block-editor/components/with-media-library-notice.js
@@ -43,6 +43,10 @@ export default ( InitialMediaUpload, minImageDimensions ) => {
 			if ( 'editor-post-featured-image__media-modal' === this.props.modalClass ) {
 				this.initFeaturedImage = this.initFeaturedImage.bind( this );
 				this.initFeaturedImage();
+			} else {
+				// Restore the original`onOpen` callback as it will be overridden by the parent class.
+				this.frame.off( 'open', this.onOpen );
+				this.frame.on( 'open', super.onOpen.bind( this ) );
 			}
 		}
 


### PR DESCRIPTION
## Summary

This PR restores the original `onOpen` callback to the media frame if the MediaModal component being overridden is not for the featured image.

## Testing instructions

1. Add a audio (or video) block to a post
2. Select a item from the media library
3. With the block toolbar active, click the "Replace" button and from the dropdown select "Open Media Library"
4. The item previously selected should be pre-selected

And a quick demo:

![](https://user-images.githubusercontent.com/16200219/93756835-42882780-fbf5-11ea-90bf-d3b433817a2f.gif)

<!-- Please reference the issue this PR addresses. -->
Fixes #5379

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
