### PR TITLE
Use AMP Settings page URL as 'Close' button link if referrer was login or customizer page

### DIFF
--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -297,7 +297,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 	public function get_close_link() {
 		$referer                    = wp_get_referer();
 
-		if ( $referer && 'wp-login.php' !== wp_basename( parse_url( $referer, PHP_URL_PATH ) ) ) {
+		if ( $referer && 'wp-login.php' !== wp_basename( wp_parse_url( $referer, PHP_URL_PATH ) ) ) {
 			return $referer;
 		}
 

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -9,13 +9,11 @@
 namespace AmpProject\AmpWP\Admin;
 
 use AMP_Options_Manager;
-use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Services;
 
@@ -217,7 +215,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 		$theme           = wp_get_theme();
 		$is_reader_theme = $this->reader_themes->theme_data_exists( get_stylesheet() );
 
-		$exit_link = menu_page_url( AMP_Options_Manager::OPTION_NAME, false );
+		$amp_settings_link = menu_page_url( AMP_Options_Manager::OPTION_NAME, false );
 
 		$setup_wizard_data = [
 			'AMP_OPTIONS_KEY'                    => AMP_Options_Manager::OPTION_NAME,
@@ -228,11 +226,11 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 			'APP_ROOT_ID'                        => self::APP_ROOT_ID,
 			'CUSTOMIZER_LINK'                    => add_query_arg(
 				[
-					'return' => rawurlencode( $exit_link ),
+					'return' => rawurlencode( $amp_settings_link ),
 				],
 				admin_url( 'customize.php' )
 			),
-			'CLOSE_LINK'                         => wp_get_referer() ?: $exit_link,
+			'CLOSE_LINK'                         => $this->get_close_link(),
 			// @todo As of June 2020, an upcoming WP release will allow this to be retrieved via REST.
 			'CURRENT_THEME'                      => [
 				'name'            => $theme->get( 'Name' ),
@@ -242,7 +240,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 				'url'             => $theme->get( 'ThemeURI' ),
 			],
 			'USING_FALLBACK_READER_THEME'        => $this->reader_themes->using_fallback_theme(),
-			'FINISH_LINK'                        => $exit_link,
+			'FINISH_LINK'                        => $amp_settings_link,
 			'OPTIONS_REST_PATH'                  => '/amp/v1/options',
 			'READER_THEMES_REST_PATH'            => '/amp/v1/reader-themes',
 			'UPDATES_NONCE'                      => wp_create_nonce( 'updates' ),
@@ -289,5 +287,22 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 		foreach ( $paths as $path ) {
 			$this->rest_preloader->add_preloaded_path( $path );
 		}
+	}
+
+	/**
+	 * Determine URL that should be used to close the Onboarding Wizard.
+	 *
+	 * @return string Close link.
+	 */
+	public function get_close_link() {
+		$referer                    = wp_get_referer();
+		$excluded_referer_basenames = [ 'customize.php', 'wp-login.php' ];
+
+		if ( $referer && ! in_array( wp_basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
+			return $referer;
+		}
+
+		// Default to the AMP Settings page if a referrer link could not be determined.
+		return menu_page_url( AMP_Options_Manager::OPTION_NAME, false );
 	}
 }

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -296,9 +296,8 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 	 */
 	public function get_close_link() {
 		$referer                    = wp_get_referer();
-		$excluded_referer_basenames = [ 'customize.php', 'wp-login.php' ];
 
-		if ( $referer && ! in_array( wp_basename( wp_parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
+		if ( $referer && 'wp-login.php' !== wp_basename( parse_url( $referer, PHP_URL_PATH ) ) ) {
 			return $referer;
 		}
 

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -298,7 +298,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 		$referer                    = wp_get_referer();
 		$excluded_referer_basenames = [ 'customize.php', 'wp-login.php' ];
 
-		if ( $referer && ! in_array( wp_basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
+		if ( $referer && ! in_array( wp_basename( wp_parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
 			return $referer;
 		}
 

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -295,7 +295,7 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 	 * @return string Close link.
 	 */
 	public function get_close_link() {
-		$referer                    = wp_get_referer();
+		$referer = wp_get_referer();
 
 		if ( $referer && 'wp-login.php' !== wp_basename( wp_parse_url( $referer, PHP_URL_PATH ) ) ) {
 			return $referer;

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -13,7 +13,6 @@ use AMP_Theme_Support;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use AmpProject\AmpWP\Option;
 
 /**
  * OptionsMenu class.
@@ -134,6 +133,8 @@ class OptionsMenu implements Conditional, Service, Registerable {
 	 * Add menu.
 	 */
 	public function add_menu_items() {
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+
 		/*
 		 * Note that the admin items for Validated URLs and Validation Errors will also be placed under this admin menu
 		 * page when the current user can manage_options.

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -7,6 +7,7 @@
 
 namespace AmpProject\AmpWP\Tests\Admin;
 
+use AMP_Options_Manager;
 use AmpProject\AmpWP\Admin\GoogleFonts;
 use AmpProject\AmpWP\Admin\OnboardingWizardSubmenuPage;
 use AmpProject\AmpWP\Admin\ReaderThemes;
@@ -59,7 +60,7 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	/**
 	 * Tests OnboardingWizardSubmenuPage::register
 	 *
-	 * @covers ::register
+	 * @covers ::register()
 	 */
 	public function test_register() {
 		$this->page->register();
@@ -70,9 +71,9 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests OnboardingWizardSubmenuPage::override_title
+	 * Tests OnboardingWizardSubmenuPage::override_title()
 	 *
-	 * @covers ::override_title
+	 * @covers ::override_title()
 	 */
 	public function test_override_title() {
 		set_current_screen( 'index.php' );
@@ -85,9 +86,9 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests OnboardingWizardSubmenuPage::render
+	 * Tests OnboardingWizardSubmenuPage::render()
 	 *
-	 * @covers ::render
+	 * @covers ::render()
 	 */
 	public function test_render() {
 		ob_start();
@@ -98,9 +99,9 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests OnboardingWizardSubmenuPage::screen_handle
+	 * Tests OnboardingWizardSubmenuPage::screen_handle()
 	 *
-	 * @covers ::screen_handle
+	 * @covers ::screen_handle()
 	 */
 	public function test_screen_handle() {
 		$this->assertEquals( $this->page->screen_handle(), 'admin_page_amp-onboarding-wizard' );
@@ -109,7 +110,7 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	/**
 	 * Tests OnboardingWizardSubmenuPage::enqueue_assets
 	 *
-	 * @covers ::enqueue_assets
+	 * @covers ::enqueue_assets()
 	 */
 	public function test_enqueue_assets() {
 		$handle = 'amp-onboarding-wizard';
@@ -117,5 +118,43 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 		$this->page->enqueue_assets( $this->page->screen_handle() );
 		$this->assertTrue( wp_script_is( $handle ) );
 		$this->assertTrue( wp_style_is( $handle ) );
+	}
+
+	public function get_referrer_links() {
+		return [
+			'tools page'        => [
+				'http://example.org/core-dev/src/wp-admin/tools.php',
+				'http://example.org/core-dev/src/wp-admin/tools.php',
+			],
+			'amp settings page' => [
+				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+			],
+			'login page'        => [
+				'http://example.org/core-dev/src/wp-login.php',
+				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+			],
+			'customizer page'   => [
+				'http://example.org/core-dev/src/wp-admin/customize.php',
+				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+			],
+		];
+	}
+
+	/**
+	 * Tests OnboardingWizardSubmenuPage::get_close_link()
+	 *
+	 * @covers ::enqueue_assets()
+	 * @dataProvider get_referrer_links()
+	 *
+	 * @param string $referrer_link Referrer link.
+	 * @param string $expected_link Expected link.
+	 */
+	public function test_get_close_link( $referrer_link, $expected_link ) {
+		// Register an instance of the AMP menu page to ensure `menu_page_url()` returns the correct URL.
+		add_menu_page( 'AMP Settings', 'AMP', 'manage_options', AMP_Options_Manager::OPTION_NAME );
+
+		$_SERVER['HTTP_REFERER'] = $referrer_link;
+		$this->assertEquals( $this->page->get_close_link(), $expected_link );
 	}
 }

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -157,6 +157,9 @@ class OnboardingWizardSubmenuPageTest extends DependencyInjectedTestCase {
 		$this->options_menu->add_menu_items();
 
 		$_SERVER['HTTP_REFERER'] = $referrer_link;
-		$this->assertEquals( $expected_link, $this->onboarding_wizard_submenu_page->get_close_link() );
+		$this->assertEquals(
+			set_url_scheme( $expected_link ),
+			$this->onboarding_wizard_submenu_page->get_close_link()
+		);
 	}
 }

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -147,6 +147,7 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	 * @param string $expected_link Expected link.
 	 */
 	public function test_get_close_link( $referrer_link, $expected_link ) {
+		remove_all_filters('site_url');
 		// Register an instance of the AMP menu page to ensure `menu_page_url()` returns the correct URL.
 		add_menu_page( 'AMP Settings', 'AMP', 'manage_options', AMP_Options_Manager::OPTION_NAME );
 

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -152,7 +152,7 @@ class OnboardingWizardSubmenuPageTest extends DependencyInjectedTestCase {
 	/**
 	 * Tests OnboardingWizardSubmenuPage::get_close_link()
 	 *
-	 * @covers ::enqueue_assets()
+	 * @covers ::get_close_link()
 	 * @dataProvider get_referrer_links()
 	 *
 	 * @param callable $referrer_link_callback  Referrer link callback.

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -123,16 +123,16 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	public function get_referrer_links() {
 		return [
 			'tools page'        => [
-				'http://example.org/core-dev/src/wp-admin/tools.php',
-				'http://example.org/core-dev/src/wp-admin/tools.php',
+				admin_url( 'tools.php' ),
+				admin_url( 'tools.php' ),
 			],
 			'amp settings page' => [
-				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
-				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+				admin_url( 'admin.php?page=amp-options' ),
+				admin_url( 'admin.php?page=amp-options' ),
 			],
 			'login page'        => [
-				'http://example.org/core-dev/src/wp-login.php',
-				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
+				wp_login_url(),
+				admin_url( 'admin.php?page=amp-options' ),
 			],
 		];
 	}
@@ -147,7 +147,6 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 	 * @param string $expected_link Expected link.
 	 */
 	public function test_get_close_link( $referrer_link, $expected_link ) {
-		remove_all_filters('site_url');
 		// Register an instance of the AMP menu page to ensure `menu_page_url()` returns the correct URL.
 		add_menu_page( 'AMP Settings', 'AMP', 'manage_options', AMP_Options_Manager::OPTION_NAME );
 

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -120,17 +120,18 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 		$this->assertTrue( wp_style_is( $handle ) );
 	}
 
+	/** @return array */
 	public function get_referrer_links() {
 		return [
-			'tools page'        => [
+			'tools_page'        => [
 				admin_url( 'tools.php' ),
 				admin_url( 'tools.php' ),
 			],
-			'amp settings page' => [
+			'amp_settings_page' => [
 				admin_url( 'admin.php?page=amp-options' ),
 				admin_url( 'admin.php?page=amp-options' ),
 			],
-			'login page'        => [
+			'login_page'        => [
 				wp_login_url(),
 				admin_url( 'admin.php?page=amp-options' ),
 			],
@@ -151,6 +152,6 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 		add_menu_page( 'AMP Settings', 'AMP', 'manage_options', AMP_Options_Manager::OPTION_NAME );
 
 		$_SERVER['HTTP_REFERER'] = $referrer_link;
-		$this->assertEquals( $this->page->get_close_link(), $expected_link );
+		$this->assertEquals( $expected_link, $this->page->get_close_link() );
 	}
 }

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -134,10 +134,6 @@ class OnboardingWizardSubmenuPageTest extends WP_UnitTestCase {
 				'http://example.org/core-dev/src/wp-login.php',
 				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
 			],
-			'customizer page'   => [
-				'http://example.org/core-dev/src/wp-admin/customize.php',
-				'http://example.org/core-dev/src/wp-admin/admin.php?page=amp-options',
-			],
 		];
 	}
 

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -761,7 +761,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 	/** @covers AMP_Options_Manager::insecure_connection_notice() */
 	public function test_insecure_connection_notice() {
-		$current_server_https = isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : false;
 		$_SERVER['HTTPS'] = false;
 		$this->assertEmpty( get_echo( [ 'AMP_Options_Manager', 'insecure_connection_notice' ] ) );
 
@@ -780,7 +779,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
 		$this->assertEmpty( get_echo( [ 'AMP_Options_Manager', 'insecure_connection_notice' ] ) );
 
-		$_SERVER['HTTPS'] = $current_server_https;
+		unset( $_SERVER['HTTPS'] );
 	}
 
 	/** @covers AMP_Options_Manager::reader_theme_fallback_notice() */

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -778,8 +778,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		add_filter( 'site_url', $set_https_url );
 		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
 		$this->assertEmpty( get_echo( [ 'AMP_Options_Manager', 'insecure_connection_notice' ] ) );
-
-		unset( $_SERVER['HTTPS'] );
 	}
 
 	/** @covers AMP_Options_Manager::reader_theme_fallback_notice() */

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -761,6 +761,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 	/** @covers AMP_Options_Manager::insecure_connection_notice() */
 	public function test_insecure_connection_notice() {
+		$current_server_https = isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : false;
 		$_SERVER['HTTPS'] = false;
 		$this->assertEmpty( get_echo( [ 'AMP_Options_Manager', 'insecure_connection_notice' ] ) );
 
@@ -778,6 +779,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		add_filter( 'site_url', $set_https_url );
 		set_current_screen( 'toplevel_page_' . AMP_Options_Manager::OPTION_NAME );
 		$this->assertEmpty( get_echo( [ 'AMP_Options_Manager', 'insecure_connection_notice' ] ) );
+
+		$_SERVER['HTTPS'] = $current_server_https;
 	}
 
 	/** @covers AMP_Options_Manager::reader_theme_fallback_notice() */


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5925

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
