### PR TITLE
Fix PHPUnit tests in WordPress 5.6-beta1

### DIFF
--- a/tests/php/src/PluginRegistryTest.php
+++ b/tests/php/src/PluginRegistryTest.php
@@ -22,6 +22,13 @@ final class PluginRegistryTest extends TestCase {
 		$this->assertInstanceOf( Service::class, $plugin_registry );
 	}
 
+	/** @covers ::get_plugin_dir() */
+	public function test_get_plugin_dir() {
+		$plugin_registry  = new PluginRegistry();
+		$plugin_directory = $plugin_registry->get_plugin_dir();
+		$this->assertEquals( WP_CONTENT_DIR . '/plugins', $plugin_directory );
+	}
+
 	/** @covers ::get_plugin_slug_from_file() */
 	public function test_get_plugin_slug_from_file() {
 		$plugin_registry = new PluginRegistry();

--- a/tests/php/src/PluginRegistryTest.php
+++ b/tests/php/src/PluginRegistryTest.php
@@ -5,10 +5,12 @@ namespace AmpProject\AmpWP\Tests;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\Tests\Helpers\MockPluginEnvironment;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use PHPUnit\Framework\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\PluginRegistry */
 final class PluginRegistryTest extends TestCase {
+	use PrivateAccess;
 
 	private function populate_plugins() {
 		wp_cache_set( 'plugins', [ '' => MockPluginEnvironment::PLUGINS_DATA ], 'plugins' );
@@ -24,9 +26,14 @@ final class PluginRegistryTest extends TestCase {
 
 	/** @covers ::get_plugin_dir() */
 	public function test_get_plugin_dir() {
-		$plugin_registry  = new PluginRegistry();
+		$plugin_registry = new PluginRegistry();
+
 		$plugin_directory = $plugin_registry->get_plugin_dir();
 		$this->assertEquals( WP_CONTENT_DIR . '/plugins', $plugin_directory );
+
+		$this->set_private_property( $plugin_registry, 'plugin_folder', 'amp/tests/php/data/plugins' );
+		$plugin_directory = $plugin_registry->get_plugin_dir();
+		$this->assertEquals( WP_CONTENT_DIR . '/plugins/amp/tests/php/data/plugins', $plugin_directory );
 	}
 
 	/** @covers ::get_plugin_slug_from_file() */

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -95,14 +95,14 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @param array  $expected Expected scripts.
 	 */
 	public function test__get_scripts( $source, $expected ) {
+		if ( self::is_external_http_test_suite() ) {
+			$this->markTestSkipped( 'Endpoint is gone.' );
+		}
+
 		$embed = new AMP_Facebook_Embed_Handler();
 		$embed->register_embed();
 
 		$filtered_content = apply_filters( 'the_content', $source );
-
-		if ( self::is_external_http_test_suite() ) {
-			$this->markTestSkipped( 'Endpoint is down.' );
-		}
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
@@ -280,14 +280,14 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @covers AMP_Facebook_Embed_Handler::sanitize_raw_embeds()
 	 */
 	public function test__raw_embed_sanitizer( $source, $expected ) {
+		if ( self::is_external_http_test_suite() ) {
+			$this->markTestSkipped( 'Endpoint is gone.' );
+		}
+
 		$embed = new AMP_Facebook_Embed_Handler();
 		$embed->register_embed();
 
 		$filtered_content = apply_filters( 'the_content', $source );
-
-		if ( self::is_external_http_test_suite() ) {
-			$this->markTestSkipped( 'Endpoint is down.' );
-		}
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -100,7 +100,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 
 		$filtered_content = apply_filters( 'the_content', $source );
 
-		if ( self::is_external_http_test_suite() && "<p>$source</p>" === trim( $filtered_content ) ) {
+		if ( self::is_external_http_test_suite() ) {
 			$this->markTestSkipped( 'Endpoint is down.' );
 		}
 
@@ -285,7 +285,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 
 		$filtered_content = apply_filters( 'the_content', $source );
 
-		if ( self::is_external_http_test_suite() && "<p>$source</p>" === trim( $filtered_content ) ) {
+		if ( self::is_external_http_test_suite() ) {
 			$this->markTestSkipped( 'Endpoint is down.' );
 		}
 


### PR DESCRIPTION
## Summary

I just tried switching to WordPress 5.6-beta1 (on trunk) and did a dev build but I'm now getting a bunch of PHPUnit failures.

Part of it is that `\AmpProject\AmpWP\PluginRegistry::get_plugin_dir()` on `trunk` is returning `/app/public/core-dev/tests/phpunit/data/plugins` whereas the 5.5 branch is returning `/app/public/content/plugins`. So in WP 5.6-beta1 the `WP_PLUGIN_DIR` is being defined differently.

Looks like this was introduced in https://github.com/WordPress/wordpress-develop/commit/9e83d04f8494c1495e6e86b180b386250bbd703b#diff-0ace0b1b4bc0930162497ceb88eb1c797a466053cffa12bbe72fa4f707cfe657R80


I'm confused why tests aren't failing on Travis for `trunk`: https://travis-ci.org/github/ampproject/amp-wp/jobs/737615165

Locally the tests are failing with:

```
$ phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

.............................................................   61 / 2103 (  2%)
.............................................................  122 / 2103 (  5%)
.............................................................  183 / 2103 (  8%)
.............................................................  244 / 2103 ( 11%)
.............................................................  305 / 2103 ( 14%)
.............................................................  366 / 2103 ( 17%)
.............................................................  427 / 2103 ( 20%)
.............................................................  488 / 2103 ( 23%)
.............................................................  549 / 2103 ( 26%)
.........................FFF.F.....F.........................  610 / 2103 ( 29%)
.............................................................  671 / 2103 ( 31%)
.............................................................  732 / 2103 ( 34%)
.............................................................  793 / 2103 ( 37%)
.............................................................  854 / 2103 ( 40%)
.............................................................  915 / 2103 ( 43%)
.............................................................  976 / 2103 ( 46%)
............................................................. 1037 / 2103 ( 49%)
............................................................. 1098 / 2103 ( 52%)
............................................................. 1159 / 2103 ( 55%)
.....SSSSSSSSSS.............................................. 1220 / 2103 ( 58%)
.....................................F....................... 1281 / 2103 ( 60%)
............................................................. 1342 / 2103 ( 63%)
............................................................. 1403 / 2103 ( 66%)
............................................................. 1464 / 2103 ( 69%)
............................................................. 1525 / 2103 ( 72%)
............................................................. 1586 / 2103 ( 75%)
............................................................. 1647 / 2103 ( 78%)
............................................................. 1708 / 2103 ( 81%)
............................................................. 1769 / 2103 ( 84%)
..................................................FFFFFFFFF.F 1830 / 2103 ( 87%)
..F.F........................................................ 1891 / 2103 ( 89%)
....E...E...E................................................ 1952 / 2103 ( 92%)
............................................................. 2013 / 2103 ( 95%)
............................................................. 2074 / 2103 ( 98%)
....F...F..FFF.FF............                                 2103 / 2103 (100%)

Time: 1.01 minutes, Memory: 94.51MB

There were 3 errors:

1) AmpProject\AmpWP\Tests\DevTools\CallbackReflectionTest::test_get_source with data set "plugin_function" ('amp_after_setup_theme', 'amp_after_setup_theme', 'amp', 'plugin', 'includes/amp-helper-functions.php', 'ReflectionFunction')
Undefined index: type

/app/public/content/plugins/amp/tests/php/src/DevTools/CallbackReflectionTest.php:143

2) AmpProject\AmpWP\Tests\DevTools\CallbackReflectionTest::test_get_source with data set "plugin_closure" (Closure Object (...), 'AmpProject\AmpWP\Tests\DevToo...osure}', 'amp', 'plugin', 'tests/php/src/DevTools/Callba...st.php', 'ReflectionFunction')
Undefined index: type

/app/public/content/plugins/amp/tests/php/src/DevTools/CallbackReflectionTest.php:143

3) AmpProject\AmpWP\Tests\DevTools\FileReflectionTest::test_get_file_source_plugin
Undefined index: type

/app/public/content/plugins/amp/tests/php/src/DevTools/FileReflectionTest.php:54

--

There were 25 failures:

1) AMP_Style_Sanitizer_Test::test_css_import with data set "local_css_files" (array('http://example.org/content/pl...in.css', 'http://example.org/content/pl...ns.css'), '<style>div::after{content:"Af...</div>', 0, null, Closure Object (...))
Failed asserting that 'div::after{content:"After login"}\n
\n
/*# sourceURL=amp-custom.css */' matches PCRE pattern "/.*input\[type\="checkbox"\]\:disabled.*\.wp\-core\-ui \.button.*div\:\:after\{content\:"After login"\}/s".

/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2498
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2720

2) AMP_Style_Sanitizer_Test::test_css_import with data set "local_css_with_import_failure_rejecting" (array('http://example.org/core-dev/s...st.css', 'https://bogus.example.com/rem...st.css', 'http://example.org/content/pl...in.css', 'https://bogus.example.com/rem...st.css'), '<style>div::after{content:"En.../body>', 4, Closure Object (...), Closure Object (...), array(true))
Did not see .form-table td at position 4.
Failed asserting that '@import url("http://example.org/core-dev/src/wp-admin/css/local-does-not-exist.css");@import url("https://bogus.example.com/remote-does-not-exist.css");@import url("http://example.org/content/plugins/app/public/content/plugins/amp/tests/php/data/css/foo/../login.css");@import url("https://bogus.example.com/remote-also-does-not-exist.css");@import url("https://bogus.example.com/remote-finally-does-not-exist.css");div::after{content:"End"}\n
\n
/*# sourceURL=amp-custom.css */' contains ".form-table td".

/app/public/content/plugins/amp/tests/php/src/Helpers/AssertContainsCompatibility.php:33
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2533
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2720

3) AMP_Style_Sanitizer_Test::test_css_import with data set "local_css_with_import_failure_accepting" (array('http://example.org/core-dev/s...st.css', 'https://bogus.example.com/rem...st.css', 'http://example.org/content/pl...in.css', 'https://bogus.example.com/rem...st.css'), '<style>div::after{content:"En.../body>', 4, Closure Object (...), Closure Object (...), array(false))
Did not see .form-table td at position 0.
Failed asserting that 'div::after{content:"End"}\n
\n
/*# sourceURL=amp-custom.css */' contains ".form-table td".

/app/public/content/plugins/amp/tests/php/src/Helpers/AssertContainsCompatibility.php:33
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2579
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2720

4) AMP_Style_Sanitizer_Test::test_css_import with data set "dynamic_stylesheet_with_absolute_import" ('http://example.org/core-dev/s...ns.php', '<style>div::after{content:"Af.../body>', 1, Closure Object (...), Closure Object (...))
Failed asserting that 'body{color:#123456}div::after{content:"After import-buttons2"}\n
\n
/*# sourceURL=amp-custom.css */' matches PCRE pattern "/.*\.wp\-core\-ui \.button.*body\{color\:\#123456\}.*div\:\:after\{content\:"After import\-buttons2"\}/s".

/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2620
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2720

5) AMP_Style_Sanitizer_Test::test_prioritized_stylesheets with data set "admin_bar_included" (Closure Object (...), Closure Object (...))
Expected amp-default.css
Failed asserting that '<!DOCTYPE html>\n
<html><head><meta charset="utf-8"><title>Post title 0000159 – Test Blog</title>\n
<link rel="dns-prefetch" href="//s.w.org">\n
<link rel="alternate" type="application/rss+xml" title="Test Blog » Post title 0000159 Comments Feed" href="http://example.org/?feed=rss2&amp;p=94">\n
		\n
				\n
				\n
		\n
\n
\n
\n
\n
\n
\n
\n
<link rel="https://api.w.org/" href="http://example.org/index.php?rest_route=/"><link rel="alternate" type="application/json" href="http://example.org/index.php?rest_route=/wp/v2/posts/94"><link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://example.org/core-dev/src/xmlrpc.php?rsd">\n
<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://example.org/core-dev/src/wp-includes/wlwmanifest.xml"> \n
<meta name="generator" content="WordPress 5.6-beta1-49262-src">\n
<link rel="canonical" href="http://example.org/?p=94">\n
<link rel="shortlink" href="http://example.org/?p=94">\n
<link rel="alternate" type="application/json+oembed" href="http://example.org/index.php?rest_route=%2Foembed%2F1.0%2Fembed&amp;url=http%3A%2F%2Fexample.org%2F%3Fp%3D94">\n
<link rel="alternate" type="text/xml+oembed" href="http://example.org/index.php?rest_route=%2Foembed%2F1.0%2Fembed&amp;url=http%3A%2F%2Fexample.org%2F%3Fp%3D94&amp;format=xml">\n
\n
	<meta name="generator" content="AMP Plugin v2.1.0-alpha; mode=standard"><style amp-custom="">@font-face{font-family:dashicons;src:url("http://example.org/core-dev/src/wp-includes/fonts/dashicons.eot?99ac726223c749443b642ce33df8b800");src:url("http://example.org/core-dev/src/wp-includes/fonts/dashicons.eot?99ac726223c749443b642ce33df8b800#iefix") format("embedded-opentype"),url("http://example.org/core-dev/src/wp-includes/fonts/dashicons.woff") format("woff"),url("http://example.org/core-dev/src/wp-includes/fonts/dashicons.ttf?99ac726223c749443b642ce33df8b800") format("truetype");font-weight:400;font-style:normal;font-display:swap}#wpadminbar *{height:auto;width:auto;margin:0;padding:0;position:static;text-shadow:none;text-transform:none;letter-spacing:normal;font-size:13px;font-weight:400;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;line-height:2.46153846;border-radius:0;box-sizing:content-box;transition:none;-webkit-font-smoothing:subpixel-antialiased;-moz-osx-font-smoothing:auto}#wpadminbar .ab-empty-item{cursor:default}#wpadminbar .ab-empty-item,#wpadminbar a.ab-item{color:#eee}#wpadminbar ul li:before,#wpadminbar ul li:after{content:normal}#wpadminbar a,#wpadminbar a:hover,#wpadminbar a img,#wpadminbar a img:hover{border:none;text-decoration:none;background:none}#wpadminbar a:focus,#wpadminbar a:active,#wpadminbar input[type="text"],#wpadminbar input[type="password"],#wpadminbar input[type="number"],#wpadminbar input[type="search"],#wpadminbar input[type="email"],#wpadminbar input[type="url"],#wpadminbar div{box-shadow:none}#wpadminbar a:focus{outline-offset:-1px}#wpadminbar{direction:ltr;color:#ccc;font-size:13px;font-weight:400;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;line-height:2.46153846;height:32px;position:fixed;top:0;left:0;width:100%;min-width:600px;z-index:99999;background:#23282d}#wpadminbar .ab-sub-wrapper,#wpadminbar ul,#wpadminbar ul li{background:none;clear:none;list-style:none;margin:0;padding:0;position:relative;text-indent:0;z-index:99999}#wpadminbar ul#wp-admin-bar-root-default>li{margin-right:0}#wpadminbar .quicklinks ul{text-align:left}#wpadminbar li{float:left}#wpadminbar .ab-empty-item{outline:none}#wpadminbar .quicklinks .ab-top-secondary > li{float:right}#wpadminbar .quicklinks a,#wpadminbar .quicklinks .ab-empty-item{height:32px;display:block;padding:0 10px;margin:0}#wpadminbar .quicklinks > ul > li > a{padding:0 8px 0 7px}#wpadminbar .menupop .ab-sub-wrapper{margin:0;padding:0;box-shadow:0 3px 5px rgba(0,0,0,.2);background:#32373c;display:none;position:absolute;float:none}#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper{min-width:100%}#wpadminbar .ab-top-secondary .menupop .ab-sub-wrapper{right:0;left:auto}#wpadminbar .ab-submenu{padding:6px 0}#wpadminbar .quicklinks .menupop ul li{float:none}#wpadminbar .quicklinks .menupop ul li .ab-item,#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item{line-height:2;height:26px;white-space:nowrap;min-width:140px}#wpadminbar.nojs li:hover > .ab-sub-wrapper{display:block}#wpadminbar .menupop li:hover > .ab-sub-wrapper{margin-left:100%;margin-top:-32px}#wpadminbar .ab-top-secondary .menupop li:hover > .ab-sub-wrapper{margin-left:0;left:inherit;right:100%}#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item{background:#32373c;color:#00b9eb}#wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,#wpadminbar .ab-icon,#wpadminbar .ab-item:before{position:relative;float:left;font:normal 20px/1 dashicons;speak:none;padding:4px 0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;margin-right:6px}#wpadminbar .ab-icon:before,#wpadminbar .ab-item:before,#wpadminbar #adminbarsearch:before{color:#a0a5aa;color:rgba(240,245,250,.6)}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar .ab-icon,:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar .ab-item:before{background-image:none}#wpadminbar .ab-icon:before,#wpadminbar .ab-item:before,#wpadminbar #adminbarsearch:before{position:relative;transition:all .1s ease-in-out}#wpadminbar .ab-submenu .ab-item{color:#b4b9be;color:rgba(240,245,250,.7)}#wpadminbar .quicklinks .menupop ul li a,#wpadminbar.nojs .quicklinks .menupop:hover ul li a{color:#b4b9be;color:rgba(240,245,250,.7)}#wpadminbar .quicklinks .menupop ul li a:hover,#wpadminbar .quicklinks .menupop ul li a:focus,#wpadminbar.nojs .quicklinks .menupop:hover ul li a:hover,#wpadminbar.nojs .quicklinks .menupop:hover ul li a:focus,#wpadminbar li:hover .ab-icon:before,#wpadminbar li:hover .ab-item:before,#wpadminbar li a:focus .ab-icon:before,#wpadminbar li .ab-item:focus:before,#wpadminbar li .ab-item:focus .ab-icon:before,#wpadminbar li:hover #adminbarsearch:before{color:#00b9eb}#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before{position:absolute;font:normal 17px/1 dashicons;speak:none;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}#wpadminbar .menupop .menupop > .ab-item{display:block;padding-right:2em}#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item{padding-left:2em;padding-right:1em}#wpadminbar .quicklinks .menupop ul.ab-sub-secondary{display:block;position:relative;right:auto;margin:0;box-shadow:none}#wpadminbar .quicklinks .menupop ul.ab-sub-secondary,#wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu{background:#464b50}#wpadminbar .quicklinks .menupop .ab-sub-secondary > li > a:hover,#wpadminbar .quicklinks .menupop .ab-sub-secondary > li .ab-item:focus a{color:#00b9eb}#wpadminbar .ab-top-secondary{float:right}#wpadminbar ul li:last-child,#wpadminbar ul li:last-child .ab-item{box-shadow:none}#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon{width:15px;height:20px;margin-right:0;padding:6px 0 5px}#wpadminbar #wp-admin-bar-wp-logo > .ab-item{padding:0 7px}#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before{content:"";top:2px}#wpadminbar #wp-admin-bar-search .ab-item{padding:0;background:transparent}#wpadminbar #adminbarsearch{position:relative;height:32px;padding:0 2px;z-index:1}#wpadminbar #adminbarsearch:before{position:absolute;top:6px;left:5px;z-index:20;content:"";speak:none;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar #adminbarsearch:before{font:normal 20px/1 dashicons}#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input{display:inline-block;float:none;position:relative;z-index:30;font-size:13px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;line-height:1.84615384;text-indent:0;height:24px;width:24px;max-width:none;padding:0 3px 0 24px;margin:0;color:#ccc;background-color:rgba(255,255,255,0);border:none;outline:none;cursor:pointer;box-shadow:none;box-sizing:border-box;transition-duration:400ms;transition-property:width,background;transition-timing-function:ease}#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus{z-index:10;color:#000;width:200px;background-color:rgba(255,255,255,.9);cursor:text;border:0}#wpadminbar #adminbarsearch .adminbar-button{display:none}#wpadminbar .screen-reader-text,#wpadminbar .screen-reader-text span{border:0;clip:rect(1px,1px,1px,1px);-webkit-clip-path:inset(50%);clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar .screen-reader-text,:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar .screen-reader-text span{word-wrap:normal}#wpadminbar .screen-reader-shortcut{position:absolute;top:-1000em}#wpadminbar .screen-reader-shortcut:focus{left:6px;top:7px;height:auto;width:auto;display:block;font-size:14px;font-weight:600;padding:15px 23px 14px;background:#f1f1f1;color:#0073aa;z-index:100000;line-height:normal;text-decoration:none;box-shadow:0 0 2px 2px rgba(0,0,0,.6)}@media screen and (max-width: 782px){html #wpadminbar{height:46px;min-width:240px}#wpadminbar *{font-size:14px;font-weight:400;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;line-height:2.28571428}#wpadminbar .quicklinks > ul > li > a,#wpadminbar .quicklinks .ab-empty-item{padding:0;height:46px;line-height:3.28571428;width:auto}#wpadminbar .ab-icon{margin:0;padding:0;width:52px;height:46px;text-align:center}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar .ab-icon{font:40px/1 dashicons}#wpadminbar .ab-icon:before{text-align:center}#wpadminbar .ab-submenu{padding:0}#wpadminbar .quicklinks .menupop ul li .ab-item,#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item{line-height:1.6}#wpadminbar .menupop li:hover > .ab-sub-wrapper{margin-top:-46px}#wpadminbar .ab-top-menu .menupop .ab-sub-wrapper .menupop > .ab-item{padding-right:30px}#wpadminbar .menupop .menupop > .ab-item:before{top:10px;right:6px}#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper .ab-item{font-size:16px;padding:8px 16px}#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper a:empty{display:none}#wpadminbar #wp-admin-bar-wp-logo > .ab-item{padding:0}#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon{padding:0;width:52px;height:46px;text-align:center;vertical-align:top}#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before{top:-3px}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before{font:28px/1 dashicons}#wpadminbar .ab-icon,#wpadminbar .ab-item:before{padding:0}#wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,#wpadminbar .ab-icon,#wpadminbar .ab-item:before{padding:0;margin-right:0}#wpadminbar #wp-admin-bar-search{display:none}#wp-toolbar > ul > li{display:none}#wpadminbar li#wp-admin-bar-wp-logo{display:block}#wpadminbar li:hover ul li,#wpadminbar li:hover ul li:hover ul li{display:list-item}#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper{min-width:-webkit-fit-content;min-width:fit-content}#wpadminbar ul#wp-admin-bar-root-default > li{margin-right:0}#wpadminbar .ab-top-menu,#wpadminbar .ab-top-secondary,#wpadminbar #wp-admin-bar-wp-logo{position:static}#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before{top:10px;left:0}}@media screen and (max-width: 600px){#wpadminbar{position:absolute}#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper{width:100%;left:0}#wpadminbar .menupop .menupop > .ab-item:before{display:none}#wpadminbar #wp-admin-bar-wp-logo.menupop .ab-sub-wrapper{margin-left:0}#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper{margin:0;width:100%;top:auto;left:auto;position:relative}#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper .ab-item{font-size:16px;padding:6px 15px 19px 30px}#wpadminbar li:hover ul li ul li{display:list-item}#wpadminbar li#wp-admin-bar-wp-logo{display:none}#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper{position:static;box-shadow:none}}html:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_){margin-top:32px}@media screen and ( max-width: 782px ){html:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_){margin-top:46px}}:root{--wp-admin-theme-color:#007cba;--wp-admin-theme-color-darker-10:#006ba1;--wp-admin-theme-color-darker-20:#005a87}.wp-block-audio figcaption{margin-top:.5em;margin-bottom:1em}:root{--wp-admin-theme-color:#007cba;--wp-admin-theme-color-darker-10:#006ba1;--wp-admin-theme-color-darker-20:#005a87}.wp-block-audio figcaption{color:#555;font-size:13px;text-align:center}[class^="wp-block-"]:not(.wp-block-gallery) figcaption{color:#777;font-family:"Helvetica Neue",Arial,Helvetica,"Nimbus Sans L",sans-serif}.wp-block-audio{margin-left:0;margin-right:0}@media print{#wpadminbar{display:none}}\n
\n
/*# sourceURL=amp-custom.css */</style></head><body class="post-template-default single single-post postid-94 single-format-standard admin-bar customize-support">							<figure class="wp-block-audio"><figcaption></figcaption></figure>\n
							<div class="wp-block-foo"><figcaption></figcaption></div>\n
							<amp-img src="https://example.com/example.jpg" width="100" height="200" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/example.jpg" width="100" height="200"></noscript></amp-img>\n
							\n
\n
		<div id="wpadminbar" class="nojq nojs">\n
							<a class="screen-reader-shortcut" href="#wp-toolbar" tabindex="1">Skip to toolbar</a>\n
						<div class="quicklinks" id="wp-toolbar" role="navigation" aria-label="Toolbar">\n
				<ul id="wp-admin-bar-root-default" class="ab-top-menu"><li id="wp-admin-bar-wp-logo" class="menupop"><div class="ab-item ab-empty-item" tabindex="0" aria-haspopup="true"><span class="ab-icon"></span><span class="screen-reader-text">About WordPress</span></div><div class="ab-sub-wrapper"><ul id="wp-admin-bar-wp-logo-external" class="ab-sub-secondary ab-submenu"><li id="wp-admin-bar-wporg"><a class="ab-item" href="https://wordpress.org/">WordPress.org</a></li><li id="wp-admin-bar-documentation"><a class="ab-item" href="https://codex.wordpress.org/">Documentation</a></li><li id="wp-admin-bar-support-forums"><a class="ab-item" href="https://wordpress.org/support/">Support</a></li><li id="wp-admin-bar-feedback"><a class="ab-item" href="https://wordpress.org/support/forum/requests-and-feedback">Feedback</a></li></ul></div></li></ul><ul id="wp-admin-bar-top-secondary" class="ab-top-secondary ab-top-menu"><li id="wp-admin-bar-search" class="admin-bar-search"><div class="ab-item ab-empty-item" tabindex="-1"></div></li></ul>			</div>\n
					</div>\n
\n
		</body></html>\n
' contains "amp-img.amp-wp-enforced-sizes".

/app/public/content/plugins/amp/tests/php/src/Helpers/AssertContainsCompatibility.php:33
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2918
/app/public/content/plugins/amp/tests/php/test-amp-style-sanitizer.php:2993

6) Test_AMP_Theme_Support::test_prepare_response
Failed asserting that actual size 8 matches expected size 5.

/app/public/content/plugins/amp/tests/php/test-class-amp-theme-support.php:1966

7) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "directly_enqueued_link" (Closure Object (...), '//link[ contains( @href, "foo.css" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'style'
    'handle' => 'foo'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1002
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

8) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "stylesheet_added_as_dependency" (Closure Object (...), '//link[ contains( @href, "cod...r" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'style'
    'handle' => 'bar'
    'dependency_handle' => 'wp-codemirror'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1034
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

9) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "inline_style_for_directly_enqueued_stylesheet" (Closure Object (...), '//style[ contains( text(), "H...z" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'style'
    'extra_key' => 'after'
    'text' => '/*Hello Baz!*/'
    'handle' => 'baz'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1068
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

10) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "external_script_directly_enqueued" (Closure Object (...), '//script[ contains( @src, "foo.js" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'script'
    'handle' => 'foo'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1100
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

11) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "external_script_indirectly_enqueued" (Closure Object (...), '//script[ contains( @src, "co...r" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'script'
    'handle' => 'bar'
    'dependency_handle' => 'wp-codemirror'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1133
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

12) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "inline_script_added_via_wp_localize_script" (Closure Object (...), '//script[ contains( text(), "...!" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'script'
    'extra_key' => 'data'
    'text' => 'var Baz = {"greeting":"Hello Baz!"};'
    'handle' => 'baz'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1168
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

13) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "inline_script_added_via_add_inline_script_before" (Closure Object (...), '//script[ contains( text(), "...!" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'script'
    'extra_key' => 'before'
    'text' => '/*Hello before Baz!*/'
    'handle' => 'baz'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1203
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

14) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "inline_script_added_via_add_inline_script_after" (Closure Object (...), '//script[ contains( text(), "...!" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_enqueue_scripts'
    'priority' => 10
    'dependency_type' => 'script'
    'extra_key' => 'after'
    'text' => '/*Hello after Baz!*/'
    'handle' => 'baz'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1238
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

15) Test_AMP_Validation_Manager::test_locate_sources_e2e with data set "style_enqueued_at_wp_default_styles" (Closure Object (...), '//link[ contains( @href, "foo.css" ) ]', Closure Object (...))
Failed asserting that an array has the subset Array &0 (
    'type' => 'plugin'
    'name' => 'amp'
    'function' => '{closure}'
    'hook' => 'wp_default_styles'
    'priority' => 10
    'dependency_type' => 'style'
    'handle' => 'foo'
).
--- Expected
+++ Actual
@@ @@
-  'type' => 'plugin',
-  'name' => 'amp',

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1275
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1333

16) Test_AMP_Validation_Manager::test_add_block_source_comments with data set "latest_posts" ('<!-- wp:latest-posts {"postsT...} /-->', '<!--amp-source-stack {"block_...s"}-->', array('ul', array('core/latest-posts')))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":635,"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"core","name":"wp-includes","file":"blocks\/latest-posts.php","line":35,"function":"render_block_core_latest_posts"}--><ul class="wp-block-latest-posts wp-block-latest-posts__list"><li><a href="https://example.org/?p=635">Post title 0001107</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":635,"block_attrs":{"postsToShow":1},"type":"core","name":"wp-includes","file":"blocks\/latest-posts.php","line":35,"function":"render_block_core_latest_posts"}-->'
+'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":635,"block_content_index":0,"block_attrs":{"postsToShow":1},"type":"core","name":"wp-includes","file":"blocks\/latest-posts.php","line":35,"function":"render_block_core_latest_posts"}--><ul class="wp-block-latest-posts__list wp-block-latest-posts"><li><a href="https://example.org/?p=635">Post title 0001107</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":635,"block_attrs":{"postsToShow":1},"type":"core","name":"wp-includes","file":"blocks\/latest-posts.php","line":35,"function":"render_block_core_latest_posts"}-->'

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1437

17) Test_AMP_Validation_Manager::test_callback_wrappers
Failed asserting that '<!--amp-source-stack {"function":"_amp_show_load_errors_admin_notice","hook":"baz_action_function","priority":10}-->	<div class="notice notice-error">\n
		<p>\n
			<strong>AMP plugin unable to initialize.</strong>\n
			<ul>\n
						</ul>\n
		</p>\n
	</div>\n
	<!--/amp-source-stack {"function":"_amp_show_load_errors_admin_notice","hook":"baz_action_function","priority":10}-->' contains "<!--amp-source-stack {"type":"plugin","name":"amp"".

/app/public/content/plugins/amp/tests/php/src/Helpers/AssertContainsCompatibility.php:33
/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1563

18) Test_AMP_Validation_Manager::test_decorate_shortcode_and_filter_source
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => ''
     1 => '<!--amp-source-stack {"hook":...}]}-->'
     2 => '<p>before'
-    3 => '<!--amp-source-stack {"type":"plugin","name":"amp","file":"tests\/php\/validation\/test-class-amp-validation-manager.php","line":1676,"function":"{closure}","shortcode":"test"}-->'
+    3 => '<!--amp-source-stack {"function":"{closure}","shortcode":"test"}-->'
     4 => '<b>test'
     5 => '</b>'
-    6 => '<!--/amp-source-stack {"type":"plugin","name":"amp","file":"tests\/php\/validation\/test-class-amp-validation-manager.php","line":1676,"function":"{closure}","shortcode":"test"}-->after'
+    6 => '<!--/amp-source-stack {"function":"{closure}","shortcode":"test"}-->after'

/app/public/content/plugins/amp/tests/php/validation/test-class-amp-validation-manager.php:1903

19) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_register_reader_theme_mode
Expected suppression to happen immediately.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''
+'<script>document.write("Bad shortcode!!!");</script><noscript>Bad shortcode fallback!</noscript>'

/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:236

20) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_maybe_suppress_plugins_yes_amp_endpoint
Expected suppression since an AMP endpoint and there are suppressible plugins.
Failed asserting that false is true.

/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:302

21) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_suppress_plugins_when_conditions_satisfied_for_all
Failed asserting that false is true.

/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:360

22) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_suppress_plugins_when_conditions_satisfied_for_some
Failed asserting that false is true.

/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:389

23) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_sanitize_options
Expected one validation request to have been made since no changes were made (as both plugins are still unsuppressed).
Failed asserting that actual size 0 matches expected size 1.

/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:457

24) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_get_suppressible_plugins_with_no_errors_present
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'bad-block.php'
-    1 => 'bad-hooks.php'
-    2 => 'bad-shortcode.php'
-    3 => 'bad-widget'

/app/public/core-dev/tests/phpunit/includes/abstract-testcase.php:708
/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:500

25) AmpProject\AmpWP\Tests\PluginSuppressionTest::test_get_suppressible_plugins_with_details_when_plugins_active_and_errors_present
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'bad-block.php'
-    1 => 'bad-hooks.php'
-    2 => 'bad-shortcode.php'
-    3 => 'bad-widget'

/app/public/core-dev/tests/phpunit/includes/abstract-testcase.php:708
/app/public/content/plugins/amp/tests/php/src/PluginSuppressionTest.php:517

ERRORS!
Tests: 2103, Assertions: 7091, Errors: 3, Failures: 25, Skipped: 10.
```

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
