### PR TITLE
Set php and js coverage threshold to 0.1%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,9 +21,11 @@ coverage:
         paths:
           - includes
           - src
+        threshold: 0.1%
       js:
         paths:
           - assets/src
+        threshold: 0.1%
 
 # Pull request comments
 # See https://docs.codecov.io/docs/pull-request-comments


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Bumps the coverage threshold for the `php` and `js` projects from 0% to 0.1%

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
