### PR TITLE
Only run PHPStan (on all PHP files) in pre-commit hook if there is a modified PHP file

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -529,7 +529,7 @@ jobs:
           path: builds/prod
 
       - name: Setup Google Cloud SDK
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCS_PROJECT_ID }}
           service_account_key: ${{ secrets.GCS_APPLICATION_CREDENTIALS }}

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+	"package.json": [
+		"npm run lint:pkg-json"
+	],
+	"**/*.css": [
+		"npm run lint:css"
+	],
+	"**/*.js": [
+		"npm run lint:js"
+	],
+	"**/!(amp).php": [
+		"npm run lint:php"
+	],
+	"amp.php": [
+		"vendor/bin/phpcs --runtime-set testVersion 5.2-"
+	],
+	"*.php": () => 'composer analyze'
+};

--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,7 @@
   "scripts": {
     "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan --version; phpstan analyze --ansi; fi",
     "pre-commit": [
-      "npm run lint:staged",
-      "@analyze"
+      "npm run lint:staged"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,23 +125,6 @@
     "test:php": "vendor/bin/phpunit",
     "test:php:help": "npm run test:php -- --help"
   },
-  "lint-staged": {
-    "package.json": [
-      "npm run lint:pkg-json"
-    ],
-    "**/*.css": [
-      "npm run lint:css"
-    ],
-    "**/*.js": [
-      "npm run lint:js"
-    ],
-    "**/!(amp).php": [
-      "npm run lint:php"
-    ],
-    "amp.php": [
-      "vendor/bin/phpcs --runtime-set testVersion 5.2-"
-    ]
-  },
   "npmpackagejsonlint": {
     "extends": "@wordpress/npm-package-json-lint-config",
     "rules": {


### PR DESCRIPTION
## Summary

I found that our `pre-commit` hook was eagerly running PHPStan even when no modified PHP files were staged. We originally were going to include PHPStan in lint-staged via https://github.com/ampproject/amp-wp/pull/5424 but reverted in https://github.com/ampproject/amp-wp/pull/5438 since it's important for all PHP files to be included in the analysis. This PR conditionally runs PHPStan on all PHP files if _any_ PHP file is modified.

Logic inspired by example in lint-staged [docs](https://www.npmjs.com/package/lint-staged):

![image](https://user-images.githubusercontent.com/134745/103307818-e9831900-49c5-11eb-9847-b8f7e44127c6.png)

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
