### PR TITLE
Deprecate obsolete amp_post_template_add_analytics_script()

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -20,7 +20,6 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_default_styles' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
-	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
 
 	add_action( 'admin_bar_init', [ 'AMP_Theme_Support', 'init_admin_bar' ] );
@@ -120,22 +119,6 @@ function amp_post_template_add_styles( $amp_template ) {
 			printf( '%1$s{%2$s}', $selector, $declarations ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
-}
-
-/**
- * Add analytics scripts.
- *
- * @internal
- * @deprecated This is no longer necessary.
- *
- * @param array $data Data.
- * @return array Data.
- */
-function amp_post_template_add_analytics_script( $data ) {
-	if ( ! empty( $data['amp_analytics'] ) ) {
-		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';
-	}
-	return $data;
 }
 
 /**

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -263,6 +263,7 @@ function amp_admin_pointer() {
  *
  * @since 1.3
  * @deprecated 1.5.0 Warning moved to Site Health.
+ * @codeCoverageIgnore
  * @internal
  * @see AmpProject\AmpWP\Admin\SiteHealth::xdebug_extension()
  */
@@ -281,4 +282,23 @@ function _amp_xdebug_admin_notice() {
 		</p>
 	</div>
 	<?php
+}
+
+/**
+ * Add analytics scripts.
+ *
+ * @internal
+ * @deprecated 2.1 This is no longer necessary since amp-analytics is added automatically to the page during post-processing.
+ * @codeCoverageIgnore
+ *
+ * @param array $data Data.
+ * @return array Data.
+ */
+function amp_post_template_add_analytics_script( $data ) {
+	_deprecated_function( __FUNCTION__, '2.1' );
+
+	if ( ! empty( $data['amp_analytics'] ) ) {
+		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';
+	}
+	return $data;
 }

--- a/tests/php/test-amp-post-template-functions.php
+++ b/tests/php/test-amp-post-template-functions.php
@@ -31,7 +31,6 @@ class Test_AMP_Post_Template_Functions extends WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_default_styles' ) );
 		$this->assertSame( 99, has_action( 'amp_post_template_css', 'amp_post_template_add_styles' ) );
-		$this->assertSame( 10, has_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' ) );
 		$this->assertSame( 10, has_action( 'admin_bar_init', [ 'AMP_Theme_Support', 'init_admin_bar' ] ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_footer', 'wp_admin_bar_render' ) );
@@ -140,19 +139,6 @@ class Test_AMP_Post_Template_Functions extends WP_UnitTestCase {
 
 		$this->assertStringContains( 'body{color:red', $output );
 		$this->assertStringContains( 'body{color:blue', $output );
-	}
-
-	/** @covers ::amp_post_template_add_analytics_script() */
-	public function test_amp_post_template_add_analytics_script() {
-		$this->assertEmpty( amp_post_template_add_analytics_script( [] ) );
-
-		$data = amp_post_template_add_analytics_script(
-			[
-				'amp_analytics' => [ '...' ],
-			]
-		);
-		$this->assertArrayHasKey( 'amp_component_scripts', $data );
-		$this->assertArrayHasKey( 'amp-analytics', $data['amp_component_scripts'] );
 	}
 
 	/** @covers ::amp_post_template_add_analytics_data() */


### PR DESCRIPTION
## Summary

The `amp_post_template_add_analytics_script()` function is obsolete now that legacy Reader mode templates are sent through the post-processor and AMP scripts are automatically added.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
