### PR TITLE
Add amp_enable_ssr filter at minimum int so it can be easily overridden

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2085,7 +2085,8 @@ class AMP_Theme_Support {
 				return array_key_exists( ConfigurationArgument::ENABLE_SSR, $args )
 					? $args[ ConfigurationArgument::ENABLE_SSR ]
 					: true;
-			}
+			},
+			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		);
 
 		return Services::get( 'injector' )->make( OptimizerService::class );


### PR DESCRIPTION
## Summary

While QA'ing #6117 I was confused why I was not able to disable SSR with plugin code like:

```php
add_filter( 'amp_enable_ssr', '__return_false' );
```

The issue is that the plugin adds its own filter in `\AMP_Theme_Support::get_optimizer()` which is also at priority 10:

https://github.com/ampproject/amp-wp/blob/cca477ff9c30472488be8df841864474bc90b703/includes/class-amp-theme-support.php#L2082-L2089

In order to ensure the filtered value can be easily overridden by plugins, it should have a priority that is less than the default of 10.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
