### PR TITLE
Improve logic around WP core file imports to prevent fatal error

### DIFF
--- a/src/Admin/ReaderThemes.php
+++ b/src/Admin/ReaderThemes.php
@@ -384,8 +384,11 @@ final class ReaderThemes {
 		}
 
 		if ( null === $this->can_install_themes ) {
-			if ( ! class_exists( 'WP_Upgrader' ) ) {
+			if ( ! function_exists( 'request_filesystem_credentials' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+
+			if ( ! class_exists( 'WP_Upgrader' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 			}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #5537 

Previously, we were including `wp-admin/includes/class-wp-upgrader.php` and `wp-admin/includes/file.php` if the class `WP_Upgrader` did not exist. This worked fine in most cases, but it breaks when another plugin or theme has previously imported `wp-admin/includes/class-wp-upgrader.php`. In this case, the AMP plugin does not import `wp-admin/includes/file.php` as needed, and the required `request_filesystem_credentials` continues to not exist, resulting in a fatal error. 

For this fix, I wrapped the including of `wp-admin/includes/file.php` in a separate conditional. If the `request_filesystem_credentials` function doesn't exist, the file is included.

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
