### PR TITLE
Add sanitization of XFBML raw embeds into amp-facebook

### DIFF
--- a/includes/embeds/class-amp-facebook-embed-handler.php
+++ b/includes/embeds/class-amp-facebook-embed-handler.php
@@ -49,29 +49,19 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	/**
-	 * Sanitized <div class="fb-video" data-href=> tags to <amp-facebook>.
+	 * Sanitize raw embeds.
 	 *
 	 * @param Document $dom DOM.
 	 */
 	public function sanitize_raw_embeds( Document $dom ) {
-		$nodes     = $dom->getElementsByTagName( $this->sanitize_tag );
-		$num_nodes = $nodes->length;
+		$replaced = 0;
 
-		if ( 0 === $num_nodes ) {
+		$replaced += $this->sanitize_raw_embed_divs( $dom );
+
+		$replaced += $this->sanitize_raw_embed_fb_components( $dom );
+
+		if ( 0 === $replaced ) {
 			return;
-		}
-
-		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
-			$node = $nodes->item( $i );
-			if ( ! $node instanceof DOMElement ) {
-				continue;
-			}
-
-			$embed_type = $this->get_embed_type( $node );
-
-			if ( null !== $embed_type ) {
-				$this->create_amp_facebook_and_replace_node( $dom, $node, $embed_type );
-			}
 		}
 
 		/*
@@ -98,6 +88,65 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 				$fb_root->parentNode->removeChild( $fb_root );
 			}
 		}
+	}
+
+	/**
+	 * Sanitize <div class="fb-video" data-href=> tags to <amp-facebook>.
+	 *
+	 * @param Document $dom DOM.
+	 * @return int Replacements made.
+	 */
+	private function sanitize_raw_embed_divs( Document $dom ) {
+		$replaced  = 0;
+		$nodes     = $dom->getElementsByTagName( $this->sanitize_tag );
+		$num_nodes = $nodes->length;
+
+		if ( 0 === $num_nodes ) {
+			return 0;
+		}
+
+		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			$node = $nodes->item( $i );
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			$embed_type = $this->get_embed_type( $node );
+
+			if ( null !== $embed_type ) {
+				$this->create_amp_facebook_and_replace_node( $dom, $node, $embed_type );
+				$replaced++;
+			}
+		}
+		return $replaced;
+	}
+
+	/**
+	 * Sanitize <fb:post> tags to <amp-facebook>.
+	 *
+	 * @param Document $dom DOM.
+	 * @return int Replacements made.
+	 */
+	private function sanitize_raw_embed_fb_components( Document $dom ) {
+		$replaced  = 0;
+		$nodes     = $dom->getElementsByTagName( 'post' );
+		$num_nodes = $nodes->length;
+
+		if ( 0 === $num_nodes ) {
+			return 0;
+		}
+
+		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			$node = $nodes->item( $i );
+			if ( ! $node instanceof DOMElement ) {
+				continue;
+			}
+
+			$embed_type = 'post';
+			$this->create_amp_facebook_and_replace_node( $dom, $node, $embed_type );
+			$replaced++;
+		}
+		return $replaced;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

I'm just opening this PR as a potential starting point for converting `<fb:post>` into `<amp-facebook>`, where `fb:post` is the XFBML version of what Facebook now has replaced with `div.fb-post`. Jetpack was using `fb:post` which is why this issue was discovered, but I've opened https://github.com/Automattic/jetpack/pull/17492 to update Jetpack to use `div.fb-post` instead. Once that is released, this PR should be very low priority since XFBML is not the current best practice.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
