### PR TITLE
Fix Travis issues on 2.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,8 @@ jobs:
       env: WP_VERSION=latest DEV_LIB_ONLY=phpsyntax
       before_script:
         - phpenv config-rm xdebug.ini || echo "xdebug.ini does not exist."
-        - composer require --dev localheinz/composer-normalize --ignore-platform-reqs
+        # composer-normalize requires PHP 7.1+; locked to v2.9.0 as it's the last version that supports Composer v1
+        - composer require --no-interaction --dev ergebnis/composer-normalize:2.9.0 --ignore-platform-reqs
       script:
         - source "$DEV_LIB_PATH/travis.script.sh"
         - composer validate --no-check-all

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1627,6 +1627,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		);
 		$this->assertEquals( wp_get_attachment_image_url( $site_icon_attachment_id, 'full', false ), amp_get_publisher_logo() );
 
+		// Remove custom logo override set by Gutenberg.
+		remove_filter( 'theme_mod_custom_logo', 'gutenberg_override_custom_logo_theme_mod' );
+
 		// Set custom logo which now should get used instead of default for publisher logo.
 		set_theme_mod( 'custom_logo', $custom_logo_attachment_id );
 		$metadata = amp_get_schemaorg_metadata();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
- Locks `ergebnis/composer-normalize` to v2.9.0 for the lint job to run successfully
- Backports https://github.com/ampproject/amp-wp/commit/3f4b81bb0569a8c2d3464493231513d199ae4ecd

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
