### PR TITLE
Raise validation error if width or height attribute is invalid

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1312,7 +1312,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		$allow_fluid  = Layout::FLUID === $layout_attr;
 		$allow_auto   = true;
 
-		$input_width = new CssLength( $node->getAttribute( Attribute::WIDTH ) );
+		$input_width = new CssLength( $node->hasAttribute( Attribute::WIDTH ) ? $node->getAttribute( Attribute::WIDTH ) : null );
 		$input_width->validate( $allow_auto, $allow_fluid );
 		if ( ! $input_width->isValid() ) {
 			return [
@@ -1321,7 +1321,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			];
 		}
 
-		$input_height = new CssLength( $node->getAttribute( Attribute::HEIGHT ) );
+		$input_height = new CssLength( $node->hasAttribute( Attribute::HEIGHT ) ? $node->getAttribute( Attribute::HEIGHT ) : null );
 		$input_height->validate( $allow_auto, $allow_fluid );
 		if ( ! $input_height->isValid() ) {
 			return [

--- a/lib/common/src/CssLength.php
+++ b/lib/common/src/CssLength.php
@@ -77,7 +77,7 @@ final class CssLength
      */
     public function __construct($attrValue)
     {
-        if ((! isset($attrValue) || '' === $attrValue)) {
+        if (null === $attrValue) {
             $this->isValid = true;
             return;
         }
@@ -94,6 +94,10 @@ final class CssLength
      */
     public function validate($allowAuto, $allowFluid)
     {
+        if ( $this->isValid() ) {
+            return;
+        }
+
         if (self::AUTO === $this->attrValue) {
             $this->isAuto  = true;
             $this->isValid = $allowAuto;

--- a/lib/common/src/CssLength.php
+++ b/lib/common/src/CssLength.php
@@ -94,7 +94,7 @@ final class CssLength
      */
     public function validate($allowAuto, $allowFluid)
     {
-        if ( $this->isValid() ) {
+        if ($this->isValid()) {
             return;
         }
 

--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -298,14 +298,16 @@ final class ServerSideRendering implements Transformer
     {
         $ampLayout = $this->parseLayout($element->getAttribute(Attribute::LAYOUT));
 
-        $inputWidth = new CssLength($element->getAttribute(Attribute::WIDTH));
+        $attrWidth  = $element->hasAttribute(Attribute::WIDTH) ? $element->getAttribute(Attribute::WIDTH) : null;
+        $inputWidth = new CssLength($attrWidth);
         $inputWidth->validate(/* $allowAuto */ true, /* $allowFluid */ false);
         if (! $inputWidth->isValid()) {
             $errors->add(Error\CannotPerformServerSideRendering::fromInvalidInputWidth($element));
             return false;
         }
 
-        $inputHeight = new CssLength($element->getAttribute(Attribute::HEIGHT));
+        $attrHeight  = $element->hasAttribute(Attribute::HEIGHT) ? $element->getAttribute(Attribute::HEIGHT) : null;
+        $inputHeight = new CssLength($attrHeight);
         $inputHeight->validate(/* $allowAuto */ true, /* $allowFluid */ $ampLayout === Layout::FLUID);
         if (! $inputHeight->isValid()) {
             $errors->add(Error\CannotPerformServerSideRendering::fromInvalidInputHeight($element));

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2425,6 +2425,20 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_WIDTH ],
 			],
 
+			'empty_width_attribute'                        => [
+				'<amp-img src="/img1.png" width="" height="50"></amp-img>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_WIDTH ],
+			],
+
+			'empty_height_attribute'                       => [
+				'<amp-img src="/img1.png" width="50" height=""></amp-img>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_HEIGHT ],
+			],
+
 			'variable_attributes_in_mustache_template'     => [
 				'
 				<template type="amp-mustache">
@@ -2461,8 +2475,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 			],
 
-			'empty_width_attribute'                        => [
-				'<amp-img src="/img1.png" width="" height="50" layout="responsive"></amp-img>',
+			'empty_width_attribute_responsive_layout'      => [
+				'<amp-img src="/img1.png" width="auto" height="50" layout="responsive"></amp-img>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_AUTO_WIDTH ],
@@ -2476,28 +2490,28 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'no_height_fixed_layout'                       => [
-				'<amp-img src="/img1.png" width="50" height="" layout="fixed"></amp-img>',
+				'<amp-img src="/img1.png" width="50" layout="fixed"></amp-img>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_fixed_height_layout'                => [
-				'<amp-img src="/img1.png" width="50" height="" layout="fixed-height"></amp-img>',
+				'<amp-img src="/img1.png" width="50" layout="fixed-height"></amp-img>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_intrinsic_layout'                   => [
-				'<amp-img src="/img1.png" width="50" height="" layout="intrinsic"></amp-img>',
+				'<amp-img src="/img1.png" width="50" layout="intrinsic"></amp-img>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_responsive_layout'                  => [
-				'<amp-img src="/img1.png" width="50" height="" layout="responsive"></amp-img>',
+				'<amp-img src="/img1.png" width="50" layout="responsive"></amp-img>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
While triaging #5514 I noticed that a validation error was being leaked about the `amp-iframe` having an invalid height. While #5513 did prevent the error from occurring, the underlying issue still exists. For example, given the markup:

```html
<amp-iframe src="https://example.com/video/132886713" layout="fill" width="1200" height=""></amp-iframe>
```

The AMP Validator shows:

![image](https://user-images.githubusercontent.com/16200219/96312246-bce07780-0ffa-11eb-9115-655c88d32447.png)

while on the Validated URL screen no errors are reported:

![image](https://user-images.githubusercontent.com/16200219/96312315-dc77a000-0ffa-11eb-818b-0d025ce2d8b0.png)

This PR fixes the issue by ensuring width or height attribute values with no defined values (eg. `height=''`) no longer be marked as valid (as they should not have been in the first place, [onus is on me](https://github.com/ampproject/amp-wp/commit/3bf75cc3ac218c565528f770b84b5fc931beb404#diff-1b806653fc422015c2b19a15d58924ce869a3388ffe177b051d13055137d8bafR68)), and allows for the appropriate validation error to be raised. Now with the same markup as above the appropriate validation error is now raised with the changes from this PR:

![image](https://user-images.githubusercontent.com/16200219/96312621-7c352e00-0ffb-11eb-924b-adda5d80b5c0.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
