### PR TITLE
Harden AMP_Post_Type_Support::get_support_errors() to account for case where invalid post is supplied

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -426,7 +426,10 @@ class AMP_Post_Meta_Box {
 		if ( in_array( 'skip-post', $errors, true ) ) {
 			$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
 		}
-		if ( count( array_diff( $errors, [ 'post-type-support', 'skip-post', 'template_unsupported', 'no_matching_template' ] ) ) > 0 ) {
+		if ( in_array( 'invalid-post', $errors, true ) ) {
+			$error_messages[] = __( 'The post data could not be successfully retrieved.', 'amp' );
+		}
+		if ( count( array_diff( $errors, [ 'post-type-support', 'skip-post', 'template_unsupported', 'no_matching_template', 'invalid-post' ] ) ) > 0 ) {
 			$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
 		}
 

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -124,7 +124,7 @@ class AMP_Post_Type_Support {
 		}
 		$errors = [];
 		
-		if ( ! isset( $post->post_type ) && ! isset( $post->ID ) ) {
+		if ( ! $post instanceof WP_Post ) {
 			$errors[] = 'post-type-support';
 			return $errors;
 		}

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -124,7 +124,7 @@ class AMP_Post_Type_Support {
 		}
 		$errors = [];
 		
-		if ( ! isset($post->post_type) && !isset($post->ID) ) {
+		if ( ! isset( $post->post_type ) && ! isset( $post->ID ) ) {
 			$errors[] = 'post-type-support';
 			return $errors;
 		}

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -125,7 +125,7 @@ class AMP_Post_Type_Support {
 		$errors = [];
 		
 		if ( ! $post instanceof WP_Post ) {
-			$errors[] = 'post-type-support';
+			$errors[] = 'invalid-post';
 			return $errors;
 		}
 		

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -119,16 +119,17 @@ class AMP_Post_Type_Support {
 	 * @return array Error codes for why a given post does not have AMP support.
 	 */
 	public static function get_support_errors( $post ) {
-		if ( ! ( $post instanceof WP_Post ) ) {
+		if ( ! $post instanceof WP_Post ) {
 			$post = get_post( $post );
 		}
-		$errors = [];
-		
+
+		// If there's still not a valid post, then we have to abort.
 		if ( ! $post instanceof WP_Post ) {
-			$errors[] = 'invalid-post';
-			return $errors;
+			return [ 'invalid-post' ];
 		}
-		
+
+		$errors = [];
+
 		if ( ! in_array( $post->post_type, self::get_supported_post_types(), true ) ) {
 			$errors[] = 'post-type-support';
 		}

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -123,7 +123,12 @@ class AMP_Post_Type_Support {
 			$post = get_post( $post );
 		}
 		$errors = [];
-
+		
+		if(!isset($post->post_type) && !isset($post->ID)){
+			$errors[] = 'post-type-support';
+			return $errors;
+		}
+		
 		if ( ! in_array( $post->post_type, self::get_supported_post_types(), true ) ) {
 			$errors[] = 'post-type-support';
 		}

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -124,7 +124,7 @@ class AMP_Post_Type_Support {
 		}
 		$errors = [];
 		
-		if(!isset($post->post_type) && !isset($post->ID)){
+		if ( ! isset($post->post_type) && !isset($post->ID) ) {
 			$errors[] = 'post-type-support';
 			return $errors;
 		}

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -66,31 +66,27 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMElement $comment_form Comment form.
 	 */
 	protected function process_comment_form( $comment_form ) {
-		/**
-		 * Element.
-		 *
-		 * @var DOMElement $element
-		 */
-
-		/**
-		 * Named input elements.
-		 *
-		 * @var DOMElement[][] $form_fields
-		 */
 		$form_fields = [];
 		foreach ( $comment_form->getElementsByTagName( 'input' ) as $element ) {
+			/** @var DOMElement $element */
 			$name = $element->getAttribute( 'name' );
 			if ( $name ) {
 				$form_fields[ $name ][] = $element;
 			}
 		}
 		foreach ( $comment_form->getElementsByTagName( 'textarea' ) as $element ) {
+			/** @var DOMElement $element */
 			$name = $element->getAttribute( 'name' );
 			if ( $name ) {
 				$form_fields[ $name ][] = $element;
 			}
 		}
 
+		/**
+		 * Named input elements.
+		 *
+		 * @var DOMElement[][] $form_fields
+		 */
 		if ( empty( $form_fields['comment_post_ID'] ) ) {
 			return;
 		}

--- a/src/Validation/ScannableURLProvider.php
+++ b/src/Validation/ScannableURLProvider.php
@@ -159,7 +159,7 @@ final class ScannableURLProvider {
 
 		return array_filter(
 			$ids,
-			'post_supports_amp'
+			'amp_is_post_supported'
 		);
 	}
 

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -361,6 +361,11 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 			[ 'Unavailable for an unknown reason.' ],
 			$this->instance->get_error_messages( [ 'unknown-error' ] )
 		);
+
+		$this->assertEquals(
+			[ 'The post data could not be successfully retrieved.' ],
+			$this->instance->get_error_messages( [ 'invalid-post' ] )
+		);
 	}
 
 	/** @covers ::save_amp_status() */

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -108,6 +108,5 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 
 		// Invalid post.
 		$this->assertEquals( [ 'invalid-post' ], AMP_Post_Type_Support::get_support_errors( null ) );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 	}
 }

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -105,5 +105,9 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		$this->assertEquals( [ 'skip-post' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
+
+		// Invalid post.
+		$this->assertEquals( [ 'invalid-post' ], AMP_Post_Type_Support::get_support_errors( null ) );
+		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 	}
 }


### PR DESCRIPTION
Added fix to suppress PHP warning error on PHP 8.0 when accessing non-related wordpress file that sits on wordpress directory. I don't know if this is the cleaner way to suppress it.

$post->post_type and $post->ID is not properly isset.

2021/02/11 09:30:44 [error] 68555#68555: *13 FastCGI sent in stderr: "PHP message: PHP Warning:  Attempt to read property "post_type" on null in /var/www/gamingph.com/wp-content/plugins/amp/includes/class-amp-post-type-support.php on line 127PHP message: PHP Warning:  Attempt to read property "ID" on null in /var/www/gamingph.com/wp-content/plugins/amp/includes/class-amp-post-type-support.php on line 144PHP message: PHP Warning:  Attempt to read property "post_type" on null in /var/www/gamingph.com/wp-content/plugins/amp/includes/class-amp-post-type-support.php on line 166" while reading response header from upstream, client: 123.243.236.70, server: gamingph.com, request: "GET /doraemon/offline.js?161428 HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm.sock:", host: "gamingph.com", referrer: "https://gamingph.com/doraemon/sw.js?v2"

## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
