### PR TITLE
Prevent enabling all post types for AMP when migrating to 2.0 when Reader mode active

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -241,8 +241,8 @@ class AMP_Options_Manager {
 				(array) get_post_types_by_support( AMP_Post_Type_Support::SLUG )
 			);
 
-			// Make sure that all post types get enabled if all templates were supported since they are now independently controlled.
-			if ( ! empty( $options[ Option::ALL_TEMPLATES_SUPPORTED ] ) ) {
+			// Make sure that all post types get enabled if all templates were supported since they are now independently controlled. This only applies to non-Reader mode.
+			if ( ! empty( $options[ Option::ALL_TEMPLATES_SUPPORTED ] ) && AMP_Theme_Support::READER_MODE_SLUG !== $options[ Option::THEME_SUPPORT ] ) {
 				$options[ Option::SUPPORTED_POST_TYPES ] = array_merge(
 					$options[ Option::SUPPORTED_POST_TYPES ],
 					AMP_Post_Type_Support::get_eligible_post_types()

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -394,6 +394,91 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		);
 	}
 
+	/** @return array */
+	public function get_data_for_testing_supported_post_types_options_migration() {
+		return [
+			'reader_with_all_templates'          => [
+				[
+					'theme_support'           => 'reader',
+					'all_templates_supported' => true,
+					'supported_post_types'    => [ 'post' ],
+				],
+				[ 'post', 'book' ],
+			],
+			'reader_without_all_templates'       => [
+				[
+					'theme_support'           => 'reader',
+					'all_templates_supported' => false,
+					'supported_post_types'    => [ 'post' ],
+				],
+				[ 'post', 'book' ],
+			],
+			'transitional__with_all_templates'   => [
+				[
+					'theme_support'           => 'transitional',
+					'all_templates_supported' => true,
+					'supported_post_types'    => [ 'post' ],
+				],
+				[ 'post', 'page', 'book', 'attachment' ],
+			],
+			'transitional_without_all_templates' => [
+				[
+					'theme_support'           => 'transitional',
+					'all_templates_supported' => false,
+					'supported_post_types'    => [ 'post' ],
+				],
+				[ 'post', 'book' ],
+			],
+		];
+	}
+
+	/**
+	 * Test get_options when supported_post_types option is list of post types when upgrading from an old version.
+	 *
+	 * @dataProvider get_data_for_testing_supported_post_types_options_migration
+	 *
+	 * @param array $existing_options              Existing options.
+	 * @param array $expected_supported_post_types Expected supported post types.
+	 * @covers AMP_Options_Manager::get_options()
+	 */
+	public function test_get_options_migration_supported_post_types_from_upgrade( $existing_options, $expected_supported_post_types ) {
+		global $wpdb;
+		foreach ( get_post_types() as $post_type ) {
+			remove_post_type_support( $post_type, 'amp' );
+		}
+
+		register_post_type(
+			'book',
+			[
+				'public'   => true,
+				'supports' => [ 'amp' ],
+			]
+		);
+
+		delete_option( AMP_Options_Manager::OPTION_NAME );
+		$wpdb->insert(
+			$wpdb->options,
+			[
+				'option_name'  => AMP_Options_Manager::OPTION_NAME,
+				'option_value' => serialize( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+					array_merge(
+						[
+							'supported_templates' => [ 'is_singular' ],
+							'version'             => '1.5.5',
+						],
+						$existing_options
+					)
+				),
+			]
+		);
+		wp_cache_flush();
+
+		$this->assertEqualSets(
+			$expected_supported_post_types,
+			array_unique( AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES ) )
+		);
+	}
+
 	/**
 	 * Test get_options when all_templates_supported theme support is used.
 	 *


### PR DESCRIPTION
## Summary

A user reported on the [support forum](https://wordpress.org/support/topic/problems-plugin-amps-an-unwanted-page-google-wont-de-amp-it/):

> I am working on a client’s website that uses this plugin. Only the blog pages were AMPed. However, when the plugin was updated, the client’s main service pages had AMP turned on — and without anyone’s input or approval. […] The client had to turn off the plugin, as AMP was killing conversions on those pages. The simplified layout removed his business phone number — so that would take someone 2 more clicks before someone can call the business and make an inquiry. […] What update would cause unwanted pages to be AMPed involuntarily? Obviously, there is a problem with your plugin.

Indeed, there is a bug in the options migration logic from 1.x to 2.0 in this code:

https://github.com/ampproject/amp-wp/blob/d6a2934d0a3ac0893daba42e59141ef7ff8dd757/includes/options/class-amp-options-manager.php#L244-L250

In particular, the `! empty( $options[ Option::ALL_TEMPLATES_SUPPORTED ] )` check is insufficient. The intention was that this would apply when migrating sites that had ”All Templates Supported“ checked in older versions of the plugin, as previously this would entail that all content types are also enabled. With 2.0, however, the post types can now be individually toggled separately from the templates. Nevertheless, this “All Templates Supported” option is only applicable to non-legacy Reader mode. In spite of that, the `ALL_TEMPLATES_SUPPORTED` option is enabled by default when someone switches from Reader mode to Standard or Transitional. The migration logic is missing that additional check to verify that Reader mode is not active.

Regression introduced in #5053.

## How to test

On the command line, do the following to reset your options to 1.5.5 with only `post` content type enabled and Reader mode active:

```bash
echo '{"theme_support":"reader","supported_post_types":["post"],"analytics":[],"all_templates_supported":true,"supported_templates":["is_singular"],"version":"1.5.5"}' | wp --skip-plugins option set amp-options --format=json
```

Then go to `/wp-admin/admin.php?page=amp-options#supported-templates`.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/93829981-c6f19f00-fc23-11ea-93a6-bb86880cf77f.png) | ![image](https://user-images.githubusercontent.com/134745/93829961-b9d4b000-fc23-11ea-9e65-c8c55b3d4382.png)

Only the Post content type should remain enabled.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
