### PR TITLE
Add 'Mark as un/reviewed' buttons to URL validation bulk actions

### DIFF
--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -381,7 +381,7 @@ const handleBulkActions = () => {
 		} );
 	} );
 
-	// Handle click on bulk "Mark as reviewed" and "Mark as unreviewed" buttons.
+	// Handle click on bulk "Mark reviewed" and "Mark unreviewed" buttons.
 	global.addEventListener( 'click', ( { target } ) => {
 		if ( ! target.classList.contains( 'reviewed-toggle' ) ) {
 			return;

--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -394,6 +394,7 @@ const handleBulkActions = () => {
 			if ( row.querySelector( '.check-column input[type=checkbox]' ).checked ) {
 				row.querySelector( 'input[type=checkbox].amp-validation-error-status-review' ).checked = markingAsReviewed;
 				row.classList.toggle( 'new', ! markingAsReviewed );
+				addBeforeUnloadPrompt();
 			}
 		} );
 	} );

--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -380,6 +380,23 @@ const handleBulkActions = () => {
 			}
 		} );
 	} );
+
+	// Handle click on bulk "Mark as reviewed" and "Mark as unreviewed" buttons.
+	global.addEventListener( 'click', ( { target } ) => {
+		if ( ! target.classList.contains( 'reviewed-toggle' ) ) {
+			return;
+		}
+
+		const markingAsReviewed = target.classList.contains( 'reviewed' );
+
+		[ ...document.querySelectorAll( 'select.amp-validation-error-status' ) ].forEach( ( select ) => {
+			const row = select.closest( 'tr' );
+			if ( row.querySelector( '.check-column input[type=checkbox]' ).checked ) {
+				select.closest( 'tr' ).querySelector( 'input[type=checkbox].amp-validation-error-status-review' ).checked = markingAsReviewed;
+				row.classList.toggle( 'new', ! markingAsReviewed );
+			}
+		} );
+	} );
 };
 
 /**

--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -392,7 +392,7 @@ const handleBulkActions = () => {
 		[ ...document.querySelectorAll( 'select.amp-validation-error-status' ) ].forEach( ( select ) => {
 			const row = select.closest( 'tr' );
 			if ( row.querySelector( '.check-column input[type=checkbox]' ).checked ) {
-				select.closest( 'tr' ).querySelector( 'input[type=checkbox].amp-validation-error-status-review' ).checked = markingAsReviewed;
+				row.querySelector( 'input[type=checkbox].amp-validation-error-status-review' ).checked = markingAsReviewed;
 				row.classList.toggle( 'new', ! markingAsReviewed );
 			}
 		} );

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2794,8 +2794,8 @@ class AMP_Validated_URL_Post_Type {
 		<div id="remove-keep-buttons" class="hidden">
 			<button type="button" class="button action remove"><?php esc_html_e( 'Remove', 'amp' ); ?></button>
 			<button type="button" class="button action keep"><?php esc_html_e( 'Keep', 'amp' ); ?></button>
-			<button type="button" class="button action reviewed-toggle reviewed"><?php esc_html_e( 'Mark as reviewed', 'amp' ); ?></button>
-			<button type="button" class="button action reviewed-toggle unreviewed"><?php esc_html_e( 'Mark as unreviewed', 'amp' ); ?></button>
+			<button type="button" class="button action reviewed-toggle reviewed"><?php esc_html_e( 'Mark reviewed', 'amp' ); ?></button>
+			<button type="button" class="button action reviewed-toggle unreviewed"><?php esc_html_e( 'Mark unreviewed', 'amp' ); ?></button>
 			<div id="vertical-divider"></div>
 		</div>
 		<div id="url-post-filter" class="alignleft actions">

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2794,6 +2794,8 @@ class AMP_Validated_URL_Post_Type {
 		<div id="remove-keep-buttons" class="hidden">
 			<button type="button" class="button action remove"><?php esc_html_e( 'Remove', 'amp' ); ?></button>
 			<button type="button" class="button action keep"><?php esc_html_e( 'Keep', 'amp' ); ?></button>
+			<button type="button" class="button action reviewed-toggle reviewed"><?php esc_html_e( 'Mark as reviewed', 'amp' ); ?></button>
+			<button type="button" class="button action reviewed-toggle unreviewed"><?php esc_html_e( 'Mark as unreviewed', 'amp' ); ?></button>
 			<div id="vertical-divider"></div>
 		</div>
 		<div id="url-post-filter" class="alignleft actions">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
This fixes #5427 by adding two new bulk action buttons to the URL validation screen, one to mark all checked items as reviewed and another to mark all as unreviewed.

Result:

<img width="1215" alt="Screen Shot 2020-09-24 at 9 12 51 PM" src="https://user-images.githubusercontent.com/9020968/94218752-bc950680-feaa-11ea-9446-eb7d2dedf604.png">

Note the two new buttons, "Mark as reviewed" and "Mark as unreviewed" (open to suggestions on the wording). These buttons do as you would expect; the specified action is applied to all the rows whose leftmost column is checked. 

QA steps are on #5427.

I started looking at making the row of buttons more mobile-friendly, but then I noticed the entire screen has issues at narrower widths, so I think we can address that when we revisit these screens more fully.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
