### PR TITLE
Support late-defined slugs for paired URL structures and Reader themes

### DIFF
--- a/assets/src/components/reader-theme-carousel/index.js
+++ b/assets/src/components/reader-theme-carousel/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-settings'; // From WP inline script.
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -155,25 +150,7 @@ export function ReaderThemeCarousel() {
 					hasUnavailableThemes && (
 						<AMPNotice type={ NOTICE_TYPE_INFO }>
 							<p>
-								{ AMP_QUERY_VAR_CUSTOMIZED_LATE
-								/* dangerouslySetInnerHTML reason: Injection of code tags. */
-									? (
-										<span
-											dangerouslySetInnerHTML={ {
-												__html: sprintf(
-													/* translators: 1: customized AMP query var, 2: default query var, 3: the AMP_QUERY_VAR constant name, 4: the amp_query_var filter, 5: the plugins_loaded action */
-													__( 'Some of the themes below are not available because your site (probably the active theme) has customized the AMP query var too late (it is set to %1$s as opposed to the default of %2$s). Please make sure that any customizations done by defining the %3$s constant or adding an %4$s filter are done before the %5$s action with priority 8.', 'amp' ),
-													`<code>${ AMP_QUERY_VAR }</code>`,
-													`<code>${ DEFAULT_AMP_QUERY_VAR }</code>`,
-													'<code>AMP_QUERY_VAR</code>',
-													'<code>amp_query_var</code>',
-													'<code>plugins_loaded</code>',
-												),
-											} }
-										/>
-									)
-									: __( 'Some supported themes cannot be installed automatically on this site. To use, please install them manually or contact your hosting provider.', 'amp' )
-								}
+								{ __( 'Some supported themes cannot be installed automatically on this site. To use, please install them manually or contact your hosting provider.', 'amp' ) }
 							</p>
 							<AMPSettingToggle
 								text={ __( 'Show unavailable themes', 'amp' ) }

--- a/assets/src/components/reader-theme-selection/index.js
+++ b/assets/src/components/reader-theme-selection/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { AMP_QUERY_VAR, DEFAULT_AMP_QUERY_VAR, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-settings'; // From WP inline script.
 
 /**
  * WordPress dependencies
@@ -56,25 +55,7 @@ export function ReaderThemeSelection() {
 							{ __( 'Unavailable themes', 'amp' ) }
 						</h3>
 						<p>
-							{ AMP_QUERY_VAR_CUSTOMIZED_LATE
-								/* dangerouslySetInnerHTML reason: Injection of code tags. */
-								? (
-									<span
-										dangerouslySetInnerHTML={ {
-											__html: sprintf(
-												/* translators: 1: customized AMP query var, 2: default query var, 3: the AMP_QUERY_VAR constant name, 4: the amp_query_var filter, 5: the plugins_loaded action */
-												__( 'The following themes are not available because your site (probably the active theme) has customized the AMP query var too late (it is set to %1$s as opposed to the default of %2$s). Please make sure that any customizations done by defining the %3$s constant or adding an %4$s filter are done before the %5$s action with priority 8.', 'amp' ),
-												`<code>${ AMP_QUERY_VAR }</code>`,
-												`<code>${ DEFAULT_AMP_QUERY_VAR }</code>`,
-												'<code>AMP_QUERY_VAR</code>',
-												'<code>amp_query_var</code>',
-												'<code>plugins_loaded</code>',
-											),
-										} }
-									/>
-								)
-								: __( 'The following themes are compatible but cannot be installed automatically. Please install them manually, or contact your host if you are not able to do so.', 'amp' )
-							}
+							{ __( 'The following themes are compatible but cannot be installed automatically. Please install them manually, or contact your host if you are not able to do so.', 'amp' ) }
 						</p>
 						<ul className="choose-reader-theme__grid">
 							{ unavailableThemes.map( ( theme ) => (

--- a/assets/src/components/reader-theme-selection/index.js
+++ b/assets/src/components/reader-theme-selection/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 
 /**

--- a/assets/src/components/reader-themes-context-provider/index.js
+++ b/assets/src/components/reader-themes-context-provider/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { AMP_QUERY_VAR_CUSTOMIZED_LATE, USING_FALLBACK_READER_THEME, LEGACY_THEME_SLUG } from 'amp-settings';
+import { USING_FALLBACK_READER_THEME, LEGACY_THEME_SLUG } from 'amp-settings';
 
 /**
  * Internal dependencies
@@ -282,7 +282,7 @@ export function ReaderThemesContextProvider( { wpAjaxUrl, children, currentTheme
 	const { availableThemes, unavailableThemes } = useMemo(
 		() => ( filteredThemes || [] ).reduce(
 			( collections, theme ) => {
-				if ( ( AMP_QUERY_VAR_CUSTOMIZED_LATE && theme.slug !== LEGACY_THEME_SLUG ) || theme.availability === 'non-installable' ) {
+				if ( theme.availability === 'non-installable' ) {
 					collections.unavailableThemes.push( theme );
 				} else {
 					collections.availableThemes.push( theme );

--- a/assets/src/onboarding-wizard/pages/choose-reader-theme/index.js
+++ b/assets/src/onboarding-wizard/pages/choose-reader-theme/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { LEGACY_THEME_SLUG, AMP_QUERY_VAR_CUSTOMIZED_LATE } from 'amp-settings'; // From WP inline script.
-
-/**
  * WordPress dependencies
  */
 import { useEffect, useContext } from '@wordpress/element';
@@ -35,9 +30,7 @@ export function ChooseReaderTheme() {
 			themes &&
 			readerTheme &&
 			canGoForward === false &&
-			! AMP_QUERY_VAR_CUSTOMIZED_LATE
-				? themes.map( ( { slug } ) => slug ).includes( readerTheme )
-				: readerTheme === LEGACY_THEME_SLUG
+			themes.map( ( { slug } ) => slug ).includes( readerTheme )
 		) {
 			setCanGoForward( true );
 		}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\AmpWP\Admin\ReaderThemes;
+use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
 use AmpProject\AmpWP\AmpWpPluginFactory;
 use AmpProject\AmpWP\Exception\InvalidService;
 use AmpProject\AmpWP\Icon;
@@ -532,9 +533,21 @@ function _amp_bootstrap_customizer() {
  *
  * @since 0.7
  *
+ * @param bool $ignore_late_defined_slug Whether to ignore the late defined slug.
  * @return string Slug used for query var, endpoint, and post type support.
  */
-function amp_get_slug() {
+function amp_get_slug( $ignore_late_defined_slug = false ) {
+
+	// When a slug was defined late according to AmpSlugCustomizationWatcher, the slug will be stored in the
+	// LATE_DEFINED_SLUG option by the PairedRouting service so that it can be used early. This is only needed until
+	// the after_setup_theme action fires, because at that time the late-defined slug will have been established.
+	if ( ! $ignore_late_defined_slug && ! did_action( AmpSlugCustomizationWatcher::LATE_DETERMINATION_ACTION ) ) {
+		$slug = AMP_Options_Manager::get_option( Option::LATE_DEFINED_SLUG );
+		if ( ! empty( $slug ) && is_string( $slug ) ) {
+			return $slug;
+		}
+	}
+
 	/**
 	 * Filter the AMP query variable.
 	 *

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -532,6 +532,7 @@ function _amp_bootstrap_customizer() {
  * may be deprecated in the future. Normally the slug should be just 'amp'.
  *
  * @since 0.7
+ * @since 2.1 Added $ignore_late_defined_slug argument.
  *
  * @param bool $ignore_late_defined_slug Whether to ignore the late defined slug.
  * @return string Slug used for query var, endpoint, and post type support.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -833,6 +833,7 @@ class AMP_Theme_Support {
 		if ( has_action( 'wp_head', 'print_emoji_detection_script' ) ) {
 			remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+			remove_action( 'wp_footer', 'gutenberg_the_skip_link' ); // Temporary workaround for <https://github.com/ampproject/amp-wp/issues/6115>.
 			add_action( 'wp_print_styles', [ __CLASS__, 'print_emoji_styles' ] );
 			add_filter( 'the_title', 'wp_staticize_emoji' );
 			add_filter( 'the_excerpt', 'wp_staticize_emoji' );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -60,28 +60,6 @@ class AMP_Options_Manager {
 				'sanitize_callback' => [ __CLASS__, 'validate_options' ],
 			]
 		);
-
-		add_action( 'update_option_' . self::OPTION_NAME, [ __CLASS__, 'maybe_flush_rewrite_rules' ], 10, 2 );
-	}
-
-	/**
-	 * Flush rewrite rules if the supported_post_types have changed.
-	 *
-	 * @since 0.6.2
-	 *
-	 * @param array $old_options Old options.
-	 * @param array $new_options New options.
-	 */
-	public static function maybe_flush_rewrite_rules( $old_options, $new_options ) {
-		$old_post_types = isset( $old_options[ Option::SUPPORTED_POST_TYPES ] ) ? $old_options[ Option::SUPPORTED_POST_TYPES ] : [];
-		$new_post_types = isset( $new_options[ Option::SUPPORTED_POST_TYPES ] ) ? $new_options[ Option::SUPPORTED_POST_TYPES ] : [];
-		sort( $old_post_types );
-		sort( $new_post_types );
-		if ( $old_post_types !== $new_post_types ) {
-			// Flush rewrite rules.
-			add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK ); // @todo Why is this being added anymore?
-			flush_rewrite_rules( false );
-		}
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -79,7 +79,7 @@ class AMP_Options_Manager {
 		sort( $new_post_types );
 		if ( $old_post_types !== $new_post_types ) {
 			// Flush rewrite rules.
-			add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
+			add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK ); // @todo Why is this being added anymore?
 			flush_rewrite_rules( false );
 		}
 	}

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -220,8 +220,6 @@ final class OnboardingWizardSubmenuPage implements Conditional, Delayed, Registe
 		$setup_wizard_data = [
 			'AMP_OPTIONS_KEY'                    => AMP_Options_Manager::OPTION_NAME,
 			'AMP_QUERY_VAR'                      => amp_get_slug(),
-			'DEFAULT_AMP_QUERY_VAR'              => QueryVar::AMP,
-			'AMP_QUERY_VAR_CUSTOMIZED_LATE'      => $amp_slug_customization_watcher->did_customize_late(),
 			'LEGACY_THEME_SLUG'                  => ReaderThemes::DEFAULT_READER_THEME,
 			'APP_ROOT_ID'                        => self::APP_ROOT_ID,
 			'CUSTOMIZER_LINK'                    => add_query_arg(

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -214,28 +214,26 @@ class OptionsMenu implements Conditional, Service, Registerable {
 		$is_reader_theme = $this->reader_themes->theme_data_exists( get_stylesheet() );
 
 		$js_data = [
-			'AMP_QUERY_VAR'                 => amp_get_slug(),
-			'DEFAULT_AMP_QUERY_VAR'         => QueryVar::AMP,
-			'AMP_QUERY_VAR_CUSTOMIZED_LATE' => $amp_slug_customization_watcher->did_customize_late(),
-			'CURRENT_THEME'                 => [
+			'AMP_QUERY_VAR'               => amp_get_slug(),
+			'CURRENT_THEME'               => [
 				'name'            => $theme->get( 'Name' ),
 				'description'     => $theme->get( 'Description' ),
 				'is_reader_theme' => $is_reader_theme,
 				'screenshot'      => $theme->get_screenshot() ?: null,
 				'url'             => $theme->get( 'ThemeURI' ),
 			],
-			'OPTIONS_REST_PATH'             => '/amp/v1/options',
-			'READER_THEMES_REST_PATH'       => '/amp/v1/reader-themes',
-			'IS_CORE_THEME'                 => in_array(
+			'OPTIONS_REST_PATH'           => '/amp/v1/options',
+			'READER_THEMES_REST_PATH'     => '/amp/v1/reader-themes',
+			'IS_CORE_THEME'               => in_array(
 				get_stylesheet(),
 				AMP_Core_Theme_Sanitizer::get_supported_themes(),
 				true
 			),
-			'LEGACY_THEME_SLUG'             => ReaderThemes::DEFAULT_READER_THEME,
-			'USING_FALLBACK_READER_THEME'   => $this->reader_themes->using_fallback_theme(),
-			'THEME_SUPPORT_ARGS'            => AMP_Theme_Support::get_theme_support_args(),
-			'THEME_SUPPORTS_READER_MODE'    => AMP_Theme_Support::supports_reader_mode(),
-			'UPDATES_NONCE'                 => wp_create_nonce( 'updates' ),
+			'LEGACY_THEME_SLUG'           => ReaderThemes::DEFAULT_READER_THEME,
+			'USING_FALLBACK_READER_THEME' => $this->reader_themes->using_fallback_theme(),
+			'THEME_SUPPORT_ARGS'          => AMP_Theme_Support::get_theme_support_args(),
+			'THEME_SUPPORTS_READER_MODE'  => AMP_Theme_Support::supports_reader_mode(),
+			'UPDATES_NONCE'               => wp_create_nonce( 'updates' ),
 		];
 
 		wp_add_inline_script(

--- a/src/AmpSlugCustomizationWatcher.php
+++ b/src/AmpSlugCustomizationWatcher.php
@@ -19,6 +19,13 @@ use AmpProject\AmpWP\Infrastructure\Service;
 final class AmpSlugCustomizationWatcher implements Service, Registerable {
 
 	/**
+	 * Action at which a slug can be considered late-defined, which is the ideal case.
+	 *
+	 * @var string
+	 */
+	const LATE_DETERMINATION_ACTION = 'after_setup_theme';
+
+	/**
 	 * Whether the slug was customized early (at plugins_loaded action, priority 8).
 	 *
 	 * @var bool
@@ -68,10 +75,10 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	 * determined, so for Reader themes to apply the logic in `ReaderThemeLoader` must run beforehand.
 	 */
 	public function determine_early_customization() {
-		if ( QueryVar::AMP !== amp_get_slug() ) {
+		if ( QueryVar::AMP !== amp_get_slug( true ) ) {
 			$this->is_customized_early = true;
 		} else {
-			add_action( 'after_setup_theme', [ $this, 'determine_late_customization' ], 4 );
+			add_action( self::LATE_DETERMINATION_ACTION, [ $this, 'determine_late_customization' ], 4 );
 		}
 	}
 
@@ -90,7 +97,7 @@ final class AmpSlugCustomizationWatcher implements Service, Registerable {
 	 * @see amp_after_setup_theme()
 	 */
 	public function determine_late_customization() {
-		if ( QueryVar::AMP !== amp_get_slug() ) {
+		if ( QueryVar::AMP !== amp_get_slug( true ) ) {
 			$this->is_customized_late = true;
 		}
 	}

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -189,6 +189,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	 */
 	protected function get_shared_instances() {
 		return [
+			AmpSlugCustomizationWatcher::class,
 			PluginRegistry::class,
 			Instrumentation\StopWatch::class,
 			DevTools\CallbackReflection::class,

--- a/src/Option.php
+++ b/src/Option.php
@@ -155,9 +155,16 @@ interface Option {
 	/**
 	 * The key of the option storing whether the setup wizard has been completed.
 	 *
-	 * @var boolean
+	 * @var string
 	 */
 	const PLUGIN_CONFIGURED = 'plugin_configured';
+
+	/**
+	 * Cached slug when it is defined late.
+	 *
+	 * @var string
+	 */
+	const LATE_DEFINED_SLUG = 'late_defined_slug';
 
 	/**
 	 * Suppressed plugins

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -118,6 +118,13 @@ final class PairedRouting implements Service, Registerable {
 	private $callback_reflection;
 
 	/**
+	 * AMP slug customization watcher.
+	 *
+	 * @var AmpSlugCustomizationWatcher
+	 */
+	private $amp_slug_customization_watcher;
+
+	/**
 	 * Plugin registry.
 	 *
 	 * @var PluginRegistry
@@ -150,16 +157,18 @@ final class PairedRouting implements Service, Registerable {
 	/**
 	 * PairedRouting constructor.
 	 *
-	 * @param Injector           $injector            Injector.
-	 * @param CallbackReflection $callback_reflection Callback reflection.
-	 * @param PluginRegistry     $plugin_registry     Plugin registry.
-	 * @param PairedUrl          $paired_url          Paired URL service.
+	 * @param Injector                    $injector                       Injector.
+	 * @param CallbackReflection          $callback_reflection            Callback reflection.
+	 * @param PluginRegistry              $plugin_registry                Plugin registry.
+	 * @param PairedUrl                   $paired_url                     Paired URL service.
+	 * @param AmpSlugCustomizationWatcher $amp_slug_customization_watcher AMP slug customization watcher.
 	 */
-	public function __construct( Injector $injector, CallbackReflection $callback_reflection, PluginRegistry $plugin_registry, PairedUrl $paired_url ) {
-		$this->injector            = $injector;
-		$this->callback_reflection = $callback_reflection;
-		$this->plugin_registry     = $plugin_registry;
-		$this->paired_url          = $paired_url;
+	public function __construct( Injector $injector, CallbackReflection $callback_reflection, PluginRegistry $plugin_registry, PairedUrl $paired_url, AmpSlugCustomizationWatcher $amp_slug_customization_watcher ) {
+		$this->injector                       = $injector;
+		$this->callback_reflection            = $callback_reflection;
+		$this->plugin_registry                = $plugin_registry;
+		$this->paired_url                     = $paired_url;
+		$this->amp_slug_customization_watcher = $amp_slug_customization_watcher;
 	}
 
 	/**
@@ -665,6 +674,13 @@ final class PairedRouting implements Service, Registerable {
 	 * @return array Sanitized options.
 	 */
 	public function sanitize_options( $options, $new_options ) {
+		// Cache the AMP slug in options when it is defined late so that it can be referred to early at plugins_loaded.
+		if ( $this->amp_slug_customization_watcher->did_customize_late() ) {
+			$options[ Option::LATE_DEFINED_SLUG ] = amp_get_slug();
+		} else {
+			$options[ Option::LATE_DEFINED_SLUG ] = null;
+		}
+
 		if (
 			isset( $new_options[ Option::PAIRED_URL_STRUCTURE ] )
 			&&

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -188,27 +188,39 @@ final class PairedRouting implements Service, Registerable {
 		add_filter( 'amp_default_options', [ $this, 'filter_default_options' ], 10, 2 );
 		add_filter( 'amp_options_updating', [ $this, 'sanitize_options' ], 10, 2 );
 
-		add_action(
-			self::ACTION_UPDATE_LATE_DEFINED_SLUG_OPTION,
-			function () {
-				AMP_Options_Manager::update_option( Option::LATE_DEFINED_SLUG, $this->get_late_defined_slug() );
-			}
-		);
-
-		add_action(
-			AmpSlugCustomizationWatcher::LATE_DETERMINATION_ACTION,
-			function () {
-				$late_defined_slug = $this->get_late_defined_slug();
-				if ( AMP_Options_Manager::get_option( Option::LATE_DEFINED_SLUG ) !== $late_defined_slug ) {
-					wp_schedule_single_event( time(), self::ACTION_UPDATE_LATE_DEFINED_SLUG_OPTION );
-				}
-			}
-		);
+		add_action( self::ACTION_UPDATE_LATE_DEFINED_SLUG_OPTION, [ $this, 'update_late_defined_slug_option' ] );
+		add_action( AmpSlugCustomizationWatcher::LATE_DETERMINATION_ACTION, [ $this, 'check_stale_late_defined_slug_option' ] );
 
 		add_action( 'template_redirect', [ $this, 'redirect_extraneous_paired_endpoint' ], 9 );
 
 		// Priority 7 needed to run before PluginSuppression::initialize() at priority 8.
 		add_action( 'plugins_loaded', [ $this, 'initialize_paired_request' ], 7 );
+	}
+
+	/**
+	 * Get the late defined slug, or null if it was not defined late.
+	 *
+	 * @return string|null Slug or null.
+	 */
+	public function get_late_defined_slug() {
+		return $this->amp_slug_customization_watcher->did_customize_late() ? amp_get_slug() : null;
+	}
+
+	/**
+	 * Update late-defined slug option.
+	 */
+	public function update_late_defined_slug_option() {
+		AMP_Options_Manager::update_option( Option::LATE_DEFINED_SLUG, $this->get_late_defined_slug() );
+	}
+
+	/**
+	 * Check whether the late-defined slug option is stale and a single event needs to be scheduled to update it.
+	 */
+	public function check_stale_late_defined_slug_option() {
+		$late_defined_slug = $this->get_late_defined_slug();
+		if ( AMP_Options_Manager::get_option( Option::LATE_DEFINED_SLUG ) !== $late_defined_slug ) {
+			wp_schedule_single_event( time(), self::ACTION_UPDATE_LATE_DEFINED_SLUG_OPTION );
+		}
 	}
 
 	/**
@@ -684,17 +696,9 @@ final class PairedRouting implements Service, Registerable {
 		}
 
 		$defaults[ Option::PAIRED_URL_STRUCTURE ] = $value;
+		$defaults[ Option::LATE_DEFINED_SLUG ]    = null;
 
 		return $defaults;
-	}
-
-	/**
-	 * Get the late defined slug, or null if it was not defined late.
-	 *
-	 * @return string|null Slug or null.
-	 */
-	public function get_late_defined_slug() {
-		return $this->amp_slug_customization_watcher->did_customize_late() ? amp_get_slug() : null;
 	}
 
 	/**

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -93,7 +93,7 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 	 *
 	 * @dataProvider get_data_for_test_get_late_defined_slug
 	 * @param string|null $slug            Slug.
-	 * @param string|null $customized_late Customized late.
+	 * @param bool        $customized_late Customized late.
 	 */
 	public function test_get_late_defined_slug( $slug, $customized_late ) {
 		if ( $slug ) {

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -161,6 +161,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				Option::READER_THEME            => 'legacy',
 				Option::PLUGIN_CONFIGURED       => false,
 				Option::PAIRED_URL_STRUCTURE    => Option::PAIRED_URL_STRUCTURE_QUERY_VAR,
+				Option::LATE_DEFINED_SLUG       => null,
 			],
 			AMP_Options_Manager::get_options()
 		);

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -89,49 +89,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$registered_settings = get_registered_settings();
 		$this->assertArrayHasKey( AMP_Options_Manager::OPTION_NAME, $registered_settings );
 		$this->assertEquals( 'array', $registered_settings[ AMP_Options_Manager::OPTION_NAME ]['type'] );
-		$this->assertEquals( 10, has_action( 'update_option_' . AMP_Options_Manager::OPTION_NAME, [ 'AMP_Options_Manager', 'maybe_flush_rewrite_rules' ] ) );
-	}
-
-	/**
-	 * Test maybe_flush_rewrite_rules.
-	 *
-	 * @covers AMP_Options_Manager::maybe_flush_rewrite_rules()
-	 */
-	public function test_maybe_flush_rewrite_rules() {
-		global $wp_rewrite;
-		$wp_rewrite->init();
-		AMP_Options_Manager::register_settings();
-		$dummy_rewrite_rules = [ 'previous' => true ];
-
-		// Check change to supported_post_types.
-		update_option( 'rewrite_rules', $dummy_rewrite_rules );
-		AMP_Options_Manager::maybe_flush_rewrite_rules(
-			[ Option::SUPPORTED_POST_TYPES => [ 'page' ] ],
-			[]
-		);
-		$this->assertEmpty( get_option( 'rewrite_rules' ) );
-
-		// Check update of supported_post_types but no change.
-		update_option( 'rewrite_rules', $dummy_rewrite_rules );
-		update_option(
-			AMP_Options_Manager::OPTION_NAME,
-			[
-				[ Option::SUPPORTED_POST_TYPES => [ 'page' ] ],
-				[ Option::SUPPORTED_POST_TYPES => [ 'page' ] ],
-			]
-		);
-		$this->assertEquals( $dummy_rewrite_rules, get_option( 'rewrite_rules' ) );
-
-		// Check changing a different property.
-		update_option( 'rewrite_rules', [ 'previous' => true ] );
-		update_option(
-			AMP_Options_Manager::OPTION_NAME,
-			[
-				[ 'foo' => 'new' ],
-				[ 'foo' => 'old' ],
-			]
-		);
-		$this->assertEquals( $dummy_rewrite_rules, get_option( 'rewrite_rules' ) );
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1611,6 +1611,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers ::amp_render_scripts()
 	 */
 	public function test_prepare_response() {
+		remove_theme_support( 'block-templates' ); // Needed to prevent gutenberg_the_skip_link() from outputting anything.
+
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1611,8 +1611,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers ::amp_render_scripts()
 	 */
 	public function test_prepare_response() {
-		remove_theme_support( 'block-templates' ); // Needed to prevent gutenberg_the_skip_link() from outputting anything.
-
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -51,7 +51,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Validation_Manager::reset_validation_results();
 		unset( $GLOBALS['current_screen'] );
 		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
-		add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
 		remove_theme_support( 'amp' );
 		$this->register_core_themes();
 	}

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -152,6 +152,11 @@ class Test_Site_Health extends WP_UnitTestCase {
 			'test' => 'amp_slug_definition_timing',
 		];
 
+		/** @var AmpSlugCustomizationWatcher $amp_slug_customization_watcher */
+		$amp_slug_customization_watcher = $this->get_private_property( $this->instance, 'amp_slug_customization_watcher' );
+		$this->set_private_property( $amp_slug_customization_watcher, 'is_customized_late', false );
+		$this->assertFalse( $amp_slug_customization_watcher->did_customize_late() );
+
 		$this->assertArraySubset(
 			array_merge(
 				$data,
@@ -171,7 +176,7 @@ class Test_Site_Health extends WP_UnitTestCase {
 
 		/** @var AmpSlugCustomizationWatcher $amp_slug_customization_watcher */
 		$amp_slug_customization_watcher = $this->get_private_property( $this->instance, 'amp_slug_customization_watcher' );
-		$amp_slug_customization_watcher->determine_late_customization();
+		$this->set_private_property( $amp_slug_customization_watcher, 'is_customized_late', true );
 		$this->assertTrue( $amp_slug_customization_watcher->did_customize_late() );
 
 		$this->assertArraySubset(

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -6,8 +6,10 @@
  */
 
 use AmpProject\AmpWP\Admin\SiteHealth;
+use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
 use AmpProject\AmpWP\AmpWpPluginFactory;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 
@@ -83,14 +85,19 @@ class Test_Site_Health extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'amp_curl_multi_functions', $tests['direct'] );
 		$this->assertArrayNotHasKey( 'amp_icu_version', $tests['direct'] );
 		$this->assertArrayHasKey( 'amp_xdebug_extension', $tests['direct'] );
+		$this->assertEquals( QueryVar::AMP, amp_get_slug() );
+		$this->assertArrayNotHasKey( 'amp_slug_definition_timing', $tests['direct'] );
 
 		// Test that the the ICU version test is added only when site URL is an IDN.
 		add_filter( 'site_url', [ self::class, 'get_idn' ], 10, 4 );
+		add_filter( 'amp_query_var', [ self::class, 'get_lite_query_var' ] );
 
 		$tests = $this->instance->add_tests( [] );
 		$this->assertArrayHasKey( 'amp_icu_version', $tests['direct'] );
+		$this->assertArrayHasKey( 'amp_slug_definition_timing', $tests['direct'] );
 
 		remove_filter( 'site_url', [ self::class, 'get_idn' ] );
+		remove_filter( 'amp_query_var', [ self::class, 'get_lite_query_var' ] );
 	}
 
 	/**
@@ -132,6 +139,54 @@ class Test_Site_Health extends WP_UnitTestCase {
 				]
 			),
 			$this->instance->persistent_object_cache()
+		);
+	}
+
+	/**
+	 * Test slug_definition_timing.
+	 *
+	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::slug_definition_timing()
+	 */
+	public function test_slug_definition_timing() {
+		$data = [
+			'test' => 'amp_slug_definition_timing',
+		];
+
+		$this->assertArraySubset(
+			array_merge(
+				$data,
+				[
+					'label'  => 'The AMP slug (query var) was defined early',
+					'status' => 'good',
+					'badge'  => [
+						'label' => 'AMP',
+						'color' => 'green',
+					],
+				]
+			),
+			$this->instance->slug_definition_timing()
+		);
+
+		add_filter( 'amp_query_var', [ self::class, 'get_lite_query_var' ] );
+
+		/** @var AmpSlugCustomizationWatcher $amp_slug_customization_watcher */
+		$amp_slug_customization_watcher = $this->get_private_property( $this->instance, 'amp_slug_customization_watcher' );
+		$amp_slug_customization_watcher->determine_late_customization();
+		$this->assertTrue( $amp_slug_customization_watcher->did_customize_late() );
+
+		$this->assertArraySubset(
+			array_merge(
+				$data,
+				[
+					'label'  => 'The AMP slug (query var) was defined late',
+					'status' => 'recommended',
+					'badge'  => [
+						'label' => 'AMP',
+						'color' => 'orange',
+					],
+				]
+			),
+			$this->instance->slug_definition_timing()
 		);
 	}
 
@@ -238,6 +293,8 @@ class Test_Site_Health extends WP_UnitTestCase {
 			'amp_css_transient_caching_threshold',
 			'amp_css_transient_caching_sampling_range',
 			'amp_css_transient_caching_transient_count',
+			'amp_slug_query_var',
+			'amp_slug_defined_late',
 		];
 		foreach ( $keys as $key ) {
 			$this->assertArrayHasKey( $key, $debug_info['amp_wp']['fields'], "Expected key: $key" );
@@ -470,11 +527,20 @@ class Test_Site_Health extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Get a an IDN for testing purposes.
+	 * Get an IDN for testing purposes.
 	 *
 	 * @return string
 	 */
 	public static function get_idn() {
 		return 'https://foo.xn--57h.bar.com';
+	}
+
+	/**
+	 * Get an AMP query var for testing purposes.
+	 *
+	 * @return string
+	 */
+	public static function get_lite_query_var() {
+		return 'lite';
 	}
 }


### PR DESCRIPTION
## Summary

I just found a problem related to defining the AMP query var late. While at first this was only a problem for Reader themes, I realize it also (naturally) applies to when you're using paired URL structures, especially the legacy Reader or path suffix which involve `/amp/`. So if you have a plugin that does this:

```php
add_action( 'setup_theme', function () {
	define( 'AMP_QUERY_VAR', 'lite' );
} );
```

And you have the paired URL structure set to "Path suffix". Going to `/2020/01/07/hello-world/lite/` results in a 404. This is because the routing logic in the `PairedRouting` service gets run way earlier at `plugins_loaded`, so as far as it knows the the path suffix is `/amp/` at that point since the logic in `setup_theme` hasn't run yet.

This circles back to the discussion we had 5 days ago, captured in Joshua's notes: https://github.com/ampproject/amp-wp/pull/5859#issuecomment-824888820

The way to fix this and also to allow any Reader theme even when late-defined slug is used, is to store the late-defined slug in an option. This would cache it to allow it to be used at any point in the WP page lifecycle. 

This PR implements this idea which was first explored in #6042 for caching the primary theme's support features in options so that they are available when a Reader theme is selected.

- [x] Remove now-unnecessary late-defined slug checks for selecting a Reader theme (e.g. #5859).
- [x] Add tests.

## Site Health Check

When the AMP slug (query var) is customized, a new Site Health check is added which tells the user if it was defined early (good) or late (bad). If late, it is recommended that they change the definition to be earlier by putting in a plugin:

Defined Early | Defined Late
--------------|--------------
![image](https://user-images.githubusercontent.com/134745/116462822-c4d96980-a81e-11eb-9ca1-2a9540b1e8e9.png) | ![image](https://user-images.githubusercontent.com/134745/116462191-04538600-a81e-11eb-9096-4ec5df2891de.png)

If the user has not customized the AMP slug or if the site is in Standard mode (where the AMP slug is irrelevant), then the test is omitted entirely.

This information is also now included in Site Health Info:

![image](https://user-images.githubusercontent.com/134745/116473862-9793b800-a82c-11eb-9c99-44f779812d66.png)

## Rewrite Endpoint Removed

In 3420914 an `add_rewrite_endpoint()` call was removed which should have been removed as part of #5558. Paired URL Structures do not use rewrite endpoints now, so there is no need to add a rewrite endpoint nor to flush them when settings change.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
