### PR TITLE
Support e-content in addition to entry-content as class name for h-entry content container

### DIFF
--- a/src/Optimizer/Transformer/DetermineHeroImages.php
+++ b/src/Optimizer/Transformer/DetermineHeroImages.php
@@ -38,9 +38,12 @@ final class DetermineHeroImages implements Transformer {
 	/**
 	 * XPath query to find the first entry-content.
 	 *
+	 * Note that the 'entry-content' class name is the classic form for what the h-entry spec now has as 'e-content'.
+	 *
+	 * @link https://microformats.org/wiki/h-entry
 	 * @var string
 	 */
-	const FIRST_ENTRY_CONTENT_XPATH_QUERY = ".//*[ contains( concat( ' ', normalize-space( @class ), ' ' ), ' entry-content ' ) ]";
+	const FIRST_ENTRY_CONTENT_XPATH_QUERY = ".//*[ @class ][ contains( concat( ' ', normalize-space( @class ), ' ' ), ' entry-content ' ) or contains( concat( ' ', normalize-space( @class ), ' ' ), ' e-content ' ) ]";
 
 	/**
 	 * XPath query to find an image at the beginning of entry content (including nested inside of another block).

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -66,6 +66,19 @@ final class DetermineHeroImagesTest extends WP_UnitTestCase {
 				),
 			],
 
+			'detects custom header as in document with e-content' => [
+				$input(
+					'<div class="my-header">'
+					. '<amp-img width="789" height="539" src="https://example.com/custom-header.jpg"></amp-img>'
+					. '</div><div class="h-feed"><div class="h-entry"><div class="e-content"></div></div></div>'
+				),
+				$output(
+					'<div class="my-header">'
+					. '<amp-img width="789" height="539" src="https://example.com/custom-header.jpg" data-hero-candidate></amp-img>'
+					. '</div><div class="h-feed"><div class="h-entry"><div class="e-content"></div></div></div>'
+				),
+			],
+
 			'ignores header image which was originally lazy-loaded' => [
 				$input(
 					'<header>'


### PR DESCRIPTION
## Summary

According to the [h-entry Microformats spec](https://microformats.org/wiki/h-entry#Parser_Compatibility), the `entry-content` class name is “classic”. WordPress core themes use still use the classic `entry-content` class name, but we should support the use of `e-content` as well:

> ![image](https://user-images.githubusercontent.com/134745/115932546-02667d00-a442-11eb-9783-e82298c8711a.png)

We should double-check wpdirectory.net for how common the use of `e-content` is.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
