### PR TITLE
Skip Facebook embed test if oEmbed endpoint is down

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -11,6 +11,9 @@ $amp_plugin_root = dirname( dirname( __DIR__ ) );
 require_once $amp_plugin_root . '/vendor/xwp/wp-dev-lib/sample-config/phpunit-plugin-bootstrap.php';
 
 /**
- * Load WP CLI.
+ * Load WP CLI. Its test bootstrap file can't be required as it will load
+ * duplicate class names which are already in use.
  */
-require_once $amp_plugin_root . '/vendor/wp-cli/wp-cli/tests/bootstrap.php';
+define( 'WP_CLI_ROOT', $amp_plugin_root . '/vendor/wp-cli/wp-cli' );
+define( 'WP_CLI_VENDOR_DIR', $amp_plugin_root . '/vendor' );
+require_once WP_CLI_ROOT . '/php/utils.php';

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -39,7 +39,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array Response data.
 	 */
 	public function mock_http_request( $preempt, $r, $url ) {
-		if ( in_array( 'external-http', $_SERVER['argv'], true ) ) {
+		if ( self::is_external_http_test_suite() ) {
 			return $preempt;
 		}
 
@@ -99,6 +99,11 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 		$embed->register_embed();
 
 		$filtered_content = apply_filters( 'the_content', $source );
+
+		if ( self::is_external_http_test_suite() && "<p>$source</p>" === trim( $filtered_content ) ) {
+			$this->markTestSkipped( 'Endpoint is down.' );
+		}
+
 		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
@@ -279,6 +284,11 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 		$embed->register_embed();
 
 		$filtered_content = apply_filters( 'the_content', $source );
+
+		if ( self::is_external_http_test_suite() && "<p>$source</p>" === trim( $filtered_content ) ) {
+			$this->markTestSkipped( 'Endpoint is down.' );
+		}
+
 		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
@@ -291,5 +301,14 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 		$content = preg_replace( '#(<blockquote.*?>).+?(</blockquote>)#s', '$1<!--blockquote_contents-->$2', $content );
 
 		$this->assertEqualMarkup( $expected, $content );
+	}
+
+	/**
+	 * Whether external-http test suite is running.
+	 *
+	 * @return bool Running external-http test suite.
+	 */
+	private static function is_external_http_test_suite() {
+		return in_array( 'external-http', $_SERVER['argv'], true );
 	}
 }

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -104,7 +104,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Endpoint is down.' );
 		}
 
-		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
+		$dom = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
 		$validating_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
@@ -289,7 +289,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Endpoint is down.' );
 		}
 
-		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
+		$dom = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
 		$layout_sanitizer = new AMP_Layout_Sanitizer( $dom );


### PR DESCRIPTION
## Summary

If the oEmbed endpoint is down the test will simply be skipped.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
