### PR TITLE
Hide validation count in menu when on dev tools screen, dev tools is not enabled and Reader mode is enabled

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -466,8 +466,12 @@ class AMP_Validated_URL_Post_Type {
 				$menu_name_label = get_post_type_object( self::POST_TYPE_SLUG )->labels->menu_name;
 				$submenu_item[0] = $menu_name_label;
 
-				// Append markup to display a loading spinner while the unreviewed count is being fetched.
-				$submenu_item[0] .= ' <span class="awaiting-mod"><span id="new-validation-url-count" class="loading"></span></span>';
+				$dev_tools_user_access = Services::get( 'dev_tools.user_access' );
+				if ( $dev_tools_user_access->is_user_enabled() ) {
+					// Append markup to display a loading spinner while the unreviewed count is being fetched.
+					$submenu_item[0] .= ' <span class="awaiting-mod"><span id="new-validation-url-count" class="loading"></span></span>';
+				}
+
 				break;
 			}
 		}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1741,8 +1741,12 @@ class AMP_Validation_Error_Taxonomy {
 	 */
 	public static function add_admin_menu_validation_error_item() {
 		$menu_item_label = esc_html__( 'Error Index', 'amp' );
-		// Append markup to display a loading spinner while the unreviewed count is being fetched.
-		$menu_item_label .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>';
+
+		$dev_tools_user_access = Services::get( 'dev_tools.user_access' );
+		if ( $dev_tools_user_access->is_user_enabled() ) {
+			// Append markup to display a loading spinner while the unreviewed count is being fetched.
+			$menu_item_label .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>';
+		}
 
 		$post_menu_slug = 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
 		$term_menu_slug = 'edit-tags.php?taxonomy=' . self::TAXONOMY_SLUG . '&post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;

--- a/src/DevTools/UserAccess.php
+++ b/src/DevTools/UserAccess.php
@@ -9,12 +9,14 @@
 
 namespace AmpProject\AmpWP\DevTools;
 
+use AMP_Options_Manager;
+use AMP_Theme_Support;
+use AMP_Validated_URL_Post_Type;
+use AMP_Validation_Error_Taxonomy;
+use AMP_Validation_Manager;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Option;
-use AMP_Options_Manager;
-use AMP_Theme_Support;
-use AMP_Validation_Manager;
 use WP_Error;
 use WP_User;
 
@@ -88,7 +90,7 @@ final class UserAccess implements Service, Registerable {
 			 * @param bool $enabled DevTools enabled.
 			 * @param int  $user_id User ID.
 			 */
-			$enabled = (bool) apply_filters( 'amp_dev_tools_user_default_enabled', $enabled, $user->ID );
+			$enabled = apply_filters( 'amp_dev_tools_user_default_enabled', $enabled, $user->ID );
 		}
 		return rest_sanitize_boolean( $enabled );
 	}

--- a/src/DevTools/UserAccess.php
+++ b/src/DevTools/UserAccess.php
@@ -11,8 +11,6 @@ namespace AmpProject\AmpWP\DevTools;
 
 use AMP_Options_Manager;
 use AMP_Theme_Support;
-use AMP_Validated_URL_Post_Type;
-use AMP_Validation_Error_Taxonomy;
 use AMP_Validation_Manager;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;

--- a/src/DevTools/UserAccess.php
+++ b/src/DevTools/UserAccess.php
@@ -90,7 +90,7 @@ final class UserAccess implements Service, Registerable {
 			 * @param bool $enabled DevTools enabled.
 			 * @param int  $user_id User ID.
 			 */
-			$enabled = apply_filters( 'amp_dev_tools_user_default_enabled', $enabled, $user->ID );
+			$enabled = (bool) apply_filters( 'amp_dev_tools_user_default_enabled', $enabled, $user->ID );
 		}
 		return rest_sanitize_boolean( $enabled );
 	}

--- a/tests/php/src/Admin/ValidationCountsTest.php
+++ b/tests/php/src/Admin/ValidationCountsTest.php
@@ -89,7 +89,7 @@ class ValidationCountsTest extends WP_UnitTestCase {
 		$this->assertTrue( ValidationCounts::is_needed() );
 
 		// Should not be needed when in Reader mode and not on a devtools screen.
-		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] );
+		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		$this->assertFalse( ValidationCounts::is_needed() );
 
@@ -112,7 +112,7 @@ class ValidationCountsTest extends WP_UnitTestCase {
 
 		// Should be needed when not on a dev tools screen, dev tools has never been configured for the user, but is enabled through a filter.
 		add_filter( 'amp_dev_tools_user_default_enabled', '__return_true' );
-		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] );
+		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		delete_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
 		$this->assertTrue( ValidationCounts::is_needed() );
 	}

--- a/tests/php/src/Admin/ValidationCountsTest.php
+++ b/tests/php/src/Admin/ValidationCountsTest.php
@@ -7,12 +7,16 @@
 
 namespace AmpProject\AmpWP\Tests\Admin;
 
+use AMP_Options_Manager;
+use AMP_Theme_Support;
+use AMP_Validated_URL_Post_Type;
 use AmpProject\AmpWP\Admin\ValidationCounts;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Option;
 use WP_UnitTestCase;
 
 /**
@@ -79,8 +83,37 @@ class ValidationCountsTest extends WP_UnitTestCase {
 
 		$admin_user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_user->ID );
-		update_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( true ) );
 
+		// Should be needed when in Transitional mode and not on a devtools screen.
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+		$this->assertTrue( ValidationCounts::is_needed() );
+
+		// Should not be needed when in Reader mode and not on a devtools screen.
+		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] );
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		$this->assertFalse( ValidationCounts::is_needed() );
+
+		// Should not be needed when in Reader mode, user access has not been configured and on a devtools screen.
+		$_GET['post_type'] = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		$this->assertFalse( ValidationCounts::is_needed() );
+
+		// Should not be needed when in Reader mode, on a devtools screen, and dev tools is disabled for the user.
+		$_GET['post_type'] = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		update_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( false ) );
+		$this->assertFalse( ValidationCounts::is_needed() );
+
+		// Should be needed when in Reader mode, on a devtools screen, and dev tools is enabled for the user.
+		$_GET['post_type'] = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		update_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( true ) );
+		$this->assertTrue( ValidationCounts::is_needed() );
+
+		// Should be needed when not on a dev tools screen, dev tools has never been configured for the user, but is enabled through a filter.
+		add_filter( 'amp_dev_tools_user_default_enabled', '__return_true' );
+		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] );
+		delete_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
 		$this->assertTrue( ValidationCounts::is_needed() );
 	}
 }

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
@@ -123,7 +124,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::update_validated_url_menu_item()
 	 */
 	public function test_update_validated_url_menu_item() {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$admin_user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_user->ID );
 		global $submenu;
 
 		$original_submenu = $submenu;
@@ -153,7 +155,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		];
 
 		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
+		$this->assertSame( 'Validated URLs', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 
+		update_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( true ) );
+
+		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 		$this->assertSame( 'Validated URLs <span class="awaiting-mod"><span id="new-validation-url-count" class="loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 
 		$submenu = $original_submenu;

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
@@ -1005,7 +1006,22 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$original_submenu = $submenu;
 
 		AMP_Validation_Error_Taxonomy::register();
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$admin_user = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_user->ID );
+
+		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
+		$expected_submenu = [
+			'Error Index',
+			AMP_Validation_Manager::VALIDATE_CAPABILITY,
+			'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url',
+			'Error Index',
+		];
+		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
+		$this->assertEquals( $expected_submenu, end( $amp_options ) );
+
+		$submenu = $original_submenu;
+		update_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED, wp_json_encode( true ) );
+
 		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
 		$expected_submenu = [
 			'Error Index <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6120

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
