### PR TITLE
Add /vendor to testPathIgnorePatterns for JS unit tests

### DIFF
--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		'<rootDir>/node_modules',
 		'<rootDir>/build',
 		'<rootDir>/tests/shared',
+		'<rootDir>/vendor',
 	],
 	coveragePathIgnorePatterns: [
 		'<rootDir>/node_modules',


### PR DESCRIPTION
I noticed that Jest was looking for unit test files in `/vendor` which was problematic since the spec update script puts the entire AMP repo in `/vendor/amphtml`. This PR will prevent that directory from being needlessly scanned.
