### PR TITLE
Add expiry to stylesheet cache transients so they are not autoloaded

### DIFF
--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -135,7 +135,10 @@ final class CachedRemoteGetRequest implements RemoteGetRequest {
 
 			$cached_response = new CachedResponse( $body, $headers, $status, $expiry );
 
-			set_transient( $cache_key, serialize( $cached_response ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+			// Transient extend beyond cache expiry to allow for serving stale content.
+			// @TODO: We don't serve stale content atm, but rather synchronously refresh.
+			$transient_expiry = $expiry->modify( "+ {$this->expiry} seconds" );
+			set_transient( $cache_key, serialize( $cached_response ), $transient_expiry->getTimestamp() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		}
 
 		if ( ! $cached_response->is_valid() ) {

--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -137,6 +137,7 @@ final class CachedRemoteGetRequest implements RemoteGetRequest {
 
 			// Transient extend beyond cache expiry to allow for serving stale content.
 			// @TODO: We don't serve stale content atm, but rather synchronously refresh.
+			// See https://github.com/ampproject/amp-wp/issues/5477.
 			$transient_expiry = $expiry->modify( "+ {$this->expiry} seconds" );
 			set_transient( $cache_key, serialize( $cached_response ), $transient_expiry->getTimestamp() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		}

--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -125,9 +125,9 @@ final class CachedRemoteGetRequest implements RemoteGetRequest {
 				$response = $this->remote_request->get( $url );
 				$status   = $response->getStatusCode();
 				/** @var DateTimeImmutable $expiry */
-				$expiry   = $this->get_expiry_time( $response );
-				$headers  = $response->getHeaders();
-				$body     = $response->getBody();
+				$expiry  = $this->get_expiry_time( $response );
+				$headers = $response->getHeaders();
+				$body    = $response->getBody();
 			} catch ( FailedToGetFromRemoteUrl $exception ) {
 				$status = $exception->getStatusCode();
 				$expiry = new DateTimeImmutable( "+ {$this->min_expiry} seconds" );

--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -124,6 +124,7 @@ final class CachedRemoteGetRequest implements RemoteGetRequest {
 			try {
 				$response = $this->remote_request->get( $url );
 				$status   = $response->getStatusCode();
+				/** @var DateTimeImmutable $expiry */
 				$expiry   = $this->get_expiry_time( $response );
 				$headers  = $response->getHeaders();
 				$body     = $response->getBody();

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1931,6 +1931,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $response_body, $actual_stylesheets[0] );
 
 		$cache_key = CachedRemoteGetRequest::TRANSIENT_PREFIX . md5( CachedRemoteGetRequest::class . $href );
+
+		// Verify that the transients are not polluting the autoloaded options.
+		$autoloaded_options = wp_load_alloptions();
+		$this->assertArrayNotHasKey( "_transient_{$cache_key}", $autoloaded_options );
+
 		$transient = get_transient( $cache_key );
 		$this->assertNotFalse( $transient );
 


### PR DESCRIPTION
## Summary

This PR adds an expiry to the transients that cache remote requests (like those that fetch external stylesheets) so that WordPress does not autoload these transients (see https://github.com/WordPress/wordpress-develop/blob/af9db19b45737deaae5dfe2e0175eab1ac732450/src/wp-includes/option.php#L881-L886).

The expiry of the transient is set to the expiry of the response that was received (which might change if caching headers were added) PLUS the default expiry that is set for caching. The lifetime of the transient thus exceeds the expected caching duration, so that we can still serve the stale content from the transient while the cache is being refreshed.

Note: I left a TODO in there for https://github.com/ampproject/amp-wp/issues/5477, as we currently don't serve stale content as was planned.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
