### PR TITLE
2021 theme: Make dark mode selector more specific to override light mode CSS properties

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2040,7 +2040,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$new_styles = str_replace( '@media only screen', '@media only screen and (prefers-color-scheme: dark)', $styles );
 				// Allow for rules to override the light theme related rules.
 				$new_styles = str_replace( '.is-dark-theme.is-dark-theme', ':root', $new_styles );
-				$new_styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference body', $new_styles );
+				$new_styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference:not(#_) body', $new_styles );
 
 				wp_add_inline_style( $theme_style_handle, $new_styles );
 			},

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2040,7 +2040,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$new_styles = str_replace( '@media only screen', '@media only screen and (prefers-color-scheme: dark)', $styles );
 				// Allow for rules to override the light theme related rules.
 				$new_styles = str_replace( '.is-dark-theme.is-dark-theme', ':root', $new_styles );
-				$new_styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference:not(#_) body', $new_styles );
+				$new_styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference:not(._) body', $new_styles );
 
 				wp_add_inline_style( $theme_style_handle, $new_styles );
 			},

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -475,7 +475,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$replacements = [
 			'@media only screen'           => '@media only screen and (prefers-color-scheme: dark)',
 			'.is-dark-theme.is-dark-theme' => ':root',
-			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference body',
+			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference:not(#_) body',
 		];
 		foreach ( $replacements as $search => $replacement ) {
 			$this->assertStringNotContains( "$search {", $after );

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -475,7 +475,7 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$replacements = [
 			'@media only screen'           => '@media only screen and (prefers-color-scheme: dark)',
 			'.is-dark-theme.is-dark-theme' => ':root',
-			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference:not(#_) body',
+			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference:not(._) body',
 		];
 		foreach ( $replacements as $search => $replacement ) {
 			$this->assertStringNotContains( "$search {", $after );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5975

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
