### PR TITLE
Display SUMMARY marker by preventing inline display

### DIFF
--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -413,7 +413,6 @@ li.error-kept {
 }
 
 #paired-url-structure .amp-paired-url-examples summary {
-	display: inline-block;
 	padding-right: 4px;
 	user-select: none;
 }


### PR DESCRIPTION
## Summary

The "Examples" elements in the Paired URL Structure sections on the Settings page were missing the expander arrows.

It was caused by the fact that the `summary` element `display` value has been changed from the default value (`list-item`) to `inline-block`.

| Before | After |
| --- | --- |
| <img width="754" alt="Screenshot 2021-04-26 at 12 40 22" src="https://user-images.githubusercontent.com/478735/116070243-a93e5980-a68c-11eb-9cdc-482571306028.png"> | <img width="754" alt="Screenshot 2021-04-26 at 12 40 33" src="https://user-images.githubusercontent.com/478735/116070222-a3e10f00-a68c-11eb-9e6c-a9e778fc0fdd.png"> |


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
