### PR TITLE
Use just 'AMP' as plugin sidebar title instead of 'AMP for WordPress'

### DIFF
--- a/assets/src/block-validation/index.js
+++ b/assets/src/block-validation/index.js
@@ -19,7 +19,7 @@ import { useValidationErrorStateUpdates } from './use-validation-error-state-upd
 
 export const PLUGIN_NAME = 'amp-block-validation';
 export const SIDEBAR_NAME = 'amp-editor-sidebar';
-export const PLUGIN_TITLE = __( 'AMP for WordPress', 'amp' );
+export const PLUGIN_TITLE = __( 'AMP', 'amp' );
 
 createStore( INITIAL_STATE );
 


### PR DESCRIPTION
## Summary

The title “AMP for WordPress” is excessively verbose for the plugin title in the block editor. It's obviously for WordPress since it is inside WordPress. So it should be simplified to just “AMP”:

Before | After
-------|------
<img width="341" alt="Screen Shot 2021-02-11 at 15 36 09" src="https://user-images.githubusercontent.com/134745/107713164-7dabf580-6c7f-11eb-87b0-6b53b417acba.png"> | <img width="355" alt="Screen Shot 2021-02-11 at 15 36 31" src="https://user-images.githubusercontent.com/134745/107713165-7edd2280-6c7f-11eb-97f0-8b9acf52affe.png">
<img width="297" alt="Screen Shot 2021-02-11 at 15 37 02" src="https://user-images.githubusercontent.com/134745/107713170-7f75b900-6c7f-11eb-9ccd-f97b67e7eaef.png"> | <img width="302" alt="Screen Shot 2021-02-11 at 15 36 45" src="https://user-images.githubusercontent.com/134745/107713168-7f75b900-6c7f-11eb-8590-ff6e9e19fd83.png">

The onboarding wizard does say “Welcome to AMP for WordPress” but that's OK since it's introducing the experience of AMP inside of WordPress:

> ![image](https://user-images.githubusercontent.com/134745/107713513-412cc980-6c80-11eb-9867-5d38a4f1c54b.png)

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
