### PR TITLE
Fix document parsing when HTML start tag contains ⚡

### DIFF
--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -362,6 +362,16 @@ class DocumentTest extends TestCase
                 '<!DOCTYPE html><html>' . $head . '<body><script type="text/plain" template="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></script></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><script type="text/plain" template="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></script></body></html>',
             ],
+            'emoji_in_html_tag_for_amp_attribute' => [
+                'utf-8',
+                '<!DOCTYPE html><html ⚡ [class]="mystate.class" class="blue">' . $head . '<body></body></html>',
+                '<!DOCTYPE html><html ⚡ data-amp-bind-class="mystate.class" class="blue ⚡">' . $head . '<body></body></html>',
+            ],
+            'emoji_in_html_tag_for_data_attribute' => [
+                'utf-8',
+                '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body></body></html>',
+                '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body></body></html>',
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary

Fixes #5538.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
