### PR TITLE
Pass along document.referrer as amp_referrer query parameter during mobile redirection

### DIFF
--- a/assets/src/mobile-redirection.js
+++ b/assets/src/mobile-redirection.js
@@ -70,6 +70,11 @@
 		// from ensuing. See <https://github.com/ampproject/amp-wp/issues/5767>.
 		window.stop(); // Stop loading the page! This should cancel all loading resources.
 
+		// Pass along referrer so that amp-analytics can report the correct referrer.
+		if ( document.referrer ) {
+			amphtmlUrlObject.searchParams.set( 'amp_referrer', document.referrer );
+		}
+
 		// Replace the current page with the AMP version.
 		location.replace( amphtmlUrlObject.href );
 	}


### PR DESCRIPTION
## Summary

When client-side (JS-based) mobile redirection is enabled (which is the default instead of server-side redirection), any amp-analytics that runs on the resulting page will no longer be able to see the the `Referrer`, resulting in erroneous reports of direct traffic. See [support topic](https://wordpress.org/support/topic/force-mobile-to-amp-bug-causes-direct-traffic/).

I think we can rectify this by passing along the referrer in a query parameter, like `amp_referrer`. With the original referrer then on the destination page, it is then available to be passed along to `amp-analytics`. I believe this can be done by explicitly declaring the `referrer` in the `vars` for an analytics config as follows:

```
"vars": {
    ...
    "referrer":"QUERY_PARAM(amp_referrer,${documentReferrer})"
    ...
}
```

Here it attempts to pass `amp_referrer` query parameter as the `referrer`, or if that is not available it falls back to the document referrer. I'm not sure if the above is correct or if it should be:

```
"vars": {
    ...
    "referrer":"QUERY_PARAM(amp_referrer,DOCUMENT_REFERRER)"
    ...
}
```

See [amp-analytics variables](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables) and [AMP HTML URL Variable Substitutions](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md).

We could modify all `amp-analytics` on the page to inject this `referrer` when JS-based mobile redirection is enabled, or we could defer to the user to enable that instead such as via a plugin that filters `amp_analytics_entries`.

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
