### PR TITLE
Remove apparently obsolete polldaddy subdomain oEmbed test

### DIFF
--- a/tests/php/test-amp-crowdsignal-embed-handler.php
+++ b/tests/php/test-amp-crowdsignal-embed-handler.php
@@ -42,22 +42,16 @@ class AMP_Crowdsignal_Embed_Handler_Test extends WP_UnitTestCase {
 		];
 
 		$data = [
-			'poll.fm'          => [
+			'poll.fm'        => [
 				'https://poll.fm/7012505',
 				'<p><iframe title="Which design do you prefer?" src="https://poll.fm/7012505/embed" frameborder="0" class="cs-iframe-embed"></iframe></p>',
 				$poll_response,
 			],
 
-			'polldaddy_poll'   => [
+			'polldaddy_poll' => [
 				'https://polldaddy.com/poll/7012505/',
 				'<p><iframe title="Which design do you prefer?" src="https://poll.fm/7012505/embed" frameborder="0" class="cs-iframe-embed"></iframe></p>',
 				$poll_response,
-			],
-
-			'polldaddy_survey' => [
-				'https://rydk.polldaddy.com/s/test-survey',
-				'<p><a href="https://rydk.polldaddy.com/s/test-survey" target="_blank">View Survey</a></p>',
-				$survey_response,
 			],
 		];
 


### PR DESCRIPTION
## Summary

Polldaddy was rebranded to Crowdsignal, and it appears that the old subdomain URLs under polldaddy.com now no longer work. This PR removes the breaking external-http test case.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
