### PR TITLE
Bump editor support minimum requirements

### DIFF
--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -25,14 +25,14 @@ final class EditorSupport implements Registerable, Service {
 	 *
 	 * @var string
 	 */
-	const GB_MIN_VERSION = '5.4.0';
+	const GB_MIN_VERSION = '9.2.0';
 
 	/**
 	 * The minimum version of WordPress supported by editor features.
 	 *
 	 * @var string
 	 */
-	const WP_MIN_VERSION = '5.3';
+	const WP_MIN_VERSION = '5.6';
 
 	/**
 	 * Runs on instantiation.

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -34,7 +34,11 @@ final class EditorSupportTest extends WP_UnitTestCase {
 
 	/** @covers ::has_support_from_gutenberg_plugin */
 	public function test_has_support_from_gutenberg_plugin() {
-		if ( defined( 'GUTENBERG_VERSION' ) ) {
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&&
+			version_compare( GUTENBERG_VERSION, EditorSupport::GB_MIN_VERSION, '>=' )
+		) {
 			$this->assertTrue( $this->instance->has_support_from_gutenberg_plugin() );
 		} else {
 			if ( version_compare( get_bloginfo( 'version' ), EditorSupport::WP_MIN_VERSION, '>=' ) ) {
@@ -46,7 +50,11 @@ final class EditorSupportTest extends WP_UnitTestCase {
 	}
 
 	public function test_editor_supports_amp_block_editor_features() {
-		if ( defined( 'GUTENBERG_VERSION' ) ) {
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&&
+			version_compare( GUTENBERG_VERSION, EditorSupport::GB_MIN_VERSION, '>=' )
+		) {
 			$this->assertTrue( $this->instance->editor_supports_amp_block_editor_features() );
 		} else {
 			if ( version_compare( get_bloginfo( 'version' ), EditorSupport::WP_MIN_VERSION, '>=' ) ) {

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -93,10 +93,6 @@ final class EditorSupportTest extends WP_UnitTestCase {
 	public function test_show_notice_for_supported_post_type() {
 		global $post;
 
-		if ( version_compare( get_bloginfo( 'version' ), '5.3', '<=' ) ) {
-			$this->markTestSkipped();
-		}
-
 		set_current_screen( 'edit.php' );
 		$post = $this->factory()->post->create();
 		setup_postdata( get_post( $post ) );

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -101,6 +101,10 @@ final class EditorSupportTest extends WP_UnitTestCase {
 	public function test_show_notice_for_supported_post_type() {
 		global $post;
 
+		if ( version_compare( get_bloginfo( 'version' ), EditorSupport::WP_MIN_VERSION, '<' ) ) {
+			$this->markTestSkipped();
+		}
+
 		set_current_screen( 'edit.php' );
 		$post = $this->factory()->post->create();
 		setup_postdata( get_post( $post ) );
@@ -111,7 +115,10 @@ final class EditorSupportTest extends WP_UnitTestCase {
 		if ( $this->instance->editor_supports_amp_block_editor_features() ) {
 			$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
 		} else {
-			$this->assertContains( 'AMP f', wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
+			$this->assertContains(
+				'AMP functionality is not available',
+				wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false )
+			);
 		}
 		unset( $GLOBALS['current_screen'] );
 		unset( $GLOBALS['wp_scripts'] );

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Editor\EditorSupport;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\Helpers\AssertRestApiField;
@@ -118,8 +119,12 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		set_current_screen( 'post.php' );
 		get_current_screen()->is_block_editor = true;
 
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The block editor is not available' );
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&&
+			version_compare( GUTENBERG_VERSION, EditorSupport::GB_MIN_VERSION, '>=' )
+		) {
+			$this->markTestSkipped( 'The version of Gutenberg installed is not compatible with the plugin.' );
 		}
 
 		// If a post type doesn't have AMP enabled, the script shouldn't be enqueued.

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -122,7 +122,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		if (
 			defined( 'GUTENBERG_VERSION' )
 			&&
-			version_compare( GUTENBERG_VERSION, EditorSupport::GB_MIN_VERSION, '>=' )
+			version_compare( GUTENBERG_VERSION, EditorSupport::GB_MIN_VERSION, '<' )
 		) {
 			$this->markTestSkipped( 'The version of Gutenberg installed is not compatible with the plugin.' );
 		}

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -119,6 +119,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		set_current_screen( 'post.php' );
 		get_current_screen()->is_block_editor = true;
 
+		if ( ! function_exists( 'register_block_type' ) ) {
+			$this->markTestSkipped( 'The block editor is not available' );
+		}
+
 		if (
 			defined( 'GUTENBERG_VERSION' )
 			&&


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
This PR bumps the minimum versions of WordPress and the Gutenberg plugin required to reliably use the plugin in the editor.

This should prevent issues such as [this](https://wordpress.org/support/topic/error-after-last-update-38/) from being reported in the future.

Fixes #6236.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
