### PR TITLE
Escape instances of '</style>' as '<\/style>' in parsed (external) stylesheets

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1561,7 +1561,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$parsed         = null;
 		$cache_key      = null;
 		$cached         = true;
-		$cache_group    = 'amp-parsed-stylesheet-v34'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group    = 'amp-parsed-stylesheet-v35'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 		$use_transients = $this->should_use_transient_caching();
 
 		$cache_impacting_options = array_merge(
@@ -1954,7 +1954,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			$split_stylesheet = preg_split( $pattern, $stylesheet_string, -1, PREG_SPLIT_DELIM_CAPTURE );
-			$length           = count( $split_stylesheet );
+
+			// Ensure all instances of </style> are escaped as <\/style> (such as can occur in SVG data: URLs) to prevent
+			// the inline style from prematurely closing style[amp-custom].
+			$split_stylesheet = str_replace( '</style>', '<\/style>', $split_stylesheet, $count );
+
+			$length = count( $split_stylesheet );
 			for ( $i = 0; $i < $length; $i++ ) {
 				// Skip empty tokens.
 				if ( '' === $split_stylesheet[ $i ] ) {

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1818,18 +1818,21 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'external_file' => [
 				'https://stylesheets.example.com/style.css',
 				'text/css',
-				'html{background-color:lightblue}',
+				'html { background-color: lightblue; } body::after { content:"This body has no </style>." }',
+				'html{background-color:lightblue}body::after{content:"This body has no <\/style>."}',
 				[],
 			],
 			'external_file_schemeless' => [
 				'//stylesheets.example.com/style.css',
 				'text/css',
-				'html{background-color:lightblue}',
+				'html { background-color: lightblue; background-image: url("data:image/svg+xml;utf8,<svg xmlns=\\\'http://www.w3.org/2000/svg\\\' version=\\\'1.1\\\' viewBox=\\\'0 0 30 30\\\' width=\\\'30\\\' height=\\\'30\\\'><defs><style>circle{fill:red}</style></defs><circle cx=\\\'15\\\' cy=\\\'15\\\' r=\\\'15\\\'/></svg>" ); }',
+				'html{background-color:lightblue;background-image:url("data:image/svg+xml;utf8,<svg xmlns=\\\'http://www.w3.org/2000/svg\\\' version=\\\'1.1\\\' viewBox=\\\'0 0 30 30\\\' width=\\\'30\\\' height=\\\'30\\\'><defs><style>circle{fill:red}<\/style></defs><circle cx=\\\'15\\\' cy=\\\'15\\\' r=\\\'15\\\'/></svg>")}',
 				[],
 			],
 			'dynamic_file' => [
 				set_url_scheme( add_query_arg( 'action', 'kirki-styles', home_url() ), 'http' ),
 				'text/css',
+				'body{color:red}',
 				'body{color:red}',
 				[],
 			],
@@ -1837,12 +1840,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				home_url( '/style.css' ),
 				'text/css',
 				'body{color:green}',
+				'body{color:green}',
 				[],
 			],
 			'not_css_file' => [
 				home_url( '/this.is.not.css' ),
 				'image/jpeg',
 				'JPEG...',
+				null,
 				[ AMP_Style_Sanitizer::STYLESHEET_FETCH_ERROR ],
 			],
 		];
@@ -1857,9 +1862,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string $href                 Request URL.
 	 * @param string $content_type         Content type.
 	 * @param string $response_body        Response body.
+	 * @param string $expected_stylesheet  Expected stylesheet.
 	 * @param array  $expected_error_codes Error codes when getting the stylesheet.
 	 */
-	public function test_external_stylesheet_handling( $href, $content_type, $response_body, $expected_error_codes ) {
+	public function test_external_stylesheet_handling( $href, $content_type, $response_body, $expected_stylesheet, $expected_error_codes ) {
 		$request_count = 0;
 		add_filter(
 			'pre_http_request',
@@ -1909,8 +1915,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, $request_count, 'Expected HTTP request.' );
 
 		if ( empty( $expected_error_codes ) ) {
-			$this->assertCount( 1, $actual_stylesheets ); // @todo Change
-			$this->assertEquals( $response_body, $actual_stylesheets[0] );
+			$this->assertCount( 1, $actual_stylesheets );
+			$this->assertEquals( $expected_stylesheet, $actual_stylesheets[0] );
 		} else {
 			$this->assertEquals( $expected_error_codes, $found_error_codes );
 			$this->assertCount( 0, $actual_stylesheets );


### PR DESCRIPTION
## Summary

This addresses an issue that was discovered in https://github.com/Automattic/jetpack/issues/18714. An external stylesheet may include a `background-image` that has an SVG defined as a data: URL as follows:

```css
 .mejs-button.mejs-jump-button > button { 
 	background-image: url( 'data:image/svg+xml;utf8,<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60.78 35.3"><defs><style>.cls-1{fill-rule:evenodd;}</style></defs><title>testsprite</title><g id="layer1"><g id="mask0"><path id="path44" class="cls-1" d="M42.49,6.27v3.87a7.72,7.72,0,1,1-7.68,7.72h1.92a5.77,5.77,0,1,0,5.76-5.79v3.86l-4.8-4.83Zm-1,10.36-.24,2.1.65.15,0,0a.46.46,0,0,1,.07-.07s0,0,.06,0l.06,0,.14-.05.19,0a.79.79,0,0,1,.29.05.48.48,0,0,1,.2.14.65.65,0,0,1,.13.23,1,1,0,0,1,0,.3h0a1,1,0,0,1,0,.3.9.9,0,0,1-.11.24.46.46,0,0,1-.17.17.5.5,0,0,1-.26.06.6.6,0,0,1-.4-.15.56.56,0,0,1-.19-.39h-.8a1.2,1.2,0,0,0,.12.51,1.12,1.12,0,0,0,.31.37,1.45,1.45,0,0,0,.44.24,2.24,2.24,0,0,0,.51.07,1.91,1.91,0,0,0,.62-.11,1.33,1.33,0,0,0,.43-.3,1.39,1.39,0,0,0,.26-.44,1.46,1.46,0,0,0,.08-.52,2.14,2.14,0,0,0-.08-.58,1.05,1.05,0,0,0-.64-.7,1.21,1.21,0,0,0-.52-.1l-.2,0-.08,0-.09,0a.38.38,0,0,0-.14.05l0,0s0,0-.06,0l.11-.89h1.63v-.69Z"/></g><g id="g34"><g id="g32"><path id="path26" d="M23.81,17.58a6,6,0,1,1-6-6v4l5-5-5-5v4a8,8,0,1,0,8,8Z"/><path id="path28" d="M15.87,20a.57.57,0,0,1-.62-.54H14.4a1.3,1.3,0,0,0,1.45,1.23c.87,0,1.51-.46,1.51-1.25a1,1,0,0,0-.71-1,1.06,1.06,0,0,0,.65-.92c0-.21-.05-1.22-1.44-1.22a1.27,1.27,0,0,0-1.4,1.16h.85a.58.58,0,0,1,1.15.06.56.56,0,0,1-.63.59h-.46v.66h.45c.65,0,.7.42.7.64A.58.58,0,0,1,15.87,20Z"/><path id="path30" d="M19.66,16.26c-.14,0-1.44-.08-1.44,1.82v.74c0,1.9,1.31,1.82,1.44,1.82s1.44.09,1.44-1.82v-.74C21.11,16.17,19.8,16.26,19.66,16.26Zm.6,2.67c0,.77-.21,1-.59,1s-.6-.26-.6-1V18c0-.75.22-1,.59-1s.6.26.6,1Z"/></g></g></g></svg>' ); 
 	background-size: 60.78px 35.296px; 
 } 
```

Notice that the SVG includes an inline style which is involves `</style>`. If this stylesheet is parsed and added to the `style[amp-custom]` as is, then it will cause the stylesheet to unexpectedly get truncated and CSS text content to appear in the page. To prevent this from happening, any instance of `</style>` needs to be escaped as `<\/style>`. This is similar to what `json_encode()` does when printing `</script>` as `<\/script>` unless `JSON_UNESCAPED_SLASHES` is passed.

Before | After
--------|-----
<img width="684" alt="Screen Shot 2021-03-02 at 15 05 07" src="https://user-images.githubusercontent.com/134745/109727212-c5c88480-7b68-11eb-970c-528dc235b189.png"> | <img width="683" alt="Screen Shot 2021-03-02 at 15 05 25" src="https://user-images.githubusercontent.com/134745/109727219-c7924800-7b68-11eb-9301-83a1aa315e23.png">

See test case plugin: https://gist.github.com/westonruter/35959595840823f77e4f85e584578bc3

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
