### PR TITLE
Local env: Ensure default database is created for WP to be installed

### DIFF
--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
-      MYSQL_DATABASE: wordpress_test
+      MYSQL_DATABASE: wordpress
 
 volumes:
   wordpress_data:

--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
-    image: wordpress
+    image: wordpress:5.6
     ports:
       - "127.0.0.1:8890:80"
     environment:
@@ -36,7 +36,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
-      MYSQL_DATABASE: wordpress
+      MYSQL_DATABASE: wordpress_test
 
 volumes:
   wordpress_data:


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
This fixes the [recent CI E2E job failure](https://github.com/ampproject/amp-wp/runs/2083758914#step:11:638) where the Docker environment fails to start because of WordPress not being able to be installed, due to the database `wordpress` not being created. It turns out the Docker image `wordpress` has been creating this default database all this time, until [recently](https://github.com/docker-library/wordpress/pull/572/files?file-filters%5B%5D=.php&file-filters%5B%5D=.sh&file-filters%5B%5D=.template&file-filters%5B%5D=No+extension&hide-deleted-files=true#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aL263).

~This PR ensures the `wordpress` database is made available by updating the `MYSQL_DATABASE` environment variable on the `mysql` container to `wordpress` (which would then create the database of said name when the `mysql` container starts), and also waiting for the `mysql` container is to accept connections before installing WordPress.~

This PR downgrades the WP image to 5.6 for now until there is a better way of using the latest image.  Otherwise we would have to to build our own WP image to wait on the `mysql` container to fully start and create the needed DB.