### PR TITLE
Revert "Run phpstan on staged PHP source files" and add pre-commit composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi"
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi",
+    "pre-commit": [
+      "npm run lint:staged",
+      "@analyze"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -154,9 +154,6 @@
     "**/!(amp).php": [
       "npm run lint:php"
     ],
-    "(includes|src)/**/*.php": [
-      "vendor/bin/phpstan analyze --"
-    ],
     "amp.php": [
       "vendor/bin/phpcs --runtime-set testVersion 5.2-"
     ]


### PR DESCRIPTION
Reverts ampproject/amp-wp#5424 per @schlessera in https://github.com/ampproject/amp-wp/pull/5424#issuecomment-698150198.

Adds composer `pre-commit` script which can be used in pre-commit hook, like so:

```bash
set -e
composer run-script pre-commit
```

If using Lando, can be done via:

```bash
set -e
lando composer run-script pre-commit
```