### PR TITLE
Account for recursive request parsing in PairedRouting

### DIFF
--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -401,7 +401,7 @@ final class PairedRouting implements Service, Registerable {
 		$this->detect_endpoint_in_environment();
 		add_filter( 'do_parse_request', [ $this, 'extract_endpoint_from_environment_before_parse_request' ], PHP_INT_MAX );
 		add_filter( 'request', [ $this, 'filter_request_after_endpoint_extraction' ] );
-		add_action( 'parse_request', [ $this, 'restore_path_endpoint_in_environment' ] );
+		add_action( 'parse_request', [ $this, 'restore_path_endpoint_in_environment' ], defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 
 		// Reserve the 'amp' slug for paired URL structures that use paths.
 		if ( $this->is_using_path_suffix() ) {

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -468,18 +468,6 @@ final class PairedRouting implements Service, Registerable {
 
 			$this->did_request_endpoint = true;
 		}
-
-		// @todo Also do same for $_GET?
-		if ( $this->did_request_endpoint && isset( $this->suspended_environment_variables['REQUEST_URI'] ) ) {
-			$old_query_string = wp_parse_url( $this->suspended_environment_variables['REQUEST_URI'][0], PHP_URL_QUERY );
-			$new_query_string = wp_parse_url( $this->suspended_environment_variables['REQUEST_URI'][1], PHP_URL_QUERY );
-			if ( $old_query_string !== $new_query_string ) {
-				$this->suspended_environment_variables['QUERY_STRING'] = [
-					(string) $old_query_string,
-					(string) $new_query_string,
-				];
-			}
-		}
 	}
 
 	/**

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -153,6 +153,17 @@ final class PairedRouting implements Service, Registerable {
 	private $did_request_endpoint;
 
 	/**
+	 * Current nesting level for the request.
+	 *
+	 * This is used to capture cases where `WP::parse_request()` is called from inside of a `request`
+	 * filter, a case of a nested/recursive request. It is similar in concept to `ob_get_level()` for
+	 * output buffering.
+	 *
+	 * @var int
+	 */
+	private $current_request_nesting_level = 0;
+
+	/**
 	 * Original environment variables that were rewritten before parsing the request.
 	 *
 	 * @see PairedRouting::detect_endpoint_in_environment()
@@ -388,7 +399,7 @@ final class PairedRouting implements Service, Registerable {
 
 		// Run necessary logic to properly route a request using the registered paired URL structures.
 		$this->detect_endpoint_in_environment();
-		add_filter( 'do_parse_request', [ $this, 'extract_endpoint_from_environment_before_parse_request' ] );
+		add_filter( 'do_parse_request', [ $this, 'extract_endpoint_from_environment_before_parse_request' ], PHP_INT_MAX );
 		add_filter( 'request', [ $this, 'filter_request_after_endpoint_extraction' ] );
 		add_action( 'parse_request', [ $this, 'restore_path_endpoint_in_environment' ] );
 
@@ -484,11 +495,28 @@ final class PairedRouting implements Service, Registerable {
 	 * @return bool Passed-through argument.
 	 */
 	public function extract_endpoint_from_environment_before_parse_request( $do_parse_request ) {
-		if ( $this->did_request_endpoint ) {
+		// If request parsing was aborted, then there's nothing for us to do.
+		if ( ! $do_parse_request ) {
+			return $do_parse_request;
+		}
+
+		// Only do something if doing the outermost request. Note that this function runs with the
+		// latest priority in order to make sure that any other `do_parse_request` filter will have
+		// already applied, and thus we know that the request is indeed going to be parsed.
+		if (
+			$this->did_request_endpoint
+			&&
+			0 === $this->current_request_nesting_level
+		) {
 			foreach ( $this->suspended_environment_variables as $var_name => list( , $new_path ) ) {
 				$_SERVER[ $var_name ] = wp_slash( $new_path ); // Because of wp_magic_quotes().
 			}
 		}
+
+		// Increase the nesting level so we can prevent calling ourselves for any recursive calls
+		// to `WP::parse_request()` during the `request` filter.
+		$this->current_request_nesting_level++;
+
 		return $do_parse_request;
 	}
 
@@ -513,7 +541,17 @@ final class PairedRouting implements Service, Registerable {
 	 * @param WP $wp WP object.
 	 */
 	public function restore_path_endpoint_in_environment( WP $wp ) {
-		if ( ! $this->did_request_endpoint ) {
+		// Since the request has finished the parsing which was detected above in the
+		// `PairedRouting::extract_endpoint_from_environment_before_parse_request()`
+		// method, now decrement the level.
+		$this->current_request_nesting_level--;
+
+		// Only run for the outermost/root request when an AMP endpoint was requested.
+		if (
+			! $this->did_request_endpoint
+			||
+			0 !== $this->current_request_nesting_level
+		) {
 			return;
 		}
 		foreach ( $this->suspended_environment_variables as $var_name => list( $old_path, ) ) {

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -457,6 +457,18 @@ final class PairedRouting implements Service, Registerable {
 
 			$this->did_request_endpoint = true;
 		}
+
+		// @todo Also do same for $_GET?
+		if ( $this->did_request_endpoint && isset( $this->suspended_environment_variables['REQUEST_URI'] ) ) {
+			$old_query_string = wp_parse_url( $this->suspended_environment_variables['REQUEST_URI'][0], PHP_URL_QUERY );
+			$new_query_string = wp_parse_url( $this->suspended_environment_variables['REQUEST_URI'][1], PHP_URL_QUERY );
+			if ( $old_query_string !== $new_query_string ) {
+				$this->suspended_environment_variables['QUERY_STRING'] = [
+					(string) $old_query_string,
+					(string) $new_query_string,
+				];
+			}
+		}
 	}
 
 	/**

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -322,6 +322,39 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 				'/amp/',
 				true,
 			],
+			'path_suffix_mode_amp_with_subrequest'  => [
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+				Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
+				'/amp/',
+				true,
+				function ( $query ) {
+					static $recursing = false;
+					global $wp;
+
+					if ( $recursing ) {
+						return $query;
+					}
+					$recursing = true;
+
+					$old_request_uri = $_SERVER['REQUEST_URI'];
+					$old_wp_request  = $wp->request;
+
+					$post = self::factory()->post->create();
+					$path = wp_parse_url( get_permalink( $post ), PHP_URL_PATH );
+
+					$_SERVER['REQUEST_URI'] = $path;
+					$wp->matched_rule       = null;
+					$wp->parse_request();
+
+					$query = $wp->query_vars;
+
+					$_SERVER['REQUEST_URI'] = $old_request_uri;
+					$wp->request            = $old_wp_request;
+
+					$recursing = false;
+					return $query;
+				},
+			],
 			'path_suffix_transitional_mode_non_amp' => [
 				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
 				Option::PAIRED_URL_STRUCTURE_PATH_SUFFIX,
@@ -364,8 +397,9 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 	 * @param string $structure
 	 * @param string $request_uri
 	 * @param bool $did_request_endpoint
+	 * @param callable $nested_request_callback
 	 */
-	public function test_initialize_paired_request_integration( $mode, $structure, $request_uri, $did_request_endpoint ) {
+	public function test_initialize_paired_request_integration( $mode, $structure, $request_uri, $did_request_endpoint, $nested_request_callback = null ) {
 		global $wp;
 		$post_id = self::factory()->post->create();
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
@@ -376,10 +410,17 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 		$request_uri = rtrim( wp_parse_url( $permalink, PHP_URL_PATH ), '/' ) . $request_uri;
 
 		$request_uri_during_parse_request = null;
+		$first_request                    = true;
 		add_filter(
 			'request',
-			function ( $query_vars ) use ( &$request_uri_during_parse_request ) {
-				$request_uri_during_parse_request = $_SERVER['REQUEST_URI'];
+			function ( $query_vars ) use ( &$request_uri_during_parse_request, &$first_request, $nested_request_callback ) {
+				if ( $first_request ) {
+					$request_uri_during_parse_request = $_SERVER['REQUEST_URI'];
+					$first_request                    = false;
+				}
+				if ( $nested_request_callback ) {
+					$query_vars = $nested_request_callback( $query_vars );
+				}
 				return $query_vars;
 			}
 		);

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -436,9 +436,9 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		$this->instance->initialize_paired_request();
 		$this->assertFalse( $this->get_private_property( $this->instance, 'did_request_endpoint' ) );
-		$this->assertEquals( 10, has_filter( 'do_parse_request', [ $this->instance, 'extract_endpoint_from_environment_before_parse_request' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'do_parse_request', [ $this->instance, 'extract_endpoint_from_environment_before_parse_request' ] ) );
 		$this->assertEquals( 10, has_filter( 'request', [ $this->instance, 'filter_request_after_endpoint_extraction' ] ) );
-		$this->assertEquals( 10, has_action( 'parse_request', [ $this->instance, 'restore_path_endpoint_in_environment' ] ) );
+		$this->assertEquals( defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX, has_action( 'parse_request', [ $this->instance, 'restore_path_endpoint_in_environment' ] ) ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		if ( $filtering_unique_post_slug ) {
 			$this->assertEquals( 10, has_filter( 'wp_unique_post_slug', [ $this->instance, 'filter_unique_post_slug' ] ) );
 		} else {

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1344,6 +1344,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::ensure_required_markup()
 	 */
 	public function test_unneeded_scripts_get_removed() {
+		wp_styles(); // Needed after <https://core.trac.wordpress.org/changeset/50836>.
+
 		wp();
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Theme_Support::init();
@@ -1417,6 +1419,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::ensure_required_markup()
 	 */
 	public function test_duplicate_scripts_are_removed() {
+		wp_styles(); // Needed after <https://core.trac.wordpress.org/changeset/50836>.
+
 		wp();
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Theme_Support::init();
@@ -1532,6 +1536,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::is_output_buffering()
 	 */
 	public function test_finish_output_buffering() {
+		wp_styles(); // Needed after <https://core.trac.wordpress.org/changeset/50836>.
+
 		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );


### PR DESCRIPTION
## Summary

As reported in two support topics:

* https://wordpress.org/support/topic/amp-urls-404/
* https://wordpress.org/support/topic/conflict-with-the-custom-permalinks-plugin/

When using AMP with the [Custom Permalinks](https://wordpress.org/plugins/custom-permalinks/) plugin, attempting to access a paired AMP page for a post with a custom permalink results in a 404.

To replicate the issue:

0. Set the Paired URL Structure to query param (`?amp=1`)
1. Install Custom Permalinks
2. Create a post (and reload the editor)
3. Find Custom Permalinks metabox on the bottom and supply some custom path
4. View the non-AMP page
5. Try viewing the AMP version, and see a 404.

### Editor

![image](https://user-images.githubusercontent.com/134745/117882166-e85cd500-b25e-11eb-9ffc-b0d3780562f2.png)

### Frontend

Non-AMP | AMP
----------|------
![image](https://user-images.githubusercontent.com/134745/117882272-04607680-b25f-11eb-8c57-cf47a58ffa12.png) | ![image](https://user-images.githubusercontent.com/134745/117882427-2fe36100-b25f-11eb-9626-a2e91552371a.png)

Note that if you set the Paired URL Structure to endpoint suffix (`/amp/`) then attempting to access the AMP version of a page will cause a redirect to the non-AMP version (which is working as intended since a 404 was served).

### Solution

The issue is that the Custom Permalinks plugin is doing (in [`Custom_Permalinks_Frontend::parse_request()`](https://github.com/samiahmedsiddiqui/custom-permalinks/blob/da6f1d7a17ff72e3d1cb498621e11a09b5169db0/includes/class-custom-permalinks-frontend.php#L193-L389)) a secondary/recursive call to `$wp->parse_request()` inside of a `request` filter callback. This is conflicting with the request manipulation logic that we are doing in the `do_parse_request`, `request`, and `parse_request` hooks. 

The fix is to make sure that our logic only runs during the outermost/root request and not for any inner/recursive request.

This PR also changes the filter priorities, so that `extract_endpoint_from_environment_before_parse_request` runs as late as possible for the `do_parse_request` filter so that it can short-circuit if another theme/plugin aborts the request parsing. In the same way, `restore_path_endpoint_in_environment` now runs at the minimum priority to clean up the environment as early as possible after the AMP request has been parsed.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
