### PR TITLE
Make AMP_DOM_Utils non-internal since useful for devs and already in third party use

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -13,7 +13,7 @@ use AmpProject\Tag;
  *
  * Functionality to simplify working with Dom\Documents and DOMElements.
  *
- * @internal
+ * @since 0.2
  */
 class AMP_DOM_Utils {
 


### PR DESCRIPTION
## Summary

In a [support topic](https://wordpress.org/support/topic/custom-sanitizers-example-of-using-amp_dom_utils-in-themes/) request, a developer wanted to be able to use `AMP_DOM_Utils::add_amp_action()` in theme code but was discouraged from doing so since it doesn't show up on [our documentation](https://amp-wp.org/documentation/reference-docs/?s=AMP_DOM_Utils&post_type%5B%5D=wp-parser-class&post_type%5B%5D=wp-parser-function&post_type%5B%5D=wp-parser-hook&post_type%5B%5D=wp-parser-method).

We have marked this class as internal, which is why it isn't showing up in the documentation.  

Many of the methods in that class have been marked as deprecated as they have moved over to the amp-toolbox-php project dependency as part of the `AmpProject\Dom\Document` class. 

Nevertheless, there are <a href="https://wpdirectory.net/search/01EYXS5Q9W0W320S9DPZ9RBJJD">plugins</a> and <a href="https://wpdirectory.net/search/01EYXSEVJGMKH05HA0QQS30HYZ">a theme</a> which are using `AMP_DOM_Utils` today in the directory, so we might as well make the class non-internal. 

Just be aware that additional methods in the class may be deprecated in favor of code in the `AmpProject\Dom` namespace in future releases.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
