### PR TITLE
Fix polyfill dependency issues on WP 4.9

### DIFF
--- a/src/Admin/Polyfills.php
+++ b/src/Admin/Polyfills.php
@@ -51,7 +51,7 @@ final class Polyfills implements Delayed, Service, Registerable {
 				'lodash',
 				amp_get_asset_url( 'js/vendor/lodash.js' ),
 				[],
-				'4.17.19',
+				'4.17.21',
 				true
 			);
 
@@ -62,7 +62,7 @@ final class Polyfills implements Delayed, Service, Registerable {
 		 * Polyfill dependencies that are registered in Gutenberg and WordPress 5.0.
 		 * Note that Gutenberg will override these at wp_enqueue_scripts if it is active.
 		 */
-		$handles = [ 'wp-i18n', 'wp-dom-ready', 'wp-polyfill', 'wp-url' ];
+		$handles = [ 'wp-i18n', 'wp-dom-ready', 'wp-hooks', 'wp-polyfill', 'wp-url' ];
 		foreach ( $handles as $handle ) {
 			if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
 				$asset_file   = AMP__DIR__ . "/assets/js/{$handle}.asset.php";

--- a/src/Admin/Polyfills.php
+++ b/src/Admin/Polyfills.php
@@ -83,12 +83,13 @@ final class Polyfills implements Delayed, Service, Registerable {
 			$asset_handle = 'wp-api-fetch';
 			$asset_file   = AMP__DIR__ . "/assets/js/{$asset_handle}.asset.php";
 			$asset        = require $asset_file;
+			$dependencies = $asset['dependencies'];
 			$version      = $asset['version'];
 
 			$wp_scripts->add(
 				$asset_handle,
 				amp_get_asset_url( "js/{$asset_handle}.js" ),
-				[],
+				$dependencies,
 				$version,
 				true
 			);

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -59,6 +59,9 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * Enqueue admin assets.
 	 */
 	public function enqueue_scripts() {
+		/** This action is documented in includes/class-amp-theme-support.php */
+		do_action( 'amp_register_polyfills' );
+
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSETS_HANDLE . '.asset.php';
 		$asset        = require $asset_file;
 		$dependencies = $asset['dependencies'];

--- a/tests/php/src/Admin/PolyfillsTest.php
+++ b/tests/php/src/Admin/PolyfillsTest.php
@@ -69,6 +69,7 @@ class PolyfillsTest extends WP_UnitTestCase {
 		// These should pass in WP 4.9 tests.
 		$this->assertTrue( wp_script_is( 'lodash', 'registered' ) );
 		$this->assertTrue( wp_script_is( 'wp-api-fetch', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'wp-hooks', 'registered' ) );
 		$this->assertTrue( wp_script_is( 'wp-i18n', 'registered' ) );
 		$this->assertTrue( wp_script_is( 'wp-dom-ready', 'registered' ) );
 		$this->assertTrue( wp_script_is( 'wp-polyfill', 'registered' ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,7 +160,7 @@ const customizer = {
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const BABEL_NAMESPACE = '@babel/';
-const gutenbergPackages = [ '@babel/polyfill', '@wordpress/dom-ready', '@wordpress/i18n', '@wordpress/url' ].map(
+const gutenbergPackages = [ '@babel/polyfill', '@wordpress/dom-ready', '@wordpress/i18n', '@wordpress/hooks', '@wordpress/url' ].map(
 	( packageName ) => {
 		if ( 0 !== packageName.indexOf( WORDPRESS_NAMESPACE ) && 0 !== packageName.indexOf( BABEL_NAMESPACE ) ) {
 			return null;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6100

The `wp-i18n` script now depends on `wp-hooks` (see https://github.com/WordPress/gutenberg/pull/27966), so that dependency is now polyfilled. Also, this PR ensures dependencies for the `wp-api-fetch` script are being registered, which they previously were not.

This PR also enqueues the polyfills before loading any assets for the `amp-validation-counts` handle.

## Demo

https://user-images.githubusercontent.com/16200219/116166274-2e595b00-a6ed-11eb-89fd-54389a812795.mp4


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
