### PR TITLE
Ensure iframes in embeds with aspect ratios get responsive layout

### DIFF
--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -76,10 +76,11 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 			// @todo Should we consider just eliminating the .wp-block-embed__wrapper element since unnecessary?
 			// For visual parity with blocks in non-AMP pages, override the oEmbed's natural responsive dimensions with the aspect ratio specified in the wp-embed-aspect-* class name.
 			if ( $responsive_width && $responsive_height ) {
-				$amp_element = $this->dom->xpath->query( './div[ contains( @class, "wp-block-embed__wrapper" ) ]/*[ @layout = "responsive" ]', $node )->item( 0 );
+				$amp_element = $this->dom->xpath->query( './div[ contains( @class, "wp-block-embed__wrapper" ) ]/*[ @layout = "responsive" or @layout = "intrinsic"  ]', $node )->item( 0 );
 				if ( $amp_element instanceof DOMElement ) {
 					$amp_element->setAttribute( 'width', $responsive_width );
 					$amp_element->setAttribute( 'height', $responsive_height );
+					$amp_element->setAttribute( 'layout', 'responsive' );
 				}
 			}
 

--- a/tests/php/test-class-amp-block-sanitizer.php
+++ b/tests/php/test-class-amp-block-sanitizer.php
@@ -46,6 +46,11 @@ class AMP_Block_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="640" layout="responsive"></amp-soundcloud></div></figure>',
 				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="3" width="4" layout="responsive"></amp-soundcloud></div></figure>',
 			],
+
+			'intrinsic_layout'     => [
+				'<figure class="wp-block-embed-slideshare wp-block-embed is-type-rich is-provider-slideshare wp-embed-aspect-1-1 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-iframe title="AMP in WordPress, the WordPress Way" src="https://www.slideshare.net/slideshow/embed_code/key/4wRcvt5FDQhkgB" width="427" height="356" frameborder="0" scrolling="no" allowfullscreen="" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation" layout="intrinsic" class="amp-wp-enforced-sizes"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe></div></figure>',
+				'<figure class="wp-block-embed-slideshare wp-block-embed is-type-rich is-provider-slideshare"><div class="wp-block-embed__wrapper"><amp-iframe title="AMP in WordPress, the WordPress Way" src="https://www.slideshare.net/slideshow/embed_code/key/4wRcvt5FDQhkgB" width="1" height="1" frameborder="0" scrolling="no" allowfullscreen="" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation" layout="responsive" class="amp-wp-enforced-sizes"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe></div></figure>',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

I noticed that responsive Embed blocks that have videos were not getting `layout=responsive` as they should. 

Given this `post_content`:

```html
<!-- wp:paragraph -->
<p>Speaker Deck:</p>
<!-- /wp:paragraph -->

<!-- wp:embed {"url":"https://speakerdeck.com/zenorocha/web-components-a-chance-to-create-the-future","type":"rich","providerNameSlug":"speaker-deck","responsive":true,"className":"wp-embed-aspect-4-3 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-rich is-provider-speaker-deck wp-block-embed-speaker-deck wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://speakerdeck.com/zenorocha/web-components-a-chance-to-create-the-future
</div></figure>
<!-- /wp:embed -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Slideshare:</p>
<!-- /wp:paragraph -->

<!-- wp:embed {"url":"https://www.slideshare.net/AlbertoMedina9/amp-in-wordpress-the-wordpress-way-161633421","type":"rich","providerNameSlug":"slideshare","responsive":true,"className":"wp-embed-aspect-1-1 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-rich is-provider-slideshare wp-block-embed-slideshare wp-embed-aspect-1-1 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.slideshare.net/AlbertoMedina9/amp-in-wordpress-the-wordpress-way-161633421
</div></figure>
<!-- /wp:embed -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>TED:</p>
<!-- /wp:paragraph -->

<!-- wp:embed {"url":"https://www.ted.com/talks/jessy_kate_schingler_civilization_on_the_moon_and_what_it_means_for_life_on_earth","type":"video","providerNameSlug":"ted","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-ted wp-block-embed-ted wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.ted.com/talks/jessy_kate_schingler_civilization_on_the_moon_and_what_it_means_for_life_on_earth
</div></figure>
<!-- /wp:embed -->
```

Before AMP 👎  | Non-AMP (Control) | After AMP 👍 
----------------|--------------------|---------------
<img width="504" alt="before-amp" src="https://user-images.githubusercontent.com/134745/95548668-710a4e80-09ba-11eb-9757-cbd44908ba81.png"> | <img width="520" alt="non-amp" src="https://user-images.githubusercontent.com/134745/95548671-723b7b80-09ba-11eb-8773-bd085148655e.png"> | <img width="509" alt="after-amp" src="https://user-images.githubusercontent.com/134745/95548673-723b7b80-09ba-11eb-9d37-09c27483c11a.png">

This issue has not been noticed before very often because YouTube videos, for example, are getting generated with `layout=responsive` from the start. This is specifically to fix responsiveness for `iframe` elements that we pass through which get converted to `amp-iframe` with `layout=intrinsic` by default in the iframe sanitizer.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
