### PR TITLE
Bootstrap WP CLI in PHPUnit environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "sirbrillig/phpcs-variable-analysis": "2.9.0",
     "wp-cli/export-command": "^2.0",
     "wp-cli/extension-command": "^2.0",
+    "wp-cli/wp-cli": "^2.4",
     "wp-coding-standards/wpcs": "2.3.0",
     "xwp/wp-dev-lib": "1.6.4"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e307e09d72e2a194042c57c5265696b9",
+    "content-hash": "529568a8a21c834b9b73d724e3485ca0",
     "packages": [
         {
             "name": "ampproject/common",
@@ -346,6 +346,13 @@
                 "phpunit/phpunit": "^4.8.36"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Add additional validation for size unit <https://github.com/sabberworm/PHP-CSS-Parser/pull/193>": "patches/php-css-parser-pull-193.patch",
+                    "Validate name-start code points for identifier <https://github.com/sabberworm/PHP-CSS-Parser/pull/185>": "patches/php-css-parser-pull-185.patch",
+                    "Fix parsing CSS selectors which contain commas <https://github.com/westonruter/PHP-CSS-Parser/pull/1>": "patches/php-css-parser-commit-10a2501.patch"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Sabberworm\\CSS\\": "lib/Sabberworm/CSS/"
@@ -3021,12 +3028,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "4221b5b0103e375a52483a9c95bad2e092d86904"
+                "reference": "d394b395995e70932df5a58baab18f2942afbc28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/4221b5b0103e375a52483a9c95bad2e092d86904",
-                "reference": "4221b5b0103e375a52483a9c95bad2e092d86904",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/d394b395995e70932df5a58baab18f2942afbc28",
+                "reference": "d394b395995e70932df5a58baab18f2942afbc28",
                 "shasum": ""
             },
             "require": {
@@ -3079,7 +3086,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2020-09-29T08:28:11+00:00"
+            "time": "2020-10-09T07:57:08+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3174,7 +3181,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit
-	bootstrap="vendor/xwp/wp-dev-lib/sample-config/phpunit-plugin-bootstrap.php"
+	bootstrap="tests/php/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -3,6 +3,8 @@
  * PHPUnit bootstrap file.
  */
 
+define( 'WP_TESTS_DIR', '../../../../tests/phpunit' );
+
 $amp_plugin_root = dirname( dirname( __DIR__ ) );
 
 /**

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -3,8 +3,6 @@
  * PHPUnit bootstrap file.
  */
 
-define( 'WP_TESTS_DIR', '../../../../tests/phpunit' );
-
 $amp_plugin_root = dirname( dirname( __DIR__ ) );
 
 /**

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ */
+
+$amp_plugin_root = dirname( dirname( __DIR__ ) );
+
+/**
+ * Include bootstrap file from wp-dev-lib.
+ */
+require_once $amp_plugin_root . '/vendor/xwp/wp-dev-lib/sample-config/phpunit-plugin-bootstrap.php';
+
+/**
+ * Load WP CLI.
+ */
+require_once $amp_plugin_root . '/vendor/wp-cli/wp-cli/tests/bootstrap.php';


### PR DESCRIPTION
## Summary
  
Fixes #5523 by making WP CLI utility functions available in the PHPUnit environment. Currently, PR #5306 is failing with a fatal error due to a missing WP CLI utility function, and this will fix that. 

To fix it, I created a `bootstrap.php` file inside `tests/php` and from there imported the `wp-dev-lib` bootstrap file along with WP CLI's own PHPUnit bootstrap file. As @schlessera suggested on Slack, I also added `wp-cli/wp-cli` as a dev dependency with Composer to make sure it's actually there. 

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
