### PR TITLE
Support @-moz-document url-prefix() Firefox CSS hack by transforming into @supports (-moz-appearance:meterbar)

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -130,7 +130,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					],
 					'add_twentynineteen_masthead_styles' => [],
 					'adjust_twentynineteen_images'       => [],
-					'accept_remove_moz_document_at_rule' => [],
 				];
 
 			// Twenty Seventeen.
@@ -287,27 +286,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public static function get_acceptable_errors() {
 		_deprecated_function( __METHOD__, '1.5' );
 		return [];
-	}
-
-	/**
-	 * Accept the removal of `@-moz-document` at-rules.
-	 *
-	 * This is temporary with the hope that the at-rule will become allowed in AMP.
-	 *
-	 * @since 2.0.1
-	 * @link https://github.com/ampproject/amp-wp/issues/5302
-	 * @link https://github.com/ampproject/amphtml/issues/26406
-	 */
-	public static function accept_remove_moz_document_at_rule() {
-		AMP_Validation_Error_Taxonomy::accept_validation_errors(
-			[
-				AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE => [
-					[
-						'at_rule' => '-moz-document',
-					],
-				],
-			]
-		);
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2150,9 +2150,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					// yet allowed in AMP, and this use of @supports is another recognized Firefox-specific CSS hack,
 					// per <http://browserhacks.com/#hack-8e9b5504d9fda44ec75169381b3c3157>.
 					// For adding @-moz-document to AMP, see <https://github.com/ampproject/amphtml/issues/26406>.
-					$supports_at_rule = new AtRuleBlockList( 'supports', '(-moz-appearance:meterbar)' );
-					$supports_at_rule->setContents( $css_item->getContents() );
-					$css_list->splice( $i, 1, [ $supports_at_rule ] );
+					$new_css_item = new AtRuleBlockList( 'supports', '(-moz-appearance:meterbar)' );
+					$new_css_item->setContents( $css_item->getContents() );
+					$css_list->splice( $i, 1, [ $new_css_item ] );
+					$css_item  = $new_css_item; // To process_css_list below.
+					$sanitized = false;
 				} elseif ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
 					$error                = [
 						'code'      => self::CSS_SYNTAX_INVALID_AT_RULE,

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -381,15 +381,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return bool Returns true if the plugin's forked version of PHP-CSS-Parser is loaded by Composer.
 	 */
 	public static function has_required_php_css_parser() {
-		$has_required_methods = (
-			method_exists( 'Sabberworm\CSS\CSSList\Document', 'splice' )
-			&&
-			method_exists( 'Sabberworm\CSS\CSSList\Document', 'replace' )
-		);
-		if ( ! $has_required_methods ) {
-			return false;
-		}
-
 		$reflection = new ReflectionClass( 'Sabberworm\CSS\OutputFormat' );
 
 		$has_output_format_extensions = (
@@ -1743,7 +1734,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		);
 		$viewport_rules     = $parsed_stylesheet['viewport_rules'];
 
-		if ( ! empty( $parsed_stylesheet['css_document'] ) && method_exists( $css_list, 'replace' ) ) {
+		if ( ! empty( $parsed_stylesheet['css_document'] ) ) {
 			/**
 			 * CSS Doc.
 			 *
@@ -1751,15 +1742,38 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			$css_document = $parsed_stylesheet['css_document'];
 
-			// Work around bug in \Sabberworm\CSS\CSSList\CSSList::replace() when array keys are not 0-based.
-			$css_list->setContents( array_values( $css_list->getContents() ) );
-
-			$css_list->replace( $item, $css_document->getContents() );
+			$this->replace_inside_css_list( $css_list, $item, $css_document->getContents() );
 		} else {
 			$css_list->remove( $item );
 		}
 
 		return compact( 'validation_results', 'imported_font_urls', 'viewport_rules' );
+	}
+
+	/**
+	 * Replace an item inside of a CSSList.
+	 *
+	 * This is being used instead of `CSSList::splice()` because it uses `array_splice()` which does not work properly
+	 * if the array keys are not sequentially indexed from 0, which happens when `CSSList::remove()` is employed.
+	 *
+	 * @see CSSList::splice()
+	 * @see CSSList::replace()
+	 * @see CSSList::remove()
+	 *
+	 * @param CSSList                      $css_list  CSS list.
+	 * @param AtRule|RuleSet|CSSList       $old_item  Old item.
+	 * @param AtRule[]|RuleSet[]|CSSList[] $new_items New item(s). If empty, the old item is simply removed.
+	 * @return bool Whether the replacement was successful.
+	 */
+	private function replace_inside_css_list( CSSList $css_list, $old_item, $new_items = [] ) {
+		$contents = array_values( $css_list->getContents() ); // Required to obtain the offset instead of the index.
+		$offset   = array_search( $old_item, $contents, true );
+		if ( false !== $offset ) {
+			array_splice( $contents, $offset, 1, $new_items );
+			$css_list->setContents( $contents );
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -2152,8 +2166,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					// For adding @-moz-document to AMP, see <https://github.com/ampproject/amphtml/issues/26406>.
 					$new_css_item = new AtRuleBlockList( 'supports', '(-moz-appearance:meterbar)' );
 					$new_css_item->setContents( $css_item->getContents() );
-					$css_list->replace( $css_item, $new_css_item );
-					$css_list->remove( $css_item ); // @todo This should be redundant with the replace() above.
+					$this->replace_inside_css_list( $css_list, $css_item, [ $new_css_item ] );
 					$css_item  = $new_css_item; // To process_css_list below.
 					$sanitized = false;
 				} elseif ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
@@ -2720,13 +2733,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		);
 		$important_ruleset->setRules( $importants );
 
-		$i = array_search( $ruleset, $css_list->getContents(), true );
-		if ( false !== $i && method_exists( $css_list, 'splice' ) ) {
-			$css_list->splice( $i + 1, 0, [ $important_ruleset ] );
-		} else {
-			$css_list->append( $important_ruleset );
+		$contents = array_values( $css_list->getContents() ); // Ensure keys are 0-indexed and sequential.
+		$offset   = array_search( $ruleset, $contents, true );
+		if ( false !== $offset ) {
+			array_splice( $contents, $offset + 1, 0, [ $important_ruleset ] );
+			$css_list->setContents( $contents );
 		}
-
 		return $results;
 	}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2130,7 +2130,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$viewport_rules     = [];
 		$imported_font_urls = [];
 
-		foreach ( $css_list->getContents() as $i => $css_item ) {
+		foreach ( $css_list->getContents() as $css_item ) {
 			$sanitized = false;
 			if ( $css_item instanceof DeclarationBlock && empty( $options['validate_keyframes'] ) ) {
 				$validation_results = array_merge(
@@ -2152,7 +2152,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					// For adding @-moz-document to AMP, see <https://github.com/ampproject/amphtml/issues/26406>.
 					$new_css_item = new AtRuleBlockList( 'supports', '(-moz-appearance:meterbar)' );
 					$new_css_item->setContents( $css_item->getContents() );
-					$css_list->splice( $i, 1, [ $new_css_item ] );
+					$css_list->replace( $css_item, $new_css_item );
+					$css_list->remove( $css_item ); // @todo This should be redundant with the replace() above.
 					$css_item  = $new_css_item; // To process_css_list below.
 					$sanitized = false;
 				} elseif ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -150,6 +150,7 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		update_option( 'active_plugins', $bad_plugin_files );
 
 		foreach ( $bad_plugin_files as $bad_plugin_file ) {
+			/** @noinspection PhpIncludeInspection */
 			require AMP__DIR__ . '/' . MockPluginEnvironment::BAD_PLUGINS_DIR . '/' . $bad_plugin_file;
 		}
 

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -46,8 +46,7 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$this->reset_widgets();
 		add_filter(
 			'pre_http_request',
-			function( $r, $args, $url ) {
-				unset( $args );
+			function( $r, /** @noinspection PhpUnusedParameterInspection */ $args, $url ) {
 				if ( false === strpos( $url, 'amp_validate=' ) ) {
 					return $r;
 				}

--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -33,6 +33,9 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 
 	private $attempted_validate_request_urls = [];
 
+	/** @var PluginSuppression */
+	private $instance;
+
 	/**
 	 * Set up.
 	 */
@@ -44,6 +47,7 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		add_filter(
 			'pre_http_request',
 			function( $r, $args, $url ) {
+				unset( $args );
 				if ( false === strpos( $url, 'amp_validate=' ) ) {
 					return $r;
 				}
@@ -63,6 +67,7 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 
 		$plugin_suppression = $this->injector->make( PluginSuppression::class );
 		$plugin_registry    = $this->get_private_property( $plugin_suppression, 'plugin_registry' );
+		$this->instance     = $plugin_suppression;
 		$this->set_private_property(
 			$plugin_registry,
 			'plugin_folder',
@@ -187,88 +192,70 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		return $plugin_file_slugs;
 	}
 
-	/**
-	 * @param bool $register Call the register method.
-	 * @return PluginSuppression
-	 */
-	private function get_instance( $register = false ) {
-		$instance = $this->injector->make( PluginSuppression::class );
-		if ( $register ) {
-			$instance->register();
-		}
-		return $instance;
-	}
-
 	public function test_it_can_be_initialized() {
-		$instance = $this->get_instance();
-
-		$this->assertInstanceOf( PluginSuppression::class, $instance );
-		$this->assertInstanceOf( Service::class, $instance );
-		$this->assertInstanceOf( Registerable::class, $instance );
+		$this->assertInstanceOf( PluginSuppression::class, $this->instance );
+		$this->assertInstanceOf( Service::class, $this->instance );
+		$this->assertInstanceOf( Registerable::class, $this->instance );
 	}
 
 	/** @covers ::register() */
 	public function test_register_standard_mode() {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-		$instance = $this->get_instance();
-		$this->assertFalse( $instance->is_reader_theme_request() );
+		$this->assertFalse( $this->instance->is_reader_theme_request() );
 
-		$instance->register();
+		$this->instance->register();
 		$this->assertEquals(
 			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX, // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-			has_action( 'wp', [ $instance, 'maybe_suppress_plugins' ] )
+			has_action( 'wp', [ $this->instance, 'maybe_suppress_plugins' ] )
 		);
-		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $instance, 'filter_default_options' ] ) );
+		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
 	}
 
 	/** @covers ::register() */
 	public function test_register_reader_theme_mode() {
-		$instance = $this->get_instance();
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentynineteen' );
 		$_GET[ amp_get_slug() ] = 1;
-		$this->assertTrue( $instance->is_reader_theme_request() );
+		$this->assertTrue( $this->instance->is_reader_theme_request() );
 
 		$this->init_plugins();
 		$this->update_suppressed_plugins_option( array_fill_keys( $this->get_bad_plugin_file_slugs(), true ) );
-		$instance->register();
-		$this->assertFalse( has_action( 'plugins_loaded', [ $instance, 'suppress_plugins' ] ), 'Expected suppression to happen immediately.' );
+		$this->instance->register();
+		$this->assertFalse( has_action( 'plugins_loaded', [ $this->instance, 'suppress_plugins' ] ), 'Expected suppression to happen immediately.' );
 		$this->assertEquals( '', do_shortcode( '[bad]' ), 'Expected suppression to happen immediately.' );
-		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $instance, 'filter_default_options' ] ) );
+		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
 	}
 
 	/** @covers ::is_reader_theme_request() */
 	public function test_is_reader_theme_request() {
-		$instance = $this->get_instance();
-
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-		$this->assertFalse( $instance->is_reader_theme_request() );
+		$this->assertFalse( $this->instance->is_reader_theme_request() );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, ReaderThemes::DEFAULT_READER_THEME );
-		$this->assertFalse( $instance->is_reader_theme_request() );
+		$this->assertFalse( $this->instance->is_reader_theme_request() );
 		$_GET[ amp_get_slug() ] = 1;
-		$this->assertFalse( $instance->is_reader_theme_request() );
+		$this->assertFalse( $this->instance->is_reader_theme_request() );
 
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentynineteen' );
 		unset( $_GET[ amp_get_slug() ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$this->assertFalse( $instance->is_reader_theme_request() );
+		$this->assertFalse( $this->instance->is_reader_theme_request() );
 		$_GET[ amp_get_slug() ] = 1;
-		$this->assertTrue( $instance->is_reader_theme_request() );
+		$this->assertTrue( $this->instance->is_reader_theme_request() );
 	}
 
 	/** @covers ::filter_default_options() */
 	public function test_filter_default_options() {
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->assertEquals(
 			[
 				'foo'                      => 'bar',
 				Option::SUPPRESSED_PLUGINS => [],
 			],
-			$instance->filter_default_options( [ 'foo' => 'bar' ] )
+			$this->instance->filter_default_options( [ 'foo' => 'bar' ] )
 		);
-		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $instance, 'filter_default_options' ] ) );
+		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
 	}
 
 	/** @covers ::maybe_suppress_plugins() */
@@ -279,11 +266,11 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
 		$this->update_suppressed_plugins_option( array_fill_keys( $bad_plugin_file_slugs, true ) );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->go_to( $url );
 
 		$this->assertFalse( amp_is_request() );
-		$this->assertFalse( $instance->maybe_suppress_plugins(), 'Expected no suppression since not an AMP endpoint.' );
+		$this->assertFalse( $this->instance->maybe_suppress_plugins(), 'Expected no suppression since not an AMP endpoint.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
 
@@ -295,11 +282,11 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
 		$this->update_suppressed_plugins_option( array_fill_keys( $bad_plugin_file_slugs, true ) );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->go_to( $url );
 
 		$this->assertTrue( amp_is_request() );
-		$this->assertTrue( $instance->maybe_suppress_plugins(), 'Expected suppression since an AMP endpoint and there are suppressible plugins.' );
+		$this->assertTrue( $this->instance->maybe_suppress_plugins(), 'Expected suppression since an AMP endpoint and there are suppressible plugins.' );
 		$this->assert_plugin_suppressed_state( true, $bad_plugin_file_slugs );
 	}
 
@@ -311,11 +298,11 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		update_option( 'active_plugins', [] );
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->go_to( $url );
 
 		$this->assertTrue( amp_is_request() );
-		$this->assertFalse( $instance->suppress_plugins(), 'Expected no suppression since no suppressible plugins.' );
+		$this->assertFalse( $this->instance->suppress_plugins(), 'Expected no suppression since no suppressible plugins.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
 
@@ -326,12 +313,12 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$this->init_plugins();
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->go_to( $url );
 		AMP_Options_Manager::update_option( Option::SUPPRESSED_PLUGINS, [] );
 
 		$this->assertTrue( amp_is_request() );
-		$this->assertFalse( $instance->suppress_plugins(), 'Expected no suppression since no plugins are being suppressed.' );
+		$this->assertFalse( $this->instance->suppress_plugins(), 'Expected no suppression since no plugins are being suppressed.' );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
 
@@ -346,18 +333,18 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	public function test_suppress_plugins_when_conditions_satisfied_for_all() {
 		$url = home_url( '/' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-		$this->init_plugins();
 
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->assertGreaterThan( 0, $bad_plugin_file_slugs );
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
+		$this->init_plugins();
 		$this->go_to( $url );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 
 		$this->update_suppressed_plugins_option( array_fill_keys( $bad_plugin_file_slugs, true ) );
 		$this->assertTrue( amp_is_request() );
-		$this->assertTrue( $instance->suppress_plugins() );
+		$this->assertTrue( $this->instance->suppress_plugins() );
 		$this->assert_plugin_suppressed_state( true, $bad_plugin_file_slugs );
 	}
 
@@ -372,7 +359,6 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	public function test_suppress_plugins_when_conditions_satisfied_for_some() {
 		$url = home_url( '/' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-		$this->init_plugins();
 
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->assertGreaterThan( 0, $bad_plugin_file_slugs );
@@ -380,13 +366,14 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$unsuppressed_slugs = array_slice( $bad_plugin_file_slugs, 2 );
 
 		$this->populate_validation_errors( $url, $bad_plugin_file_slugs );
-		$instance = $this->get_instance( true );
+		$this->instance->register();
+		$this->init_plugins();
 		$this->go_to( $url );
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 
 		$this->update_suppressed_plugins_option( array_fill_keys( $suppressed_slugs, true ) );
 		$this->assertTrue( amp_is_request() );
-		$this->assertTrue( $instance->suppress_plugins() );
+		$this->assertTrue( $this->instance->suppress_plugins() );
 		$this->assert_plugin_suppressed_state( true, $suppressed_slugs );
 		$this->assert_plugin_suppressed_state( false, $unsuppressed_slugs );
 	}
@@ -400,8 +387,7 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	public function test_sanitize_options() {
 		remove_all_filters( 'amp_options_updating' ); // @todo Figure out why this is needed to prevent duplicate PluginSuppression::sanitize_options() callbacks from being added.
 
-		$instance = $this->get_instance();
-		$instance->register();
+		$this->instance->register();
 
 		$this->init_plugins();
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
@@ -485,8 +471,8 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	 * @covers ::get_sorted_plugin_validation_errors()
 	 */
 	public function test_get_suppressible_plugins_with_details_but_no_plugins_active() {
-		$instance = $this->get_instance( true );
-		$this->assertCount( 0, array_keys( $instance->get_suppressible_plugins_with_details() ) );
+		$this->instance->register();
+		$this->assertCount( 0, array_keys( $this->instance->get_suppressible_plugins_with_details() ) );
 	}
 
 	/**
@@ -495,8 +481,8 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	 */
 	public function test_get_suppressible_plugins_with_no_errors_present() {
 		$this->init_plugins();
-		$instance             = $this->get_instance( true );
-		$suppressible_plugins = $instance->get_suppressible_plugins_with_details();
+		$this->instance->register();
+		$suppressible_plugins = $this->instance->get_suppressible_plugins_with_details();
 		$this->assertEqualSets( $this->get_bad_plugin_file_slugs(), array_keys( $suppressible_plugins ) );
 		foreach ( $suppressible_plugins as $suppressible_plugin ) {
 			$this->assertCount( 0, $suppressible_plugin['validation_errors'] );
@@ -508,12 +494,12 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 	 * @covers ::get_sorted_plugin_validation_errors()
 	 */
 	public function test_get_suppressible_plugins_with_details_when_plugins_active_and_errors_present() {
-		$instance = $this->get_instance( true );
+		$this->instance->register();
 		$this->init_plugins();
 		$bad_plugin_file_slugs = $this->get_bad_plugin_file_slugs();
 		$this->update_suppressed_plugins_option( array_fill_keys( $bad_plugin_file_slugs, false ) );
 		$this->populate_validation_errors( home_url( '/' ), $bad_plugin_file_slugs );
-		$suppressible_plugins = $instance->get_suppressible_plugins_with_details();
+		$suppressible_plugins = $this->instance->get_suppressible_plugins_with_details();
 		$this->assertEqualSets( $bad_plugin_file_slugs, array_keys( $suppressible_plugins ) );
 		foreach ( $suppressible_plugins as $suppressible_plugin ) {
 			$this->assertCount( 1, $suppressible_plugin['validation_errors'] );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -202,7 +202,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'allowed_at_rules_retained' => [
-				'<style>@charset "UTF-8"; @media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<style>@charset "UTF-8"; @charset "UTF-8"; @charset "UTF-8"; @media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
 				[
 					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (-moz-appearance:meterbar){body{color:red}}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -202,10 +202,60 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'allowed_at_rules_retained' => [
-				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
 				[
-					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',
+					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (-moz-appearance:meterbar){body{color:red}}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',
+				],
+			],
+
+			'moz_document_transformed' => [
+				'
+					<style>
+						@-moz-document url-prefix() {
+							/* From Twenty Nineteen. */
+							.entry .entry-content .has-drop-cap:not(:focus):first-letter {
+								margin-top: 0.2em;
+							}
+						}
+					</style>
+					<style>
+						@-moz-document url-prefix(   ) {
+							.has-drop-cap {
+								/* Firefox does not even allow whitespace in the url-prefix() args. */
+								color: red;
+							}
+						}
+					</style>
+					<style>
+						@-moz-document url-prefix("http://") {
+							/* This rule will be dropped as a validation error since the url-prefix() is not empty. */
+							.has-drop-cap {
+								color: red;
+							}
+						}
+					</style>
+					<style>
+						@-moz-document url("https://example.com/") {
+							/* This rule will be dropped as a validation error since only an empty url-prefix() is allowed. */
+							.has-drop-cap {
+								color: red;
+							}
+						}
+					</style>
+					<div class="entry"><div class="entry-content"><p class="has-drop-cap">Hello</p></div></div>
+				',
+				'
+					<div class="entry"><div class="entry-content"><p class="has-drop-cap">Hello</p></div></div>
+				',
+				[
+					'@supports (-moz-appearance:meterbar){.entry .entry-content .has-drop-cap:not(:focus):first-letter{margin-top:.2em}}',
+					'',
+				],
+				[
+					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,
+					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,
+					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,
 				],
 			],
 

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -202,7 +202,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'allowed_at_rules_retained' => [
-				'<style>@charset "UTF-8"; @charset "UTF-8"; @charset "UTF-8"; @media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<style>@charset "UTF-8"; @charset "UTF-8"; @charset "UTF-8"; html:lang(zz){ color: gray; } @media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
 				[
 					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (-moz-appearance:meterbar){body{color:red}}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -216,6 +216,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 							/* From Twenty Nineteen. */
 							.entry .entry-content .has-drop-cap:not(:focus):first-letter {
 								margin-top: 0.2em;
+								behavior: url(hilite.htc);
+								-moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox);
 							}
 						}
 					</style>
@@ -253,6 +255,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'',
 				],
 				[
+					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_PROPERTY_NOLIST,
+					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_PROPERTY_NOLIST,
 					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,
 					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,
 					AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE,

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -202,7 +202,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'allowed_at_rules_retained' => [
-				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<style>@charset "UTF-8"; @media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @-moz-document url-prefix() { body { color:red; } } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
 				[
 					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (-moz-appearance:meterbar){body{color:red}}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1363,7 +1363,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}--><ul class="%6$s"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1},"type":"%1$s","name":"%2$s","file":%4$s,"line":%5$s,"function":"%3$s"}-->',
 					$is_gutenberg ? 'plugin' : 'core',
 					$is_gutenberg ? 'gutenberg' : 'wp-includes',
-					$latest_posts_block->render_callback,
+					$latest_posts_block->render_callback instanceof Closure ? '{closure}' : $latest_posts_block->render_callback,
 					wp_json_encode(
 						$is_gutenberg
 						? preg_replace( ':.*gutenberg/:', '', $reflection_function->getFileName() )


### PR DESCRIPTION
## Summary

In #5305 the AMP plugin suppressed any validation error caused by Twenty Nineteen's introduction (#5302) of the `@-moz-document url-prefix()` hack to add Firefox-specific CSS style rules. This at-rule causes an AMP validation error because it is not yet allowed, per https://github.com/ampproject/amphtml/issues/26406. Nevertheless, there are other ways of writing Firefox-specific style rules. One [way](http://browserhacks.com/#hack-8e9b5504d9fda44ec75169381b3c3157) is `@supports (-moz-appearance:meterbar)`. A benefit of using `@supports` is that it will also work in `style[amp-keyframes]`.

Given this `post_content`:

```html
<!-- wp:paragraph {"dropCap":true} -->
<p class="has-drop-cap">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae nibh at neque faucibus dignissim. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis lorem eros, condimentum nec vulputate id, lacinia sed lorem. Donec mattis dignissim eros, sit amet gravida lorem imperdiet et. Ut fringilla laoreet viverra. Nullam ac lorem sit amet enim viverra aliquet sed nec tellus. Proin sed pharetra mauris. Duis commodo leo nec finibus blandit.</p>
<!-- /wp:paragraph -->
```

Chrome | Firefox Before 👎  | Firefox After 👍 
--------|-------------------|----------------
![image](https://user-images.githubusercontent.com/134745/96673163-badc2880-131a-11eb-9994-a63835a056e4.png) | ![image](https://user-images.githubusercontent.com/134745/96673186-c4fe2700-131a-11eb-8a48-5fb5f5d6d5ef.png) | ![image](https://user-images.githubusercontent.com/134745/96673202-cfb8bc00-131a-11eb-83da-fe0de9eea3aa.png)

(Note how the drop-cap “L” is mispositioned vertically in Firefox before compared to Chrome and Firefox after.)

There are [162 themes](https://wpdirectory.net/search/01EN4P8CPK16HNEX5HSPYHHB6M) and [559 plugins](https://wpdirectory.net/search/01EN4P9QDAE35W09WV1H5SBEE5) which are using this hack which now will not have to do anything to become AMP-compatible in this regard.

----

This pull request also fixes compatibility with Gutenberg 9.2.1 due to `gutenberg_current_parsed_block_tracking()` wrapping the `render_callback` of all registered blocks. This caused test failures for block source attribution as well as plugin suppression. The changes improve the reliability of Plugin Suppression for dynamic blocks.