### PR TITLE
Use current timestamp if post does not have a date

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -302,15 +302,19 @@ class AMP_Post_Template {
 	 * @return int Post publish UTC timestamp.
 	 */
 	private function build_post_publish_timestamp() {
-		$format    = 'U';
-		$timestamp = (int) get_post_time( $format, true, $this->post, true );
+		if ( empty( $this->post->post_date_gmt ) || '0000-00-00 00:00:00' === $this->post->post_date_gmt ) {
+			$timestamp = time();
+		} else {
+			$format    = 'U';
+			$timestamp = (int) get_post_time( $format, true, $this->post, true );
 
-		/** This filter is documented in wp-includes/general-template.php. */
-		$filtered_timestamp = apply_filters( 'get_the_date', $timestamp, $format, $this->post );
+			/** This filter is documented in wp-includes/general-template.php. */
+			$filtered_timestamp = apply_filters( 'get_the_date', $timestamp, $format, $this->post );
 
-		// Guard against a plugin poorly filtering get_the_date to be something other than a Unix timestamp.
-		if ( is_int( $filtered_timestamp ) ) {
-			$timestamp = $filtered_timestamp;
+			// Guard against a plugin poorly filtering get_the_date to be something other than a Unix timestamp.
+			if ( is_int( $filtered_timestamp ) ) {
+				$timestamp = $filtered_timestamp;
+			}
 		}
 
 		return $timestamp;

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -302,19 +302,20 @@ class AMP_Post_Template {
 	 * @return int Post publish UTC timestamp.
 	 */
 	private function build_post_publish_timestamp() {
+		$format = 'U';
+
 		if ( empty( $this->post->post_date_gmt ) || '0000-00-00 00:00:00' === $this->post->post_date_gmt ) {
 			$timestamp = time();
 		} else {
-			$format    = 'U';
 			$timestamp = (int) get_post_time( $format, true, $this->post, true );
+		}
 
-			/** This filter is documented in wp-includes/general-template.php. */
-			$filtered_timestamp = apply_filters( 'get_the_date', $timestamp, $format, $this->post );
+		/** This filter is documented in wp-includes/general-template.php. */
+		$filtered_timestamp = apply_filters( 'get_the_date', $timestamp, $format, $this->post );
 
-			// Guard against a plugin poorly filtering get_the_date to be something other than a Unix timestamp.
-			if ( is_int( $filtered_timestamp ) ) {
-				$timestamp = $filtered_timestamp;
-			}
+		// Guard against a plugin poorly filtering get_the_date to be something other than a Unix timestamp.
+		if ( is_int( $filtered_timestamp ) ) {
+			$timestamp = $filtered_timestamp;
 		}
 
 		return $timestamp;


### PR DESCRIPTION
## Summary

Uses the current Unix timestamp for the post date if the post does not have one (i.e. post does not have the `post_date_gmt` property set or has the value `0000-00-00 00:00:00`).

<!-- Please reference the issue this PR addresses. -->
Fixes #5449

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
