### PR TITLE
Optimize GHA runtime

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -6,9 +6,23 @@ on:
       - develop
       # Include all release branches.
       - '[0-9]+.[0-9]+'
+    # Don't run for irrelevant changes.
+    paths-ignore:
+      - '!.github/workflows/*'
+      - '.wordpress-org/**'
+      - '!bin/ci/**'
+      - '!bin/local-env/**'
+      - 'docs/**'
   pull_request:
     # Run workflow whenever a PR is opened, updated (synchronized), or marked ready for review.
     types: [opened, synchronize, ready_for_review]
+    # Don't run for irrelevant changes.
+    paths-ignore:
+      - '!.github/workflows/*'
+      - '.wordpress-org/**'
+      - '!bin/ci/**'
+      - '!bin/local-env/**'
+      - 'docs/**'
 
 jobs:
 

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,4 +1,4 @@
-name: Cancel
+name: Auto Cancel
 
 on: [push]
 

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,10 +1,10 @@
-name: Cancel previous runs
+name: Cancel
 
 on: [push]
 
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: 'Previous Runs'
     # Skip if push is from PR fork.
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   cancel:
-    name: 'Previous Runs'
+    name: 'Cancel Previous Runs'
     # Skip if push is from PR fork.
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: styfle/cancel-workflow-action@0.8.0
         with:
-          workflow_id: 1364807 # ID of the `build-test-measure` workflow
+          workflow_id: build-test-measure.yml
           access_token: ${{ github.token }}

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,0 +1,15 @@
+name: Cancel previous runs
+
+on: [push]
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    # Skip if push is from PR fork.
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          workflow_id: 1364807 # ID of the `build-test-measure` workflow
+          access_token: ${{ github.token }}


### PR DESCRIPTION
## Summary

- [ ] ~Improve installation time of dependencies by caching resolved dependencies and only running installation commands when the relevant lock file changes or there is no cache hit.~
    Turns out that this has a negligible effect on the overall run time. Although the time spent installing dependencies is reduced, that time is now spent on restoring and serializing the much bigger cache.

- [x] Cancel previous in-progress or queued workflow runs for a branch when new commits are pushed to it.
    - [Example workflow that cancelled other workflow](https://github.com/ampproject/amp-wp/runs/2099469440?check_suite_focus=true#step:2:31)
    - [Example workflow that was cancelled](https://github.com/ampproject/amp-wp/actions/runs/647734771)

- [x] Only run jobs specific to the files that are changed in a PR
