### PR TITLE
Prevent fatal error when invoking MonitorCssTransientCaching::process() during WP Cron

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -79,10 +79,9 @@ class AMP_Validation_Manager {
 	/**
 	 * The errors encountered when validating.
 	 *
-	 * @var array[][] {
-	 *     @type array  $error     Error code.
-	 *     @type bool   $sanitized Whether sanitized.
-	 *     @type string $slug      Hash of the error.
+	 * @var array[] {
+	 *     @type array $error     Error data.
+	 *     @type bool  $sanitized Whether sanitized.
 	 * }
 	 */
 	public static $validation_results = [];

--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -163,7 +163,7 @@ final class ServerSideRendering implements Transformer
             }
 
             // Skip tags inside a template tag.
-            if ($this->hasAncestorWithTag($ampElement, Tag::TEMPLATE)) {
+            if ($this->isWithinTemplate($ampElement)) {
                 continue;
             }
 
@@ -682,21 +682,27 @@ final class ServerSideRendering implements Transformer
     }
 
     /**
-     * Check whether the element has an ancestor of a given tag type.
+     * Check whether the element is within a template.
      *
-     * @param DOMElement $element Element to check the ancestor tree of.
-     * @param string     $tagName Name of the tag to look for.
-     * @return bool Whether the element has an ancestor of the given tag name.
+     * @param DOMElement $element Element to check.
+     * @return bool Whether the element is within a template.
      */
-    private function hasAncestorWithTag(DOMElement $element, $tagName)
+    private function isWithinTemplate(DOMElement $element)
     {
         $parent = $element->parentNode;
         while ($parent !== null) {
-            if ($parent instanceof DOMElement && $parent->tagName === $tagName) {
-                return true;
+            if ($parent instanceof DOMElement) {
+                if ($parent->tagName === Tag::TEMPLATE) {
+                    return true;
+                }
+
+                if ($parent->tagName === Tag::SCRIPT && $parent->hasAttribute(Attribute::TEMPLATE)) {
+                    return true;
+                }
             }
             $parent = $parent->parentNode;
         }
+
         return false;
     }
 

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -92,21 +92,21 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	 * @todo This has arbitrary arguments to allow for testing, as we don't have dependency injection for services.
 	 *       With dependency injection, we could for example inject a Clock object and mock it for testing.
 	 *
-	 * @param DateTimeInterface $date            Optional. Date to use for timestamping the processing (for testing).
-	 * @param int               $transient_count Optional. Count of transients to use for the processing (for testing).
+	 * @param DateTimeInterface|string $date            Optional. Date to use for timestamping the processing (for testing). An empty string is provided during cron.
+	 * @param int|string               $transient_count Optional. Count of transients to use for the processing (for testing). An empty string is provided during cron.
 	 * @return void
 	 * @throws Exception If a date could not be instantiated.
 	 */
-	public function process( DateTimeInterface $date = null, $transient_count = null ) {
+	public function process( $date = '', $transient_count = '' ) {
 		if ( wp_using_ext_object_cache() || $this->is_css_transient_caching_disabled() ) {
 			return;
 		}
 
-		if ( null === $date ) {
+		if ( ! $date instanceof DateTimeInterface ) {
 			$date = new DateTimeImmutable();
 		}
 
-		if ( null === $transient_count ) {
+		if ( ! is_int( $transient_count ) ) {
 			$transient_count = $this->query_css_transient_count();
 		}
 


### PR DESCRIPTION
## Summary

See #5838

Before:

```
$ wp cron event run --all
Executed the cron event 'amp_validated_url_stylesheet_gc' in 0.007s.
Executed the cron event 'amp_validated_url_stylesheet_gc' in 0.009s.
Executed the cron event 'wp_privacy_delete_old_export_files' in 0.006s.
Executed the cron event 'amp_validate_urls' in 0.005s.
Executed the cron event 'wp_site_health_scheduled_check' in 3.853s.
Executed the cron event 'recovery_mode_clean_expired_keys' in 0.007s.
Executed the cron event 'wp_version_check' in 1.817s.
Executed the cron event 'wp_update_plugins' in 0.451s.
Executed the cron event 'wp_update_themes' in 0.008s.
Executed the cron event 'wp_scheduled_delete' in 0.006s.
Executed the cron event 'delete_expired_transients' in 0.008s.
Executed the cron event 'wp_scheduled_auto_draft_delete' in 0.006s.
Executed the cron event 'amp_monitor_css_transient_caching' in 0.007s.
Fatal error: Uncaught TypeError: Argument 1 passed to AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching::process() must implement interface DateTimeInterface or be null, string given, called in /app/public/wp-includes/class-wp-hook.php on line 287 and defined in /app/public/wp-content/plugins/amp/src/BackgroundTask/MonitorCssTransientCaching.php:100
Stack trace:
#0 /app/public/wp-includes/class-wp-hook.php(287): AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching->process('')
#1 /app/public/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters('', Array)
#2 /app/public/wp-includes/plugin.php(551): WP_Hook->do_action(Array)
#3 phar:///usr/local/bin/wp/vendor/wp-cli/cron-command/src/Cron_Event_Command.php(293): do_action_ref_array('amp_monitor_css...', Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/cron-command/src/Cron_Event_Command.php(262): Cron_Event_Command::run_event(Object(stdClass))
#5 [internal function]: Cron_Event_Command->run(Array, Array)
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/p in /app/public/wp-content/plugins/amp/src/BackgroundTask/MonitorCssTransientCaching.php on line 100
Error: There has been a critical error on this website.Learn more about debugging in WordPress. There has been a critical error on this website.
```

After:

```
$ wp cron event run --all
Executed the cron event 'amp_validated_url_stylesheet_gc' in 0.007s.
Executed the cron event 'amp_validated_url_stylesheet_gc' in 0.006s.
Executed the cron event 'wp_privacy_delete_old_export_files' in 0.005s.
Executed the cron event 'wp_version_check' in 1.926s.
Executed the cron event 'wp_update_plugins' in 0.459s.
Executed the cron event 'wp_update_themes' in 0.007s.
Executed the cron event 'amp_validate_urls' in 0.005s.
Executed the cron event 'recovery_mode_clean_expired_keys' in 0.005s.
Executed the cron event 'wp_scheduled_delete' in 0.007s.
Executed the cron event 'delete_expired_transients' in 0.007s.
Executed the cron event 'wp_scheduled_auto_draft_delete' in 0.006s.
Executed the cron event 'amp_monitor_css_transient_caching' in 0.008s.
Executed the cron event 'amp_monitor_css_transient_caching' in 0.007s.
Executed the cron event 'wp_site_health_scheduled_check' in 2.808s.
Success: Executed a total of 14 cron events.
```

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
