### PR TITLE
Fix incorrect validation count in admin sidebar

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -492,6 +492,14 @@ class AMP_Validated_URL_Post_Type {
 			return (int) $count;
 		}
 
+		// Make sure filter is added in REST API context which is otherwise only added via AMP_Validation_Error_Taxonomy::add_admin_hooks().
+		$callback   = [ AMP_Validation_Error_Taxonomy::class, 'filter_posts_where_for_validation_error_status' ];
+		$priority   = 10;
+		$has_filter = has_filter( 'posts_where', $callback );
+		if ( false === $has_filter ) {
+			add_filter( 'posts_where', $callback, $priority, 2 );
+		}
+
 		$query = new WP_Query(
 			[
 				'post_type'              => self::POST_TYPE_SLUG,
@@ -503,6 +511,11 @@ class AMP_Validated_URL_Post_Type {
 				'update_post_term_cache' => false,
 			]
 		);
+
+		// Remove filter if we added it in this method.
+		if ( false === $has_filter ) {
+			remove_filter( 'posts_where', $callback, $priority );
+		}
 
 		$count = $query->found_posts;
 

--- a/src/Validation/ValidationCountsRestController.php
+++ b/src/Validation/ValidationCountsRestController.php
@@ -49,6 +49,8 @@ final class ValidationCountsRestController extends WP_REST_Controller implements
 		$this->namespace             = 'amp/v1';
 		$this->rest_base             = 'unreviewed-validation-counts';
 		$this->dev_tools_user_access = $user_access;
+
+		add_filter( 'posts_where', [ AMP_Validation_Error_Taxonomy::class, 'filter_posts_where_for_validation_error_status' ], 10, 2 );
 	}
 
 	/**

--- a/src/Validation/ValidationCountsRestController.php
+++ b/src/Validation/ValidationCountsRestController.php
@@ -49,8 +49,6 @@ final class ValidationCountsRestController extends WP_REST_Controller implements
 		$this->namespace             = 'amp/v1';
 		$this->rest_base             = 'unreviewed-validation-counts';
 		$this->dev_tools_user_access = $user_access;
-
-		add_filter( 'posts_where', [ AMP_Validation_Error_Taxonomy::class, 'filter_posts_where_for_validation_error_status' ], 10, 2 );
 	}
 
 	/**

--- a/tests/php/src/Validation/ValidationCountsRestControllerTest.php
+++ b/tests/php/src/Validation/ValidationCountsRestControllerTest.php
@@ -8,6 +8,7 @@
 namespace AmpProject\AmpWP\Tests\Validation;
 
 use AMP_Validated_URL_Post_Type;
+use AMP_Validation_Error_Taxonomy;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Validation\ValidationCountsRestController;
@@ -34,6 +35,7 @@ class ValidationCountsRestControllerTest extends DependencyInjectedTestCase {
 		parent::setUp();
 
 		$this->controller = $this->injector->make( ValidationCountsRestController::class );
+		$this->assertSame( 10, has_filter( 'posts_where', [ AMP_Validation_Error_Taxonomy::class, 'filter_posts_where_for_validation_error_status' ] ) );
 	}
 
 	/**

--- a/tests/php/src/Validation/ValidationCountsRestControllerTest.php
+++ b/tests/php/src/Validation/ValidationCountsRestControllerTest.php
@@ -8,7 +8,6 @@
 namespace AmpProject\AmpWP\Tests\Validation;
 
 use AMP_Validated_URL_Post_Type;
-use AMP_Validation_Error_Taxonomy;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Validation\ValidationCountsRestController;
@@ -35,7 +34,6 @@ class ValidationCountsRestControllerTest extends DependencyInjectedTestCase {
 		parent::setUp();
 
 		$this->controller = $this->injector->make( ValidationCountsRestController::class );
-		$this->assertSame( 10, has_filter( 'posts_where', [ AMP_Validation_Error_Taxonomy::class, 'filter_posts_where_for_validation_error_status' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Should fix the issue reported in [this](https://wordpress.org/support/topic/validated-urls-badge/) support topic.

> Updated AMP to v2.1 and having a weird issue. In the left panel, if the AMP plugin section expanded it Validated URLs Badge displays that all URLs are not validated (red circle with a number), but in the full URLs list it says “All markup valid”.

> ![image](https://user-images.githubusercontent.com/16200219/117493256-4b4e2380-af62-11eb-94e9-ef25b73f9a8a.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
