### PR TITLE
Sanitize keys in Server-Timing instead of adding slashes for escaping

### DIFF
--- a/src/Instrumentation/Event.php
+++ b/src/Instrumentation/Event.php
@@ -97,7 +97,7 @@ class Event {
 	}
 
 	/**
-	 * Sanitize key.
+	 * Sanitize key to use it for an HTTP header label (alphanumeric and dashes/underscores only).
 	 *
 	 * @param string $key Unsanitized key.
 	 * @return string Sanitized key.

--- a/src/Instrumentation/Event.php
+++ b/src/Instrumentation/Event.php
@@ -103,7 +103,7 @@ class Event {
 	 * @return string Sanitized key.
 	 */
 	private function sanitize_key( $key ) {
-		return preg_replace( '/\W+/', '_', $key );
+		return preg_replace( '/[^a-zA-Z0-9_-]+/', '_', $key );
 	}
 
 	/**

--- a/src/Instrumentation/Event.php
+++ b/src/Instrumentation/Event.php
@@ -97,6 +97,16 @@ class Event {
 	}
 
 	/**
+	 * Sanitize key.
+	 *
+	 * @param string $key Unsanitized key.
+	 * @return string Sanitized key.
+	 */
+	private function sanitize_key( $key ) {
+		return preg_replace( '/\W+/', '_', $key );
+	}
+
+	/**
 	 * Get the server timing header string.
 	 *
 	 * @return string Server timing header string representing this event.
@@ -108,19 +118,19 @@ class Event {
 			if ( is_float( $value ) ) {
 				$property_strings[] = sprintf(
 					';%s="%.1f"',
-					addslashes( $property ),
+					$this->sanitize_key( $property ),
 					$value
 				);
 			} else {
 				$property_strings[] = sprintf(
 					';%s="%s"',
-					addslashes( $property ),
+					$this->sanitize_key( $property ),
 					addslashes( $value )
 				);
 			}
 		}
 
-		$event_string = addslashes( $this->get_name() );
+		$event_string = $this->sanitize_key( $this->get_name() );
 
 		$description = $this->get_description();
 		if ( ! empty( $description ) ) {

--- a/src/Instrumentation/ServerTiming.php
+++ b/src/Instrumentation/ServerTiming.php
@@ -158,7 +158,7 @@ final class ServerTiming implements Service, Registerable, Delayed {
 		return implode(
 			',',
 			array_map(
-				static function ( $event ) {
+				static function ( Event $event ) {
 					return $event->get_header_string();
 				},
 				$this->events


### PR DESCRIPTION
## Summary

When a sanitizer class is namespaced and verbose server-timing is enabled (via `/?amp_verbose_server_timing=1`), the server Timing rows will include properties that include escaped backslashes, for example with [AMP Auto-Lightbox Disable](https://gist.github.com/westonruter/b6691407af1648b402b09371a9faf7f0): `google\\amp_auto_lightbox_disable\\sanitizer;dur="0.0"`. This ends up breaking the display of Timing data in Chrome DevTools. So this PR sanitizes the key by replacing any non-word characters with underscores.

Given a `Server-Timing` header that contains values like this (with commas replaced by newlines):

```
amp_dom_parse;dur="10.1"
amp_sanitizer;dur="432.5"
amp_dev_mode_sanitizer;dur="0.8"
amp_embed_sanitizer;dur="0.6"
amp_core_theme_sanitizer;dur="0.6"
amp_srcset_sanitizer;dur="0.1"
amp_img_sanitizer;dur="0.3"
amp_form_sanitizer;dur="0.2"
amp_comments_sanitizer;dur="0.2"
amp_video_sanitizer;dur="0.0"
amp_o2_player_sanitizer;dur="0.1"
amp_audio_sanitizer;dur="0.0"
amp_playbuzz_sanitizer;dur="0.2"
amp_iframe_sanitizer;dur="0.0"
amp_gallery_block_sanitizer;dur="0.1"
amp_block_sanitizer;dur="0.0"
amp_script_sanitizer;dur="0.1"
amp_accessibility_sanitizer;dur="0.3"
amp_link_sanitizer;dur="2.8"
google\\amp_auto_lightbox_disable\\sanitizer;dur="0.0"
amp_layout_sanitizer;dur="0.3"
amp_style_sanitizer;dur="408.5"
amp_parse_css;dur="365.1"
amp_shake_css;dur="7.9"
amp_meta_sanitizer;dur="0.2"
amp_tag_and_attribute_sanitizer;dur="16.2"
amp_dom_serialize;dur="8.7"
amp_optimizer;dur="7.7"
```

Before | After
-------|------
<img width="431" alt="Screen Shot 2021-03-03 at 12 46 15" src="https://user-images.githubusercontent.com/134745/109872606-7f832c00-7c21-11eb-9034-c58cf72b2884.png"> | <img width="529" alt="Screen Shot 2021-03-03 at 13 03 33" src="https://user-images.githubusercontent.com/134745/109872612-814cef80-7c21-11eb-977a-edfb0c0d9ba5.png">

Notice how before the timing gets truncated at `google`.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
