### PR TITLE
Disable lazy-loading during AMP_Scribd_Embed_Handler_Test for WP 5.7-alpha

### DIFF
--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -112,6 +112,7 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	public function test__conversion( $source, $expected ) {
 		$embed = new AMP_Scribd_Embed_Handler();
 		$embed->register_embed();
+		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 		$filtered_content = apply_filters( 'the_content', $source );
 
 		$this->assertEquals( $expected, $filtered_content );


### PR DESCRIPTION
## Summary

Fix tests running against WordPress trunk which recently got lazy-loading iframes merged: https://core.trac.wordpress.org/changeset/49808

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
