### PR TITLE
Prevent generating invalid width/height for amp-iframe when fill layout is detected via inline style

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -321,6 +321,7 @@ abstract class AMP_Base_Sanitizer {
 					$attributes['style'] = $this->reassemble_style_string( $styles );
 				}
 				$attributes['layout'] = 'fill';
+				unset( $attributes['height'], $attributes['width'] );
 				return $attributes;
 			}
 

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -566,6 +566,25 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					'add_placeholder' => true,
 				],
 			],
+
+			'iframe_with_100_percent_with_100_percent_height_position_absolute_top_zero_left_zero' => [
+				'
+					<iframe
+						style="width: 100%; height: 100%; position: absolute; left: 0px; top: 0px;"
+						src="https://example.com/video/132886713"
+						width="100%"
+						height="100%"
+					>
+					</iframe>
+				',
+				'
+					<amp-iframe src="https://example.com/video/132886713" layout="fill" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation">
+						<noscript>
+							<iframe style="width: 100%; height: 100%; position: absolute; left: 0px; top: 0px;" src="https://example.com/video/132886713" width="100%" height="100%"></iframe>
+						</noscript>
+					</amp-iframe>
+				'
+			]
 		];
 	}
 

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -583,8 +583,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 							<iframe style="width: 100%; height: 100%; position: absolute; left: 0px; top: 0px;" src="https://example.com/video/132886713" width="100%" height="100%"></iframe>
 						</noscript>
 					</amp-iframe>
-				'
-			]
+				',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Client noticed lots of failing amp URLs due to amp-iframes containing invalid heights..

> The attribute 'height' in tag 'amp-iframe' is set to the invalid value ''.

It seems that this only occurred when they had a style attribute on the iframe with an absolute position and 0 top and left. 

This adds a failing test to first prove the issue exists followed by a potential fix.

<!-- Please reference the issue this PR addresses. -->
Fixes #5514

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
