### PR TITLE
Update amphtml spec to 68e4db07

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -532,7 +532,7 @@ def GetTagRules(tag_spec):
 
 	if hasattr(tag_spec, 'also_requires_tag_warning') and len( tag_spec.also_requires_tag_warning ) != 0:
 		for also_requires_tag_warning in tag_spec.also_requires_tag_warning:
-			matches = re.search( r'(amp-\S+) extension .js script', also_requires_tag_warning )
+			matches = re.search( r'(amp-\S+) extension( \.js)? script', also_requires_tag_warning )
 			if not matches:
 				raise Exception( 'Unexpected also_requires_tag_warning format: ' + also_requires_tag_warning )
 			requires_extension_list.add(matches.group(1))

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15,7 +15,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1131;
+	private static $spec_file_revision = 1132;
 	private static $minimum_validator_revision_required = 475;
 
 	private static $descendant_tag_lists = array(
@@ -6777,6 +6777,7 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
+							9,
 							1,
 							4,
 						),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15,7 +15,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1119;
+	private static $spec_file_revision = 1123;
 	private static $minimum_validator_revision_required = 475;
 
 	private static $descendant_tag_lists = array(
@@ -2277,6 +2277,11 @@ class AMP_Allowed_Tags_Generated {
 							'seconds',
 						),
 					),
+					'data-count-up' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'end-date' => array(
 						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])',
 					),
@@ -3910,7 +3915,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'data-media-id' => array(
-						'value_regex_casei' => '[0-9a-z]{8}',
+						'value_regex_casei' => '[0-9a-z]{8}|outstream',
 					),
 					'data-player-id' => array(
 						'mandatory' => true,
@@ -6213,7 +6218,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'option-1-results-threshold' => array(
-						'value_regex' => '\\d+[.\\d+]?',
+						'value_regex' => '\\d+(\\.\\d+)?',
 					),
 					'option-1-text' => array(),
 					'option-2-image' => array(),
@@ -6221,19 +6226,19 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'option-2-results-threshold' => array(
-						'value_regex' => '\\d+[.\\d+]?',
+						'value_regex' => '\\d+(\\.\\d+)?',
 					),
 					'option-2-text' => array(),
 					'option-3-image' => array(),
 					'option-3-results-category' => array(),
 					'option-3-results-threshold' => array(
-						'value_regex' => '\\d+[.\\d+]?',
+						'value_regex' => '\\d+(\\.\\d+)?',
 					),
 					'option-3-text' => array(),
 					'option-4-image' => array(),
 					'option-4-results-category' => array(),
 					'option-4-results-threshold' => array(
-						'value_regex' => '\\d+[.\\d+]?',
+						'value_regex' => '\\d+(\\.\\d+)?',
 					),
 					'option-4-text' => array(),
 					'prompt-text' => array(),
@@ -16883,6 +16888,11 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'access-hide' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'data-amp-bind-data-expand' => array(),
 					'expanded' => array(
 						'value' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15,7 +15,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1130;
+	private static $spec_file_revision = 1131;
 	private static $minimum_validator_revision_required = 475;
 
 	private static $descendant_tag_lists = array(
@@ -6663,6 +6663,7 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
+							9,
 							1,
 							4,
 						),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15,7 +15,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 1123;
+	private static $spec_file_revision = 1130;
 	private static $minimum_validator_revision_required = 475;
 
 	private static $descendant_tag_lists = array(
@@ -246,7 +246,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-fit-text',
 			'amp-font',
 			'amp-gist',
-			'amp-google-vrview-image',
 			'amp-img',
 			'amp-install-serviceworker',
 			'amp-list',
@@ -258,6 +257,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-story-interactive-poll',
 			'amp-story-interactive-quiz',
 			'amp-story-interactive-results',
+			'amp-story-panning-media',
 			'amp-timeago',
 			'amp-twitter',
 			'amp-video',
@@ -404,7 +404,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-gfycat',
 			'amp-gist',
 			'amp-google-document-embed',
-			'amp-google-vrview-image',
 			'amp-hulu',
 			'amp-ima-video',
 			'amp-image-slider',
@@ -6349,6 +6348,23 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-story-panning-media' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+						),
+					),
+					'mandatory_ancestor' => 'amp-story-grid-layer',
+					'requires_extension' => array(
+						'amp-story-panning-media',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-panning-media',
+				),
+			),
+		),
 		'amp-story-player' => array(
 			array(
 				'attr_spec_list' => array(),
@@ -6359,8 +6375,8 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
-							9,
 							4,
+							9,
 						),
 					),
 					'descendant_tag_list' => 'amp-story-player-allowed-descendants',
@@ -6647,7 +6663,6 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
-							9,
 							1,
 							4,
 						),
@@ -6761,7 +6776,6 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
-							9,
 							1,
 							4,
 						),
@@ -12451,9 +12465,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine v0.js script',
+					'mandatory_alternatives' => 'amphtml engine script',
 					'mandatory_parent' => 'head',
-					'spec_name' => 'amphtml engine v0.js script',
+					'spec_name' => 'amphtml engine script',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
@@ -12494,9 +12508,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine v0.js script',
+					'mandatory_alternatives' => 'amphtml engine script',
 					'mandatory_parent' => 'head',
-					'spec_name' => 'amphtml engine v0.js lts script',
+					'spec_name' => 'amphtml engine script (LTS)',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
 					'unique' => true,
 				),
@@ -12920,7 +12934,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
-					'spec_name' => 'amp-ad extension .js script',
+					'spec_name' => 'amp-ad extension script',
 				),
 			),
 			array(
@@ -16123,6 +16137,36 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-story-panning-media',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-story-player',
 						'requires_usage' => true,
 						'version' => array(
@@ -16621,7 +16665,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
-					'spec_name' => 'amp-video extension .js script',
+					'spec_name' => 'amp-video extension script',
 				),
 			),
 			array(

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1926,7 +1926,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'amp-date-countdown'                           => [
-				'<amp-date-countdown timestamp-seconds="2147483648" layout="fixed-height" height="50"><template type="amp-mustache"><p class="p1"> {{d}} days, {{h}} hours, {{m}} minutes and {{s}} seconds until <a href="https://en.wikipedia.org/wiki/Year_2038_problem">Y2K38</a>.</p></template></amp-date-countdown>',
+				'<amp-date-countdown timestamp-seconds="2147483648" data-count-up layout="fixed-height" height="50"><template type="amp-mustache"><p class="p1"> {{d}} days, {{h}} hours, {{m}} minutes and {{s}} seconds until <a href="https://en.wikipedia.org/wiki/Year_2038_problem">Y2K38</a>.</p></template></amp-date-countdown>',
 				null,
 				[ 'amp-date-countdown', 'amp-mustache' ],
 			],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -559,7 +559,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								<amp-story-grid-layer template="fill">
 									<amp-story-interactive-poll id="correct-poll" endpoint="https://webstoriesinteractivity-beta.web.app/api/v1" theme="dark" chip-style="shadow" class="nice-quiz" prompt-text="What country do you like the most?" option-1-text="France" option-1-confetti="🇺🇾" option-1-results-category="Dog" option-2-text="Spain" option-2-confetti="🇺🇾" option-2-results-category="Cat" option-3-text="Uruguay" option-3-confetti="🇺🇾" option-3-results-category="Bunny" option-4-text="Brazil" option-4-confetti="🇺🇾" option-4-results-category="Mouse">
 									</amp-story-interactive-poll>
-									<amp-story-interactive-results prompt-text="Your level is" option-1-results-category="Beginner" option-1-image="beginner.png" option-1-results-threshold="10" option-2-results-category="Expet" option-2-image="expert.png" option-2-results-threshold="80"></amp-story-interactive-results>
+									<amp-story-interactive-results prompt-text="Your level is" option-1-results-category="Beginner" option-1-image="beginner.png" option-1-results-threshold="1.0" option-2-results-category="Expet" option-2-image="expert.png" option-2-results-threshold="80"></amp-story-interactive-results>
 								</amp-story-grid-layer>
 							</amp-story-page>
 							<amp-story-page id="amp-story-interactive-binary-poll">
@@ -580,6 +580,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 									</amp-story-interactive-results>
 								</amp-story-grid-layer>
 							</amp-story-page>
+							<amp-story-page id="cover">
+								<amp-story-grid-layer template="fill">
+							 		<amp-story-panning-media layout="fill"></amp-story-panning-media>
+								</amp-story-grid-layer>
+						 	</amp-story-page>
 							<amp-story-bookend src="bookendv1.json" layout="nodisplay"></amp-story-bookend>
 							<amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics>
 						</amp-story>
@@ -589,7 +594,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					return [
 						$html,
 						preg_replace( '#<\w+[^>]*>bad</\w+>#', '', $html ),
-						[ 'amp-story', 'amp-analytics', 'amp-story-360', 'amp-twitter', 'amp-youtube', 'amp-video', 'amp-story-interactive' ],
+						[ 'amp-story', 'amp-analytics', 'amp-story-360', 'amp-twitter', 'amp-youtube', 'amp-video', 'amp-story-interactive', 'amp-story-panning-media' ],
 						[
 							[
 								'code'      => AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_DESCENDANT_TAG,
@@ -1023,7 +1028,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								<h4>Section 1</h4>
 								<p>Bunch of awesome content.</p>
 							</section>
-							<section>
+							<section access-hide>
 								<h4>Section 2</h4>
 								<div>Bunch of even more awesome content. This time in a <code>&lt;div&gt;</code>.</div>
 							</section>
@@ -1041,7 +1046,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 					return [
 						$html,
-						preg_replace( '#<\w+>bad</\w+>#', '', $html ),
+						null, // No change.
 						[ 'amp-accordion' ],
 					];
 				}


### PR DESCRIPTION
Previously #5608 (and #5659).

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [x] Update spec generator as needed based on spec format changes.
- [ ] ~Modify validating sanitizer based on changes to spec, if needed.~
- [x] Add tests for key changes.

## Changelog

* Replace `amp-google-vrview-image` with `amp-story-panning-media` in AMP Stories, and add `amp-story-panning-media` component.
* Add `data-count-up` to `amp-date-countdown`.
* Allow `outstream` as value for `data-media-id` attribute on `amp-jwplayer`.
* Fix decimal pattern for `option-*-results-threshold` attributes on `amp-story-interactive-results`.
* Add `access-hide` to `section` element in `amp-accordion`.
* ~Remove `intrinsic` layout from `amp-video`. 🐛 This appears to have been a [mistaken revert](https://github.com/ampproject/amphtml/pull/31373/files#r544645139) of https://github.com/ampproject/amphtml/pull/28349. It needs to be reverted and the spec updated before this PR is merged.~

## Details

```bash
(
    PREV_VERSION=2011140244000;
    THIS_VERSION=68e4db07;
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

(Originally 2012112254000 but changed to 68e4db07 to include https://github.com/ampproject/amphtml/pull/31800 and https://github.com/ampproject/amphtml/pull/31922.)

<details>
<summary>2011140244000...68e4db07</summary>

```diff
diff --git a/extensions/amp-accordion/validator-amp-accordion.protoascii b/extensions/amp-accordion/validator-amp-accordion.protoascii
index ef60a92c3..6cc558009 100644
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -70,6 +70,12 @@ tags: {  # <amp-accordion> > <section>
   spec_name: "amp-accordion > section"
   descriptive_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"
+  attrs: {
+    # amp-access is disabled in AMP4EMAIL
+    disabled_by: "amp4email"
+    name: "access-hide"
+    value: ""
+  }
   attrs: { name: "expanded" value: "" }
   # amp-bind
   attrs: {
diff --git a/extensions/amp-ad/validator-amp-ad.protoascii b/extensions/amp-ad/validator-amp-ad.protoascii
index 639a4ddd9..4d777d3c4 100644
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -33,7 +33,7 @@ tags: {  # amp-ad
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
-  spec_name: "amp-ad extension .js script"
+  spec_name: "amp-ad extension script"
   extension_spec: {
     name: "amp-ad"
     version: "0.1"
@@ -47,7 +47,7 @@ tags: {  # <amp-ad>
   html_format: AMP  # Ads are not allowed inside ads
   tag_name: "AMP-AD"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -83,7 +83,7 @@ tags: {  # <amp-ad type="custom">
   tag_name: "AMP-AD"
   spec_name: "amp-ad with type=custom"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -119,7 +119,7 @@ tags: {  # <amp-ad data-multi-size>
   tag_name: "AMP-AD"
   spec_name: "amp-ad with data-multi-size attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -166,7 +166,7 @@ tags: {  # <amp-ad data-enable-refresh>
   tag_name: "AMP-AD"
   spec_name: "amp-ad with data-enable-refresh attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   # If modifying disallowed_ancestors, then please also edit
   # extensions/amp-auto-ads/*/placement.js
   disallowed_ancestor: "AMP-APP-BANNER"
@@ -209,7 +209,7 @@ tags: {  # <amp-embed>
   html_format: AMP
   tag_name: "AMP-EMBED"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   disallowed_ancestor: "AMP-APP-BANNER"
   attrs: { name: "alt" }
   attrs: { name: "json" }
@@ -241,7 +241,7 @@ tags: {  # <amp-embed data-multi-size>
   tag_name: "AMP-EMBED"
   spec_name: "amp-embed with data-multi-size attribute"
   requires_extension: "amp-ad"  # See note at top of file
-  also_requires_tag_warning: "amp-ad extension .js script"
+  also_requires_tag_warning: "amp-ad extension script"
   disallowed_ancestor: "AMP-APP-BANNER"
   # amp-embed elements cannot be both children of an amp ad container and have
   # data-multi-size attribute.
diff --git a/extensions/amp-anim/validator-amp-anim.protoascii b/extensions/amp-anim/validator-amp-anim.protoascii
index 39aa3e94f..d842fdec6 100644
--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -30,7 +30,7 @@ tags: {  # amp-anim
 tags: {  # amp-anim
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "amp-anim extension .js script (AMP4EMAIL)"
+  spec_name: "amp-anim extension script (AMP4EMAIL)"
   extension_spec: {
     name: "amp-anim"
     # AMP4EMAIL doesn't allow version: "latest".
diff --git a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
index 32e59aff9..fd0486f27 100644
--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -36,6 +36,10 @@ tags: {  # <amp-date-countdown>
     value_casei: "minutes"
     value_casei: "seconds"
   }
+  attrs {
+    name: "data-count-up"
+    value: ""
+  }
   attrs: {
     name: "end-date"
     mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
diff --git a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
index 9e48a1094..1638b2da5 100644
--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
@@ -37,7 +37,7 @@ tags: {  # <amp-jwplayer>
   attrs: {
     name: "data-media-id"
     mandatory_oneof: "['data-media-id', 'data-playlist-id']"
-    value_regex_casei: "[0-9a-z]{8}"
+    value_regex_casei: "[0-9a-z]{8}|outstream"
   }
   attrs: {
     name: "data-player-id"
diff --git a/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii b/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii
index 132cad177..7636182af 100644
--- a/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii
+++ b/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii
@@ -146,22 +146,22 @@ tags: {  # <amp-story-interactive-results>
   }
   attrs: {
     name: "option-1-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\\.\\d+)?"
   }
   attrs: {
     name: "option-2-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\\.\\d+)?"
   }
   attrs: {
     name: "option-3-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\\.\\d+)?"
     trigger: {
       also_requires_attr: "option-3-results-category"
     }
   }
   attrs: {
     name: "option-4-results-threshold"
-    value_regex: "\\d+[.\\d+]?"
+    value_regex: "\\d+(\\.\\d+)?"
     trigger: {
       also_requires_attr: "option-4-results-category"
     }
diff --git a/extensions/amp-story-player/validator-amp-story-player.protoascii b/extensions/amp-story-panning-media/validator-amp-story-panning-media.protoascii
similarity index 61%
copy from extensions/amp-story-player/validator-amp-story-player.protoascii
copy to extensions/amp-story-panning-media/validator-amp-story-panning-media.protoascii
index 9f714de55..992835f6d 100644
--- a/extensions/amp-story-player/validator-amp-story-player.protoascii
+++ b/extensions/amp-story-panning-media/validator-amp-story-panning-media.protoascii
@@ -14,32 +14,23 @@
 # limitations under the license.
 #
 
-tags: {  # amp-story-player
+tags: {  # amp-story-panning-media
   html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
-    name: "amp-story-player"
+    name: "amp-story-panning-media"
     version: "0.1"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-story-player>
+tags: {  # <amp-story-panning-media>
   html_format: AMP
-  tag_name: "AMP-STORY-PLAYER"
-  requires_extension: "amp-story-player"
-  descendant_tag_list: "amp-story-player-allowed-descendants"
+  tag_name: "AMP-STORY-PANNING-MEDIA"
+  requires_extension: "amp-story-panning-media"
+  mandatory_ancestor: "AMP-STORY-GRID-LAYER"
+  spec_url: "https://amp.dev/documentation/components/amp-story-panning-media"
   amp_layout: {
     supported_layouts: FILL
-    supported_layouts: FIXED
-    supported_layouts: FIXED_HEIGHT
-    supported_layouts: FLEX_ITEM
-    supported_layouts: RESPONSIVE
   }
 }
-descendant_tag_list {
-  name: "amp-story-player-allowed-descendants"
-  tag: "A"
-  tag: "SPAN"
-  tag: "I-AMPHTML-SIZER"  # Only allowed when document is transformed AMP
-}
diff --git a/extensions/amp-story-player/validator-amp-story-player.protoascii b/extensions/amp-story-player/validator-amp-story-player.protoascii
index 9f714de55..45f7dff61 100644
--- a/extensions/amp-story-player/validator-amp-story-player.protoascii
+++ b/extensions/amp-story-player/validator-amp-story-player.protoascii
@@ -35,6 +35,7 @@ tags: {  # <amp-story-player>
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
     supported_layouts: RESPONSIVE
+    supported_layouts: INTRINSIC
   }
 }
 descendant_tag_list {
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index 5b11c2eed..52897853d 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -655,7 +655,6 @@ descendant_tag_list: {
   tag: "AMP-FIT-TEXT"
   tag: "AMP-FONT"
   tag: "AMP-GIST"
-  tag: "AMP-GOOGLE-VRVIEW-IMAGE"
   tag: "AMP-IMG"
   tag: "AMP-INSTALL-SERVICEWORKER"
   tag: "AMP-LIST"
@@ -667,6 +666,7 @@ descendant_tag_list: {
   tag: "AMP-STORY-INTERACTIVE-POLL"
   tag: "AMP-STORY-INTERACTIVE-QUIZ"
   tag: "AMP-STORY-INTERACTIVE-RESULTS"
+  tag: "AMP-STORY-PANNING-MEDIA"
   tag: "AMP-TIMEAGO"
   tag: "AMP-TWITTER"
   tag: "AMP-VIDEO"
@@ -941,7 +941,6 @@ descendant_tag_list {
   tag: "AMP-GFYCAT"
   tag: "AMP-GIST"
   tag: "AMP-GOOGLE-DOCUMENT-EMBED"
-  tag: "AMP-GOOGLE-VRVIEW-IMAGE"
   tag: "AMP-HULU"
   tag: "AMP-IMA-VIDEO"
   tag: "AMP-IMAGE-SLIDER"
diff --git a/extensions/amp-video/validator-amp-video.protoascii b/extensions/amp-video/validator-amp-video.protoascii
index fba174053..7c4ab5167 100644
--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-video
   # Typically the extension_spec takes care of this, but we have
   # a unique situation where we need to refer to this earlier in
   # the rules processing for the also_requires_tag_warning below.
-  spec_name: "amp-video extension .js script"
+  spec_name: "amp-video extension script"
   extension_spec: {
     name: "amp-video"
     version: "0.1"
@@ -114,7 +114,7 @@ tags: {  # <amp-video> not in amp-story.
   # Typically we'd require the extension j/s, but for historical reasons
   # many pages don't have it, so it ends up late loaded and we warn, instead
   # of making this a validation error.
-  also_requires_tag_warning: "amp-video extension .js script"
+  also_requires_tag_warning: "amp-video extension script"
   attrs: { name: "poster" }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
@@ -137,7 +137,7 @@ tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHT
   tag_name: "AMP-VIDEO"
   spec_name: "amp-story >> amp-story-page-attachment >> amp-video"
   mandatory_ancestor: "AMP-STORY-PAGE-ATTACHMENT"
-  also_requires_tag_warning: "amp-video extension .js script"
+  also_requires_tag_warning: "amp-video extension script"
   attrs: { name: "poster" }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index 14181ff3e..91cfa1362 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 475
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 1119
+spec_file_revision: 1132
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors/#custom-javascript-is-not-allowed"
@@ -3835,7 +3835,7 @@ tags: {
 # Note that the type TEXT/PLAIN description is define in
 # validator-amp-mustache.protoascii.
 
-# The three tagspecs below all handle the runtime engine v0.js script. They
+# The three tagspecs below all handle the runtime engine script. They
 # enforce that exactly one runtime script must be included. This tagspec is
 # for the standard runtime, while the one below it is an identical spec but for
 # the LTS runtime, with the only difference being the src attribute. The third
@@ -3856,12 +3856,52 @@ attr_lists: {
     value_casei: "text/javascript"
   }
 }
+attr_lists: {
+  name: "amphtml-module-engine-attrs"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "crossorigin"
+    mandatory: true
+    value: "anonymous"
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "module"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
+attr_lists: {
+  name: "amphtml-nomodule-engine-attrs"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
+    name: "nomodule"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+}
 tags: {
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js script"
-  descriptive_name: "amphtml engine v0.js script"
-  mandatory_alternatives: "amphtml engine v0.js script"
+  spec_name: "amphtml engine script"
+  descriptive_name: "amphtml engine script"
+  mandatory_alternatives: "amphtml engine script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -3883,9 +3923,9 @@ tags: {
 tags: {
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js lts script"
-  descriptive_name: "amphtml engine v0.js script"
-  mandatory_alternatives: "amphtml engine v0.js script"
+  spec_name: "amphtml engine script (LTS)"
+  descriptive_name: "amphtml engine script"
+  mandatory_alternatives: "amphtml engine script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
@@ -3904,11 +3944,115 @@ tags: {
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
+# TODO(b/167681900): update documentation to cover these script release versions
+# TODO(b/173803451): allow module/nomodule tagspecs.
+#tags: {
+#  html_format: AMP
+#  enabled_by: "transformed"
+#  tag_name: "SCRIPT"
+#  spec_name: "amphtml module engine script"
+#  descriptive_name: "amphtml engine script"
+#  mandatory_alternatives: "amphtml engine script"
+#  unique: true
+#  mandatory_parent: "HEAD"
+#  satisfies: "amphtml module engine script"
+#  requires: "amphtml nomodule engine script"
+#  attr_lists: "nonce-attr"
+#  attr_lists: "amphtml-module-engine-attrs"
+#  attrs: {
+#    name: "src"
+#    mandatory: true
+#    value: "https://cdn.ampproject.org/v0.mjs"
+#    dispatch_key: NAME_VALUE_DISPATCH
+#  }
+#  cdata: {
+#    whitespace_only: true
+#  }
+#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+#}
+# TODO(b/167681900): update documentation to cover these script release versions
+# TODO(b/173803451): allow module/nomodule tagspecs.
+#tags: {
+#  html_format: AMP
+#  enabled_by: "transformed"
+#  tag_name: "SCRIPT"
+#  spec_name: "amphtml nomodule engine script"
+#  descriptive_name: "amphtml engine script"
+#  mandatory_alternatives: "amphtml engine script"
+#  unique: true
+#  mandatory_parent: "HEAD"
+#  satisfies: "amphtml nomodule engine script"
+#  requires: "amphtml module engine script"
+#  attr_lists: "nonce-attr"
+#  attr_lists: "amphtml-nomodule-engine-attrs"
+#  attrs: {
+#    name: "src"
+#    mandatory: true
+#    value: "https://cdn.ampproject.org/v0.js"
+#    dispatch_key: NAME_VALUE_DISPATCH
+#  }
+#  cdata: {
+#    whitespace_only: true
+#  }
+#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+#}
+# TODO(b/167681900): update documentation to cover these script release versions
+# TODO(b/173803451): allow module/nomodule tagspecs.
+#tags: {
+#  html_format: AMP
+#  enabled_by: "transformed"
+#  tag_name: "SCRIPT"
+#  spec_name: "amphtml module LTS engine script"
+#  descriptive_name: "amphtml engine script"
+#  mandatory_alternatives: "amphtml engine script"
+#  unique: true
+#  mandatory_parent: "HEAD"
+#  satisfies: "amphtml module LTS engine script"
+#  requires: "amphtml nomodule LTS engine script"
+#  attr_lists: "nonce-attr"
+#  attr_lists: "amphtml-module-engine-attrs"
+#  attrs: {
+#    name: "src"
+#    mandatory: true
+#    value: "https://cdn.ampproject.org/lts/v0.mjs"
+#    dispatch_key: NAME_VALUE_DISPATCH
+#  }
+#  cdata: {
+#    whitespace_only: true
+#  }
+#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+#}
+# TODO(b/167681900): update documentation to cover these script release versions
+# TODO(b/173803451): allow module/nomodule tagspecs.
+#tags: {
+#  html_format: AMP
+#  enabled_by: "transformed"
+#  tag_name: "SCRIPT"
+#  spec_name: "amphtml nomodule LTS engine script"
+#  descriptive_name: "amphtml engine script"
+#  mandatory_alternatives: "amphtml engine script"
+#  unique: true
+#  mandatory_parent: "HEAD"
+#  satisfies: "amphtml nomodule LTS engine script"
+#  requires: "amphtml module LTS engine script"
+#  attr_lists: "nonce-attr"
+#  attr_lists: "amphtml-nomodule-engine-attrs"
+#  attrs: {
+#    name: "src"
+#    mandatory: true
+#    value: "https://cdn.ampproject.org/lts/v0.js"
+#    dispatch_key: NAME_VALUE_DISPATCH
+#  }
+#  cdata: {
+#    whitespace_only: true
+#  }
+#  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
+#}
 tags: {
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "amphtml engine v0.js script [AMP4EMAIL]"
-  descriptive_name: "amphtml engine v0.js script"
+  spec_name: "amphtml engine script [AMP4EMAIL]"
+  descriptive_name: "amphtml engine script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -3931,8 +4075,8 @@ tags: {
 tags: {
   html_format: AMP4ADS
   tag_name: "SCRIPT"
-  spec_name: "amp4ads engine amp4ads-v0.js script"
-  descriptive_name: "amphtml engine amp4ads-v0.js script"
+  spec_name: "amp4ads engine script"
+  descriptive_name: "amphtml engine script"
   mandatory: true
   unique: true
   mandatory_parent: "HEAD"
@@ -4469,15 +4613,16 @@ tags: {
   attrs: { name: "attribution" }
   attrs: {
     name: "class"
-    mandatory: true
     value: "i-amphtml-blurry-placeholder"
+    mandatory: true
   }
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: {
     name: "placeholder"
-    mandatory: true
     value: ""
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
   }
   attrs: { name: "referrerpolicy" }
   attrs: { name: "sizes" }
@@ -4517,8 +4662,7 @@ attr_lists: {
   }
 }
 
-# AMP Extension attributes. These attributes are used in every AMP
-# extension script tag
+# AMP Extension attributes.
 attr_lists: {
   name: "common-extension-attrs"
   attrs: {
@@ -5709,100 +5853,101 @@ error_specificity { code: WARNING_EXTENSION_UNUSED specificity: 16 }
 error_specificity { code: WARNING_EXTENSION_DEPRECATED_VERSION specificity: 17 }
 error_specificity { code: NON_LTS_SCRIPT_AFTER_LTS specificity: 18 }
 error_specificity { code: LTS_SCRIPT_AFTER_NON_LTS specificity: 19 }
-error_specificity { code: DISALLOWED_TAG specificity: 20 }
-error_specificity { code: DISALLOWED_ATTR specificity: 21 }
-error_specificity { code: INVALID_ATTR_VALUE specificity: 22 }
-error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 23 }
-error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 24 }
-error_specificity { code: MANDATORY_ATTR_MISSING specificity: 25 }
-error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 26 }
-error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 27 }
-error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 28 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 29 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 30 }
-error_specificity { code: STYLESHEET_TOO_LONG specificity: 31 }
-error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 32 }
-error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 33 }
-error_specificity { code: INLINE_SCRIPT_TOO_LONG specificity: 34 }
-error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 35 }
+error_specificity { code: INCORRECT_SCRIPT_RELEASE_VERSION specificity: 20 }
+error_specificity { code: DISALLOWED_TAG specificity: 21 }
+error_specificity { code: DISALLOWED_ATTR specificity: 22 }
+error_specificity { code: INVALID_ATTR_VALUE specificity: 23 }
+error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 24 }
+error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 25 }
+error_specificity { code: MANDATORY_ATTR_MISSING specificity: 26 }
+error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 27 }
+error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 28 }
+error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 29 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 30 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 31 }
+error_specificity { code: STYLESHEET_TOO_LONG specificity: 32 }
+error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 33 }
+error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 34 }
+error_specificity { code: INLINE_SCRIPT_TOO_LONG specificity: 35 }
+error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 36 }
 error_specificity {
-  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 36
-}
-error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 37 }
-error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 38 }
-error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 39 }
-error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 40 }
-error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 41 }
-error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 42 }
+  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 37
+}
+error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 38 }
+error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 39 }
+error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 40 }
+error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 41 }
+error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 42 }
+error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 43 }
 error_specificity {
-  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 43
-}
-error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 44 }
-error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 45 }
-error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 46 }
-error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 47 }
-error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 48 }
-error_specificity { code: DUPLICATE_DIMENSION specificity: 49 }
-error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 50 }
-error_specificity { code: MISSING_URL specificity: 51 }
-error_specificity { code: DISALLOWED_DOMAIN specificity: 52 }
-error_specificity { code: INVALID_URL_PROTOCOL specificity: 53 }
-error_specificity { code: INVALID_URL specificity: 54 }
-error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 55 }
-error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 56 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 57 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 58 }
-error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 59 }
+  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 44
+}
+error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 45 }
+error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 46 }
+error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 47 }
+error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 48 }
+error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 49 }
+error_specificity { code: DUPLICATE_DIMENSION specificity: 50 }
+error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 51 }
+error_specificity { code: MISSING_URL specificity: 52 }
+error_specificity { code: DISALLOWED_DOMAIN specificity: 53 }
+error_specificity { code: INVALID_URL_PROTOCOL specificity: 54 }
+error_specificity { code: INVALID_URL specificity: 55 }
+error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 56 }
+error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 57 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 58 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 59 }
+error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 60 }
 error_specificity {
-  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 60
+  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 61
 }
-error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 61 }
-error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 62 }
-error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 63 }
-error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 64 }
-error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 65 }
+error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 62 }
+error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 63 }
+error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 64 }
+error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 65 }
+error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 66 }
 error_specificity {
-  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 66
-}
-error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 67 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 68 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 69 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 70 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 71 }
-error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 72 }
-error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 73 }
-error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 74 }
-error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 75 }
+  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 67
+}
+error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 68 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 69 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 70 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 71 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 72 }
+error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 73 }
+error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 74 }
+error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 75 }
+error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 76 }
 error_specificity {
-  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 76
+  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 77
 }
-error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 77 }
-error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 78 }
-error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 79 }
+error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 78 }
+error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 79 }
+error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 80 }
 error_specificity {
   code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT_SINGULAR
-  specificity: 80
+  specificity: 81
 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 81 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 82 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT
-  specificity: 82
+  specificity: 83
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE
-  specificity: 83
+  specificity: 84
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH
-  specificity: 84
+  specificity: 85
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_REQUIRES_QUALIFICATION
-  specificity: 85
+  specificity: 86
 }
 error_specificity {
   code: BASE_TAG_MUST_PRECEED_ALL_URLS
-  specificity: 86
+  specificity: 87
 }
 error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 102 }
 error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 103 }
@@ -5931,7 +6076,11 @@ error_formats {
           "deprecated version. Please use a more recent version of this "
           "extension. This may become an error in the future."
 }
-
+error_formats {
+  code: INCORRECT_SCRIPT_RELEASE_VERSION
+  format: "The script version for '%1' is a %2 version which mismatches "
+          "with the first script on the page using the %3 version."
+}
 error_formats {
   code: NON_LTS_SCRIPT_AFTER_LTS
   format: "'%1' must use the LTS version to correspond with the first script "
@@ -5942,7 +6091,6 @@ error_formats {
   format: "'%1' must use the non-LTS version to correspond with the first "
           "script in the page, which does not use LTS."
 }
-
 error_formats {
   code: ATTR_REQUIRED_BUT_MISSING
   format: "The attribute '%1' in tag '%2' is missing or incorrect, but "
```