### PR TITLE
Fix rendering translations in JS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,6 +234,7 @@ const setup = {
 					case '@wordpress/dom-ready':
 					case '@wordpress/html-entities':
 					case '@wordpress/url':
+					case '@wordpress/i18n':
 						return defaultRequestToHandle( handle );
 
 					default:
@@ -247,6 +248,7 @@ const setup = {
 					case '@wordpress/dom-ready':
 					case '@wordpress/html-entities':
 					case '@wordpress/url':
+					case '@wordpress/i18n':
 						return defaultRequestToExternal( external );
 
 					default:
@@ -293,6 +295,7 @@ const settingsPage = {
 				switch ( handle ) {
 					case 'lodash':
 					case '@wordpress/api-fetch':
+					case '@wordpress/i18n':
 						return defaultRequestToHandle( handle );
 
 					default:
@@ -303,6 +306,7 @@ const settingsPage = {
 				switch ( external ) {
 					case 'lodash':
 					case '@wordpress/api-fetch':
+					case '@wordpress/i18n':
 						return defaultRequestToExternal( external );
 
 					default:


### PR DESCRIPTION
## Summary

Fixes #5459 

Per @swissspidy in https://github.com/ampproject/amp-wp/issues/5459#issuecomment-703490232:

String extraction and actual loading of translations works fine, as can be tested by typing `wp.i18n.__( 'Reopen Wizard', 'amp')` in the console. The problem is that the settings page is bundling `@wordpress/i18n` and not actually using `wp.i18n`.

`@wordpress/i18n` needs to be added as an external in the webpack config, so that calls to `__()` in the code base are mapped to `window.wp.i18n.__()`. Then it will work.

In my quick testing, this change to the settings page config worked:

```diff
diff --git webpack.config.js webpack.config.js
index aab58f6ab..d4571c6ea 100644
--- webpack.config.js
+++ webpack.config.js
@@ -234,6 +234,7 @@ const setup = {
 					case '@wordpress/dom-ready':
 					case '@wordpress/html-entities':
 					case '@wordpress/url':
+					case '@wordpress/i18n':
 						return defaultRequestToHandle( handle );
 
 					default:
@@ -247,6 +248,7 @@ const setup = {
 					case '@wordpress/dom-ready':
 					case '@wordpress/html-entities':
 					case '@wordpress/url':
+					case '@wordpress/i18n':
 						return defaultRequestToExternal( external );
 
 					default:
@@ -293,6 +295,7 @@ const settingsPage = {
 				switch ( handle ) {
 					case 'lodash':
 					case '@wordpress/api-fetch':
+					case '@wordpress/i18n':
 						return defaultRequestToHandle( handle );
 
 					default:
@@ -303,6 +306,7 @@ const settingsPage = {
 				switch ( external ) {
 					case 'lodash':
 					case '@wordpress/api-fetch':
+					case '@wordpress/i18n':
 						return defaultRequestToExternal( external );
 
 					default:
```

This needs to be checked for all other places too.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
