### PR TITLE
Use escaped translation functions in PluginRowMeta

### DIFF
--- a/src/Admin/PluginRowMeta.php
+++ b/src/Admin/PluginRowMeta.php
@@ -49,8 +49,8 @@ final class PluginRowMeta implements Delayed, Service, Registerable {
 		}
 
 		$additional_meta = [
-			'<a href="https://wordpress.org/support/plugin/amp/" target="_blank" rel="noreferrer noopener">' . __( 'Contact support', 'amp' ) . '</a>',
-			'<a href="https://wordpress.org/support/plugin/amp/reviews/#new-post" target="_blank" rel="noreferrer noopener">' . __( 'Leave review', 'amp' ) . '</a>',
+			'<a href="https://wordpress.org/support/plugin/amp/" target="_blank" rel="noreferrer noopener">' . esc_html__( 'Contact support', 'amp' ) . '</a>',
+			'<a href="https://wordpress.org/support/plugin/amp/reviews/#new-post" target="_blank" rel="noreferrer noopener">' . esc_html__( 'Leave review', 'amp' ) . '</a>',
 		];
 
 		return array_merge( $meta, $additional_meta );


### PR DESCRIPTION
## Summary

Amends #5924 for #5893.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
