### PR TITLE
Hide AMP Noloading toggle if block does not have specified setting

### DIFF
--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -411,6 +411,8 @@ AmpLayoutControl.propTypes = {
 /**
  * Get AMP Noloading toggle control.
  *
+ * @deprecated As of v2.1. Blocks with the `ampNoLoading` attribute will still be able to use the control.
+ *
  * @param {Object} props Props.
  *
  * @return {ReactElement} Element.

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -417,10 +417,10 @@ AmpLayoutControl.propTypes = {
  *
  * @return {ReactElement} Element.
  */
-const AmpNoloadingToggle = ( props ) => {
+export const AmpNoloadingToggle = ( props ) => {
 	const { attributes: { ampNoLoading }, setAttributes } = props;
 
-	if ( ! ampNoLoading ) {
+	if ( undefined === ampNoLoading ) {
 		return null;
 	}
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -7,7 +7,7 @@ import { ReactElement } from 'react';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { cloneElement } from '@wordpress/element';
 import { TextControl, SelectControl, ToggleControl, Notice, PanelBody, FontSizePicker } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
@@ -427,11 +427,26 @@ export const AmpNoloadingToggle = ( props ) => {
 	const label = __( 'AMP Noloading', 'amp' );
 
 	return (
-		<ToggleControl
-			label={ label }
-			checked={ ampNoLoading }
-			onChange={ () => setAttributes( { ampNoLoading: ! ampNoLoading } ) }
-		/>
+		<>
+			<Notice
+				status="warning"
+				isDismissible={ false }
+			>
+				<span dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						/* translators: placeholder is link to support forum. */
+						__( 'The AMP Noloading setting is deprecated and is slated for removal. Please <a href="%s" target="_blank" rel="noreferrer">report</a> if you need it.', 'amp' ),
+						'https://wordpress.org/support/plugin/amp/#new-topic-0',
+					),
+				} } />
+			</Notice>
+
+			<ToggleControl
+				label={ label }
+				checked={ ampNoLoading }
+				onChange={ () => setAttributes( { ampNoLoading: ! ampNoLoading } ) }
+			/>
+		</>
 	);
 };
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -418,6 +418,10 @@ AmpLayoutControl.propTypes = {
 const AmpNoloadingToggle = ( props ) => {
 	const { attributes: { ampNoLoading }, setAttributes } = props;
 
+	if ( ! ampNoLoading ) {
+		return null;
+	}
+
 	const label = __( 'AMP Noloading', 'amp' );
 
 	return (

--- a/assets/src/block-editor/helpers/test/AmpNoloadingToggle.js
+++ b/assets/src/block-editor/helpers/test/AmpNoloadingToggle.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { act } from 'react-dom/test-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { AmpNoloadingToggle } from '../';
+
+let container;
+
+describe( 'AmpNoloadingToggle', () => {
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		document.body.removeChild( container );
+		container = null;
+	} );
+
+	it( 'should not render if ampNoLoading is undefined', function() {
+		act( () => {
+			render( <AmpNoloadingToggle setAttributes={ () => {} } attributes={ {} } />, container );
+		} );
+
+		const selectControl = container.querySelector( 'input' );
+		expect( selectControl ).toBeNull();
+	} );
+
+	it( 'should render if ampNoLoading is defined', function() {
+		act( () => {
+			render( <AmpNoloadingToggle setAttributes={ () => {} } attributes={ { ampNoLoading: true } } />, container );
+		} );
+
+		const selectControl = container.querySelector( 'input' );
+		expect( selectControl ).not.toBeNull();
+	} );
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4555

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
