### PR TITLE
Replace amp-lightbox with an amp-bind solution for the mobile menu in Twenty Twenty-One

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2074,7 +2074,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					/* Trap keyboard navigation within mobile menu when it\'s open */
 					@media only screen and (max-width: 481px) {
 						.primary-navigation-open #page {
-							visibility: hidden !important;
+							visibility: hidden;
 						}
 
 						#primary-mobile-menu[aria-expanded="true"] {

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2011,7 +2011,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			static function() {
 				// Bail if the dark mode stylesheet is not enqueued.
 				if ( ! wp_style_is( 'tt1-dark-mode' ) ) {
+					// @codeCoverageIgnoreStart
 					return;
+					// @codeCoverageIgnoreEnd
 				}
 
 				wp_dequeue_style( 'tt1-dark-mode' );
@@ -2021,7 +2023,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				);
 
 				if ( ! file_exists( $dark_mode_css_file ) ) {
+					// @codeCoverageIgnoreStart
 					return;
+					// @codeCoverageIgnoreEnd
 				}
 
 				$styles = file_get_contents( $dark_mode_css_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2174,7 +2174,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$menu_toggle       = $menu_toggle_query->item( 0 );
 		$menu_open_toggle  = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ]", $menu_toggle )->item( 0 );
 		$menu_close_toggle = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ]", $menu_toggle )->item( 0 );
-		if ( ! $menu_open_toggle || ! $menu_close_toggle ) {
+		if ( ! $menu_open_toggle instanceof DOMElement || ! $menu_close_toggle instanceof DOMElement ) {
 			return;
 		}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2156,7 +2156,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function add_twentytwentyone_mobile_modal() {
 		$menu_query        = $this->dom->xpath->query( "//div[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' primary-menu-container ' ) ]" );
-		$menu_toggle_query = $this->dom->xpath->query( "//button[ @id = 'primary-mobile-menu' and ./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ] and ./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ] ]" );
+		$menu_toggle_query = $this->dom->xpath->query( "//button[ @id = 'primary-mobile-menu' ]" );
 
 		if ( 1 !== $menu_query->length || 1 !== $menu_toggle_query->length ) {
 			return;
@@ -2166,6 +2166,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$menu_toggle       = $menu_toggle_query->item( 0 );
 		$menu_open_toggle  = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ]", $menu_toggle )->item( 0 );
 		$menu_close_toggle = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ]", $menu_toggle )->item( 0 );
+		if ( ! $menu_open_toggle || ! $menu_close_toggle ) {
+			return;
+		}
 
 		/** @var DOMElement $primary_menu */
 		$primary_menu      = $menu_query->item( 0 );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2071,19 +2071,32 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Append any extra rules that may be needed.
 				$styles .= '
-					/* Show the sub-menu on hover of menu item */
-					.primary-navigation > div > .menu-wrapper > .menu-item-has-children:hover > .sub-menu {
-						display: block;
+					/* Trap keyboard navigation within mobile menu when it\'s open */
+					@media only screen and (max-width: 481px) {
+						.primary-navigation-open #page {
+							visibility: hidden !important;
+						}
+
+						#primary-mobile-menu[aria-expanded="true"] {
+							visibility: visible;
+						}
 					}
 
-					/* Hide the plus icon on hover of menu item */
-					.primary-navigation > div > .menu-wrapper > .menu-item-has-children:hover > .sub-menu-toggle > .icon-plus {
-						display: none;
-					}
+					@media (min-width: 482px) {
+						/* Show the sub-menu on hover of menu item */
+						.primary-menu-container > .menu-wrapper > .menu-item-has-children:hover > .sub-menu {
+							display: block;
+						}
 
-					/* Show the minus icon on hover of menu item */
-					.primary-navigation > div > .menu-wrapper > .menu-item-has-children:hover > .sub-menu-toggle > .icon-minus {
-						display: flex;
+						/* Hide the plus icon on hover of menu item */
+						.primary-menu-container > .menu-wrapper > .menu-item-has-children:hover > .sub-menu-toggle > .icon-plus {
+							display: none;
+						}
+
+						/* Show the minus icon on hover of menu item */
+						.primary-menu-container > .menu-wrapper > .menu-item-has-children:hover > .sub-menu-toggle > .icon-minus {
+							display: flex;
+						}
 					}
 				';
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2188,6 +2188,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		$body_id = $this->dom->getElementId( $this->dom->body, 'body' );
 
+		$open_toggle_id  = $this->dom->getElementId( $menu_open_toggle );
+		$close_toggle_id = $this->dom->getElementId( $menu_close_toggle );
+
 		// Create an <amp-lightbox> element that will contain the modal.
 		$amp_lightbox = $this->dom->createElement( 'amp-lightbox' );
 		$amp_lightbox->setAttribute( 'layout', 'nodisplay' );
@@ -2199,12 +2202,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$amp_lightbox_id}.open" );
 		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=true)" );
+		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$close_toggle_id}.focus" ); // @todo This is not working since the button is not in the lightbox.
 
-		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$amp_lightbox_id}.close" );
 		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );
+		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$amp_lightbox_id}.close" );
 
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxOpen', "AMP.setState({{$state_string}:true})" );
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "AMP.setState({{$state_string}:false})" );
+		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "{$open_toggle_id}.focus" );
 
 		$menu_toggle->setAttribute( 'tabindex', '-1' );
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2054,7 +2054,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Bail if the stylesheet is not enqueued.
 				if ( ! wp_style_is( $style_handle ) ) {
+					// @codeCoverageIgnoreStart
 					return;
+					// @codeCoverageIgnoreEnd
 				}
 
 				$css_file = get_theme_file_path(
@@ -2062,7 +2064,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				);
 
 				if ( ! file_exists( $css_file ) ) {
+					// @codeCoverageIgnoreStart
 					return;
+					// @codeCoverageIgnoreEnd
 				}
 
 				/** @var _WP_Dependency $dependency */

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2069,38 +2069,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				$styles = file_get_contents( $css_file ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-				// Make the rules for the mobile menu less specific so that it can also be applied to the
-				// amp-lightbox mobile menu also.
-				$new_styles = str_replace( '.primary-navigation > .primary-menu-container', '.primary-navigation .primary-menu-container', $styles );
-				$new_styles = str_replace( '.primary-navigation > div > .menu-wrapper', '.primary-navigation div > .menu-wrapper', $new_styles );
-
 				// Append any extra rules that may be needed.
-				$new_styles .= '
-					.primary-navigation-open .menu-button-container {
-						/* Needs to be shown above amp-lightbox, which has a z-index of 1000. */
-						z-index: 1001;
-					}
-
-					.menu-button-container #primary-mobile-menu {
-						padding: 0;
-					}
-
-					#primary-mobile-menu .dropdown-icon {
-						padding: calc(var(--button--padding-vertical) - ( .25 * var(--global--spacing-unit) )) calc(.5 * var(--button--padding-horizontal))
-					}
-
-					@media only screen and (max-width: 481px) {
-						/* Hide the desktop menu so that it does not interfere when the amo-lightbox mobile menu is open. */
-						.primary-navigation > .primary-menu-container {
-							display: none;
-						}
-
-						/* Accommodate for the admin bar height */
-						.admin-bar amp-lightbox .primary-menu-container {
-							margin-top: var(--global--admin-bar--height);
-						}
-					}
-
+				$styles .= '
 					/* Show the sub-menu on hover of menu item */
 					.primary-navigation > div > .menu-wrapper > .menu-item-has-children:hover > .sub-menu {
 						display: block;
@@ -2123,7 +2093,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! isset( $dependency->extra['after'] ) ) {
 					$dependency->extra['after'] = [];
 				}
-				array_unshift( $dependency->extra['after'], $new_styles );
+				array_unshift( $dependency->extra['after'], $styles );
 			},
 			11
 		);
@@ -2163,59 +2133,19 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * Make the mobile menu for the Twenty Twenty-One theme AMP compatible.
 	 */
 	public function add_twentytwentyone_mobile_modal() {
-		$menu_query        = $this->dom->xpath->query( "//div[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' primary-menu-container ' ) ]" );
-		$menu_toggle_query = $this->dom->xpath->query( "//button[ @id = 'primary-mobile-menu' ]" );
+		$menu_toggle = $this->dom->getElementById( 'primary-mobile-menu' );
 
-		if ( 1 !== $menu_query->length || 1 !== $menu_toggle_query->length ) {
+		if ( ! $menu_toggle ) {
 			return;
 		}
 
-		/** @var DOMElement $menu_toggle */
-		$menu_toggle       = $menu_toggle_query->item( 0 );
-		$menu_open_toggle  = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ]", $menu_toggle )->item( 0 );
-		$menu_close_toggle = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ]", $menu_toggle )->item( 0 );
-		if ( ! $menu_open_toggle instanceof DOMElement || ! $menu_close_toggle instanceof DOMElement ) {
-			return;
-		}
+		$state_string = 'mobile_menu_toggled';
+		$body_id      = $this->dom->getElementId( $this->dom->body, 'body' );
 
-		/** @var DOMElement $primary_menu */
-		$primary_menu      = $menu_query->item( 0 );
-		$primary_menu_copy = $primary_menu->cloneNode( true );
-		foreach ( $this->dom->xpath->query( './/*[ @id ]', $primary_menu_copy ) as $element ) {
-			/** @var DOMElement $element */
-			$element->setAttribute( 'id', $element->getAttribute( 'id' ) . '-mobile' );
-		}
-
-		$body_id = $this->dom->getElementId( $this->dom->body, 'body' );
-
-		$open_toggle_id  = $this->dom->getElementId( $menu_open_toggle );
-		$close_toggle_id = $this->dom->getElementId( $menu_close_toggle );
-
-		// Create an <amp-lightbox> element that will contain the modal.
-		$amp_lightbox = $this->dom->createElement( 'amp-lightbox' );
-		$amp_lightbox->setAttribute( 'layout', 'nodisplay' );
-		$amp_lightbox->setAttribute( 'animate-in', 'fade-in' );
-		$amp_lightbox->setAttribute( 'scrollable', true );
-		$amp_lightbox_id = $this->dom->getElementId( $amp_lightbox );
-
-		$state_string = str_replace( '-', '_', $amp_lightbox_id );
-
-		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$amp_lightbox_id}.open" );
-		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=true)" );
-		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$close_toggle_id}.focus" ); // @todo This is not working since the button is not in the lightbox.
-
-		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );
-		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$amp_lightbox_id}.close" );
-
-		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxOpen', "AMP.setState({{$state_string}:true})" );
-		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "AMP.setState({{$state_string}:false})" );
-		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "{$open_toggle_id}.focus" );
-
-		$menu_toggle->setAttribute( 'tabindex', '-1' );
+		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "AMP.setState({{$state_string}: !{$state_string}})" );
+		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open)" );
+		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$body_id}.toggleClass(class=lock-scrolling)" );
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );
-
-		$amp_lightbox->appendChild( $primary_menu_copy );
-		$primary_menu->parentNode->insertBefore( $amp_lightbox, $primary_menu );
 	}
 
 	/**
@@ -2226,8 +2156,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see amend_twentytwentyone_styles()
 	 */
 	public function add_twentytwentyone_sub_menu_fix() {
-		// The XPath query has to be specific enough to not interfere with the mobile menu.
-		$menu_toggles = $this->dom->xpath->query( '//nav/div/ul//button[ @class and contains( concat( " ", normalize-space( @class ), " " ), " sub-menu-toggle " ) ]' );
+		$menu_toggles = $this->dom->xpath->query( '//nav//button[ @class and contains( concat( " ", normalize-space( @class ), " " ), " sub-menu-toggle " ) ]' );
 
 		if ( 0 === $menu_toggles->length ) {
 			return;

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2081,6 +2081,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						z-index: 1001;
 					}
 
+					.menu-button-container #primary-mobile-menu {
+						padding: 0;
+					}
+
+					#primary-mobile-menu .dropdown-icon {
+						padding: calc(var(--button--padding-vertical) - ( .25 * var(--global--spacing-unit) )) calc(.5 * var(--button--padding-horizontal))
+					}
+
 					@media only screen and (max-width: 481px) {
 						/* Hide the desktop menu so that it does not interfere when the amo-lightbox mobile menu is open. */
 						.primary-navigation > .primary-menu-container {
@@ -2198,6 +2206,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxOpen', "AMP.setState({{$state_string}:true})" );
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "AMP.setState({{$state_string}:false})" );
 
+		$menu_toggle->setAttribute( 'tabindex', '-1' );
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );
 
 		$amp_lightbox->appendChild( $primary_menu_copy );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2155,12 +2155,16 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * Make the mobile menu for the Twenty Twenty-One theme AMP compatible.
 	 */
 	public function add_twentytwentyone_mobile_modal() {
-		$menu_query  = $this->dom->xpath->query( "//div[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' primary-menu-container ' ) ]" );
-		$menu_toggle = $this->dom->getElementById( 'primary-mobile-menu' );
+		$menu_query        = $this->dom->xpath->query( "//div[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' primary-menu-container ' ) ]" );
+		$menu_toggle_query = $this->dom->xpath->query( "//button[ @id = 'primary-mobile-menu' and ./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ] and ./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ] ]" );
 
-		if ( 1 !== $menu_query->length || ! $menu_toggle ) {
+		if ( 1 !== $menu_query->length || 1 !== $menu_toggle_query->length ) {
 			return;
 		}
+
+		$menu_toggle       = $menu_toggle_query->item( 0 );
+		$menu_open_toggle  = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ]", $menu_toggle )->item( 0 );
+		$menu_close_toggle = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ]", $menu_toggle )->item( 0 );
 
 		/** @var DOMElement $primary_menu */
 		$primary_menu      = $menu_query->item( 0 );
@@ -2181,12 +2185,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		$state_string = str_replace( '-', '_', $amp_lightbox_id );
 
-		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$amp_lightbox_id}.open" );
-		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=true)" );
+		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$amp_lightbox_id}.open" );
+		AMP_DOM_Utils::add_amp_action( $menu_open_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=true)" );
+
+		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$amp_lightbox_id}.close" );
+		AMP_DOM_Utils::add_amp_action( $menu_close_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );
 
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxOpen', "AMP.setState({{$state_string}:true})" );
 		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "AMP.setState({{$state_string}:false})" );
-		AMP_DOM_Utils::add_amp_action( $amp_lightbox, 'lightboxClose', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );
 
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2162,6 +2162,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
+		/** @var DOMElement $menu_toggle */
 		$menu_toggle       = $menu_toggle_query->item( 0 );
 		$menu_open_toggle  = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' open ' ) ]", $menu_toggle )->item( 0 );
 		$menu_close_toggle = $this->dom->xpath->query( "./span[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' close ' ) ]", $menu_toggle )->item( 0 );

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test:js": "wp-scripts test-unit-js --config=tests/js/jest.config.js",
     "test:js:help": "wp-scripts test-unit-js --help",
     "test:js:watch": "npm run test:js -- --watch",
-    "test:php": "phpunit",
+    "test:php": "vendor/bin/phpunit",
     "test:php:help": "npm run test:php -- --help"
   },
   "lint-staged": {

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -448,6 +448,43 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, $elements->length );
 	}
 
+	/** @covers ::amend_twentytwentyone_dark_mode_styles() */
+	public function test_amend_twentytwentyone_dark_mode_styles() {
+		$theme_slug = 'twentytwentyone';
+		if ( ! wp_get_theme( $theme_slug )->exists() ) {
+			$this->markTestSkipped();
+			return;
+		}
+
+		switch_theme( $theme_slug );
+		wp_enqueue_style( 'tt1-dark-mode', get_theme_file_path( 'dark-mode.css' ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_style( 'twenty-twenty-one-style', get_theme_file_path( 'style.css' ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		$this->assertEmpty( wp_styles()->registered['twenty-twenty-one-style']->extra );
+		AMP_Core_Theme_Sanitizer::amend_twentytwentyone_dark_mode_styles();
+		wp_enqueue_scripts();
+
+		$this->assertFalse( wp_style_is( 'tt1-dark-mode', 'enqueued' ) );
+		$extra = wp_styles()->registered['twenty-twenty-one-style']->extra;
+		$this->assertNotEmpty( $extra );
+		$this->assertArrayHasKey( 'after', $extra );
+		$after = implode( '', $extra['after'] );
+
+		$replacements = [
+			'@media only screen'           => '@media only screen and (prefers-color-scheme: dark)',
+			'.is-dark-theme.is-dark-theme' => ':root',
+			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference body',
+		];
+		foreach ( $replacements as $search => $replacement ) {
+			$this->assertStringNotContains( "$search {", $after );
+			$this->assertStringContains( "$replacement {", $after );
+		}
+	}
+
+	/** @covers ::amend_twentytwentyone_styles() */
+	public function test_amend_twentytwentyone_styles() {
+		$this->markTestIncomplete();
+	}
+
 	/**
 	 * Tests add_twentytwentyone_mobile_modal.
 	 *

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -482,7 +482,26 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
 	/** @covers ::amend_twentytwentyone_styles() */
 	public function test_amend_twentytwentyone_styles() {
-		$this->markTestIncomplete();
+		$theme_slug = 'twentytwentyone';
+		if ( ! wp_get_theme( $theme_slug )->exists() ) {
+			$this->markTestSkipped();
+			return;
+		}
+
+		switch_theme( $theme_slug );
+
+		$style_handle = 'twenty-twenty-one-style';
+		wp_enqueue_style( $style_handle, get_theme_file_path( 'style.css' ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		$this->assertEmpty( wp_styles()->registered[ $style_handle ]->extra );
+
+		wp_add_inline_style( $style_handle, '/*first*/' );
+		AMP_Core_Theme_Sanitizer::amend_twentytwentyone_styles();
+		wp_enqueue_scripts();
+
+		$after = implode( '', wp_styles()->registered[ $style_handle ]->extra['after'] );
+		$this->assertNotEmpty( $after );
+		$this->assertStringContains( '@media only screen and (max-width: 481px)', $after );
+		$this->assertStringEndsWith( '/*first*/', $after );
 	}
 
 	/**

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -30,6 +30,9 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	public function tearDown() {
 		parent::tearDown();
 
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+
 		$this->restore_theme_directories();
 	}
 

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -477,14 +477,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
 		$sanitizer->add_twentytwentyone_mobile_modal();
 
-		$query = $dom->xpath->query(
-			// Verify that the menu button container exists and that it contains the button that toggles the amp-lightbox,
-			'//nav/div[ @class = "menu-button-container" and ./button[ @data-amp-bind-aria-expanded and ./span[ @on and contains( @class, " open" ) ] and ./span[ @on and contains( @class, " close" ) ] ] ]' .
-			// and is immediately followed by the primary menu container, wrapped in amp-lightbox,
-			'/following-sibling::amp-lightbox[ ./div[ @class = "primary-menu-container" and ./ul ] ]' .
-			// and is also followed by the original primary menu container.
-			'/following-sibling::div[ @class = "primary-menu-container" and ./ul ]'
-		);
+		$query = $dom->xpath->query( '//button[ @id = "primary-mobile-menu" and @data-amp-bind-aria-expanded and @on ]' );
 
 		$this->assertEquals( 1, $query->length );
 	}
@@ -500,15 +493,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 				<div class="menu-button-container">
 					<button id="primary-mobile-menu">Menu button toggle</button>
 				</div>
-				<amp-lightbox>
-					<div class="primary-menu-container">
-						<ul id="primary-menu-list">
-							<li id="menu-item-1"><button>Foo</button></li>
-							<li id="menu-item-2"><button class="sub-menu-toggle">Bar</button></li>
-							<li id="menu-item-3"><button class="sub-menu-toggle">Baz</button></li>
-						</ul>
-					</div>
-				</amp-lightbox>
 				<div class="primary-menu-container">
 					<ul id="primary-menu-list">
 						<li id="menu-item-1"><button>Foo</button></li>
@@ -523,9 +507,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer = new AMP_Core_Theme_Sanitizer( $dom );
 
 		$sanitizer->add_twentytwentyone_sub_menu_fix();
-
-		$query = $dom->xpath->query( '//amp-lightbox//button[ not( @data-amp-bind-aria-expanded ) ]' );
-		$this->assertEquals( 3, $query->length );
 
 		$query = $dom->xpath->query( '//nav/div//button[ @data-amp-bind-aria-expanded ]' );
 		$this->assertEquals( 2, $query->length );

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -457,7 +457,10 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$html = '
 			<nav>
 				<div class="menu-button-container">
-					<button id="primary-mobile-menu">Menu button toggle</button>
+					<button id="primary-mobile-menu">
+						<span class="dropdown-icon open">Menu</span>
+						<span class="dropdown-icon close">Close</span>
+					</button>
 				</div>
 				<div class="primary-menu-container">
 					<ul id="primary-menu-list">
@@ -475,8 +478,8 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer->add_twentytwentyone_mobile_modal();
 
 		$query = $dom->xpath->query(
-			// Verify that the menu button container exists,
-			'//nav/div[ @class = "menu-button-container" ]' .
+			// Verify that the menu button container exists and that it contains the button that toggles the amp-lightbox,
+			'//nav/div[ @class = "menu-button-container" and ./button[ @data-amp-bind-aria-expanded and ./span[ @on and contains( @class, " open" ) ] and ./span[ @on and contains( @class, " close" ) ] ] ]' .
 			// and is immediately followed by the primary menu container, wrapped in amp-lightbox,
 			'/following-sibling::amp-lightbox[ ./div[ @class = "primary-menu-container" and ./ul ] ]' .
 			// and is also followed by the original primary menu container.


### PR DESCRIPTION
## Summary

As discovered in a recent [support topic](https://wordpress.org/support/topic/twenty-twenty-one-theme-mobile-menu-doesnt-collapse/), when the mobile menu for the Twenty Twenty-One theme is opened in Safari, the button to close the menu does not function. @westonruter pointed out that the `amp-bind` set on the menu toggle is configured to _always_ open the menu, and it seems the only reason why the menu is being closed in other browsers is because the button somehow manages to trigger the `lightboxClose` event _after_ attempting to open the already open menu.

~To resolve this issue, this PR is assigning the opening and closing of the menu to two discrete elements within the original menu toggle button. The `<span>` element that's displayed when the menu is open closes the menu, and vice versa for the `<span>` that's shown when the menu is closed.~

Due to all the headaches `amp-lightbox` has been causing, I've decided to switch to an `amp-bind` solution for the mobile menu. The main drawback with this approach is that the menu can no longer be closed with the <key>Esc</key> key. There are ways to replicate that functionality with `amp-script`, but that requires setting a fixed layout for the menu, which (as far as I know) will not be a feasible solution.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
