### PR TITLE
Add full frontend request processing (broken)

### DIFF
--- a/src/Cli/OptimizerCommand.php
+++ b/src/Cli/OptimizerCommand.php
@@ -32,6 +32,11 @@ final class OptimizerCommand implements Service, CliCommand {
 	private $optimizer_service;
 
 	/**
+	 * @var WordPressFrontendLoader
+	 */
+	private $frontend_loader;
+
+	/**
 	 * Get the name under which to register the CLI command.
 	 *
 	 * @return string The name under which to register the CLI command.
@@ -43,10 +48,12 @@ final class OptimizerCommand implements Service, CliCommand {
 	/**
 	 * OptimizerCommand constructor.
 	 *
-	 * @param OptimizerService $optimizer_service Optimizer service instance to use.
+	 * @param OptimizerService        $optimizer_service Optimizer service instance to use.
+	 * @param WordPressFrontendLoader $frontend_loader   Frontend loader object instance to use.
 	 */
-	public function __construct( OptimizerService $optimizer_service ) {
+	public function __construct( OptimizerService $optimizer_service, WordPressFrontendLoader $frontend_loader ) {
 		$this->optimizer_service = $optimizer_service;
+		$this->frontend_loader   = $frontend_loader;
 	}
 
 	/**
@@ -62,11 +69,16 @@ final class OptimizerCommand implements Service, CliCommand {
 	 * # Test <amp-img> SSR transformations and store them in a new file named 'output.html'.
 	 * $ echo '<amp-img src="image.jpg" width="500" height="500">' | wp amp optimizer optimize > output.html
 	 *
+	 * @when before_wp_load
+	 *
 	 * @param array $args       Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
 	 * @throws WP_CLI\ExitException If the requested file could not be read.
 	 */
 	public function optimize( $args, /** @noinspection PhpUnusedParameterInspection */ $assoc_args ) {
+		// Load a full frontend request to ensure all filters can be processed.
+		$this->frontend_loader->run();
+
 		$file = '-';
 
 		if ( count( $args ) > 0 ) {

--- a/src/Cli/TransformerCommand.php
+++ b/src/Cli/TransformerCommand.php
@@ -14,7 +14,6 @@ use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\Optimizer\Configuration;
 use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
 use WP_CLI;
-use WP_CLI\Utils;
 
 /**
  * Commands that deal with the transformers registered with the AMP optimizer.
@@ -30,6 +29,11 @@ final class TransformerCommand implements Service, CliCommand {
 	private $configuration;
 
 	/**
+	 * @var WordPressFrontendLoader
+	 */
+	private $frontend_loader;
+
+	/**
 	 * Get the name under which to register the CLI command.
 	 *
 	 * @return string The name under which to register the CLI command.
@@ -41,10 +45,12 @@ final class TransformerCommand implements Service, CliCommand {
 	/**
 	 * TransformerCommand constructor.
 	 *
-	 * @param Configuration $configuration Configuration object instance to use.
+	 * @param Configuration           $configuration   Configuration object instance to use.
+	 * @param WordPressFrontendLoader $frontend_loader Frontend loader object instance to use.
 	 */
-	public function __construct( Configuration $configuration ) {
-		$this->configuration = $configuration;
+	public function __construct( Configuration $configuration, WordPressFrontendLoader $frontend_loader ) {
+		$this->configuration   = $configuration;
+		$this->frontend_loader = $frontend_loader;
 	}
 
 	/**
@@ -85,16 +91,15 @@ final class TransformerCommand implements Service, CliCommand {
 	 * +----------------------+--------+
 	 *
 	 * @subcommand list
+	 * @when before_wp_load
 	 *
 	 * @param array $args       Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
 	 * @throws WP_CLI\ExitException If the requested file could not be read.
 	 */
 	public function list_( $args, $assoc_args ) {
-		$strict = Utils\get_flag_value( $assoc_args, 'strict' );
-		if ( $strict && empty( $args ) ) {
-			WP_CLI::error( 'The --strict option can only be used in combination with a filter.' );
-		}
+		// Load a full frontend request to ensure all filters can be processed.
+		$this->frontend_loader->run();
 
 		$default_fields = [
 			'transformer',
@@ -186,11 +191,16 @@ final class TransformerCommand implements Service, CliCommand {
 	 * $ wp amp optimizer transformer config AmpRuntimeCss --format=json
 	 * {"canary":false,"styles":"","version":""}
 	 *
+	 * @when before_wp_load
+	 *
 	 * @param array $args       Array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
 	 * @throws WP_CLI\ExitException If the requested file could not be read.
 	 */
 	public function config( $args, $assoc_args ) {
+		// Load a full frontend request to ensure all filters can be processed.
+		$this->frontend_loader->run();
+
 		$transformer       = array_shift( $args );
 		$transformer_class = $this->deduce_transformer_class( $transformer );
 

--- a/src/Cli/WordPressFrontendLoader.php
+++ b/src/Cli/WordPressFrontendLoader.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class WordPressFrontendLoader.
+ *
+ * Run a full WordPress frontend request.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\Cli;
+
+use WP_CLI;
+
+/**
+ * Run a full WordPress frontend request.
+ *
+ * @package AmpProject\AmpWP\Cli
+ */
+final class WordPressFrontendLoader {
+
+	/**
+	 * Runs through the entirety of the WP bootstrap process.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		// Bail early if WordPress already ran once.
+		if ( function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		WP_CLI::get_runner()->load_wordpress();
+
+		// Set up 'main_query' main WordPress query.
+		wp();
+
+		// Enable theme support.
+		define( 'WP_USE_THEMES', true );
+
+		// Template is normally loaded in global scope, so we need to replicate.
+		foreach ( $GLOBALS as $key => $value ) {
+			global ${$key}; // phpcs:ignore PHPCompatibility.Variables.ForbiddenGlobalVariableVariable.NonBareVariableFound
+		}
+
+		// Load the theme template.
+		ob_start();
+		require_once ABSPATH . WPINC . '/template-loader.php';
+		ob_get_clean();
+	}
+}


### PR DESCRIPTION
## Summary

This PR is meant to fix the AMP CLI commands in that they would need to simulate a full frontend request under the `'cli'` SAPI to ensure that all actions and filters are triggered that might impact the optimizer and its configuration.

However, it seems that this is not easily possible if the WP-CLI commands are integrated into the plugin, as the files of the plugin are only loaded _after_ WordPress has already loaded (without a theme in the context of `'cli'`).

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
