### PR TITLE
Use wp_robots() instead of noindex() in WP 5.7

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -11,7 +11,11 @@
  * @internal
  */
 function amp_post_template_init_hooks() {
-	add_action( 'amp_post_template_head', 'noindex' );
+	if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '>=' ) ) {
+		add_action( 'amp_post_template_head', 'wp_robots' );
+	} else {
+		add_action( 'amp_post_template_head', 'noindex' );
+	}
 	add_action( 'amp_post_template_head', 'amp_post_template_add_title' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_canonical' );
 	add_action( 'amp_post_template_head', 'amp_post_template_add_fonts' );

--- a/tests/php/test-amp-post-template-functions.php
+++ b/tests/php/test-amp-post-template-functions.php
@@ -22,7 +22,11 @@ class Test_AMP_Post_Template_Functions extends WP_UnitTestCase {
 	/** @covers ::amp_post_template_init_hooks() */
 	public function test_amp_post_template_init_hooks() {
 		amp_post_template_init_hooks();
-		$this->assertSame( 10, has_action( 'amp_post_template_head', 'noindex' ) );
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '>=' ) ) {
+			$this->assertSame( 10, has_action( 'amp_post_template_head', 'wp_robots' ) );
+		} else {
+			$this->assertSame( 10, has_action( 'amp_post_template_head', 'noindex' ) );
+		}
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_title' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_canonical' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_fonts' ) );


### PR DESCRIPTION
## Summary

The `noindex()` function is now deprecated in favor of `wp_robots()` as of WP 5.7-alpha. 

See https://core.trac.wordpress.org/ticket/51511 and https://core.trac.wordpress.org/changeset/49992

## Checklist

- [ ] My pull request is addressing an open issue (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
