### PR TITLE
Prevent passing empty string as args to RecurringBackgroundTasks

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -79,10 +79,9 @@ class AMP_Validation_Manager {
 	/**
 	 * The errors encountered when validating.
 	 *
-	 * @var array[][] {
-	 *     @type array  $error     Error code.
-	 *     @type bool   $sanitized Whether sanitized.
-	 *     @type string $slug      Hash of the error.
+	 * @var array[] {
+	 *     @type array $error     Error data.
+	 *     @type bool  $sanitized Whether sanitized.
 	 * }
 	 */
 	public static $validation_results = [];

--- a/src/BackgroundTask/RecurringBackgroundTask.php
+++ b/src/BackgroundTask/RecurringBackgroundTask.php
@@ -22,14 +22,14 @@ abstract class RecurringBackgroundTask extends CronBasedBackgroundTask {
 	public function register() {
 		parent::register();
 
-		add_action( 'admin_init', [ $this, 'schedule_event' ] );
+		add_action( 'admin_init', [ $this, 'schedule_event' ], 10, 0 );
 		add_action( $this->get_event_name(), [ $this, 'process' ] );
 	}
 
 	/**
 	 * Schedule the event.
 	 *
-	 * @param mixed[] ...$args Arguments passed to the function from the action hook.
+	 * @param mixed[] ...$args Arguments passed to the function from the action hook, which here is empty always since add_action().
 	 */
 	final public function schedule_event( ...$args ) {
 		if ( ! is_user_logged_in() ) {


### PR DESCRIPTION
## Summary

Since the `schedule_event()` method is added to the `admin_init` action, and since that action is triggered via `do_action('admin_init')` with no args, the result is that [an empty string is passed](https://github.com/WordPress/wordpress-develop/blob/3c3590103a40f046cc9edaaaac6467a852c5929d/src/wp-includes/plugin.php#L477-L478). In `RecurringBackgroundTask` we don't intend to pass along any args at all, so this PR provides `0` as the `$accepted_args`, which will [prevent any args from being passed](https://github.com/WordPress/wordpress-develop/blob/3c3590103a40f046cc9edaaaac6467a852c5929d/src/wp-includes/class-wp-hook.php#L288-L290).

Fixes #5838

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
