### PR TITLE
Remove noncompulsory plugin headers

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -7,7 +7,6 @@
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
  * Version: 2.1.0-alpha
  * Text Domain: amp
- * Domain Path: /languages/
  * License: GPLv2 or later
  * Requires at least: 4.9
  * Requires PHP: 5.6

--- a/amp.php
+++ b/amp.php
@@ -6,7 +6,6 @@
  * Author: AMP Project Contributors
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
  * Version: 2.1.0-alpha
- * Text Domain: amp
  * License: GPLv2 or later
  * Requires at least: 4.9
  * Requires PHP: 5.6


### PR DESCRIPTION
## Summary

Since we're not bundling our own translations, I think we can remove the "Domain Path" header. And as [stated](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#domain-path) in the WP handbook:

> The Domain Path header can be omitted if the plugin is in the official WordPress Plugin Directory.

Also it seems we can remove the "Text Domain" header. As [stated](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains) by the handbook:

> Since WordPress 4.6 the Text Domain header is optional because it must be the same as the plugin slug. There is no harm in including it, but it is not required.

This is confirmed by the following [condition](https://github.com/WordPress/wordpress-develop/blob/af9db19b45737deaae5dfe2e0175eab1ac732450/src/wp-admin/includes/plugin.php#L97-L103) in Core:

```php
        // If no text domain is defined fall back to the plugin slug.
	if ( ! $plugin_data['TextDomain'] ) {
		$plugin_slug = dirname( plugin_basename( $plugin_file ) );
		if ( '.' !== $plugin_slug && false === strpos( $plugin_slug, '/' ) ) {
			$plugin_data['TextDomain'] = $plugin_slug;
		}
	}
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
