### PR TITLE
Strip path suffix from pagenum links to fix the posts pagination

### DIFF
--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -348,16 +348,7 @@ final class PairedRouting implements Service, Registerable {
 		add_action( 'parse_request', [ $this, 'restore_path_endpoint_in_environment' ] );
 
 		// Reserve the 'amp' slug for paired URL structures that use paths.
-		if (
-			in_array(
-				AMP_Options_Manager::get_option( Option::PAIRED_URL_STRUCTURE ),
-				[
-					Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
-					Option::PAIRED_URL_STRUCTURE_LEGACY_READER,
-				],
-				true
-			)
-		) {
+		if ( $this->is_using_path_suffix() ) {
 			// Note that the wp_unique_term_slug filter does not work in the same way. It will only be applied if there
 			// is actually a duplicate, whereas the wp_unique_post_slug filter applies regardless.
 			add_filter( 'wp_unique_post_slug', [ $this, 'filter_unique_post_slug' ], 10, 4 );
@@ -367,6 +358,22 @@ final class PairedRouting implements Service, Registerable {
 		add_action( 'wp', [ $this, 'add_paired_request_hooks' ] );
 
 		add_action( 'admin_notices', [ $this, 'add_permalink_settings_notice' ] );
+	}
+
+	/**
+	 * Determine whether the paired URL structure is using a path suffix (including the legacy Reader structure).
+	 *
+	 * @return bool
+	 */
+	public function is_using_path_suffix() {
+		return in_array(
+			AMP_Options_Manager::get_option( Option::PAIRED_URL_STRUCTURE ),
+			[
+				Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
+				Option::PAIRED_URL_STRUCTURE_LEGACY_READER,
+			],
+			true
+		);
 	}
 
 	/**
@@ -514,9 +521,67 @@ final class PairedRouting implements Service, Registerable {
 		if ( $this->has_endpoint() ) {
 			add_filter( 'old_slug_redirect_url', [ $this, 'maybe_add_paired_endpoint' ], 1000 );
 			add_filter( 'redirect_canonical', [ $this, 'maybe_add_paired_endpoint' ], 1000 );
+
+			if ( $this->is_using_path_suffix() ) {
+				// Filter priority of 0 to purge /amp/ before other filters manipulate it.
+				add_filter( 'get_pagenum_link', [ $this, 'filter_get_pagenum_link' ], 0 );
+			}
 		} else {
 			add_action( 'wp_head', 'amp_add_amphtml_link' );
 		}
+	}
+
+	/**
+	 * Fix pagenum link when using a path suffix.
+	 *
+	 * When paired AMP URLs end in /amp/, on the blog index page a call to `the_posts_pagination()` will result in
+	 * unexpected links being added to the page. For example, `get_pagenum_link(2)` will result in `/blog/amp/page/2/`
+	 * instead of the expected `/blog/page/2/amp/`. And then, when on the 2nd page of results (`/blog/page/2/amp/`), a
+	 * call to `get_pagenum_link(3)` will result in an even more unexpected result of `/blog/page/2/amp/page/3/`
+	 * instead of `/blog/page/3/amp/`, whereas `get_pagenum_link(1)` will return `/blog/page/2/amp/` as opposed to the
+	 * expected `/blog/amp/`. Note that `get_pagenum_link()` is used as the `base` for `paginate_links()` in
+	 * `the_posts_pagination()`, and it uses as its base `remove_query_arg('paged')` which returns the `REQUEST_URI`.
+	 *
+	 * @see get_pagenum_link()
+	 * @see get_the_posts_pagination()
+	 *
+	 * @param string $link Pagenum link.
+	 * @return string Fixed pagenum link.
+	 */
+	public function filter_get_pagenum_link( $link ) {
+		global $wp_rewrite;
+
+		// Only relevant when using permalinks.
+		if ( ! $wp_rewrite instanceof WP_Rewrite || ! $wp_rewrite->using_permalinks() ) {
+			return $link;
+		}
+
+		$delimiter = ':';
+		$pattern   = $delimiter;
+
+		// If the current page is a paged request, then we need to first strip that out from the link.
+		if ( get_query_var( 'paged' ) ) {
+			$pattern .= sprintf(
+				'/%s/%d',
+				preg_quote( $wp_rewrite->pagination_base, $delimiter ),
+				get_query_var( 'paged' )
+			);
+		}
+
+		// Now we remove the AMP path segment followed by the paged segments, if they are present.
+		$pattern .= sprintf(
+			'/%s((/%s/\d+)?/?(\?.*?)?(#.*)?)$',
+			preg_quote( amp_get_slug(), ':' ),
+			preg_quote( $wp_rewrite->pagination_base, ':' )
+		);
+
+		$pattern .= $delimiter;
+
+		return preg_replace(
+			$pattern,
+			'$1',
+			$link
+		);
 	}
 
 	/**

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -18,7 +18,6 @@ use AMP_Theme_Support;
 use AmpProject\AmpWP\Tests\Fixture\DummyPairedUrlStructure;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use WP_Query;
-use WP_Rewrite;
 use Exception;
 
 /** @coversDefaultClass \AmpProject\AmpWP\PairedRouting */
@@ -429,15 +428,53 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 		$this->assertSame( $expected_slug, $actual_slug );
 	}
 
-	/** @covers ::add_paired_request_hooks() */
-	public function test_add_paired_request_hooks_when_does_have_endpoint() {
+	/** @return array */
+	public function get_data_for_test_add_paired_request_hooks_when_does_have_endpoint() {
+		return [
+			'query_var'           => [
+				Option::PAIRED_URL_STRUCTURE_QUERY_VAR,
+				false,
+			],
+			'legacy_transitional' => [
+				Option::PAIRED_URL_STRUCTURE_LEGACY_TRANSITIONAL,
+				false,
+			],
+			'path_suffix'         => [
+				Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
+				true,
+			],
+			'legacy_reader'       => [
+				Option::PAIRED_URL_STRUCTURE_LEGACY_READER,
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_test_add_paired_request_hooks_when_does_have_endpoint()
+	 * @covers ::add_paired_request_hooks()
+	 * @covers ::is_using_path_suffix()
+	 * @param string $structure
+	 * @param bool   $using_path_suffix
+	 */
+	public function test_add_paired_request_hooks_when_does_have_endpoint( $structure, $using_path_suffix ) {
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		AMP_Options_Manager::update_option( Option::PAIRED_URL_STRUCTURE, $structure );
+		$this->assertEquals( $using_path_suffix, $this->instance->is_using_path_suffix() );
 		$post = self::factory()->post->create();
+		remove_all_actions( 'wp' );
 		$this->go_to( amp_get_permalink( $post ) );
-		$this->instance->add_paired_request_hooks();
 		$this->assertTrue( $this->instance->has_endpoint() );
+		$this->instance->add_paired_request_hooks();
 		$this->assertEquals( 1000, has_filter( 'old_slug_redirect_url', [ $this->instance, 'maybe_add_paired_endpoint' ] ) );
 		$this->assertEquals( 1000, has_filter( 'redirect_canonical', [ $this->instance, 'maybe_add_paired_endpoint' ] ) );
+		if ( $using_path_suffix ) {
+			$this->assertEquals( 0, has_filter( 'get_pagenum_link', [ $this->instance, 'filter_get_pagenum_link' ] ) );
+		} else {
+			$this->assertFalse( has_filter( 'get_pagenum_link', [ $this->instance, 'filter_get_pagenum_link' ] ) );
+		}
 		$this->assertFalse( has_action( 'wp_head', 'amp_add_amphtml_link' ) );
+		$this->assertEquals( $using_path_suffix, $this->instance->is_using_path_suffix() );
 	}
 
 	/** @covers ::add_paired_request_hooks() */
@@ -449,6 +486,71 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 		$this->assertEquals( 10, has_action( 'wp_head', 'amp_add_amphtml_link' ) );
 		$this->assertFalse( has_filter( 'old_slug_redirect_url', [ $this->instance, 'maybe_add_paired_endpoint' ] ) );
 		$this->assertFalse( has_filter( 'redirect_canonical', [ $this->instance, 'maybe_add_paired_endpoint' ] ) );
+	}
+
+	/** @return array */
+	public function get_data_for_test_filter_get_pagenum_link() {
+		return [
+			'not_using_permalinks' => [
+				false,
+				0,
+			],
+			'on_page_1'            => [
+				true,
+				1,
+			],
+			'on_page_2'            => [
+				true,
+				2,
+			],
+			'on_page_3'            => [
+				true,
+				3,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_test_filter_get_pagenum_link()
+	 * @covers ::filter_get_pagenum_link()
+	 * @param bool $using_permalinks
+	 * @param int  $paged
+	 */
+	public function test_filter_get_pagenum_link( $using_permalinks, $paged ) {
+		if ( $using_permalinks ) {
+			$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		} else {
+			$this->set_permalink_structure( '' );
+		}
+		AMP_Options_Manager::update_option( Option::PAIRED_URL_STRUCTURE, Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX );
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+
+		self::factory()->post->create_many( 15 );
+		update_option( 'posts_per_page', 5 );
+
+		// Nothing is done if permalinks aren't being used.
+		if ( ! $using_permalinks ) {
+			$this->assertEquals( '/amp/', $this->instance->filter_get_pagenum_link( '/amp/' ) );
+			$this->assertEquals( '/amp/page/2/', $this->instance->filter_get_pagenum_link( '/amp/page/2/' ) );
+			return;
+		}
+
+		$_SERVER['REQUEST_URI'] = ( $paged > 1 ? "/page/$paged/" : '/' ) . user_trailingslashit( amp_get_slug(), 'amp' );
+		$this->instance->initialize_paired_request();
+		$this->go_to( $_SERVER['REQUEST_URI'] );
+		$this->assertFalse( is_404() );
+		$this->assertTrue( is_home() );
+
+		if ( $paged > 1 ) {
+			$this->assertTrue( is_paged() );
+			$this->assertEquals( $paged, get_query_var( 'paged' ) );
+			$this->assertEquals( '/', $this->instance->filter_get_pagenum_link( "/page/$paged/amp/" ) );
+			$this->assertEquals( '/page/2/', $this->instance->filter_get_pagenum_link( "/page/$paged/amp/page/2/" ) );
+		} else {
+			$this->assertFalse( is_paged() );
+			$this->assertEquals( '/', $this->instance->filter_get_pagenum_link( '/amp/' ) );
+			$this->assertEquals( '/page/2/', $this->instance->filter_get_pagenum_link( '/amp/page/2/' ) );
+		}
 	}
 
 	/** @covers ::add_permalink_settings_notice() */

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -474,7 +474,6 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 			$this->assertFalse( has_filter( 'get_pagenum_link', [ $this->instance, 'filter_get_pagenum_link' ] ) );
 		}
 		$this->assertFalse( has_action( 'wp_head', 'amp_add_amphtml_link' ) );
-		$this->assertEquals( $using_path_suffix, $this->instance->is_using_path_suffix() );
 	}
 
 	/** @covers ::add_paired_request_hooks() */


### PR DESCRIPTION
## Summary

Fixes #5861

## Checklist

- [x] Add tests.
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
