### PR TITLE
Harden hash comparison by using hash_equals() instead of ===

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2171,7 +2171,7 @@ class AMP_Validation_Manager {
 	 */
 	public static function serialize_validation_error_messages( $messages ) {
 		$encoded_messages = base64_encode( wp_json_encode( array_unique( $messages ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		return wp_hash( $encoded_messages . wp_nonce_tick() ) . ':' . $encoded_messages;
+		return wp_hash( $encoded_messages . wp_nonce_tick(), 'nonce' ) . ':' . $encoded_messages;
 	}
 
 	/**
@@ -2185,7 +2185,14 @@ class AMP_Validation_Manager {
 	 */
 	public static function unserialize_validation_error_messages( $serialized ) {
 		$parts = explode( ':', $serialized, 2 );
-		if ( count( $parts ) !== 2 || ! hash_equals( $parts[0], wp_hash( $parts[1] . wp_nonce_tick() ) ) ) {
+		if (
+			count( $parts ) !== 2
+			||
+			! hash_equals(
+				$parts[0],
+				wp_hash( $parts[1] . wp_nonce_tick(), 'nonce' )
+			)
+		) {
 			return null;
 		}
 		return json_decode( base64_decode( $parts[1] ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2171,7 +2171,7 @@ class AMP_Validation_Manager {
 	 */
 	public static function serialize_validation_error_messages( $messages ) {
 		$encoded_messages = base64_encode( wp_json_encode( array_unique( $messages ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		return wp_hash( $encoded_messages ) . ':' . $encoded_messages;
+		return wp_hash( $encoded_messages . wp_nonce_tick() ) . ':' . $encoded_messages;
 	}
 
 	/**
@@ -2185,7 +2185,7 @@ class AMP_Validation_Manager {
 	 */
 	public static function unserialize_validation_error_messages( $serialized ) {
 		$parts = explode( ':', $serialized, 2 );
-		if ( count( $parts ) !== 2 || wp_hash( $parts[1] ) !== $parts[0] ) {
+		if ( count( $parts ) !== 2 || ! hash_equals( $parts[0], wp_hash( $parts[1] . wp_nonce_tick() ) ) ) {
 			return null;
 		}
 		return json_decode( base64_decode( $parts[1] ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2478,6 +2478,31 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * @covers AMP_Validation_Manager::serialize_validation_error_messages()
+	 * @covers AMP_Validation_Manager::unserialize_validation_error_messages()
+	 */
+	public function test_serialize_unserialize_validation_error_messages() {
+		$messages = [
+			'foo',
+			'bar',
+			'bar',
+			'baz',
+		];
+
+		$encoded_messages = AMP_Validation_Manager::serialize_validation_error_messages( $messages );
+		$this->assertTrue( is_string( $encoded_messages ) );
+		$this->assertStringContains( ':', $encoded_messages );
+
+		$decoded_messages = AMP_Validation_Manager::unserialize_validation_error_messages( $encoded_messages );
+		$this->assertTrue( is_array( $decoded_messages ) );
+		$this->assertCount( 3, $decoded_messages );
+		$this->assertEqualSets( array_unique( $messages ), $decoded_messages );
+
+		$decoded_messages = AMP_Validation_Manager::unserialize_validation_error_messages( 'badhash:badencoding' );
+		$this->assertNull( $decoded_messages );
+	}
+
+	/**
 	 * Test for print_plugin_notice()
 	 *
 	 * @covers AMP_Validation_Manager::print_plugin_notice()


### PR DESCRIPTION
## Summary

To guard against the possibility of timing attacks, the `hash_equals()` function should always be used to compare hashes. 

We were already doing so when comparing hashes for validation requests:

https://github.com/ampproject/amp-wp/blob/234be39b3b458aeaf4ddaa9d53e8ec7a8c0825e8/includes/validation/class-amp-validation-manager.php#L1648

But we weren't doing it for this case of checking the integrity of error messages on the validation admin screen. This PR aligns the usage not only of `hash_equals()` but also using the same `nonce` scheme as opposed to the default `auth` scheme, which is also being used for validation requests:

https://github.com/ampproject/amp-wp/blob/234be39b3b458aeaf4ddaa9d53e8ec7a8c0825e8/includes/validation/class-amp-validation-manager.php#L1628-L1630

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
