### PR TITLE
Update ataylorme/eslint-annotate-action to v1.1.2

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
 
       - name: Annotate code linting results
-        uses: ataylorme/eslint-annotate-action@1.0.4
+        uses: ataylorme/eslint-annotate-action@1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'lint-js-report.json'

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -73,6 +73,8 @@ jobs:
         continue-on-error: true
 
       - name: Annotate code linting results
+        # The action cannot annotate the PR diff when run from a PR fork
+        if: github.event.pull_request.head.repo.fork == false
         uses: ataylorme/eslint-annotate-action@1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Annotate code linting results
         # The action cannot annotate the PR diff when run from a PR fork
         if: github.event.pull_request.head.repo.fork == false
-        uses: ataylorme/eslint-annotate-action@1
+        uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'lint-js-report.json'


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Updates the `ataylorme/eslint-annotate-action` GitHub Action to v1.1.2.

Also skips the JS annotation step if run from a PR fork, as it doesn't have write permissions to annotate the PR diff.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
