### PR TITLE
Replace Codecov bash uploader with GHA counterpart

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -237,9 +237,14 @@ jobs:
           CI: true
 
       - name: Run unit tests (with coverage)
-        run: |
-          npm run test:js -- --ci --cacheDirectory="$HOME/.jest-cache" --collectCoverage
-          bash <(curl -s https://codecov.io/bash) -cF javascript -f build/logs/lcov.info
+        run: npm run test:js -- --ci --cacheDirectory="$HOME/.jest-cache" --collectCoverage
+
+      - name: Upload code coverage report
+        uses: codecov/codecov-action@v1.4.0
+        with:
+          file: build/logs/lcov.info
+          flags: javascript
+          fail_ci_if_error: true
 
 #-----------------------------------------------------------------------------------------------------------------------
 
@@ -471,10 +476,16 @@ jobs:
 
       - name: Run tests with coverage
         if: ${{ matrix.coverage == true }}
-        run: |
-          vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-          bash <(curl -s https://codecov.io/bash) -cF php -f "$PWD/build/logs/clover.xml"
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
         working-directory: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp
+
+      - name: Upload code coverage report
+        if: ${{ matrix.coverage == true }}
+        uses: codecov/codecov-action@v1.4.0
+        with:
+          file: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp/build/logs/clover.xml
+          flags: php
+          fail_ci_if_error: true
 
       - name: Run external HTTP tests
         if: ${{ matrix.external-http == true }}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
As of [v1.4.0](https://github.com/codecov/codecov-action/releases/tag/v1.4.0) the Codecov GHA calculates and verifies the checksum of the bash script used to upload code coverage reports.

This should help to prevent executing any unauthorized code if the bash script were to ever be compromised again (see https://about.codecov.io/security-update/).

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
