### PR TITLE
Prevent fatal error when `amp_*_paired_endpoint()` functions are called before `plugins_loaded` action

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1846,6 +1846,10 @@ function amp_generate_script_hash( $script ) {
  * @return string AMP URL.
  */
 function amp_add_paired_endpoint( $url ) {
+	if ( ! did_action( 'plugins_loaded' ) ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+		return $url;
+	}
 	return Services::get( 'paired_routing' )->add_endpoint( $url );
 }
 
@@ -1858,6 +1862,10 @@ function amp_add_paired_endpoint( $url ) {
  * @return bool True if the AMP query parameter is set with the required value, false if not.
  */
 function amp_has_paired_endpoint( $url = '' ) {
+	if ( ! did_action( 'plugins_loaded' ) ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+		return false;
+	}
 	return Services::get( 'paired_routing' )->has_endpoint( $url );
 }
 
@@ -1870,5 +1878,9 @@ function amp_has_paired_endpoint( $url = '' ) {
  * @return string URL with AMP stripped.
  */
 function amp_remove_paired_endpoint( $url ) {
+	if ( ! did_action( 'plugins_loaded' ) ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+		return $url;
+	}
 	return Services::get( 'paired_routing' )->remove_endpoint( $url );
 }


### PR DESCRIPTION
## Summary

If a site has a plugin which at its root is doing something like this:

```php
if ( is_amp_endpoint() ) { // or amp_is_request()!
    require __DIR__ . '/amp.php';
} else {
    require __DIR__ . '/non-amp.php';
}
```

This causes a fatal error because it happens before the `plugins_loaded` action which is when the services are registered.  The error and stack trace are:

```
 PHP Fatal error:  Uncaught AmpProject\AmpWP\Exception\InvalidService: The service ID "paired_routing" is not recognized and cannot be retrieved. in /app/public/content/plugins/amp/src/Exception/InvalidService.php:57
Stack trace:
#0 /app/public/content/plugins/amp/src/Infrastructure/ServiceContainer/SimpleServiceContainer.php(39): AmpProject\AmpWP\Exception\InvalidService::from_service_id('paired_routing')
#1 /app/public/content/plugins/amp/src/Services.php(55): AmpProject\AmpWP\Infrastructure\ServiceContainer\SimpleServiceContainer->get('paired_routing')
#2 /app/public/content/plugins/amp/includes/amp-helper-functions.php(1861): AmpProject\AmpWP\Services::get('paired_routing')
#3 /app/public/content/plugins/amp/includes/amp-helper-functions.php(744): amp_has_paired_endpoint()
#4 /app/public/content/plugins/amp/includes/amp-helper-functions.php(779): amp_is_request()
#5 /app/public/content/plugins/try-early-is-amp-endpoint-check.php(6): is_amp_endpoint()
#6 /app/public/core-dev/src/wp-settings.php(395): include_once('/app/publi in /app/public/content/plugins/amp/src/Exception/InvalidService.php on line 57
```

This is similar to what occurred in #5899.

To prevent a fatal error, a `_doing_it_wrong()` should be emitted instead. In fact, `amp_is_request()` already emits `_doing_it_wrong()` when it is called before the `wp` action. So with the changes in this PR, two errors are then emitted:

<blockquote>
<b>Notice</b>:  amp_has_paired_endpoint was called <strong>incorrectly</strong>. Function cannot be called before the plugins_loaded action. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 2.1.1.) in <b>/app/public/core-dev/src/wp-includes/functions.php</b> on line <b>5319</b><br />
<br />
<b>Notice</b>:  amp_is_available was called <strong>incorrectly</strong>. `amp_is_available()` (or `amp_is_request()`, formerly `is_amp_endpoint()`) was called too early and so it will not work properly. WordPress is not currently doing any hook. Calling this function before the `wp` action means it will not have access to `WP_Query` and the queried object to determine if it is an AMP response, thus neither the `amp_skip_post()` filter nor the AMP enabled toggle will be considered. The function was called too early (before the plugins_loaded action) to determine the plugin source. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 2.0.0.) in <b>/app/public/core-dev/src/wp-includes/functions.php</b> on line <b>5319</b><br />
</blockquote>

Possible fix for https://wordpress.org/support/topic/critical-error-after-the-last-update/

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
