### PR TITLE
Normalize string and number literals in script text contents for validation errors

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -405,7 +405,7 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.coverage == false }}
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --debug
         working-directory: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp
 
       - name: Run tests with coverage

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -405,7 +405,7 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.coverage == false }}
-        run: vendor/bin/phpunit --debug
+        run: vendor/bin/phpunit
         working-directory: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp
 
       - name: Run tests with coverage

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -595,16 +595,9 @@ abstract class AMP_Base_Sanitizer {
 			}
 
 			// Capture element contents.
-			if (
-				( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) )
-				||
-				// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
-				// already be detailed in the stylesheets metabox.
-				( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) )
-			) {
-				$error['text'] = $node->textContent;
-
-				// Normalize string and number literals to prevent nonces, random numbers, and timestamps from generating endless number of validation errors.
+			if ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) ) {
+				// For inline scripts, normalize string and number literals to prevent nonces, random numbers, and timestamps
+				// from generating endless number of validation errors.
 				$error['text'] = preg_replace(
 					[
 						'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
@@ -618,8 +611,12 @@ abstract class AMP_Base_Sanitizer {
 						'__FLOAT__',
 						'__INT__',
 					],
-					$error['text']
+					$node->textContent
 				);
+			} elseif ( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) ) {
+				// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
+				// already be detailed in the stylesheets metabox.
+				$error['text'] = $node->textContent;
 			}
 
 			// Suppress 'ver' param from enqueued scripts and styles.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -603,6 +603,28 @@ abstract class AMP_Base_Sanitizer {
 				( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) )
 			) {
 				$error['text'] = $node->textContent;
+
+				// Normalize string and number literals to prevent nonces, random numbers, and timestamps from generating endless number of validation errors.
+				$error['text'] = preg_replace(
+					'/"([^"\\\\]*+|\\\\(\\\\\\\\)*+.)+"/',
+					'__DOUBLE_QUOTED_STRING__',
+					$error['text']
+				);
+				$error['text'] = preg_replace(
+					'/\'([^\'\\\\]*+|\\\\(\\\\\\\\)*+.)+\'/',
+					'__SINGLE_QUOTED_STRING__',
+					$error['text']
+				);
+				$error['text'] = preg_replace(
+					'/(\b|-)\d+\.\d+\b/',
+					'__FLOAT__',
+					$error['text']
+				);
+				$error['text'] = preg_replace(
+					'/(\b|-)\d+\b/',
+					'__INT__',
+					$error['text']
+				);
 			}
 
 			// Suppress 'ver' param from enqueued scripts and styles.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -594,7 +594,7 @@ abstract class AMP_Base_Sanitizer {
 				}
 			}
 
-			// Capture element contents, if less than 10K bytes.
+			// Capture element contents.
 			$is_inline_script = ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) );
 			$is_inline_style  = ( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) );
 			if ( $is_inline_script || $is_inline_style ) {
@@ -604,6 +604,7 @@ abstract class AMP_Base_Sanitizer {
 					// from generating endless number of validation errors.
 					$error['text'] = preg_replace(
 						[
+							// Regex credit to <https://stackoverflow.com/a/5696141/93579>.
 							'/"[^"\\\\\n]*(?:\\\\.[^"\\\\\n]*)*"/s',
 							'/\'[^\'\\\\\n]*(?:\\\\.[^\'\\\\\n]*)*\'/s',
 							'/(\b|-)\d+\.\d+\b/',

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -604,8 +604,8 @@ abstract class AMP_Base_Sanitizer {
 					// from generating endless number of validation errors.
 					$error['text'] = preg_replace(
 						[
-							'/"[^"\\\\\n\r]*(?:\\\\.[^"\\\\\n\r]*)*"/s',
-							'/\'[^\'\\\\\n\r]*(?:\\\\.[^\'\\\\\n\r]*)*\'/s',
+							'/"[^"\\\\\n]*(?:\\\\.[^"\\\\\n]*)*"/s',
+							'/\'[^\'\\\\\n]*(?:\\\\.[^\'\\\\\n]*)*\'/s',
 							'/(\b|-)\d+\.\d+\b/',
 							'/(\b|-)\d+\b/',
 						],

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -606,23 +606,18 @@ abstract class AMP_Base_Sanitizer {
 
 				// Normalize string and number literals to prevent nonces, random numbers, and timestamps from generating endless number of validation errors.
 				$error['text'] = preg_replace(
-					'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
-					'__DOUBLE_QUOTED_STRING__',
-					$error['text']
-				);
-				$error['text'] = preg_replace(
-					'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
-					'__SINGLE_QUOTED_STRING__',
-					$error['text']
-				);
-				$error['text'] = preg_replace(
-					'/(\b|-)\d+\.\d+\b/',
-					'__FLOAT__',
-					$error['text']
-				);
-				$error['text'] = preg_replace(
-					'/(\b|-)\d+\b/',
-					'__INT__',
+					[
+						'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
+						'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
+						'/(\b|-)\d+\.\d+\b/',
+						'/(\b|-)\d+\b/',
+					],
+					[
+						'__DOUBLE_QUOTED_STRING__',
+						'__SINGLE_QUOTED_STRING__',
+						'__FLOAT__',
+						'__INT__',
+					],
 					$error['text']
 				);
 			}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -599,30 +599,28 @@ abstract class AMP_Base_Sanitizer {
 			$is_inline_style  = ( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) );
 			if ( $is_inline_script || $is_inline_style ) {
 				$text_content = $node->textContent;
-				if ( strlen( $text_content ) < 10000 ) {
-					if ( $is_inline_script ) {
-						// For inline scripts, normalize string and number literals to prevent nonces, random numbers, and timestamps
-						// from generating endless number of validation errors.
-						$error['text'] = preg_replace(
-							[
-								'/"[^"\\\\\n\r]*(?:\\\\.[^"\\\\\n\r]*)*"/s',
-								'/\'[^\'\\\\\n\r]*(?:\\\\.[^\'\\\\\n\r]*)*\'/s',
-								'/(\b|-)\d+\.\d+\b/',
-								'/(\b|-)\d+\b/',
-							],
-							[
-								'__DOUBLE_QUOTED_STRING__',
-								'__SINGLE_QUOTED_STRING__',
-								'__FLOAT__',
-								'__INT__',
-							],
-							$text_content
-						);
-					} elseif ( $is_inline_style ) {
-						// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
-						// already be detailed in the stylesheets metabox.
-						$error['text'] = $text_content;
-					}
+				if ( $is_inline_script ) {
+					// For inline scripts, normalize string and number literals to prevent nonces, random numbers, and timestamps
+					// from generating endless number of validation errors.
+					$error['text'] = preg_replace(
+						[
+							'/"[^"\\\\\n\r]*(?:\\\\.[^"\\\\\n\r]*)*"/s',
+							'/\'[^\'\\\\\n\r]*(?:\\\\.[^\'\\\\\n\r]*)*\'/s',
+							'/(\b|-)\d+\.\d+\b/',
+							'/(\b|-)\d+\b/',
+						],
+						[
+							'__DOUBLE_QUOTED_STRING__',
+							'__SINGLE_QUOTED_STRING__',
+							'__FLOAT__',
+							'__INT__',
+						],
+						$text_content
+					);
+				} elseif ( $is_inline_style ) {
+					// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
+					// already be detailed in the stylesheets metabox.
+					$error['text'] = $text_content;
 				}
 			}
 

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -606,12 +606,12 @@ abstract class AMP_Base_Sanitizer {
 
 				// Normalize string and number literals to prevent nonces, random numbers, and timestamps from generating endless number of validation errors.
 				$error['text'] = preg_replace(
-					'/"([^"\\\\]*+|\\\\(\\\\\\\\)*+.)+"/',
+					'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
 					'__DOUBLE_QUOTED_STRING__',
 					$error['text']
 				);
 				$error['text'] = preg_replace(
-					'/\'([^\'\\\\]*+|\\\\(\\\\\\\\)*+.)+\'/',
+					'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
 					'__SINGLE_QUOTED_STRING__',
 					$error['text']
 				);

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -605,8 +605,8 @@ abstract class AMP_Base_Sanitizer {
 						// from generating endless number of validation errors.
 						$error['text'] = preg_replace(
 							[
-								'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
-								'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
+								'/"[^"\\\\\n\r]*(?:\\\\.[^"\\\\\n\r]*)*"/s',
+								'/\'[^\'\\\\\n\r]*(?:\\\\.[^\'\\\\\n\r]*)*\'/s',
 								'/(\b|-)\d+\.\d+\b/',
 								'/(\b|-)\d+\b/',
 							],

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -594,29 +594,36 @@ abstract class AMP_Base_Sanitizer {
 				}
 			}
 
-			// Capture element contents.
-			if ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) ) {
-				// For inline scripts, normalize string and number literals to prevent nonces, random numbers, and timestamps
-				// from generating endless number of validation errors.
-				$error['text'] = preg_replace(
-					[
-						'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
-						'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
-						'/(\b|-)\d+\.\d+\b/',
-						'/(\b|-)\d+\b/',
-					],
-					[
-						'__DOUBLE_QUOTED_STRING__',
-						'__SINGLE_QUOTED_STRING__',
-						'__FLOAT__',
-						'__INT__',
-					],
-					$node->textContent
-				);
-			} elseif ( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) ) {
-				// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
-				// already be detailed in the stylesheets metabox.
-				$error['text'] = $node->textContent;
+			// Capture element contents, if less than 10K bytes.
+			$is_inline_script = ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) );
+			$is_inline_style  = ( 'style' === $node->nodeName && ! $node->hasAttribute( 'amp-custom' ) && ! $node->hasAttribute( 'amp-keyframes' ) );
+			if ( $is_inline_script || $is_inline_style ) {
+				$text_content = $node->textContent;
+				if ( strlen( $text_content ) < 10000 ) {
+					if ( $is_inline_script ) {
+						// For inline scripts, normalize string and number literals to prevent nonces, random numbers, and timestamps
+						// from generating endless number of validation errors.
+						$error['text'] = preg_replace(
+							[
+								'/"([^"\n\\\\]|\\\\(\\\\\\\\)*+.)*"/s',
+								'/\'([^\'\n\\\\]|\\\\(\\\\\\\\)*+.)*\'/s',
+								'/(\b|-)\d+\.\d+\b/',
+								'/(\b|-)\d+\b/',
+							],
+							[
+								'__DOUBLE_QUOTED_STRING__',
+								'__SINGLE_QUOTED_STRING__',
+								'__FLOAT__',
+								'__INT__',
+							],
+							$text_content
+						);
+					} elseif ( $is_inline_style ) {
+						// Include stylesheet text except for amp-custom and amp-keyframes since it is large and since it should
+						// already be detailed in the stylesheets metabox.
+						$error['text'] = $text_content;
+					}
+				}
 			}
 
 			// Suppress 'ver' param from enqueued scripts and styles.

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -365,6 +365,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Base_Sanitizer::prepare_validation_error()
 	 */
 	public function test_remove_invalid_child_with_script_text_normalization() {
+		$this->markTestSkipped();
 		$dom        = new Document( '1.0', 'utf-8' );
 		$parent_tag = 'div';
 		$parent     = $dom->createElement( $parent_tag );

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -377,23 +377,34 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 			var exampleSingleQuotedUniqid = '60187a1866338';
 			var exampleDoubleQuotedNonce = "d62af2ae67";
 			var exampleDoubleQuotedUniqid = "60187a1866350";
-			var exampleDoubleQuotedStringWithEscapedChars = "599152239'\" \\ \\\\60187a1866359";
-			var exampleSingleQuotedStringWithEscapedChars = '908945391\'\" \\ \\\\60187a186635f';
+			var exampleDoubleQuotedStringWithEscapedChars = "599152239'\" \\\" \\\\60187a1866359";
+			var exampleSingleQuotedStringWithEscapedChars = '908945391\'" \\\' \\\\60187a186635f';
+			var exampleEmptyDoubleString = "";
+			var exampleEmptySingleString = '';
 			var exampleRandomNumber1 = 980714337;
 			var exampleRandomNumber2 = -482244956 ;
 			var exampleRandomNumber3=482244956;
 			var exampleRandomNumber4=-482244956;
-			var exampleRandomFloat = 1612216856.418668;
+			var exampleRandomFloat1 = 1612216856.418668;
 			var exampleRandomFloat2 = -1612216856.418682 ;
+			var singleQuotedStringWithSlashes = 'start\
+				middle\
+				end';
+			var doubleQuotedStringWithSlashes = "start\
+				middle\
+				end";
 			var exampleObject={
 				'foo':123,
 				'bar':"92y49234gb",
 				baz:-1234.245
 			};
+			var exampleRandomObject = {"nonce":"f0ca042a3b","datetime":"2021-02-01T23:32:16+00:00","random":1167384492,"microtime":1612222336.178891};
 		</script>
 		<?php
-		$text = str_replace( [ '<script>', '</script>' ], '', ob_get_clean() );
-		$child->appendChild( $dom->createTextNode( $text ) );
+		$initial_text  = str_replace( [ '<script>', '</script>' ], '', ob_get_clean() );
+		$expected_text = "\t\t\n\t\t\tvar exampleSingleQuotedNonce = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedUniqid = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedNonce = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedUniqid = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedStringWithEscapedChars = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedStringWithEscapedChars = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptyDoubleString = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptySingleString = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleRandomNumber1 = __INT__;\n\t\t\tvar exampleRandomNumber2 = __INT__ ;\n\t\t\tvar exampleRandomNumber3=__INT__;\n\t\t\tvar exampleRandomNumber4=__INT__;\n\t\t\tvar exampleRandomFloat1 = __FLOAT__;\n\t\t\tvar exampleRandomFloat2 = __FLOAT__ ;\n\t\t\tvar singleQuotedStringWithSlashes = __SINGLE_QUOTED_STRING__;\n\t\t\tvar doubleQuotedStringWithSlashes = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleObject={\n\t\t\t\t__SINGLE_QUOTED_STRING__:__INT__,\n\t\t\t\t__SINGLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,\n\t\t\t\tbaz:__FLOAT__\n\t\t\t};\n\t\t\tvar exampleRandomObject = {__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__INT__,__DOUBLE_QUOTED_STRING__:__FLOAT__};\n\t\t\n\t\t";
+
+		$child->appendChild( $dom->createTextNode( $initial_text ) );
 		$parent->appendChild( $child );
 
 		$expected_error = [
@@ -404,7 +415,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 			'type'            => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 			'node_type'       => XML_ELEMENT_NODE,
 			'node_attributes' => [],
-			'text'            => "\t\t\n\t\t\tvar exampleSingleQuotedNonce = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedUniqid = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedNonce = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedUniqid = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedStringWithEscapedChars = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedStringWithEscapedChars = '__INT__\\'\\__DOUBLE_QUOTED_STRING__92y49234gb\",\n\t\t\t\tbaz:__FLOAT__\n\t\t\t};\n\t\t\n\t\t",
+			'text'            => $expected_text,
 		];
 
 		$sanitizer = new AMP_Iframe_Sanitizer(
@@ -415,6 +426,12 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer->remove_invalid_child( $child );
 		$this->assertNull( $parent->firstChild );
 		$this->assertCount( 1, AMP_Validation_Manager::$validation_results );
+		$actual_text = AMP_Validation_Manager::$validation_results[0]['error']['text'];
+		$this->assertEquals(
+			$expected_text,
+			$actual_text
+		);
+
 		$this->assertEquals(
 			[
 				'error'     => $expected_error,

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -365,7 +365,6 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Base_Sanitizer::prepare_validation_error()
 	 */
 	public function test_remove_invalid_child_with_script_text_normalization() {
-		$this->markTestSkipped();
 		$dom        = new Document( '1.0', 'utf-8' );
 		$parent_tag = 'div';
 		$parent     = $dom->createElement( $parent_tag );

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -381,6 +381,8 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 			var exampleSingleQuotedStringWithEscapedChars = '908945391\'" \\\' \\\\60187a186635f';
 			var exampleEmptyDoubleString = "";
 			var exampleEmptySingleString = '';
+			var exampleEscapedQuoteInSingleString = '\'';
+			var exampleEscapedQuoteInDoubleString = "\"";
 			var exampleRandomNumber1 = 980714337;
 			var exampleRandomNumber2 = -482244956 ;
 			var exampleRandomNumber3=482244956;
@@ -402,7 +404,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		</script>
 		<?php
 		$initial_text  = str_replace( [ '<script>', '</script>' ], '', ob_get_clean() );
-		$expected_text = "\t\t\n\t\t\tvar exampleSingleQuotedNonce = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedUniqid = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedNonce = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedUniqid = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedStringWithEscapedChars = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedStringWithEscapedChars = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptyDoubleString = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptySingleString = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleRandomNumber1 = __INT__;\n\t\t\tvar exampleRandomNumber2 = __INT__ ;\n\t\t\tvar exampleRandomNumber3=__INT__;\n\t\t\tvar exampleRandomNumber4=__INT__;\n\t\t\tvar exampleRandomFloat1 = __FLOAT__;\n\t\t\tvar exampleRandomFloat2 = __FLOAT__ ;\n\t\t\tvar singleQuotedStringWithSlashes = __SINGLE_QUOTED_STRING__;\n\t\t\tvar doubleQuotedStringWithSlashes = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleObject={\n\t\t\t\t__SINGLE_QUOTED_STRING__:__INT__,\n\t\t\t\t__SINGLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,\n\t\t\t\tbaz:__FLOAT__\n\t\t\t};\n\t\t\tvar exampleRandomObject = {__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__INT__,__DOUBLE_QUOTED_STRING__:__FLOAT__};\n\t\t\n\t\t";
+		$expected_text = "\t\t\n\t\t\tvar exampleSingleQuotedNonce = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedUniqid = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedNonce = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedUniqid = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleDoubleQuotedStringWithEscapedChars = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleSingleQuotedStringWithEscapedChars = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptyDoubleString = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleEmptySingleString = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleEscapedQuoteInSingleString = __SINGLE_QUOTED_STRING__;\n\t\t\tvar exampleEscapedQuoteInDoubleString = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleRandomNumber1 = __INT__;\n\t\t\tvar exampleRandomNumber2 = __INT__ ;\n\t\t\tvar exampleRandomNumber3=__INT__;\n\t\t\tvar exampleRandomNumber4=__INT__;\n\t\t\tvar exampleRandomFloat1 = __FLOAT__;\n\t\t\tvar exampleRandomFloat2 = __FLOAT__ ;\n\t\t\tvar singleQuotedStringWithSlashes = __SINGLE_QUOTED_STRING__;\n\t\t\tvar doubleQuotedStringWithSlashes = __DOUBLE_QUOTED_STRING__;\n\t\t\tvar exampleObject={\n\t\t\t\t__SINGLE_QUOTED_STRING__:__INT__,\n\t\t\t\t__SINGLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,\n\t\t\t\tbaz:__FLOAT__\n\t\t\t};\n\t\t\tvar exampleRandomObject = {__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__DOUBLE_QUOTED_STRING__,__DOUBLE_QUOTED_STRING__:__INT__,__DOUBLE_QUOTED_STRING__:__FLOAT__};\n\t\t\n\t\t";
 
 		$child->appendChild( $dom->createTextNode( $initial_text ) );
 		$parent->appendChild( $child );
@@ -429,7 +431,8 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$actual_text = AMP_Validation_Manager::$validation_results[0]['error']['text'];
 		$this->assertEquals(
 			$expected_text,
-			$actual_text
+			$actual_text,
+			'Actual text: ' . wp_json_encode( $actual_text )
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
## Summary

Fixes #4753

Given this plugin:

```php
<?php
/**
 * Plugin Name: Random Content Scripts
 */

add_action(
	'wp_footer',
	function () {
		wp_enqueue_script( 'example', 'https://example.com/script.js', [], time(), true );

		wp_add_inline_script(
			'example',
			sprintf( 'var exampleSingleQuotedNonce = \'%s\';', wp_create_nonce( 'example' ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleSingleQuotedUniqid = \'%s\';', uniqid() )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleDoubleQuotedNonce = %s;', wp_json_encode( wp_create_nonce( 'example' ) ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleDoubleQuotedUniqid = %s;', wp_json_encode( uniqid() ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleDoubleQuotedStringWithEscapedChars = %s;', wp_json_encode( (string) rand() . '\'" \\ \\\\' . uniqid() ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleSingleQuotedStringWithEscapedChars = \'%s\';', addslashes( (string) rand() . '\'" \\ \\\\' . uniqid() ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleRandomNumber = %d;', rand() )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleRandomNumber = %d ;', - rand() )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleRandomFloat = %f;', microtime( true ) )
		);
		wp_add_inline_script(
			'example',
			sprintf( 'var exampleRandomFloat2 = %f ;', -microtime( true ) )
		);
		wp_add_inline_script(
			'example',
			sprintf(
				'var exampleRandomObject = %s;',
				wp_json_encode(
					[
						'nonce' => wp_create_nonce( 'example3' ),
						'datetime' => date( 'c' ),
						'random' => rand(),
						'microtime' => microtime( true ),
					]
				)
			)
		);
	}
);
```

Without the changes in this PR, the validation error for the inline script can seem to never be marked as "reviewed" because every time the URL is re-validated, a brand never-before-seen validation error is generated. With the changes in this PR, the source of the error variability is eliminated by replacing number and string literals with placeholders.

Before:

https://user-images.githubusercontent.com/134745/106540460-d8da2d00-64b4-11eb-80bb-9e641a17e46d.mov

After:

https://user-images.githubusercontent.com/134745/106540480-e1326800-64b4-11eb-9ed5-543e27a03a0f.mov

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
