### PR TITLE
Prevent empty query var from causing false positive endpoint detection

### DIFF
--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -391,12 +391,15 @@ final class PairedRouting implements Service, Registerable {
 				continue;
 			}
 
+			$paired_url_structure = $this->get_paired_url_structure();
+
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$old_path = wp_unslash( $_SERVER[ $var_name ] ); // Because of wp_magic_quotes().
-			$new_path = $this->get_paired_url_structure()->remove_endpoint( $old_path );
-			if ( $old_path === $new_path ) {
+			if ( ! $paired_url_structure->has_endpoint( $old_path ) ) {
 				continue;
 			}
+
+			$new_path = $this->get_paired_url_structure()->remove_endpoint( $old_path );
 
 			$this->suspended_environment_variables[ $var_name ] = [ $old_path, $new_path ];
 

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -399,7 +399,7 @@ final class PairedRouting implements Service, Registerable {
 				continue;
 			}
 
-			$new_path = $this->get_paired_url_structure()->remove_endpoint( $old_path );
+			$new_path = $paired_url_structure->remove_endpoint( $old_path );
 
 			$this->suspended_environment_variables[ $var_name ] = [ $old_path, $new_path ];
 

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -214,6 +214,12 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 				'/',
 				false,
 			],
+			'url_with_empty_query_var'              => [
+				AMP_Theme_Support::READER_MODE_SLUG,
+				Option::PAIRED_URL_STRUCTURE_QUERY_VAR,
+				'/?foo=',
+				false,
+			],
 			'path_suffix_transitional_mode_amp'     => [
 				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
 				Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
@@ -370,6 +376,10 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 		$_SERVER['REQUEST_URI'] = $this->instance->add_endpoint( '/' );
 		$this->instance->detect_endpoint_in_environment();
 		$this->assertTrue( $this->get_private_property( $this->instance, 'did_request_endpoint' ) );
+
+		$_SERVER['REQUEST_URI'] = '/?foo=';
+		$this->instance->detect_endpoint_in_environment();
+		$this->assertFalse( $this->get_private_property( $this->instance, 'did_request_endpoint' ) );
 	}
 
 	/** @return array */


### PR DESCRIPTION
Amends #5558. See #2204.

Thanks to @milindmore22 for pointing this out, there's a bug with in how the AMP endpoints are detected. In particular, when a non-AMP URL is request with an empty query var, e.g. `?foo=`, the result is the URL erroneously being identified as an AMP one. The reason for this is that I was removing the endpoint from the URL and then checking of the endpoint-removed URL was not equal to the original URL as a shortcut to identify an AMP URL. This, however, doesn't work because `remove_query_var()` doesn't preserve the distinction between a query var with an empty value and one with no value:

```
wp> remove_query_arg( 'foo', '?bar=' )
=> string(4) "?bar"
wp> remove_query_arg( 'foo', '?bar' )
=> string(4) "?bar"
```

Notice how `?bar=` and `?bar` both end up the same as `?bar` when being passed into `remove_query_arg()`.

So the fix is to check if the URL has the endpoint first, and then if it has it, proceed with removing it. This avoids the false positive.