### PR TITLE
Close Twenty Twenty and Twenty Twenty-One mobile menus when clicking on in-page anchor link menu items

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1746,7 +1746,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$close_xpaths = isset( $args['close_button_xpath'] ) ? $args['close_button_xpath'] : [];
 
 		// Ensure anchor links also close the modal the same as the the Close Menu button.
-		$close_xpaths[] = sprintf( "//*[ @id = '{$modal_id}' ]//a[ @href and substring( @href, 1, 1 ) = '#' ]" );
+		$close_xpaths[] = sprintf( "//*[ @id = '{$modal_id}' ]//a[ @href and contains( @href, '#' ) ]" );
 
 		$modal_actions = [
 			"{$modal_id}.open"  => $open_xpaths,
@@ -2164,7 +2164,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );
 
 		// Close the mobile modal when clicking in-page anchor links in the menu.
-		foreach ( $this->dom->xpath->query( '//*[ @id = "site-navigation" ]//a[ @href and substring( @href, 1, 1 ) = "#" ]' ) as $link ) {
+		foreach ( $this->dom->xpath->query( '//*[ @id = "site-navigation" ]//a[ @href and contains( @href, "#" ) ]' ) as $link ) {
 			/** @var DOMElement $link */
 			AMP_DOM_Utils::add_amp_action( $link, 'tap', "AMP.setState({{$state_string}: false})" );
 			AMP_DOM_Utils::add_amp_action( $link, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2162,6 +2162,21 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open)" );
 		AMP_DOM_Utils::add_amp_action( $menu_toggle, 'tap', "{$body_id}.toggleClass(class=lock-scrolling)" );
 		$menu_toggle->setAttribute( 'data-amp-bind-aria-expanded', "{$state_string} ? 'true' : 'false'" );
+
+		// Close the mobile modal when clicking in-page anchor links in the menu.
+		foreach ( $this->dom->xpath->query( '//*[ @id = "site-navigation" ]//a[ @href and substring( @href, 1, 1 ) = "#" ]' ) as $link ) {
+			/** @var DOMElement $link */
+			AMP_DOM_Utils::add_amp_action( $link, 'tap', "AMP.setState({{$state_string}: false})" );
+			AMP_DOM_Utils::add_amp_action( $link, 'tap', "{$body_id}.toggleClass(class=primary-navigation-open,force=false)" );
+			AMP_DOM_Utils::add_amp_action( $link, 'tap', "{$body_id}.toggleClass(class=lock-scrolling,force=false)" );
+
+			// Ensure target is scrolled into view. Note that in-page anchor links currently do not work in the non-AMP
+			// version. Normally scrollTo shouldn't be necessary but it appears necessary due to scroll locking.
+			$target = substr( $link->getAttribute( 'href' ), 1 );
+			if ( $target ) {
+				AMP_DOM_Utils::add_amp_action( $link, 'tap', "{$target}.scrollTo" );
+			}
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1745,9 +1745,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$open_xpaths  = isset( $args['open_button_xpath'] ) ? $args['open_button_xpath'] : [];
 		$close_xpaths = isset( $args['close_button_xpath'] ) ? $args['close_button_xpath'] : [];
 
-		// Ensure anchor links also close the modal the same as the the Close Menu button.
-		$close_xpaths[] = sprintf( "//*[ @id = '{$modal_id}' ]//a[ @href and contains( @href, '#' ) ]" );
-
 		$modal_actions = [
 			"{$modal_id}.open"  => $open_xpaths,
 			// Although we add the 'show-modal' class here, we don't remove it again, as it will
@@ -1887,6 +1884,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			// With twentytwenty compat, the lightbox fills the entire screen, and only an inner wrapper will contain
 			// the actionable elements in the modal. Therefore, the lightbox represents the "background".
 			$close_button_xpaths[] = "//*[ @id = '{$modal_id}' ]";
+
+			// Ensure anchor links also close the modal the same as the the Close Menu button.
+			$close_button_xpaths[] = sprintf( "//*[ @id = '{$modal_id}' ]//a[ @href and contains( @href, '#' ) ]" );
 
 			// Then, add the inner element of the lightbox as an open button xpath.
 			// This is done to prevent the above close action from closing the modal when an inner element is clicked.

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2172,8 +2172,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Ensure target is scrolled into view. Note that in-page anchor links currently do not work in the non-AMP
 			// version. Normally scrollTo shouldn't be necessary but it appears necessary due to scroll locking.
-			$target = substr( $link->getAttribute( 'href' ), 1 );
-			if ( $target ) {
+			$target = preg_replace( '/.*#/', '', $link->getAttribute( 'href' ) );
+			if ( $target && $this->dom->getElementById( $target ) ) {
 				AMP_DOM_Utils::add_amp_action( $link, 'tap', "{$target}.scrollTo" );
 			}
 		}

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1745,6 +1745,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$open_xpaths  = isset( $args['open_button_xpath'] ) ? $args['open_button_xpath'] : [];
 		$close_xpaths = isset( $args['close_button_xpath'] ) ? $args['close_button_xpath'] : [];
 
+		// Ensure anchor links also close the modal the same as the the Close Menu button.
+		$close_xpaths[] = sprintf( "//*[ @id = '{$modal_id}' ]//a[ @href and substring( @href, 1, 1 ) = '#' ]" );
+
 		$modal_actions = [
 			"{$modal_id}.open"  => $open_xpaths,
 			// Although we add the 'show-modal' class here, we don't remove it again, as it will

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -526,6 +526,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 						<li id="menu-item-1"><a href="https://example.com/">Foo</a></li>
 						<li id="menu-item-2"><a href="#colophon">Bar</a></li>
 						<li id="menu-item-3"><a href="https://example.com/#site-footer">Baz</a></li>
+						<li id="menu-item-2"><a href="' . esc_url( home_url( '/#colophon' ) ) . '">Quux</a></li>
 					</ul>
 				</div>
 			</nav>
@@ -542,12 +543,17 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, $query->length );
 
 		$query = $dom->xpath->query( '//a[ @href ]' );
-		$this->assertSame( 3, $query->length );
+		$this->assertSame( 4, $query->length );
 		foreach ( $query as $link ) {
 			/** @var DOMElement $link */
 			$href = $link->getAttribute( 'href' );
 			if ( false !== strpos( $href, '#' ) ) {
 				$this->assertTrue( $link->hasAttribute( 'on' ) );
+				if ( false !== strpos( $href, '#colophon' ) ) {
+					$this->assertStringContains( 'colophon.scrollTo', $link->getAttribute( 'on' ) );
+				} else {
+					$this->assertStringNotContains( 'colophon.scrollTo', $link->getAttribute( 'on' ) );
+				}
 			} else {
 				$this->assertFalse( $link->hasAttribute( 'on' ) );
 			}

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -514,7 +514,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_twentytwentyone_mobile_modal() {
 		$html = '
-			<nav>
+			<nav id="site-navigation">
 				<div class="menu-button-container">
 					<button id="primary-mobile-menu">
 						<span class="dropdown-icon open">Menu</span>
@@ -523,12 +523,13 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 				</div>
 				<div class="primary-menu-container">
 					<ul id="primary-menu-list">
-						<li id="menu-item-1">Foo</li>
-						<li id="menu-item-2">Bar</li>
-						<li id="menu-item-3">Baz</li>
+						<li id="menu-item-1"><a href="https://example.com/">Foo</a></li>
+						<li id="menu-item-2"><a href="#colophon">Bar</a></li>
+						<li id="menu-item-3"><a href="https://example.com/">Baz</a></li>
 					</ul>
 				</div>
 			</nav>
+			<div id="colophon"></div>
 		';
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $html );
@@ -539,6 +540,18 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$query = $dom->xpath->query( '//button[ @id = "primary-mobile-menu" and @data-amp-bind-aria-expanded and @on ]' );
 
 		$this->assertEquals( 1, $query->length );
+
+		$query = $dom->xpath->query( '//a[ @href ]' );
+		$this->assertSame( 3, $query->length );
+		foreach ( $query as $link ) {
+			/** @var DOMElement $link */
+			$href = $link->getAttribute( 'href' );
+			if ( '#' === substr( $href, 0, 1 ) ) {
+				$this->assertTrue( $link->hasAttribute( 'on' ) );
+			} else {
+				$this->assertFalse( $link->hasAttribute( 'on' ) );
+			}
+		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -525,7 +525,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 					<ul id="primary-menu-list">
 						<li id="menu-item-1"><a href="https://example.com/">Foo</a></li>
 						<li id="menu-item-2"><a href="#colophon">Bar</a></li>
-						<li id="menu-item-3"><a href="https://example.com/">Baz</a></li>
+						<li id="menu-item-3"><a href="https://example.com/#site-footer">Baz</a></li>
 					</ul>
 				</div>
 			</nav>
@@ -546,7 +546,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		foreach ( $query as $link ) {
 			/** @var DOMElement $link */
 			$href = $link->getAttribute( 'href' );
-			if ( '#' === substr( $href, 0, 1 ) ) {
+			if ( false !== strpos( $href, '#' ) ) {
 				$this->assertTrue( $link->hasAttribute( 'on' ) );
 			} else {
 				$this->assertFalse( $link->hasAttribute( 'on' ) );


### PR DESCRIPTION
## Summary

Fixes #5719.

### Twenty Twenty

Before: https://youtu.be/r8B-23CYWx4

After: https://youtu.be/843vlDtM3Bo

### Twenty Twenty-One

Before: https://youtu.be/1zeuIkPyyMc

After: https://youtu.be/5TUeeo5fXY0

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
