### PR TITLE
Mark optimizer CLI commands as experimental in their docblock

### DIFF
--- a/src/Cli/OptimizerCommand.php
+++ b/src/Cli/OptimizerCommand.php
@@ -17,7 +17,11 @@ use AmpProject\Optimizer\ErrorCollection;
 use WP_CLI;
 
 /**
- * Commands that deal with the AMP optimizer.
+ * Commands that deal with the AMP optimizer. (EXPERIMENTAL)
+ *
+ * Note: The Optimizer CLI commands are to be considered experimental, as
+ * the output they produce is currently not guaranteed to be consistent
+ * with the corresponding output from the web server code path.
  *
  * @since 2.1.0
  * @internal
@@ -50,7 +54,11 @@ final class OptimizerCommand implements Service, CliCommand {
 	}
 
 	/**
-	 * Run a file through the AMP Optimizer.
+	 * Run a file through the AMP Optimizer. (EXPERIMENTAL)
+	 *
+	 * Note: The Optimizer CLI commands are to be considered experimental, as
+	 * the output they produce is currently not guaranteed to be consistent
+	 * with the corresponding output from the web server code path.
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Cli/TransformerCommand.php
+++ b/src/Cli/TransformerCommand.php
@@ -17,7 +17,11 @@ use WP_CLI;
 use WP_CLI\Utils;
 
 /**
- * Commands that deal with the transformers registered with the AMP optimizer.
+ * Commands that deal with the transformers registered with the AMP optimizer. (EXPERIMENTAL)
+ *
+ * Note: The Optimizer CLI commands are to be considered experimental, as
+ * the output they produce is currently not guaranteed to be consistent
+ * with the corresponding output from the web server code path.
  *
  * @since 2.1.0
  * @internal
@@ -48,7 +52,11 @@ final class TransformerCommand implements Service, CliCommand {
 	}
 
 	/**
-	 * List the transformers registered with the AMP Optimizer.
+	 * List the transformers registered with the AMP Optimizer. (EXPERIMENTAL)
+	 *
+	 * Note: The Optimizer CLI commands are to be considered experimental, as
+	 * the output they produce is currently not guaranteed to be consistent
+	 * with the corresponding output from the web server code path.
 	 *
 	 * ## OPTIONS
 	 *
@@ -135,7 +143,11 @@ final class TransformerCommand implements Service, CliCommand {
 	}
 
 	/**
-	 * List the configuration of a given transformer.
+	 * List the configuration of a given transformer. (EXPERIMENTAL)
+	 *
+	 * Note: The Optimizer CLI commands are to be considered experimental, as
+	 * the output they produce is currently not guaranteed to be consistent
+	 * with the corresponding output from the web server code path.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
## Summary

This adds an `(EXPERIMENTAL)` suffix to the short descriptions of the following commands:

* `amp optimizer optimize`
* `amp optimizer transformer list`
* `amp optimizer transformer config`

It also adds the following note to each of these commands:

```
Note: The Optimizer CLI commands are to be considered experimental, as
the output they produce is currently not guaranteed to be consistent
with the corresponding output from the web server code path.
```

Example screenshot:

![lando 2021-04-25 at 7 41 50 AM](https://user-images.githubusercontent.com/83631/115983683-93506c00-a59a-11eb-8a9d-66a4eec7fc96.jpeg)

Related #6089 

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
