### PR TITLE
Make parameters to Gutenberg filter callbacks more robust

### DIFF
--- a/assets/src/block-editor/components/with-media-library-notice.js
+++ b/assets/src/block-editor/components/with-media-library-notice.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { dispatch } from '@wordpress/data';
@@ -21,6 +26,10 @@ const { wp } = window;
  * @return {Function} The wrapped component.
  */
 export default ( InitialMediaUpload, minImageDimensions ) => {
+	if ( ! isObject( InitialMediaUpload ) ) {
+		return InitialMediaUpload;
+	}
+
 	const { width: EXPECTED_WIDTH, height: EXPECTED_HEIGHT } = minImageDimensions;
 
 	/**

--- a/assets/src/block-editor/components/with-media-library-notice.js
+++ b/assets/src/block-editor/components/with-media-library-notice.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isObject } from 'lodash';
+import { isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -26,7 +26,7 @@ const { wp } = window;
  * @return {Function} The wrapped component.
  */
 export default ( InitialMediaUpload, minImageDimensions ) => {
-	if ( ! isObject( InitialMediaUpload ) ) {
+	if ( ! isFunction( InitialMediaUpload ) ) {
 		return InitialMediaUpload;
 	}
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { ReactElement } from 'react';
+import { isObject, isString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,7 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { SelectControl, ToggleControl, Notice, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
-import { cloneElement } from '@wordpress/element';
+import { cloneElement, isValidElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -89,6 +90,10 @@ const ampLayoutOptions = [
  * @return {Object} Modified block settings.
  */
 export const addAMPAttributes = ( settings, name ) => {
+	if ( ! isObject( settings ) || ! isString( name ) ) {
+		return settings;
+	}
+
 	// AMP Carousel settings.
 	if ( 'core/gallery' === name ) {
 		if ( ! settings.attributes ) {
@@ -139,6 +144,10 @@ export const addAMPAttributes = ( settings, name ) => {
  * @return {Object} Modified block settings.
  */
 export const removeAmpFitTextFromBlocks = ( settings, name ) => {
+	if ( ! isObject( settings ) || ! isString( name ) ) {
+		return settings;
+	}
+
 	if ( TEXT_BLOCKS.includes( name ) ) {
 		if ( ! settings.deprecated ) {
 			settings.deprecated = [];
@@ -220,7 +229,7 @@ export const removeAmpFitTextFromBlocks = ( settings, name ) => {
  * @return {ReactElement} Modified block if it is of `amp-fit-text` type, otherwise the  original element is returned.
  */
 export const removeClassFromAmpFitTextBlocks = ( element ) => {
-	if ( 'amp-fit-text' === element.type && undefined !== element.props.className ) {
+	if ( isValidElement( element ) && 'amp-fit-text' === element.type && undefined !== element.props.className ) {
 		const { className, ...props } = element.props;
 		props.className = null;
 		element = cloneElement( element, props );
@@ -266,6 +275,10 @@ export const getLayoutOptions = ( block ) => {
  * @return {Function} Edit function.
  */
 export const filterBlocksEdit = ( BlockEdit ) => {
+	if ( ! isObject( BlockEdit ) ) {
+		return BlockEdit;
+	}
+
 	const EnhancedBlockEdit = function( props ) {
 		const { attributes: { ampLayout }, name } = props;
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { ReactElement } from 'react';
-import { isObject, isString } from 'lodash';
+import { isFunction, isObject, isString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -275,7 +275,7 @@ export const getLayoutOptions = ( block ) => {
  * @return {Function} Edit function.
  */
 export const filterBlocksEdit = ( BlockEdit ) => {
-	if ( ! isObject( BlockEdit ) ) {
+	if ( ! isFunction( BlockEdit ) ) {
 		return BlockEdit;
 	}
 

--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { isObject } from 'lodash';
+import { isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,7 +24,7 @@ import { validateFeaturedImage, getMinimumFeaturedImageDimensions } from '../../
  */
 export default createHigherOrderComponent(
 	( PostFeaturedImage ) => {
-		if ( ! isObject( PostFeaturedImage ) ) {
+		if ( ! isFunction( PostFeaturedImage ) ) {
 			return PostFeaturedImage;
 		}
 

--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { isObject } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,6 +24,10 @@ import { validateFeaturedImage, getMinimumFeaturedImageDimensions } from '../../
  */
 export default createHigherOrderComponent(
 	( PostFeaturedImage ) => {
+		if ( ! isObject( PostFeaturedImage ) ) {
+			return PostFeaturedImage;
+		}
+
 		const withFeaturedImageNotice = ( props ) => {
 			const { media } = props;
 


### PR DESCRIPTION
## Summary

Fixes a [reported issue](https://wordpress.org/support/topic/data-hero-for-amp-optimizer/#post-14016460) on the support forums, where depending on the Gutenberg version editing a post could produce an error like:

```
TypeError: Cannot read property 'type' of null
    at v (https://www.ryansmithphotography.com/wp-content/plugins/amp/assets/js/amp-block-editor.js?ver=401ab3f2d960ecfe6233b84afa6650f8:13:5950)
    at https://www.ryansmithphotography.com/wp-includes/js/dist/hooks.min.js?ver=84b89ab09cbfb4469f02183611cc0939:2:5031
    at Qt (https://www.ryansmithphotography.com/wp-includes/js/dist/blocks.min.js?ver=f4636ab86bbcd1d9adb613a053f522e7:3:114677)
    at https://www.ryansmithphotography.com/wp-includes/js/dist/block-editor.min.js?ver=ee2642fa39827fa8f0de00446089caf1:12:277174
    at we (https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:84:293)
    at zj (https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:226:496)
    at Th (https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:152:223)
    at tj (https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:152:152)
    at Te (https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:146:151)
    at https://www.ryansmithphotography.com/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:61:68
```

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
