### PR TITLE
Fix undefined index notice for some layout error titles

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3220,12 +3220,20 @@ class AMP_Validation_Error_Taxonomy {
 			case AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_FIXED_HEIGHT:
 			case AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_AUTO_WIDTH:
 			case AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_HEIGHTS:
-				return sprintf(
-					/* translators: %1$s is the invalid attribute value, %2$s is the attribute name */
-					esc_html__( 'Invalid value %1$s for attribute %2$s', 'amp' ),
-					'<code>' . esc_html( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) . '</code>',
-					'<code>' . esc_html( $validation_error['attribute'] ) . '</code>'
-				);
+				if ( isset( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) ) {
+					return sprintf(
+						/* translators: %1$s is the invalid attribute value, %2$s is the attribute name */
+						esc_html__( 'Invalid value %1$s for attribute %2$s', 'amp' ),
+						'<code>' . esc_html( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) . '</code>',
+						'<code>' . esc_html( $validation_error['attribute'] ) . '</code>'
+					);
+				} else {
+					return sprintf(
+						/* translators: %s is the invalid attribute value */
+						esc_html__( 'Invalid or missing value for attribute %s', 'amp' ),
+						'<code>' . esc_html( $validation_error['attribute'] ) . '</code>'
+					);
+				}
 
 			case AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_UNIT_DIMENSIONS:
 				return esc_html__( 'Inconsistent units for width and height', 'amp' );


### PR DESCRIPTION
## Summary

I was testing the Google Calendar block in Jetpack and there was a validation error, but there was also a PHP notice at the same time:

> <b>Notice</b>:  Undefined index: width in <b>/app/public/content/plugins/amp/includes/validation/class-amp-validation-error-taxonomy.php</b> on line <b>3226</b>

The HTML block being validated indeed lacked a `width`:

```html
<amp-iframe src="https://calendar.google.com/calendar/embed?src=askenergy%40oregon.gov&amp;ctz=America/Los_Angeles" frameborder="0" style="border:0" scrolling="no" height="600" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe>
```

So this needs to not be assumed when we construct the error title. This PR adds the necessary `isset()` check.

Before | After
-------|------
<img width="1205" alt="Screen Shot 2020-09-23 at 16 50 29" src="https://user-images.githubusercontent.com/134745/94085840-0eac2e00-fdbe-11ea-9c7d-ecfe7eb46f7c.png"> | <img width="1206" alt="Screen Shot 2020-09-23 at 16 52 14" src="https://user-images.githubusercontent.com/134745/94085846-14097880-fdbe-11ea-835a-dd587904f922.png">


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
