### PR TITLE
Update GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Create a report to help us improve
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: 🐛 Bug report
 about: Create a report to help us improve
+labels: Bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: AMP for WordPress
-    url: https://amp-wp.org/
-    about: Find documentation, a showcase of sites using the official AMP plugin, an ecosystem directory of compatible themes/plugins, and a blog with news on the plugin site.
-  - name: Plugin Support Forum
+  - name: ❓ Plugin Support Forum
     url: https://wordpress.org/support/plugin/amp/
     about: For plugin usage questions and compatibility issues with other plugins, please use the plugin's support forum. Before opening a new topic, please search the forum for existing topics as someone else has likely reported the issue already.
-  - name: Video Series
+  - name: ℹ️ AMP for WordPress
+    url: https://amp-wp.org/
+    about: Find documentation, a showcase of sites using the official AMP plugin, an ecosystem directory of compatible themes/plugins, and a blog with news on the plugin site.
+  - name: 📺 Video Series
     url: https://www.youtube.com/playlist?list=PLXTOW_XMsIDRGRr5QDffrvND8Qh1RndFb
     about: Check out our video series on YouTube for an introduction to the plugin and how you can leverage it on your site.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: AMP for WordPress
+    url: https://amp-wp.org/
+    about: Find documentation, a showcase of sites using the official AMP plugin, an ecosystem directory of compatible themes/plugins, and a blog with news on the plugin site.
+  - name: Plugin Support Forum
+    url: https://wordpress.org/support/plugin/amp/
+    about: For plugin usage questions and compatibility issues with other plugins, please use the plugin's support forum. Before opening a new topic, please search the forum for existing topics as someone else has likely reported the issue already.
+  - name: Video Series
+    url: https://www.youtube.com/playlist?list=PLXTOW_XMsIDRGRr5QDffrvND8Qh1RndFb
+    about: Check out our video series on YouTube for an introduction to the plugin and how you can leverage it on your site.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: ✨ Feature request
 about: Suggest an idea for this project
+labels: Enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/help_request.md
+++ b/.github/ISSUE_TEMPLATE/help_request.md
@@ -1,9 +1,0 @@
----
-name: Help Request
-about: Please post help requests or ‘how to’ questions in support forum
-
----
-
-For general, technical and product help requests, please post it on the [AMP Plugin support forum](https://wordpress.org/support/plugin/amp/). Support will not be provided on GitHub.
-
-Thank you!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,9 @@
 ## Summary
 
-<!-- Please reference the issue this PR addresses. -->
+<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
 Fixes #
 
 ## Checklist
 
-- [ ] My pull request is addressing an open issue (please create one otherwise).
 - [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
 - [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+For plugin usage questions and compatibility issues with other plugins, please use the [plugin's support forum](https://wordpress.org/support/plugin/amp/). Before opening a new topic, please search the forum for existing topics as someone else has likely reported the issue already.
+
+Find documentation, a showcase of sites using the official AMP plugin, an ecosystem directory of compatible themes/plugins, and a blog with news on the plugin site: [amp-wp.org](https://amp-wp.org/).
+
+Check out our [video series on YouTube](https://www.youtube.com/playlist?list=PLXTOW_XMsIDRGRr5QDffrvND8Qh1RndFb) for an introduction to the plugin and how you can leverage it on your site.


### PR DESCRIPTION
It's been awhile since we've touched the issue and PR templates, and GitHub has improved support for them in the past years.

* Now that we're no longer requiring an issue to be created prior to opening a PR, I've removed that checkbox from the PR template.
* Added `SUPPORT.md` (see [GitHub docs](https://docs.github.com/en/github/building-a-strong-community/adding-support-resources-to-your-project)) which will be linked to automatically when a new issue is created.
* Added `ISSUE_TEMPLATES/config.yml` (see [GitHub docs](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)) with links to direct the user to the support forum, product site, and video series. (These same links are also added to `SUPPORT.md`.)
* Eliminate the `help_request.md` template which is now obsolete in favor of the previous two points.
* For the `bug_report` and `feature_request` templates, add default labels (Bug and Enhancement respectively).
* Add emoji to the issue templates and contact links for the issue template chooser, inspired by [React's issue template chooser](https://github.com/facebook/react/issues/new/choose). 

Before | After
-------|-------
![image](https://user-images.githubusercontent.com/134745/105642875-55c82f80-5e41-11eb-8da6-b65995c00f7b.png) | ![image](https://user-images.githubusercontent.com/134745/105646066-8c5a7600-5e52-11eb-8dc4-9b935410f136.png)
