### PR TITLE
Utilize wp_print_inline_script_tag() to print mobile redirection script

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,7 @@ parameters:
 		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/pwa.php
 		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/twentyseventeen.php
 		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/legacy-i18n.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/wordpress-stubs-57.php
 		- %currentWorkingDirectory%/vendor/autoload.php
 		- %currentWorkingDirectory%/amp.php
 		- %currentWorkingDirectory%/includes/amp-frontend-actions.php

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -416,7 +416,63 @@ final class MobileRedirection implements Service, Registerable {
 
 		$source = preg_replace( '/\bAMP_MOBILE_REDIRECTION\b/', wp_json_encode( $exports ), $source );
 
-		printf( '<script>%s</script>', $source ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( function_exists( 'wp_print_inline_script_tag' ) ) {
+			wp_print_inline_script_tag( $source );
+		} else {
+			echo $this->get_inline_script_tag( $source ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
+
+	/**
+	 * Wraps inline JavaScript in `<script>` tag.
+	 *
+	 * This is copied from WordPress 5.7, the version in which it was introduced.
+	 *
+	 * @see wp_get_inline_script_tag()
+	 *
+	 * @param string $javascript Inline JavaScript code.
+	 * @param array  $attributes  Optional. Key-value pairs representing `<script>` tag attributes.
+	 * @return string String containing inline JavaScript code wrapped around `<script>` tag.
+	 */
+	private function get_inline_script_tag( $javascript, $attributes = [] ) {
+		if ( ! isset( $attributes['type'] ) && ! is_admin() && ! current_theme_supports( 'html5', 'script' ) ) {
+			$attributes['type'] = 'text/javascript';
+		}
+
+		/** This filter is documented in wp-includes/script-loader.php */
+		$attributes = apply_filters( 'wp_inline_script_attributes', $attributes, $javascript );
+
+		$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
+
+		return sprintf( "<script%s>%s</script>\n", $this->sanitize_script_attributes( $attributes ), $javascript );
+	}
+
+	/**
+	 * Sanitizes an attributes array into an attributes string to be placed inside a `<script>` tag.
+	 *
+	 * This is copied from WordPress 5.7, the version in which it was introduced.
+	 *
+	 * @see wp_sanitize_script_attributes()
+	 *
+	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+	 * @return string String made of sanitized `<script>` tag attributes.
+	 */
+	private function sanitize_script_attributes( $attributes ) {
+		$html5_script_support = ! is_admin() && ! current_theme_supports( 'html5', 'script' );
+		$attributes_string    = '';
+
+		// If HTML5 script tag is supported, only the attribute name is added
+		// to $attributes_string for entries with a boolean value, and that are true.
+		foreach ( $attributes as $attribute_name => $attribute_value ) {
+			if ( is_bool( $attribute_value ) ) {
+				if ( $attribute_value ) {
+					$attributes_string .= $html5_script_support ? sprintf( ' %1$s="%2$s"', esc_attr( $attribute_name ), esc_attr( $attribute_name ) ) : ' ' . $attribute_name;
+				}
+			} else {
+				$attributes_string .= sprintf( ' %1$s="%2$s"', esc_attr( $attribute_name ), esc_attr( $attribute_value ) );
+			}
+		}
+		return $attributes_string;
 	}
 
 	/**

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -485,7 +485,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		ob_start();
 		$this->instance->add_mobile_redirect_script();
 		$output = ob_get_clean();
-		$this->assertRegExp( '#<script\b[^>]*>#', $output );
+		$this->assertStringContains( '<script type="text/javascript">', $output );
 		$this->assertStringContains( 'noampQueryVarName', $output );
 
 		add_filter(

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -476,13 +476,33 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		$this->assertArrayNotHasKey( MobileRedirection::DISABLED_STORAGE_KEY, $_COOKIE );
 	}
 
-	/** @covers ::add_mobile_redirect_script() */
+	/**
+	 * @covers ::add_mobile_redirect_script()
+	 * @covers ::get_inline_script_tag()
+	 * @covers ::sanitize_script_attributes()
+	 */
 	public function test_add_mobile_redirect_script() {
 		ob_start();
 		$this->instance->add_mobile_redirect_script();
 		$output = ob_get_clean();
+		$this->assertRegExp( '#<script\b[^>]*>#', $output );
+		$this->assertStringContains( 'noampQueryVarName', $output );
 
-		$this->assertStringContains( '<script>', $output );
+		add_filter(
+			'wp_inline_script_attributes',
+			function ( $attributes, $source ) {
+				if ( false !== strpos( $source, 'amp_mobile_redirect_disabled' ) ) {
+					$attributes['data-cfasync'] = 'false';
+				}
+				return $attributes;
+			},
+			10,
+			2
+		);
+		ob_start();
+		$this->instance->add_mobile_redirect_script();
+		$output = ob_get_clean();
+		$this->assertRegExp( '#<script\b[^>]*? data-cfasync="false"[^>]*>#', $output );
 		$this->assertStringContains( 'noampQueryVarName', $output );
 	}
 

--- a/tests/php/static-analysis-stubs/wordpress-stubs-57.php
+++ b/tests/php/static-analysis-stubs/wordpress-stubs-57.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Prints inline JavaScript wrapped in `<script>` tag.
+ *
+ * It is possible to inject attributes in the `<script>` tag via the  {@see 'wp_script_attributes'}  filter.
+ * Automatically injects type attribute if needed.
+ *
+ * @since 5.7.0
+ *
+ * @param string $javascript Inline JavaScript code.
+ * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
+ */
+function wp_print_inline_script_tag( $javascript, $attributes = [] ) {}


### PR DESCRIPTION
## Summary

In order to allow plugins to add attributes to the `script` tag that is emitted for mobile redirection, we can utilize the [new `wp_print_inline_script_tag()` function](https://make.wordpress.org/core/2021/02/23/introducing-script-attributes-related-functions-in-wordpress-5-7/) in WordPress 5.7. This function allows the attributes to be modified by the `wp_inline_script_attributes` filter. If the function is not defined, then we can polyfill it.

In order to add `data-cfasync="false"` to the mobile redirection `script`, this PHP filter code can then be used:

```php
add_filter( 'wp_inline_script_attributes', function ( $attributes, $source ) {
	if ( false !== strpos( $source, 'amp_mobile_redirect_disabled' ) ) {
		$attributes['data-cfasync'] = 'false';
	}
	return $attributes;
}, 10, 2 );
```

Fixes #5942

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
