### PR TITLE
Allow for tests to be run on PHP 8

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -57,7 +57,6 @@ function after_wp_install {
 		)
 
 		sed -i "/register-wp-cli-commands.php\"$/a , $(echo ${PATCH})" composer.json
-		cat composer.json
 		composer require --dev --ignore-platform-reqs phpunit/phpunit:^7.5
 
 		PATH="$(composer config bin-dir --absolute):$PATH"

--- a/.dev-lib
+++ b/.dev-lib
@@ -38,6 +38,10 @@ function after_wp_install {
 		unzip -d "$WP_CORE_DIR/src/wp-content/plugins/pwa/" "$WP_CORE_DIR/src/wp-content/plugins/pwa.zip"
 		echo "done"
 	fi
+
+	if [[ ! -z USE_LOCAL_PHPUNIT ]]; then
+		PATH="$(composer config home)/vendor/bin:$PATH"
+	fi
 }
 
 function coverage_clover {

--- a/.dev-lib
+++ b/.dev-lib
@@ -43,16 +43,16 @@ function after_wp_install {
 		echo "Installing compatible PHPUnit for use with PHP 8..."
 
 		PATCH=$(cat <<-EOF
-      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
-      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
-      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/InvocationMocker.php",
-      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/MockMethod.php"
-    ],
-    "exclude-from-classmap": [
-      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
-      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
-      "vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
-      "vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
+				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
+				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
+				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/InvocationMocker.php",
+				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/MockMethod.php"
+			],
+			"exclude-from-classmap": [
+				"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
+				"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
+				"vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
+				"vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
 		EOF
 		)
 

--- a/.dev-lib
+++ b/.dev-lib
@@ -39,8 +39,29 @@ function after_wp_install {
 		echo "done"
 	fi
 
-	if [[ ! -z USE_LOCAL_PHPUNIT ]]; then
-		PATH="$(composer config home)/vendor/bin:$PATH"
+	if [[ $(php -r "echo PHP_VERSION;") == 8.0* ]]; then
+		echo "Installing compatible PHPUnit for use with PHP 8..."
+
+		PATCH=$(cat <<-EOF
+      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
+      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
+      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/InvocationMocker.php",
+      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/MockMethod.php"
+    ],
+    "exclude-from-classmap": [
+      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
+      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
+      "vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
+      "vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
+		EOF
+		)
+
+		sed -i "/register-wp-cli-commands.php\"$/a , $(echo ${PATCH})" composer.json
+		cat composer.json
+		composer require --dev --ignore-platform-reqs phpunit/phpunit:^7.5
+
+		PATH="$(composer config bin-dir --absolute):$PATH"
+		echo "done"
 	fi
 }
 

--- a/.dev-lib
+++ b/.dev-lib
@@ -42,21 +42,34 @@ function after_wp_install {
 	if [[ $(php -r "echo PHP_VERSION;") == 8.0* ]]; then
 		echo "Installing compatible PHPUnit for use with PHP 8..."
 
-		PATCH=$(cat <<-EOF
-				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
-				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
-				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/InvocationMocker.php",
-				"${WP_TESTS_DIR}/includes/phpunit7/MockObject/MockMethod.php"
-			],
-			"exclude-from-classmap": [
-				"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
-				"vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
-				"vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
-				"vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
+		DIFF=$(cat <<-EOF
+diff --git a/composer.json b/composer.json
+index 4accd09f0..c1ff59f54 100644
+--- a/composer.json
++++ b/composer.json
+@@ -85,7 +85,17 @@
+     ],
+     "files": [
+       "tests/php/register-wp-cli-commands.php",
+-      "docs/includes/register-wp-cli-commands.php"
++      "docs/includes/register-wp-cli-commands.php",
++      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/NamespaceMatch.php",
++      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/Builder/ParametersMatch.php",
++      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/InvocationMocker.php",
++      "${WP_TESTS_DIR}/includes/phpunit7/MockObject/MockMethod.php"
++    ],
++    "exclude-from-classmap": [
++      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/NamespaceMatch.php",
++      "vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php",
++      "vendor/phpunit/phpunit/src/Framework/MockObject/InvocationMocker.php",
++      "vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
+     ]
+   },
+   "repositories": [
 		EOF
 		)
 
-		sed -i "/register-wp-cli-commands.php\"$/a , $(echo ${PATCH})" composer.json
+		echo "${DIFF}" | git apply -
 		composer require --dev --ignore-platform-reqs phpunit/phpunit:^7.5
 
 		PATH="$(composer config bin-dir --absolute):$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,12 @@ jobs:
 
     - name: PHP unit tests (8.0, WordPress trunk)
       php: "nightly"
-      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 USE_LOCAL_PHPUNIT=1
+      script:
+        - npm run build:js
+        - npm run build:css
+        - composer global require --dev phpunit/phpunit:^9
+        - source "$DEV_LIB_PATH/travis.script.sh"
 
     - name: PHP and JavaScript unit tests (7.4, WordPress trunk, with code coverage)
       if: branch = develop AND type = push

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,9 @@ jobs:
   fast_finish: true
   # These need to be exact matches, including whitespace!
   allow_failures:
-    # PHP unit tests (7.3, WordPress trunk)
-    - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
-    # PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)
-    - env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 RUN_PHPUNIT_COVERAGE=1
     # PHP unit tests (8.0, WordPress trunk)
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
-      php: nightly
+      php: "nightly"
   include:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)
@@ -142,12 +138,7 @@ jobs:
 
     - name: PHP unit tests (8.0, WordPress trunk)
       php: "nightly"
-      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 USE_LOCAL_PHPUNIT=1
-      script:
-        - npm run build:js
-        - npm run build:css
-        - composer global require --dev phpunit/phpunit:^9
-        - source "$DEV_LIB_PATH/travis.script.sh"
+      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
 
     - name: PHP and JavaScript unit tests (7.4, WordPress trunk, with code coverage)
       if: branch = develop AND type = push

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/ampproject/amp-wp",
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^5.6 || ^7.0 || ^8.0",
     "ext-curl": "*",
     "ext-date": "*",
     "ext-dom": "*",

--- a/tests/php/src/DevTools/CallbackReflectionTest.php
+++ b/tests/php/src/DevTools/CallbackReflectionTest.php
@@ -93,7 +93,7 @@ class CallbackReflectionTest extends DependencyInjectedTestCase {
 				ReflectionMethod::class,
 			],
 			'core_widget_display_callback_array'  => [
-				[ 'WP_Widget_Text', 'display_callback' ],
+				[ new \WP_Widget_Text(), 'display_callback' ],
 				'WP_Widget_Text::widget',
 				'wp-includes',
 				'core',

--- a/tests/php/src/DevTools/CallbackReflectionTest.php
+++ b/tests/php/src/DevTools/CallbackReflectionTest.php
@@ -84,24 +84,16 @@ class CallbackReflectionTest extends DependencyInjectedTestCase {
 				'includes/amp-helper-functions.php',
 				ReflectionFunction::class,
 			],
-			'core_includes_wp_scripts_method'     => [
-				'WP_Scripts::print_scripts',
-				'WP_Scripts::print_scripts',
+			'core_includes_wp_user_static_method' => [
+				'WP_User::get_data_by',
+				'WP_User::get_data_by',
 				'wp-includes',
 				'core',
-				'class.wp-scripts.php',
+				'class-wp-user.php',
 				ReflectionMethod::class,
 			],
 			'core_widget_display_callback_array'  => [
 				[ 'WP_Widget_Text', 'display_callback' ],
-				'WP_Widget_Text::widget',
-				'wp-includes',
-				'core',
-				'widgets/class-wp-widget-text.php',
-				ReflectionMethod::class,
-			],
-			'core_widget_display_callback_string' => [
-				'WP_Widget_Text::display_callback',
 				'WP_Widget_Text::widget',
 				'wp-includes',
 				'core',


### PR DESCRIPTION
## Summary

Fixes #5480.

This PR updates the PHP 8 Travis job to run our test suite against PHP 8. This is made possible by applying the same [patch Core uses](https://github.com/WordPress/wordpress-develop/commit/c31a5512732647412d8df03f43c1e0768db281ea#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R21-R33) to allow for PHPUnit v7 to be compatible with PHP 8.

According to CodeCov ~73% of the PHP codebase is covered, and with all tests passing I'd say it is a good baseline to measure compatibility with PHP 8.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
