### PR TITLE
Enforce custom CSS byte count limit in SSR

### DIFF
--- a/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
+++ b/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
@@ -307,6 +307,24 @@ final class ServerSideRenderingTest extends TestCase
                 ),
                 [],
             ],
+
+            'css overage skips SSR' => [
+                $input(
+                    '<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes="(min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" width="400"></amp-img>',
+                    '<style amp-custom>' . str_pad('', ServerSideRendering::MAX_CSS_BYTE_COUNT - 1, 'X') . '</style>'
+                ),
+                $expectWithBoilerplate(
+                    '<amp-img class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" height="300" i-amphtml-layout="responsive" id="i-amp-0" layout="responsive" sizes="(min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" width="400"><i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer></amp-img>',
+                    '<style amp-custom>' . str_pad('', ServerSideRendering::MAX_CSS_BYTE_COUNT - 1, 'X') . '</style>'
+                ),
+                [
+                    Error\CannotRemoveBoilerplate::fromAttributesRequiringBoilerplate(
+                        Document::fromHtmlFragment(
+                            '<amp-img height="300" layout="responsive" srcset="https://acme.org/image1.png 320w, https://acme.org/image2.png 640w, https://acme.org/image3.png 1280w" sizes="(min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" width="400"></amp-img>'
+                        )->body->firstChild
+                    ),
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary

Ensure that the Optimizer never breaks AMP validity by going over custom CSS byte count limit.

NOTE: WIP, as the issue could not be replicated yet...

Fixes #5517 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
