### PR TITLE
Catch exceptions when calling services; prevent service activation/deactivation when disabled

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -15,6 +15,26 @@ use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Services;
 
 /**
+ * Determine whether AMP is enabled on the current site.
+ *
+ * @since 2.1.1
+ * @internal
+ *
+ * @return bool Whether enabled.
+ */
+function amp_is_enabled() {
+	/**
+	 * Filters whether AMP is enabled on the current site.
+	 *
+	 * Useful if the plugin is network activated and you want to turn it off on select sites.
+	 *
+	 * @since 0.2
+	 * @since 2.0 Filter now runs earlier at plugins_loaded (with earliest priority) rather than at the after_setup_theme action.
+	 */
+	return (bool) apply_filters( 'amp_is_enabled', true );
+}
+
+/**
  * Handle activation of plugin.
  *
  * @since 0.2
@@ -23,7 +43,9 @@ use AmpProject\AmpWP\Services;
  * @param bool $network_wide Whether the activation was done network-wide.
  */
 function amp_activate( $network_wide = false ) {
-	AmpWpPluginFactory::create()->activate( $network_wide );
+	if ( amp_is_enabled() ) {
+		AmpWpPluginFactory::create()->activate( $network_wide );
+	}
 }
 
 /**
@@ -35,7 +57,9 @@ function amp_activate( $network_wide = false ) {
  * @param bool $network_wide Whether the activation was done network-wide.
  */
 function amp_deactivate( $network_wide = false ) {
-	AmpWpPluginFactory::create()->deactivate( $network_wide );
+	if ( amp_is_enabled() ) {
+		AmpWpPluginFactory::create()->deactivate( $network_wide );
+	}
 }
 
 /**
@@ -45,15 +69,7 @@ function amp_deactivate( $network_wide = false ) {
  * @internal
  */
 function amp_bootstrap_plugin() {
-	/**
-	 * Filters whether AMP is enabled on the current site.
-	 *
-	 * Useful if the plugin is network activated and you want to turn it off on select sites.
-	 *
-	 * @since 0.2
-	 * @since 2.0 Filter now runs earlier at plugins_loaded (with earliest priority) rather than at the after_setup_theme action.
-	 */
-	if ( false === apply_filters( 'amp_is_enabled', true ) ) {
+	if ( ! amp_is_enabled() ) {
 		return;
 	}
 
@@ -1846,11 +1862,17 @@ function amp_generate_script_hash( $script ) {
  * @return string AMP URL.
  */
 function amp_add_paired_endpoint( $url ) {
-	if ( ! did_action( 'plugins_loaded' ) ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+	try {
+		return Services::get( 'paired_routing' )->add_endpoint( $url );
+	} catch ( InvalidService $e ) {
+		if ( ! amp_is_enabled() ) {
+			$reason = __( 'Function called while AMP is disabled via `amp_is_enabled` filter.', 'amp' );
+		} else {
+			$reason = __( 'Function cannot be called before services are registered.', 'amp' );
+		}
+		_doing_it_wrong( __FUNCTION__, esc_html( $reason ) . ' ' . esc_html( $e->getMessage() ), '2.1.1' );
 		return $url;
 	}
-	return Services::get( 'paired_routing' )->add_endpoint( $url );
 }
 
 /**
@@ -1862,11 +1884,17 @@ function amp_add_paired_endpoint( $url ) {
  * @return bool True if the AMP query parameter is set with the required value, false if not.
  */
 function amp_has_paired_endpoint( $url = '' ) {
-	if ( ! did_action( 'plugins_loaded' ) ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+	try {
+		return Services::get( 'paired_routing' )->has_endpoint( $url );
+	} catch ( InvalidService $e ) {
+		if ( ! amp_is_enabled() ) {
+			$reason = __( 'Function called while AMP is disabled via `amp_is_enabled` filter.', 'amp' );
+		} else {
+			$reason = __( 'Function cannot be called before services are registered.', 'amp' );
+		}
+		_doing_it_wrong( __FUNCTION__, esc_html( $reason ) . ' ' . esc_html( $e->getMessage() ), '2.1.1' );
 		return false;
 	}
-	return Services::get( 'paired_routing' )->has_endpoint( $url );
 }
 
 /**
@@ -1878,9 +1906,15 @@ function amp_has_paired_endpoint( $url = '' ) {
  * @return string URL with AMP stripped.
  */
 function amp_remove_paired_endpoint( $url ) {
-	if ( ! did_action( 'plugins_loaded' ) ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Function cannot be called before the plugins_loaded action.', 'amp' ), '2.1.1' );
+	try {
+		return Services::get( 'paired_routing' )->remove_endpoint( $url );
+	} catch ( InvalidService $e ) {
+		if ( ! amp_is_enabled() ) {
+			$reason = __( 'Function called while AMP is disabled via `amp_is_enabled` filter.', 'amp' );
+		} else {
+			$reason = __( 'Function cannot be called before services are registered.', 'amp' );
+		}
+		_doing_it_wrong( __FUNCTION__, esc_html( $reason ) . ' ' . esc_html( $e->getMessage() ), '2.1.1' );
 		return $url;
 	}
-	return Services::get( 'paired_routing' )->remove_endpoint( $url );
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -30,6 +30,8 @@ function amp_is_enabled() {
 	 *
 	 * @since 0.2
 	 * @since 2.0 Filter now runs earlier at plugins_loaded (with earliest priority) rather than at the after_setup_theme action.
+	 *
+	 * @param bool $enabled Whether the AMP plugin's functionality should be enabled.
 	 */
 	return (bool) apply_filters( 'amp_is_enabled', true );
 }


### PR DESCRIPTION
## Summary

This is a follow-up for #6181 to address a [support topic](https://wordpress.org/support/topic/critical-error-after-the-last-update/) and others related to a fatal error when using the tagDiv Mobile theme with a certain configuration.

Given plugin code which does the following:

```php
add_filter( 'amp_is_enabled', '__return_false' );

add_action( 'template_redirect', function () {
	error_log( is_amp_endpoint() ? 'enabled' : 'disabled' );
} );
```

This causes a fatal error:

<pre>
<b>Fatal error</b>:  Uncaught AmpProject\AmpWP\Exception\InvalidService: The service ID &quot;paired_routing&quot; is not recognized and cannot be retrieved. in /app/public/content/plugins/amp/src/Exception/InvalidService.php:57
Stack trace:
#0 /app/public/content/plugins/amp/src/Infrastructure/ServiceContainer/SimpleServiceContainer.php(39): AmpProject\AmpWP\Exception\InvalidService::from_service_id('paired_routing')
#1 /app/public/content/plugins/amp/src/Services.php(55): AmpProject\AmpWP\Infrastructure\ServiceContainer\SimpleServiceContainer-&gt;get('paired_routing')
#2 /app/public/content/plugins/amp/includes/amp-helper-functions.php(1869): AmpProject\AmpWP\Services::get('paired_routing')
#3 /app/public/content/plugins/amp/includes/amp-helper-functions.php(744): amp_has_paired_endpoint()
#4 /app/public/content/plugins/amp/includes/amp-helper-functions.php(779): amp_is_request()
#5 /app/public/content/plugins/try-early-is-amp-endpoint-check.php(9): is_amp_endpoint()
#6 /app/public/core-dev/src/wp-includes/class-wp-hook.php(292): {closure}( in <b>/app/public/content/plugins/amp/src/Exception/InvalidService.php</b> on line <b>57</b>
</pre>

So in this PR such exceptions are now caught with a `_doing_it_wrong()` message that indicates if AMP was disabled via the `amp_is_enabled` filter.

Similarly, I noticed when testing the tagDiv Mobile Theme plugin (which uses this filter) attempting to activate or deactivate AMP from the tagDiv settings screen would cause another error:

<pre>
PHP Fatal error:  Uncaught AmpProject\AmpWP\Exception\InvalidService: The service ID "dev_tools.user_access" is not recognized and cannot be retrieved. in /app/public/wp-content/plugins/amp/src/Exception/InvalidService.php:57
Stack trace:
#0 /app/public/wp-content/plugins/amp/src/Infrastructure/ServiceContainer/SimpleServiceContainer.php(39): AmpProject\AmpWP\Exception\InvalidService::from_service_id('dev_tools.user_...')
#1 /app/public/wp-content/plugins/amp/src/Services.php(55): AmpProject\AmpWP\Infrastructure\ServiceContainer\SimpleServiceContainer->get('dev_tools.user_...')
#2 /app/public/wp-content/plugins/amp/src/Admin/ValidationCounts.php(47): AmpProject\AmpWP\Services::get('dev_tools.user_...')
#3 /app/public/wp-content/plugins/amp/src/Infrastructure/ServiceBasedPlugin.php(289): AmpProject\AmpWP\Admin\ValidationCounts::is_needed()
#4 /app/public/wp-content/plugins/amp/src/Infrastructure/ServiceBasedPlugin.php(200): AmpProject\AmpWP\Infrastructure\ServiceBasedPlugin->register_service('admin.validatio...', 'AmpProject\\A in /app/public/wp-content/plugins/amp/src/Exception/InvalidService.php on line 57
</pre>

The way to address this seems to be to check whether AMP is enabled before attempting to activate or deactivate. 

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
