### PR TITLE
Add theme-unit-test reference site

### DIFF
--- a/tests/php/src/Cli/Import/ImportWxrFile.php
+++ b/tests/php/src/Cli/Import/ImportWxrFile.php
@@ -62,7 +62,6 @@ final class ImportWxrFile implements ImportStep {
 	public function __construct( $wxr_file ) {
 		$this->wxr_file = $wxr_file;
 
-		WP_CLI::warning( $this->wxr_file );
 		if ( preg_match( self::IS_REMOTE_URL, $this->wxr_file ) ) {
 			$this->wxr_is_temporary_file = true;
 

--- a/tests/php/src/Cli/ReferenceSiteImportCommand.php
+++ b/tests/php/src/Cli/ReferenceSiteImportCommand.php
@@ -7,6 +7,7 @@
 
 namespace AmpProject\AmpWP\Tests\Cli;
 
+use AmpProject\AmpWP\Tests\Cli\Import\ImportWxrFile;
 use Exception;
 use Google\Cloud\Storage\StorageClient;
 use RuntimeException;
@@ -191,7 +192,11 @@ final class ReferenceSiteImportCommand extends WP_CLI_Command {
 				case 'import_wxr_file':
 					$wxr_path = $import_step['filename'];
 
-					if ( ! path_is_absolute( $wxr_path ) ) {
+					if (
+						! path_is_absolute( $wxr_path )
+						&&
+						! preg_match( ImportWxrFile::IS_REMOTE_URL, $wxr_path )
+					) {
 						$wxr_path = ReferenceSiteCommandNamespace::REFERENCE_SITES_ROOT . $wxr_path;
 					}
 

--- a/tests/reference-sites/theme-unit-test.json
+++ b/tests/reference-sites/theme-unit-test.json
@@ -1,0 +1,14 @@
+{
+  "name": "Theme Unit Test",
+  "version": "1.0",
+  "description": "Theme unit test data from the theme review team.",
+  "attributions": [
+    "Site content created by the Wordpress.org theme review team.\nSee https://github.com/WPTT/theme-unit-test"
+  ],
+  "import-steps": [
+    {
+      "type": "import_wxr_file",
+      "filename": "https://raw.githubusercontent.com/WPTT/theme-unit-test/master/themeunittestdata.wordpress.xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a new reference site called `theme-unit-test` that retrieves the latest [theme unit test data from the theme review team](https://github.com/WPTT/theme-unit-test) and populates the site with it.

To implement this, the `ImportWxrFile` step was modified so that it can deal with remote URLs. This will result in always using the very latest theme unit test data.

To use:
```
wp amp reference-site import theme-unit-test [--empty-uploads] [--empty-extensions] [--empty-options] [--empty-content]
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
