### PR TITLE
Prevent AMP-to-AMP linking for link with Mustache template variables

### DIFF
--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -141,6 +141,23 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Check if element is descendant of a template element.
+	 *
+	 * @param DOMElement $node Node.
+	 * @return bool Descendant of template.
+	 */
+	private function is_descendant_of_template_element( DOMElement $node ) {
+		while ( $node instanceof DOMElement ) {
+			$parent = $node->parentNode;
+			if ( $parent instanceof DOMElement && Tag::TEMPLATE === $parent->tagName ) {
+				return true;
+			}
+			$node = $parent;
+		}
+		return false;
+	}
+
+	/**
 	 * Process element.
 	 *
 	 * @param DOMElement $element        Element to process.
@@ -151,6 +168,11 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Skip page anchor links or non-frontend links.
 		if ( empty( $url ) || '#' === substr( $url, 0, 1 ) || ! $this->is_frontend_url( $url ) ) {
+			return;
+		}
+
+		// Skip links with template variables.
+		if ( preg_match( '/{{[^}]+?}}/', $url ) && $this->is_descendant_of_template_element( $element ) ) {
 			return;
 		}
 

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -170,6 +170,7 @@ class AMP_Link_Sanitizer_Test extends DependencyInjectedTestCase {
 		$html .= sprintf( '<form id="internal-search" action="%s" method="get"><input name="s" type="search"></form>', esc_url( home_url( '/' ) ) );
 		$html .= sprintf( '<form id="internal-post" action="%s" method="post"><input name="content" type="text"></form>', esc_url( home_url( '/' ) ) );
 		$html .= '<form id="external-search" action="https://search.example.com/" method="get"><input name="s" type="search"></form>';
+		$html .= '<template type="amp-mustache"><div><a id="template-link" href="{{url}}">Link</a></div></template>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $html );
 
@@ -203,6 +204,8 @@ class AMP_Link_Sanitizer_Test extends DependencyInjectedTestCase {
 		$this->assertEquals( $paired ? 1 : 0, $dom->xpath->query( '//form[ @id = "internal-search" ]//input[ @name = "amp" ]' )->length );
 		$this->assertEquals( 0, $dom->xpath->query( '//form[ @id = "internal-post" ]//input[ @name = "amp" ]' )->length );
 		$this->assertEquals( 0, $dom->xpath->query( '//form[ @id = "external-search" ]//input[ @name = "amp" ]' )->length );
+
+		$this->assertEquals( '{{url}}', $dom->getElementById( 'template-link' )->getAttribute( 'href' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

In looking at Jetpack's AMP implementation of Infinite Scroll (https://github.com/Automattic/jetpack/pull/17497), I saw something unexpected:

![image](https://user-images.githubusercontent.com/134745/96214551-8c340b80-0f30-11eb-8f69-c3ca7bd98223.png)

The `{{url}}` here should not be getting `?amp=1` appended to it.

This PR prevents that from happening.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
