### PR TITLE
Include `OptimizeAmpBind` among transformers omitted for SSR

### DIFF
--- a/src/Optimizer/AmpWPConfiguration.php
+++ b/src/Optimizer/AmpWPConfiguration.php
@@ -57,6 +57,7 @@ final class AmpWPConfiguration extends DefaultConfiguration {
 				$transformers,
 				[
 					Transformer\AmpRuntimeCss::class,
+					Transformer\OptimizeAmpBind::class,
 					Transformer\PreloadHeroImage::class,
 					Transformer\RewriteAmpUrls::class,
 					Transformer\ServerSideRendering::class,

--- a/tests/php/src/Validation/URLValidationRESTControllerTest.php
+++ b/tests/php/src/Validation/URLValidationRESTControllerTest.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-namespace AmpProject\AmpWP\Tests;
+namespace AmpProject\AmpWP\Tests\Validation;
 
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Noticed the issue while performing QA on #5823.

When a page has elements with bindings and SSR is disabled the page becomes invalid AMP:

![image](https://user-images.githubusercontent.com/16200219/116039057-c443a600-a659-11eb-8c4d-0da1c0a72f5b.png)

This PR adds the `OptimizeAmpBind` transformer to the list of omitted transformers when SSR is disabled.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
