### PR TITLE
Persist URL fragment during client-side mobile redirection and guard against infinite redirect

### DIFF
--- a/assets/src/mobile-redirection.js
+++ b/assets/src/mobile-redirection.js
@@ -58,14 +58,17 @@
 	if ( url.searchParams.has( noampQueryVarName ) && noampQueryVarValue === url.searchParams.get( noampQueryVarName ) ) {
 		// If the noamp query param is present, remember that redirection should be disabled.
 		sessionStorage.setItem( disabledStorageKey, '1' );
-	} else {
+	} else if ( ampUrl !== location.href ) {
 		// Otherwise, since JS is running then we know it's not an AMP page and we need to redirect to the AMP version.
+		// Nevertheless, the `url.href !== location.href` condition was added for the edge case where a caching plugin
+		// is erroneously serving a cached non-AMP page at the AMP URL, so the condition prevents an infinite redirect
+		// from ensuing. See <https://github.com/ampproject/amp-wp/issues/5767>.
 		window.stop(); // Stop loading the page! This should cancel all loading resources.
 
 		// Replace the current page with the AMP version.
 		location.replace( ampUrl );
 	}
 }(
-	// Note: The argument here is replaced with JSON in PHP by \AmpProject\AmpWP\MobileRedirection::add_mobile_redirect_script().
+	// Note: The argument here is replaced with a JSON object literal in PHP by \AmpProject\AmpWP\MobileRedirection::add_mobile_redirect_script().
 	AMP_MOBILE_REDIRECTION,
 ) );

--- a/assets/src/mobile-redirection.js
+++ b/assets/src/mobile-redirection.js
@@ -53,12 +53,17 @@
 		return;
 	}
 
-	const url = new URL( location.href );
+	const locationUrlObject = new URL( location.href );
+	const amphtmlUrlObject = new URL( ampUrl );
 
-	if ( url.searchParams.has( noampQueryVarName ) && noampQueryVarValue === url.searchParams.get( noampQueryVarName ) ) {
+	// Persist the URL fragment when redirecting to the AMP version. This is needed because the server-generated amphtml
+	// link has no awareness of the client-side URL target.
+	amphtmlUrlObject.hash = locationUrlObject.hash;
+
+	if ( locationUrlObject.searchParams.has( noampQueryVarName ) && noampQueryVarValue === locationUrlObject.searchParams.get( noampQueryVarName ) ) {
 		// If the noamp query param is present, remember that redirection should be disabled.
 		sessionStorage.setItem( disabledStorageKey, '1' );
-	} else if ( ampUrl !== location.href ) {
+	} else if ( amphtmlUrlObject.href !== locationUrlObject.href ) {
 		// Otherwise, since JS is running then we know it's not an AMP page and we need to redirect to the AMP version.
 		// Nevertheless, the `url.href !== location.href` condition was added for the edge case where a caching plugin
 		// is erroneously serving a cached non-AMP page at the AMP URL, so the condition prevents an infinite redirect
@@ -66,7 +71,7 @@
 		window.stop(); // Stop loading the page! This should cancel all loading resources.
 
 		// Replace the current page with the AMP version.
-		location.replace( ampUrl );
+		location.replace( amphtmlUrlObject.href );
 	}
 }(
 	// Note: The argument here is replaced with a JSON object literal in PHP by \AmpProject\AmpWP\MobileRedirection::add_mobile_redirect_script().


### PR DESCRIPTION
## Summary

Fixes #5767.

This fixes an issue which can occur when a caching plugin is failing to vary the cache by query parameters. This can result in cache pollution, where a non-AMP page is cached and served for both non-AMP URLs and AMP URLs alike, and vice-versa. When a non-AMP page is served for an AMP URL, mobile redirection can end up endlessly attempting to redirect to the AMP version, even though the user is already at the AMP URL. So the fix here is merely to check that the user is not at the AMP URL already. This fixes a symptom of a misconfigured caching plugin, although the underlying cache misconfiguration issue remains to be addressed by the site owner.

This PR also fixes a related issue I discovered where client-side mobile redirection was not persisting the URL fragment. For example, if attempting to go to `/#colophon` then redirection would result in the user going to `/?amp=1` instead of the expected `/?amp=1#colophon`.

### Before

https://user-images.githubusercontent.com/134745/104235907-830cea80-540a-11eb-8031-0c52351a56b7.mov

### After

https://user-images.githubusercontent.com/134745/104235953-97e97e00-540a-11eb-8d45-b509749e9ca8.mov

## Checklist

- [x] My pull request is addressing an open issue (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
