### PR TITLE
Preemptively add intrinsic layout support for amp-story-player

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -6354,6 +6354,7 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
+							9,
 							4,
 						),
 					),

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -603,7 +603,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp_story_player'                             => [
 				'
-				<amp-story-player width="360" height="600">
+				<amp-story-player width="360" height="600" layout="intrinsic">
 					<a href="https://www.example.com" class="story">
 						<span class="title">A local’s guide to what to eat and do in New York City</span>
 					</a>


### PR DESCRIPTION
## Summary

This applies the validator patch from https://github.com/ampproject/amphtml/pull/31433 (for https://github.com/ampproject/amphtml/issues/31432). This is not yet live, but it will be needed soon by the Web Stories plugin per https://github.com/google/web-stories-wp/issues/5562. So we should include it in the next patch release.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
