### PR TITLE
Add support for Instagram Reel permalinks

### DIFF
--- a/includes/embeds/class-amp-instagram-embed-handler.php
+++ b/includes/embeds/class-amp-instagram-embed-handler.php
@@ -198,7 +198,7 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 				]
 			);
 
-			$new_node->textContent = esc_html( $permalink );
+			$new_node->textContent = __( 'View on Instagram', 'amp' );
 		}
 
 		$this->sanitize_embed_script( $node );

--- a/tests/php/test-amp-instagram-embed-handler.php
+++ b/tests/php/test-amp-instagram-embed-handler.php
@@ -8,23 +8,27 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 
 	public function get_conversion_data() {
 		return [
-			'no_embed'      => [
+			'no_embed'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
-			'simple_url'    => [
+			'simple_url'      => [
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
 			],
-			'simple_tv_url' => [
+			'simple_tv_url'   => [
 				'https://instagram.com/tv/7-l0z_p4A4/' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
 			],
-			'short_url'     => [
+			'simple_reel_url' => [
+				'https://instagram.com/reel/COWmlFLB_7P/' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="COWmlFLB_7P" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+			],
+			'short_url'       => [
 				'https://instagr.am/p/7-l0z_p4A4' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
 			],
-			'short_tv_url'  => [
+			'short_tv_url'    => [
 				'https://instagr.am/tv/7-l0z_p4A4' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
 			],
@@ -113,6 +117,11 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
 			],
 
+			'blockquote_reel_embed'                  => [
+				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/reel/COWmlFLB_7P/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+				'<amp-instagram data-shortcode="COWmlFLB_7P" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
+			],
+
 			'blockquote_embed_notautop'              => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram> ',
@@ -126,6 +135,11 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 			'blockquote_embed_with_caption_notautop' => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/" data-instgrm-captioned><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned=""></amp-instagram> ',
+			],
+
+			'blockquote_unsupported_permalink'       => [
+				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/unsupported/post_id"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+				'<a href="https://www.instagram.com/unsupported/post_id" class="amp-wp-embed-fallback">https://www.instagram.com/unsupported/post_id</a>' . "\n\n",
 			],
 		];
 	}

--- a/tests/php/test-amp-instagram-embed-handler.php
+++ b/tests/php/test-amp-instagram-embed-handler.php
@@ -139,7 +139,7 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 
 			'blockquote_unsupported_permalink'       => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/unsupported/post_id"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<a href="https://www.instagram.com/unsupported/post_id" class="amp-wp-embed-fallback">https://www.instagram.com/unsupported/post_id</a>' . "\n\n",
+				'<a href="https://www.instagram.com/unsupported/post_id" class="amp-wp-embed-fallback">View on Instagram</a>' . "\n\n",
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6169

Also adds a fallback if the Instagram ID could not be parsed during sanitization of the raw embed.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
