### PR TITLE
Avoid failing validation requests when response is redirect

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1813,7 +1813,7 @@ class AMP_Theme_Support {
 			// since \AMP_Validation_Manager::validate_url() follows redirects.
 			$sent_location_header = false;
 			foreach ( headers_list() as $sent_header ) {
-				if ( preg_match( '#^location:#i', $sent_header, $matches ) ) {
+				if ( preg_match( '#^location:#i', $sent_header ) ) {
 					$sent_location_header = true;
 					break;
 				}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1809,7 +1809,18 @@ class AMP_Theme_Support {
 				$response
 			)
 		) ) {
-			if ( AMP_Validation_Manager::$is_validate_request ) {
+			// Detect whether redirect happened and prevent failing a validation request when that happens,
+			// since \AMP_Validation_Manager::validate_url() follows redirects.
+			$sent_location_header = false;
+			foreach ( headers_list() as $sent_header ) {
+				if ( preg_match( '#^location:#i', $sent_header, $matches ) ) {
+					$sent_location_header = true;
+					break;
+				}
+			}
+			$did_redirect = $status_code >= 300 && $status_code < 400 && $sent_location_header;
+
+			if ( AMP_Validation_Manager::$is_validate_request && ! $did_redirect ) {
 				if ( ! headers_sent() ) {
 					status_header( 400 );
 					header( 'Content-Type: application/json; charset=utf-8' );

--- a/src/Infrastructure/ServiceBasedPlugin.php
+++ b/src/Infrastructure/ServiceBasedPlugin.php
@@ -293,7 +293,7 @@ abstract class ServiceBasedPlugin implements Plugin {
 
 		$this->service_container->put( $id, $service );
 
-		if ( $service instanceof CliCommand && is_callable( $service ) && defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( $service instanceof CliCommand && defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( $service::get_command_name(), $service );
 		}
 


### PR DESCRIPTION
## Summary

This fixes a regression introduced by ae367696fb8daa7049cd22c3e1c128081580df31 in #5296 whereby a validation request returned JSON error data if the response was not an AMP page. An exception is needed for when the response is not an AMP page and yet is an HTTP redirect. The `\AMP_Validation_Manager::validate_url()` follows redirects, so we should allow redirects to pass through. 

I discovered this when trying to do `wp amp validation run --limit=1 --include=is_date` which resulted in:

> Warning: Validate URL error (RENDERED_PAGE_NOT_AMP): The requested URL did not result in an AMP page being rendered. URL: https://wordpressdev.lndo.site/?year=2021

This fixes that problem by allowing the request for `https://wordpressdev.lndo.site/?year=2021` to redirect to `https://wordpressdev.lndo.site/2021/`.

Also amends #6063 by undoing erroneous addition of is_callable() check in d0d2137.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
