### PR TITLE
Persist focus on mobile menu button when toggling

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2085,7 +2085,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 							visibility: hidden;
 						}
 
-						.primary-navigation-open #primary-mobile-menu {
+						.primary-navigation-open .menu-button-container {
 							visibility: visible;
 						}
 					}

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2011,9 +2011,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			static function() {
 				// Bail if the dark mode stylesheet is not enqueued.
 				if ( ! wp_style_is( 'tt1-dark-mode' ) ) {
-					// @codeCoverageIgnoreStart
-					return;
-					// @codeCoverageIgnoreEnd
+					return; // @codeCoverageIgnore
 				}
 
 				wp_dequeue_style( 'tt1-dark-mode' );
@@ -2023,9 +2021,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				);
 
 				if ( ! file_exists( $dark_mode_css_file ) ) {
-					// @codeCoverageIgnoreStart
-					return;
-					// @codeCoverageIgnoreEnd
+					return; // @codeCoverageIgnore
 				}
 
 				$styles = file_get_contents( $dark_mode_css_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
@@ -2054,9 +2050,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Bail if the stylesheet is not enqueued.
 				if ( ! wp_style_is( $style_handle ) ) {
-					// @codeCoverageIgnoreStart
-					return;
-					// @codeCoverageIgnoreEnd
+					return; // @codeCoverageIgnore
 				}
 
 				$css_file = get_theme_file_path(
@@ -2064,9 +2058,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				);
 
 				if ( ! file_exists( $css_file ) ) {
-					// @codeCoverageIgnoreStart
-					return;
-					// @codeCoverageIgnoreEnd
+					return; // @codeCoverageIgnore
 				}
 
 				/** @var _WP_Dependency $dependency */

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2085,7 +2085,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 							visibility: hidden;
 						}
 
-						#primary-mobile-menu[aria-expanded="true"] {
+						.primary-navigation-open #primary-mobile-menu {
 							visibility: visible;
 						}
 					}


### PR DESCRIPTION
## Summary

Amends #5692.

After merging #5692 I realized that toggling the mobile menu did not persist the focus on the menu button. The issue appears to be due to the menu momentarily getting `visibility:hidden` before `aria-expanded` is set to `true`. This prevents that from happening by forcing the button it to always be visible regardless of the `aria-expanded` state, which is in fact what it is supposed to be.

This also fixes an issue with the mobile button overlapping text in the menu, by making the `.menu-button-container` always `visible` and not just the `#primary-mobile-menu`: this retains the background color so create a bar at the top. 

Before:
![Before](https://user-images.githubusercontent.com/134745/102181859-2694ca80-3e60-11eb-9245-e3b211780db8.png)

After:
![After](https://user-images.githubusercontent.com/134745/102181919-3dd3b800-3e60-11eb-88d9-5b37358a2fdd.png)


## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
