### PR TITLE
Prevent possible PHP Notice from occuring when global `$post` is null when editing a post

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -211,7 +211,7 @@ class AMP_Post_Meta_Box {
 	 */
 	public function enqueue_block_assets() {
 		$post = get_post();
-		if ( ! in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true ) ) {
+		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

With the plugin:

```php
<?php
/**
 * Plugin Name: I love crashing the editor
 */

add_action( 'enqueue_block_editor_assets', function () {
	global $post;
	$post = null;
}, 9 );
```

The following PHP notice can be observed when attempting to edit a post:

```
[09-Mar-2021 03:54:02 UTC] PHP Notice:  Trying to get property 'post_type' of non-object in /app/public/content/plugins/amp/includes/admin/class-amp-post-meta-box.php on line 21
```

This was discovered while performing QA on #5871.

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
