### PR TITLE
Prevent page_for_posts from interfering with hero image candidate identification

### DIFF
--- a/src/Optimizer/HeroCandidateFiltering.php
+++ b/src/Optimizer/HeroCandidateFiltering.php
@@ -104,7 +104,7 @@ final class HeroCandidateFiltering implements Service, Delayed, Conditional, Reg
 		$queried_post = get_queried_object();
 		if ( is_singular() && $queried_post instanceof WP_Post ) {
 			$post = $queried_post;
-		} elseif ( $wp_query->is_main_query() && $wp_query->post_count > 0 ) {
+		} elseif ( $wp_query->is_main_query() && isset( $wp_query->posts[0] ) ) {
 			$post = $wp_query->posts[0];
 		}
 

--- a/src/Optimizer/HeroCandidateFiltering.php
+++ b/src/Optimizer/HeroCandidateFiltering.php
@@ -102,7 +102,7 @@ final class HeroCandidateFiltering implements Service, Delayed, Conditional, Reg
 
 		$post         = null;
 		$queried_post = get_queried_object();
-		if ( $queried_post instanceof WP_Post ) {
+		if ( is_singular() && $queried_post instanceof WP_Post ) {
 			$post = $queried_post;
 		} elseif ( $wp_query->is_main_query() && $wp_query->post_count > 0 ) {
 			$post = $wp_query->posts[0];

--- a/tests/php/src/Optimizer/HeroCandidateFilteringTest.php
+++ b/tests/php/src/Optimizer/HeroCandidateFilteringTest.php
@@ -97,12 +97,22 @@ final class HeroCandidateFilteringTest extends DependencyInjectedTestCase {
 	public function test_filter_attachment_image_attributes() {
 		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg', 0 );
 		$attachment    = get_post( $attachment_id );
-		$post_ids      = self::factory()->post->create_many(
-			2,
-			[ 'post_content' => __FUNCTION__ ]
-		);
+		$post_ids      = [
+			self::factory()->post->create(
+				[
+					'post_date'    => '2021-02-03 04:05:06',
+					'post_content' => __FUNCTION__,
+				]
+			),
+			self::factory()->post->create(
+				[
+					'post_date'    => '2020-01-02 03:04:05',
+					'post_content' => __FUNCTION__,
+				]
+			),
+		];
 
-		$search_request_uri = sprintf( '/?s=%s&orderby=ID&order=asc', __FUNCTION__ );
+		$search_request_uri = sprintf( '/?s=%s', __FUNCTION__ );
 
 		$initial_attrs = [ 'data-foo' => 'bar' ];
 		$merged_attrs  = array_merge(
@@ -135,6 +145,20 @@ final class HeroCandidateFilteringTest extends DependencyInjectedTestCase {
 		delete_post_thumbnail( $post_ids[1] );
 		set_post_thumbnail( $post_ids[0], $attachment->ID );
 		$this->go_to( $search_request_uri );
+		$this->assertEquals(
+			$merged_attrs,
+			$this->instance->filter_attachment_image_attributes( $initial_attrs, $attachment )
+		);
+
+		// When on the page for posts, the the first post in the loop is considered and not the queried object (the page for posts).
+		$page_for_posts = self::factory()->post->create( [ 'post_type' => 'page' ] );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', $page_for_posts );
+		$this->go_to( get_permalink( $page_for_posts ) );
+		$this->assertEquals(
+			wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' ),
+			$post_ids
+		);
 		$this->assertEquals(
 			$merged_attrs,
 			$this->instance->filter_attachment_image_attributes( $initial_attrs, $attachment )


### PR DESCRIPTION
## Summary

I noticed that when there is a page set for posts, the first post in the loop does not get identified as a hero:

![image](https://user-images.githubusercontent.com/134745/116794278-aa062f80-aa80-11eb-874f-3caa776c1e5e.png)

For example, when on the Blog index in Twenty Nineteen:

![image](https://user-images.githubusercontent.com/134745/116794306-ee91cb00-aa80-11eb-97c6-c15d9180009a.png)

The issue is that on a page for posts, the queried object is that page. If no featured image is set for that page, then no image is identified as the hero. This fixes that problem:

![image](https://user-images.githubusercontent.com/134745/116794319-0b2e0300-aa81-11eb-9ad1-2b8673e16ce6.png)
 
- [ ] Also verify behavior of sticky posts.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
