### PR TITLE
Remove initial-scale=1 meta viewport property by default to disable tap delay

### DIFF
--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -25,6 +25,15 @@ use AmpProject\Tag;
 class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
+	 * Default args.
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = [ // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+		'remove_initial_scale_viewport_property' => true,
+	];
+
+	/**
 	 * Tag.
 	 *
 	 * @var string HTML <meta> tag to identify and replace with AMP version.
@@ -189,6 +198,17 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 						$parsed_rules[ trim( $exploded_pair[0] ) ] = trim( $exploded_pair[1] );
 					}
 				}
+			}
+
+			// Remove initial-scale=1 to leave just width=device-width in order to avoid a tap delay hurts FID.
+			if (
+				! empty( $this->args['remove_initial_scale_viewport_property'] )
+				&&
+				isset( $parsed_rules['initial-scale'] )
+				&&
+				abs( (float) $parsed_rules['initial-scale'] - 1.0 ) < 0.0001
+			) {
+				unset( $parsed_rules['initial-scale'] );
 			}
 
 			$viewport_value = implode(

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -180,7 +180,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<html>
 						<head>
 							<meta name="viewport" content="width=device-width">
-							<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { initial-scale: 1.0 } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>
+							<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { initial-scale: 2.0 } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>
 						</head>
 						<body></body>
 					</html>
@@ -190,7 +190,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<html>
 						<head>
 							<meta charset="utf-8">
-							<meta name="viewport" content="width=device-width,initial-scale=1">
+							<meta name="viewport" content="width=device-width,initial-scale=2">
 						</head>
 						<body></body>
 					</html>
@@ -3317,8 +3317,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<meta name="viewport" content="width=device-width">',
 			],
 			'viewport_merged_rules' => [
-				'<meta name="viewport" content="width=device-width,user-scalable=no"><style>@viewport{ initial-scale: 1; }</style><style>@-moz-viewport{ user-scalable: yes; }</style><style>@-o-viewport { minimum-scale: 0.5; }</style><style>@-baz-viewport { unrecognized: 1; }</style>',
-				'<meta name="viewport" content="width=device-width,user-scalable=yes,initial-scale=1,minimum-scale=.5,unrecognized=1">',
+				'<meta name="viewport" content="width=device-width,user-scalable=no"><style>@viewport{ initial-scale: 2; }</style><style>@-moz-viewport{ user-scalable: yes; }</style><style>@-o-viewport { minimum-scale: 0.5; }</style><style>@-baz-viewport { unrecognized: 1; }</style>',
+				'<meta name="viewport" content="width=device-width,user-scalable=yes,initial-scale=2,minimum-scale=.5,unrecognized=1">',
 			],
 			'nested_viewport_in_at_rule' => [
 				'<style>@media screen { @viewport{ width: device-width; } }</style>',

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -106,8 +106,8 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 			],
 
 			'Do not break the correct viewport tag'       => [
-				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">' . $amp_boilerplate . '</head><body></body></html>',
-				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">' . $amp_boilerplate . '</head><body></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">' . $amp_boilerplate . '</head><body></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
 			],
 
 			'Move charset and viewport tags from body to head' => [
@@ -230,5 +230,31 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 		$sanitizer->sanitize();
 
 		$this->assertEqualMarkup( $expected_content, $dom->saveHTML() );
+	}
+
+	/** @covers \AMP_Meta_Sanitizer::sanitize() */
+	public function test_initial_scale_removal() {
+		$html = '<html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head></html>';
+
+		$dom       = Document::fromHtml( $html );
+		$sanitizer = new AMP_Meta_Sanitizer( $dom, [] );
+		$sanitizer->sanitize();
+		$this->assertEquals( 'width=device-width', $dom->viewport->getAttribute( 'content' ) );
+
+		$dom       = Document::fromHtml( $html );
+		$sanitizer = new AMP_Meta_Sanitizer( $dom, [ 'remove_initial_scale_viewport_property' => true ] );
+		$sanitizer->sanitize();
+		$this->assertEquals( 'width=device-width', $dom->viewport->getAttribute( 'content' ) );
+
+		$dom       = Document::fromHtml( $html );
+		$sanitizer = new AMP_Meta_Sanitizer( $dom, [ 'remove_initial_scale_viewport_property' => false ] );
+		$sanitizer->sanitize();
+		$this->assertEquals( 'width=device-width,initial-scale=1', $dom->viewport->getAttribute( 'content' ) );
+
+		$html      = '<html><head><meta name="viewport" content="width=device-width, initial-scale=2"></head></html>';
+		$dom       = Document::fromHtml( $html );
+		$sanitizer = new AMP_Meta_Sanitizer( $dom, [ 'remove_initial_scale_viewport_property' => true ] );
+		$sanitizer->sanitize();
+		$this->assertEquals( 'width=device-width,initial-scale=2', $dom->viewport->getAttribute( 'content' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #5894

Behavior can be disabled via this plugin code:

```php
add_filter(
	'amp_content_sanitizers',
	function ( $sanitizers ) {
		$sanitizers[ AMP_Meta_Sanitizer::class ]['remove_initial_scale_viewport_property'] = false;
		return $sanitizers;
	}
);
```

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
