### PR TITLE
Eliminate redundant legacy method of adding Schema.org metadata

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -15,7 +15,6 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_title' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_canonical' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_fonts' );
-	add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_head', 'wp_generator' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1729,6 +1729,27 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amp_print_schemaorg_metadata().
+	 *
+	 * @covers ::amp_print_schemaorg_metadata()
+	 */
+	public function test_amp_print_schemaorg_metadata() {
+		add_filter( 'amp_schemaorg_metadata', '__return_empty_array' );
+		$output = get_echo( 'amp_print_schemaorg_metadata' );
+		$this->assertEmpty( $output );
+
+		remove_filter( 'amp_schemaorg_metadata', '__return_empty_array' );
+		add_filter(
+			'amp_schemaorg_metadata',
+			static function () {
+				return [ 'foo' => 'bar' ];
+			}
+		);
+		$output = trim( get_echo( 'amp_print_schemaorg_metadata' ) );
+		$this->assertSame( '<script type="application/ld+json">{"foo":"bar"}</script>', $output );
+	}
+
+	/**
 	 * Test amp_add_admin_bar_view_link()
 	 *
 	 * @covers ::amp_add_admin_bar_view_link()


### PR DESCRIPTION
## Summary

See [support topic reply](https://wordpress.org/support/topic/remove-blogposting-structured-data/#post-13754119) by @milindmore22:

> You can remove Schema simply by removing the `amp_print_schemaorg_metadata` action. Add the below code in your themes function.php or add it in your custom plugin.
>
> `remove_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );`
>
> or returning an empty array through `amp_schemaorg_metadata`:
>
> `add_filter( 'amp_schemaorg_metadata', '__return_empty_array' );`

It turns out that the we don't need to even be doing `amp_print_schemaorg_metadata()` at `amp_post_template_head` anymore since the legacy AMP post templates are being sent through the post-processor, and there is an Optimizer transformer which is adding this if no Schema.org metadata is present:

https://github.com/ampproject/amp-wp/blob/778838d2407ef8ba2c2dcb9ffb2bb1a19adb361e/src/Transformer/AmpSchemaOrgMetadata.php#L56-L77

Therefore, the only recommended way to prevent the AMP plugin from adding its own Schema.org metadata to the page is to use `add_filter( 'amp_schemaorg_metadata', '__return_empty_array' );`.

This PR prevents the scenario where the AMP plugin's own Schema.org metadata is added in addition to a plugin adding their own.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
