### PR TITLE
Move validation background tasks behind feature flag filter until Site Scanning is implemented

### DIFF
--- a/src/Validation/SavePostValidationEvent.php
+++ b/src/Validation/SavePostValidationEvent.php
@@ -11,6 +11,7 @@ namespace AmpProject\AmpWP\Validation;
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\SingleScheduledBackgroundTask;
 use AmpProject\AmpWP\DevTools\UserAccess;
+use AmpProject\AmpWP\Infrastructure\Conditional;
 
 /**
  * SavePostValidationEvent class.
@@ -19,7 +20,7 @@ use AmpProject\AmpWP\DevTools\UserAccess;
  *
  * @internal
  */
-final class SavePostValidationEvent extends SingleScheduledBackgroundTask {
+final class SavePostValidationEvent extends SingleScheduledBackgroundTask implements Conditional {
 
 	/**
 	 * Instance of URLValidationProvider
@@ -41,6 +42,15 @@ final class SavePostValidationEvent extends SingleScheduledBackgroundTask {
 	 * @var string
 	 */
 	const BACKGROUND_TASK_NAME = 'amp_single_post_validate';
+
+	/**
+	 * Check whether the service is currently needed.
+	 *
+	 * @return bool Whether needed.
+	 */
+	public static function is_needed() {
+		return URLValidationCron::is_needed();
+	}
 
 	/**
 	 * Class constructor.

--- a/src/Validation/SavePostValidationEvent.php
+++ b/src/Validation/SavePostValidationEvent.php
@@ -121,6 +121,7 @@ final class SavePostValidationEvent extends SingleScheduledBackgroundTask implem
 
 		$post = get_post( $id );
 
+		// @todo This needs to be limited to when the status is publish because otherwise the validation request will fail to be able to access the post, as the request is not authenticated.
 		if ( ! $post
 			||
 			wp_is_post_revision( $post )

--- a/src/Validation/URLValidationCron.php
+++ b/src/Validation/URLValidationCron.php
@@ -10,6 +10,7 @@ namespace AmpProject\AmpWP\Validation;
 
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\RecurringBackgroundTask;
+use AmpProject\AmpWP\Infrastructure\Conditional;
 
 /**
  * URLValidationCron class.
@@ -18,7 +19,7 @@ use AmpProject\AmpWP\BackgroundTask\RecurringBackgroundTask;
  *
  * @internal
  */
-final class URLValidationCron extends RecurringBackgroundTask {
+final class URLValidationCron extends RecurringBackgroundTask implements Conditional {
 
 	/**
 	 * ScannableURLProvider instance.
@@ -47,6 +48,33 @@ final class URLValidationCron extends RecurringBackgroundTask {
 	 * @var int
 	 */
 	const DEFAULT_SLEEP_TIME = 1;
+
+	/**
+	 * Check whether the service is currently needed.
+	 *
+	 * @return bool Whether needed.
+	 */
+	public static function is_needed() {
+		/**
+		 * Filters whether to enable URL validation cron tasks.
+		 *
+		 * This is a feature flag used to control whether the sample set of site URLs are scanned on a daily basis and
+		 * whether post permalinks are scheduled for immediate validation as soon as they are updated by a user who has
+		 * DevTools turned off. This conditional flag will be removed once Site Scanning is implemented, likely in v2.2.
+		 *
+		 * @link https://github.com/ampproject/amp-wp/issues/5750
+		 * @link https://github.com/ampproject/amp-wp/issues/4779
+		 * @link https://github.com/ampproject/amp-wp/issues/4795
+		 * @link https://github.com/ampproject/amp-wp/issues/4719
+		 * @link https://github.com/ampproject/amp-wp/issues/5671
+		 * @link https://github.com/ampproject/amp-wp/issues/5101
+		 * @link https://github.com/ampproject/amp-wp/issues?q=label%3A%22Site+Scanning%22
+		 *
+		 * @param bool $enabled Enabled.
+		 * @internal
+		 */
+		return apply_filters( 'amp_temp_validation_cron_tasks_enabled', false );
+	}
 
 	/**
 	 * Class constructor.

--- a/tests/php/src/Validation/SavePostValidationEventTest.php
+++ b/tests/php/src/Validation/SavePostValidationEventTest.php
@@ -8,6 +8,7 @@ namespace AmpProject\AmpWP\Tests\Validation;
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\SingleScheduledBackgroundTask;
 use AmpProject\AmpWP\DevTools\UserAccess;
+use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
@@ -49,6 +50,17 @@ final class SavePostValidationEventTest extends WP_UnitTestCase {
 		$this->assertInstanceof( SavePostValidationEvent::class, $this->test_instance );
 		$this->assertInstanceof( Service::class, $this->test_instance );
 		$this->assertInstanceof( Registerable::class, $this->test_instance );
+		$this->assertInstanceof( Conditional::class, $this->test_instance );
+	}
+
+	/** @covers ::is_needed() */
+	public function test_is_needed() {
+		$this->assertFalse( SavePostValidationEvent::is_needed() );
+
+		add_filter( 'amp_temp_validation_cron_tasks_enabled', '__return_true' );
+		$this->assertTrue( SavePostValidationEvent::is_needed() );
+
+		remove_filter( 'amp_temp_validation_cron_tasks_enabled', '__return_true' );
 	}
 
 	/**

--- a/tests/php/src/Validation/URLValidationCronTest.php
+++ b/tests/php/src/Validation/URLValidationCronTest.php
@@ -4,6 +4,7 @@ namespace AmpProject\AmpWP\Tests\Validation;
 
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\CronBasedBackgroundTask;
+use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
@@ -45,11 +46,22 @@ final class URLValidationCronTest extends WP_UnitTestCase {
 		$this->assertInstanceof( URLValidationCron::class, $this->test_instance );
 		$this->assertInstanceof( Service::class, $this->test_instance );
 		$this->assertInstanceof( Registerable::class, $this->test_instance );
+		$this->assertInstanceof( Conditional::class, $this->test_instance );
 
 		$this->test_instance->register();
 
 		$this->assertEquals( 10, has_action( 'admin_init', [ $this->test_instance, 'schedule_event' ] ) );
 		$this->assertEquals( 10, has_action( URLValidationCron::BACKGROUND_TASK_NAME, [ $this->test_instance, 'process' ] ) );
+	}
+
+	/** @covers ::is_needed() */
+	public function test_is_needed() {
+		$this->assertFalse( URLValidationCron::is_needed() );
+
+		add_filter( 'amp_temp_validation_cron_tasks_enabled', '__return_true' );
+		$this->assertTrue( URLValidationCron::is_needed() );
+
+		remove_filter( 'amp_temp_validation_cron_tasks_enabled', '__return_true' );
 	}
 
 	/** @covers ::schedule_event() */


### PR DESCRIPTION
I've been thinking about the new cron jobs for checking site validation, specifically these introduced in #5515 for #1756: 

* The `amp_validate_urls` cron which checks a sample set of URLs. 
* The `amp_single_post_validate` cron which checks a URL after a post is published and the user doesn't have DevTools enabled.

At the moment, these two cron jobs are responsible for generating validation data which we are not yet using. We do not have the aforementioned notification center to communicate AMP Site Health and we haven't yet implemented [Site Scanning](https://github.com/ampproject/amp-wp/issues?q=label%3A%22Site+Scanning%22) as part of the onboarding wizard. Validation data is being generated even when DevTools is disabled now. This causes a problem also because we don't have any garbage collection of validation data (#4779). Therefore, since we aren't using the output of these additional validation checks, I propose that we put them behind a feature flag (internal filter) and turn them off for 2.1. This will allow us to punt a couple more issues to 2.2 to coincide with Site Scanning which is what they are the foundation for. Specifically #5750 and #4779.