### PR TITLE
Always normalize to use HTML5 doctype

### DIFF
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -644,7 +644,7 @@ final class Document extends DOMDocument
         $content = "{$htmlStart}{$content}{$htmlEnd}";
 
         // Reinsert a standard doctype (while preserving any potentially leading comments).
-        $doctype = preg_replace( '#<!doctype\s+html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype );
+        $doctype = preg_replace('#<!doctype\s+html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype);
         $content = "{$doctype}{$content}";
 
         return $content;

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -54,6 +54,13 @@ final class Document extends DOMDocument
     const DEFAULT_DOCTYPE = '<!DOCTYPE html>';
 
     /**
+     * Regular expression to match the HTML doctype.
+     *
+     * @var string
+     */
+    const HTML_DOCTYPE_REGEX_PATTERN = '#<!doctype\s+html[^>]+?>#si';
+
+    /**
      * Encoding detection order in case we have to guess.
      *
      * This list of encoding detection order is just a wild guess and might need fine-tuning over time.
@@ -644,7 +651,7 @@ final class Document extends DOMDocument
         $content = "{$htmlStart}{$content}{$htmlEnd}";
 
         // Reinsert a standard doctype (while preserving any potentially leading comments).
-        $doctype = preg_replace('#<!doctype\s+html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype);
+        $doctype = preg_replace(self::HTML_DOCTYPE_REGEX_PATTERN, self::DEFAULT_DOCTYPE, $doctype);
         $content = "{$doctype}{$content}";
 
         return $content;

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -105,8 +105,6 @@ final class Document extends DOMDocument
     const HTML_STRUCTURE_BODY_START_TAG  = '/^[^<]*(?><!--.*-->\s*)*(?><body(?>\s+[^>]*)?>)/is';
     const HTML_STRUCTURE_BODY_END_TAG    = '/(?><\/body(?>\s+[^>]*)?>.*)$/is';
     const HTML_STRUCTURE_HEAD_TAG        = '/^(?>[^<]*(?><head(?>\s+[^>]*)?>).*?<\/head(?>\s+[^>]*)?>)/is';
-    const HTML_DOCTYPE_HTML_4_SUFFIX     = ' PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" '
-                                           . '"http://www.w3.org/TR/REC-html40/loose.dtd"';
 
     // Regex patterns used for securing and restoring the doctype node.
     const HTML_SECURE_DOCTYPE_IF_NOT_FIRST_PATTERN = '/(^[^<]*(?>\s*<!--[^>]*>\s*)+<)(!)(doctype)(\s+[^>]+?)(>)/i';
@@ -646,7 +644,7 @@ final class Document extends DOMDocument
         $content = "{$htmlStart}{$content}{$htmlEnd}";
 
         // Reinsert a standard doctype (while preserving any potentially leading comments).
-        $doctype = str_ireplace(self::HTML_DOCTYPE_HTML_4_SUFFIX, '', $doctype);
+        $doctype = preg_replace( '#<!doctype\s*html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype );
         $content = "{$doctype}{$content}";
 
         return $content;

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -644,7 +644,7 @@ final class Document extends DOMDocument
         $content = "{$htmlStart}{$content}{$htmlEnd}";
 
         // Reinsert a standard doctype (while preserving any potentially leading comments).
-        $doctype = preg_replace( '#<!doctype\s*html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype );
+        $doctype = preg_replace( '#<!doctype\s+html[^>]+?>#si', self::DEFAULT_DOCTYPE, $doctype );
         $content = "{$doctype}{$content}";
 
         return $content;

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -153,9 +153,19 @@ class DocumentTest extends TestCase
                 '<html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
                 '<!DOCTYPE html><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
             ],
-            'html_4_doctype'                           => [
+            'html_4_loose_doctype'                     => [
                 'utf-8',
                 '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd"><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
+                '<!DOCTYPE html><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
+            ],
+            'html_401_strict_doctype'                  => [
+                'utf-8',
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
+                '<!DOCTYPE html><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
+            ],
+            'xhtml_10_strict_doctype'                  => [
+                'utf-8',
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
                 '<!DOCTYPE html><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
             ],
             'html_with_xmlns_and_xml_lang'             => [


### PR DESCRIPTION
## Summary

There appears to be a bug in `\AmpProject\Dom\Document::normalizeDocumentStructure()` in which it assumes the only non-HTML5 doctype that may appear in the page is HTML 4.0 Transitional. This does not account for other doctypes, including HTML 4.01 Strict, XHTML 1.0 Strict, etc. This ensures the doctype is always set to be HTML5.

Fixes #5462

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
