### PR TITLE
Prevent paired browsing client script from being sanitized

### DIFF
--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -191,7 +191,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional {
 		// Mark enqueued script for AMP dev mode so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
 		$dev_mode_handles = array_merge(
-			[ $handle, 'wp-i18n' ],
+			[ $handle, 'wp-i18n', 'wp-hooks' ],
 			$dependencies
 		);
 		add_filter(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
In Gutenberg v9.9 the `wp-i18n` script is now dependent on the `wp-hooks` script (see https://github.com/WordPress/gutenberg/pull/27966/). This has now caused a validation error to occur for the paired browsing client script as `wp-hooks` is not apart of the list of dependencies to mark with the `data-ampdevmode` attribute. This PR fixes that.

Before | After
---|---
![image](https://user-images.githubusercontent.com/16200219/115819731-03ba8a00-a3ef-11eb-8e2b-1cc160b93d36.png) | ![image](https://user-images.githubusercontent.com/16200219/115819679-e84f7f00-a3ee-11eb-9149-2bd23fc29092.png)

Aside: We may want to give higher priority to https://github.com/ampproject/amp-wp/pull/4001 since we didn't immediately catch this.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
