### PR TITLE
Run phpstan on staged PHP source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,9 @@
     "**/!(amp).php": [
       "npm run lint:php"
     ],
+    "(includes|src)/**/*.php": [
+      "vendor/bin/phpstan analyze --"
+    ],
     "amp.php": [
       "vendor/bin/phpcs --runtime-set testVersion 5.2-"
     ]


### PR DESCRIPTION
## Summary

This PR is a followup from #4441, which runs phpstan on staged PHP files within the `includes` or `src` folders.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
