### PR TITLE
Increase default Jest timeout to 30s

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -39,7 +39,7 @@ const OBSERVED_CONSOLE_MESSAGE_TYPES = {
 const pageEvents = [];
 
 // The Jest timeout is increased because these tests are a bit slow
-jest.setTimeout( PUPPETEER_TIMEOUT || 100000 );
+jest.setTimeout( PUPPETEER_TIMEOUT || 300000 );
 
 /**
  * Adds an event listener to the page to handle additions of page event


### PR DESCRIPTION
## Summary

The E2E test [`Template mode recommendations with non-reader-theme active › makes correct recommendations when user is not technical and the current theme is not a reader theme`](https://github.com/ampproject/amp-wp/blob/6d0958d6b3102b9e8f6dada921aa43ed8dcbacf1/tests/e2e/specs/amp-onboarding/template-mode.js#L98-L104) has become flaky as it now sometimes times out while attempting to [install the `hestia` theme](https://github.com/ampproject/amp-wp/blob/6d0958d6b3102b9e8f6dada921aa43ed8dcbacf1/tests/e2e/specs/amp-onboarding/template-mode.js#L90).

To resolve this, this PR increases the default Jest timeout from 10s to 30s. Alternatively, the 30s timeout could be applied specifically to the aforementioned test, but that may also have to be done for similar tests that sometimes have long timeouts (like the ones that `await` on installing themes and plugins, for example).

Example of flaky test: https://github.com/ampproject/amp-wp/runs/1930306642#step:12:17
