### PR TITLE
Fix test_decorate_shortcode_and_filter_source in WP 5.7-alpha after HTTPS migration commit

### DIFF
--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1730,21 +1730,6 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'name'     => 'wp-includes',
 					'function' => version_compare( get_bloginfo( 'version' ), '5.5-alpha', '>' ) ? 'wp_filter_content_tags' : 'wp_make_content_images_responsive',
 				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'capital_P_dangit',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_shortcode',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'convert_smilies',
-				],
 			];
 		} elseif ( has_filter( 'the_content', 'do_blocks' ) ) {
 			$sources = [
@@ -1788,21 +1773,6 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'name'     => 'wp-includes',
 					'function' => 'wp_make_content_images_responsive',
 				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'capital_P_dangit',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_shortcode',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'convert_smilies',
-				],
 			];
 		} else {
 			$sources = [
@@ -1841,6 +1811,20 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'name'     => 'wp-includes',
 					'function' => 'wp_make_content_images_responsive',
 				],
+			];
+		}
+
+		if ( function_exists( 'wp_replace_insecure_home_url' ) ) {
+			$sources[] = [
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wp_replace_insecure_home_url',
+			];
+		}
+
+		$sources = array_merge(
+			$sources,
+			[
 				[
 					'type'     => 'core',
 					'name'     => 'wp-includes',
@@ -1856,8 +1840,8 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'name'     => 'wp-includes',
 					'function' => 'convert_smilies',
 				],
-			];
-		}
+			]
+		);
 
 		foreach ( $sources as &$source ) {
 			$function = $source['function'];


### PR DESCRIPTION
## Summary

Changes needed due to https://core.trac.wordpress.org/changeset/50131

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
