### PR TITLE
Update `amp_is_available()` to check for cron & CLI

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -410,7 +410,7 @@ function amp_is_available() {
 	global $pagenow, $wp_query;
 
 	// Short-circuit for cron, CLI, admin requests or requests to non-frontend pages.
-	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || defined( 'WP_CLI' ) || is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
+	if ( wp_doing_cron() || defined( 'WP_CLI' ) || is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
 		return false;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -409,8 +409,8 @@ function amp_add_frontend_actions() {
 function amp_is_available() {
 	global $pagenow, $wp_query;
 
-	// Short-circuit for admin requests or requests to non-frontend pages.
-	if ( is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
+	// Short-circuit for cron, CLI, admin requests or requests to non-frontend pages.
+	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || defined( 'WP_CLI' ) || is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
 		return false;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -410,7 +410,7 @@ function amp_is_available() {
 	global $pagenow, $wp_query;
 
 	// Short-circuit for cron, CLI, admin requests or requests to non-frontend pages.
-	if ( wp_doing_cron() || defined( 'WP_CLI' ) || is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
+	if ( wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php', 'repair.php' ], true ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

Checks for cron and WP CLI contexts to short-circuit `amp_is_available()` and return `false`.

<!-- Please reference the issue this PR addresses. -->
Fixes #5546

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
