### PR TITLE
Include PreloadHeroImage among transformers omitted for SSR

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2112,6 +2112,7 @@ class AMP_Theme_Support {
 				$transformers,
 				[
 					Optimizer\Transformer\AmpRuntimeCss::class,
+					Optimizer\Transformer\PreloadHeroImage::class,
 					Optimizer\Transformer\ServerSideRendering::class,
 					Optimizer\Transformer\TransformedIdentifier::class,
 				]


### PR DESCRIPTION
## Summary

When SSR is disabled via `add_filter( 'amp_enable_ssr', '__return_false' );` I found that the `data-hero` attributes were still getting added, along with prerendering and the `i-amphtml-ssr` attributes. This transformer should not be running when SSR is disabled.

The result is also an invalid AMP page since it is not marked as `transformed`:

![image](https://user-images.githubusercontent.com/134745/106393160-5ebd8180-63aa-11eb-8d80-4d6787643299.png)

Amends #5350 for #5055.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
