### PR TITLE
Fix AMP admin menu item link tooltips when DevTools disabled

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1758,13 +1758,16 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 		'class' => 'ab-icon',
 	];
 
+	$non_amp_view_title = __( 'View non-AMP version', 'amp' );
+	$amp_view_title     = __( 'View AMP version', 'amp' );
+
 	$wp_admin_bar->add_node(
 		[
 			'id'    => 'amp',
 			'title' => $icon->to_html( $attr ) . ' ' . esc_html__( 'AMP', 'amp' ),
 			'href'  => esc_url( $is_amp_request ? $non_amp_url : $amp_url ),
 			'meta'  => [
-				'title' => esc_attr( $is_amp_request ? __( 'Validate URL', 'amp' ) : __( 'View AMP version', 'amp' ) ),
+				'title' => esc_attr( $is_amp_request ? $non_amp_view_title : $amp_view_title ),
 			],
 		]
 	);
@@ -1773,7 +1776,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 		[
 			'parent' => 'amp',
 			'id'     => 'amp-view',
-			'title'  => esc_html( $is_amp_request ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) ),
+			'title'  => esc_html( $is_amp_request ? $non_amp_view_title : $amp_view_title ),
 			'href'   => esc_url( $is_amp_request ? $non_amp_url : $amp_url ),
 		]
 	);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -356,6 +356,8 @@ class AMP_Validation_Manager {
 			]
 		);
 
+		$validate_url_title = __( 'Validate URL', 'amp' );
+
 		$parent = [
 			'id'    => 'amp',
 			'title' => sprintf(
@@ -364,13 +366,16 @@ class AMP_Validation_Manager {
 				esc_html__( 'AMP', 'amp' )
 			),
 			'href'  => esc_url( $href ),
+			'meta'  => [
+				'title' => esc_attr( $is_amp_request ? $validate_url_title : __( 'View AMP version', 'amp' ) ),
+			],
 		];
 
 		// Construct admin bar item for validation.
 		$validate_item = [
 			'parent' => 'amp',
 			'id'     => 'amp-validity',
-			'title'  => esc_html__( 'Validate URL', 'amp' ),
+			'title'  => esc_html( $validate_url_title ),
 			'href'   => esc_url( $validate_url ),
 		];
 


### PR DESCRIPTION
## Summary

Fixes #6124

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
