### PR TITLE
Temporarily force use of Composer v1 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
     - /^\d+\.\d+$/
 
 install:
+  - travis_retry composer self-update --1
   - nvm install
   - composer install
   - export DEV_LIB_PATH=vendor/xwp/wp-dev-lib/scripts
@@ -82,6 +83,7 @@ jobs:
       name: Static analysis (PHP)
       php: "7.4"
       install:
+        - travis_retry composer self-update --1
         - composer install
       script:
         - composer analyze
@@ -98,6 +100,7 @@ jobs:
       php: "7.4"
       env: WP_VERSION=latest DEV_LIB_SKIP=phpcs,eslint,xmllint,phpsyntax,phpunit
       install:
+        - travis_retry composer self-update --1
         - nvm install
         - composer install
         - npm install
@@ -158,6 +161,7 @@ jobs:
       php: "5.6"
       env: TEST_SKIP_PHPSTAN=1
       install:
+        - travis_retry composer self-update --1
         - composer --working-dir=lib/common install
         - composer --working-dir=lib/optimizer install
       script:
@@ -168,6 +172,7 @@ jobs:
       php: "7.4"
 
       install:
+        - travis_retry composer self-update --1
         - composer --working-dir=lib/common install
         - composer --working-dir=lib/optimizer install
       script:


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Travis has defaulted to Composer v2, and because of that all jobs are failing as we have dependencies that are not v2 compatible yet. This PR forces the use of v1 as a temporary measure until all of our dependencies are v2 compatible.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
