### PR TITLE
Defer obtaining URL for Customizer preview until AMP Customizer is accessed

### DIFF
--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -71,8 +71,8 @@ class AMP_Template_Customizer {
 	 * @since 0.4
 	 * @access public
 	 *
-	 * @param WP_Customize_Manager $wp_customize        Customizer instance.
-	 * @param ReaderThemeLoader    $reader_theme_loader Reader theme loader.
+	 * @param WP_Customize_Manager   $wp_customize        Customizer instance.
+	 * @param ReaderThemeLoader|null $reader_theme_loader Reader theme loader.
 	 * @return AMP_Template_Customizer Instance.
 	 */
 	public static function init( WP_Customize_Manager $wp_customize, ReaderThemeLoader $reader_theme_loader = null ) {

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -7,6 +7,7 @@
 
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\ReaderThemeLoader;
 use AmpProject\AmpWP\Services;
 
@@ -85,6 +86,8 @@ class AMP_Template_Customizer {
 		$has_reader_theme = ( ReaderThemes::DEFAULT_READER_THEME !== AMP_Options_Manager::get_option( Option::READER_THEME ) ); // @todo Verify that the theme actually exists.
 
 		if ( $is_reader_mode ) {
+			add_action( 'customize_controls_init', [ $self, 'set_reader_preview_url' ] );
+
 			if ( $has_reader_theme ) {
 				add_action( 'customize_save_after', [ $self, 'store_modified_theme_mod_setting_timestamps' ] );
 			}
@@ -121,6 +124,18 @@ class AMP_Template_Customizer {
 			add_action( 'customize_controls_print_footer_scripts', [ $self, 'add_dark_mode_toggler_button_notice' ] );
 		}
 		return $self;
+	}
+
+	/**
+	 * Set the preview URL when using a Reader theme if the AMP preview permalink was requested and no URL was provided.
+	 */
+	public function set_reader_preview_url() {
+		if ( isset( $_GET[ QueryVar::AMP_PREVIEW ] ) && ! isset( $_GET['url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$url = amp_admin_get_preview_permalink();
+			if ( $url ) {
+				$this->wp_customize->set_preview_url( $url );
+			}
+		}
 	}
 
 	/**

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -262,7 +262,8 @@ class AMP_Template_Customizer {
 		// action and in `WP_Customize_Manager::customize_preview_init()` the `wp_robots_no_robots()` function is added
 		// to the `wp_robots` filter.
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '<' ) ) {
-			add_action( 'amp_post_template_head', 'wp_no_robots' );
+			// There is code coverage for this, but code coverage is only collected for the latest WP version.
+			add_action( 'amp_post_template_head', 'wp_no_robots' ); // @codeCoverageIgnore
 		}
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_legacy_preview_scripts' ] );

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -243,7 +243,13 @@ class AMP_Template_Customizer {
 	 * @since 0.4
 	 */
 	public function init_legacy_preview() {
-		add_action( 'amp_post_template_head', 'wp_no_robots' );
+		// This is only needed in WP<5.7 because in 5.7 the `wp_robots()` function runs at the `amp_post_template_head`
+		// action and in `WP_Customize_Manager::customize_preview_init()` the `wp_robots_no_robots()` function is added
+		// to the `wp_robots` filter.
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '<' ) ) {
+			add_action( 'amp_post_template_head', 'wp_no_robots' );
+		}
+
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_legacy_preview_scripts' ] );
 		add_action( 'amp_customizer_enqueue_preview_scripts', [ $this, 'enqueue_legacy_preview_scripts' ] );
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -6,6 +6,7 @@
  */
 
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\QueryVar;
 
 /**
  * Sets up the AMP template editor for the Customizer.
@@ -98,7 +99,7 @@ function amp_get_customizer_url() {
 	}
 
 	$args = [
-		'url' => amp_admin_get_preview_permalink(),
+		QueryVar::AMP_PREVIEW => '1',
 	];
 	if ( $is_legacy ) {
 		$args['autofocus[panel]'] = AMP_Template_Customizer::PANEL_ID;

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -133,37 +133,6 @@ function amp_add_customizer_link() {
 }
 
 /**
- * Add custom analytics.
- *
- * This is currently only used for legacy AMP post templates.
- *
- * @since 0.5
- * @see amp_get_analytics()
- * @internal
- *
- * @param array $analytics Analytics.
- * @return array Analytics.
- */
-function amp_add_custom_analytics( $analytics = [] ) {
-	$analytics = amp_get_analytics( $analytics );
-
-	/**
-	 * Add amp-analytics tags.
-	 *
-	 * This filter allows you to easily insert any amp-analytics tags without needing much heavy lifting.
-	 * This filter should be used to alter entries for legacy AMP templates.
-	 *
-	 * @since 0.4
-	 *
-	 * @param array   $analytics An associative array of the analytics entries we want to output. Each array entry must have a unique key, and the value should be an array with the following keys: `type`, `attributes`, `script_data`. See readme for more details.
-	 * @param WP_Post $post      The current post.
-	 */
-	$analytics = apply_filters( 'amp_post_template_analytics', $analytics, get_queried_object() );
-
-	return $analytics;
-}
-
-/**
  * Bootstrap AMP Editor core blocks.
  *
  * @internal

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -39,6 +39,7 @@ function amp_admin_get_preview_permalink() {
 	/**
 	 * Filter the post type to retrieve the latest for use in the AMP template customizer.
 	 *
+	 * @todo This filter doesn't actually do anything at present. Instead of array_unique() below, an array_intersect() should have been used.
 	 * @param string $post_type Post type slug. Default 'post'.
 	 */
 	$post_type = (string) apply_filters( 'amp_customizer_post_type', 'post' );
@@ -46,7 +47,7 @@ function amp_admin_get_preview_permalink() {
 	// Make sure the desired post type is actually supported, and if so, prefer it.
 	$supported_post_types = AMP_Post_Type_Support::get_supported_post_types();
 	if ( in_array( $post_type, $supported_post_types, true ) ) {
-		$supported_post_types = array_unique( array_merge( [ $post_type ], $supported_post_types ) );
+		$supported_post_types = array_values( array_unique( array_merge( [ $post_type ], $supported_post_types ) ) );
 	}
 
 	// Bail if there are no supported post types.

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -126,6 +126,37 @@ function amp_post_template_add_styles( $amp_template ) {
 }
 
 /**
+ * Add custom analytics.
+ *
+ * This is currently only used for legacy AMP post templates.
+ *
+ * @since 0.5
+ * @see amp_get_analytics()
+ * @internal
+ *
+ * @param array $analytics Analytics.
+ * @return array Analytics.
+ */
+function amp_add_custom_analytics( $analytics = [] ) {
+	$analytics = amp_get_analytics( $analytics );
+
+	/**
+	 * Add amp-analytics tags.
+	 *
+	 * This filter allows you to easily insert any amp-analytics tags without needing much heavy lifting.
+	 * This filter should be used to alter entries for legacy AMP templates.
+	 *
+	 * @since 0.4
+	 *
+	 * @param array   $analytics An associative array of the analytics entries we want to output. Each array entry must have a unique key, and the value should be an array with the following keys: `type`, `attributes`, `script_data`. See readme for more details.
+	 * @param WP_Post $post      The current post.
+	 */
+	$analytics = apply_filters( 'amp_post_template_analytics', $analytics, get_queried_object() );
+
+	return $analytics;
+}
+
+/**
  * Print analytics data.
  *
  * @internal

--- a/src/QueryVar.php
+++ b/src/QueryVar.php
@@ -70,4 +70,11 @@ interface QueryVar {
 	 * @var string
 	 */
 	const VERBOSE_SERVER_TIMING = 'amp_verbose_server_timing';
+
+	/**
+	 * Query parameter provided to customize.php to indicate that the preview should be loaded with an AMP URL.
+	 *
+	 * @var string
+	 */
+	const AMP_PREVIEW = 'amp_preview';
 }

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -279,7 +279,9 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		$wp_customize = $this->get_customize_manager();
 		$instance     = AMP_Template_Customizer::init( $wp_customize );
 		$instance->init_legacy_preview();
-		$this->assertEquals( 10, has_action( 'amp_post_template_head', 'wp_no_robots' ) );
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '<' ) ) {
+			$this->assertEquals( 10, has_action( 'amp_post_template_head', 'wp_no_robots' ) );
+		}
 		$this->assertEquals( 10, has_action( 'amp_customizer_enqueue_preview_scripts', [ $instance, 'enqueue_legacy_preview_scripts' ] ) );
 		$this->assertNull( $wp_customize->get_messenger_channel() );
 	}
@@ -290,7 +292,9 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		$wp_customize->start_previewing_theme();
 		$instance = AMP_Template_Customizer::init( $wp_customize );
 		$instance->init_legacy_preview();
-		$this->assertEquals( 10, has_action( 'amp_post_template_head', 'wp_no_robots' ) );
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '<' ) ) {
+			$this->assertEquals( 10, has_action( 'amp_post_template_head', 'wp_no_robots' ) );
+		}
 		$this->assertEquals( 10, has_action( 'amp_customizer_enqueue_preview_scripts', [ $instance, 'enqueue_legacy_preview_scripts' ] ) );
 		$this->assertEquals( '123', $wp_customize->get_messenger_channel() );
 

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -69,6 +69,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		}
 
 		$instance = AMP_Template_Customizer::init( $wp_customize );
+		$this->assertFalse( has_action( 'customize_controls_init', [ $instance, 'set_reader_preview_url' ] ) );
 		$this->assertEquals( 0, did_action( 'amp_customizer_init' ) );
 		$this->assertFalse( has_action( 'customize_controls_enqueue_scripts', [ $instance, 'add_customizer_scripts' ] ) );
 
@@ -93,6 +94,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		}
 
 		$instance = AMP_Template_Customizer::init( $wp_customize );
+		$this->assertFalse( has_action( 'customize_controls_init', [ $instance, 'set_reader_preview_url' ] ) );
 		$this->assertEquals( 0, did_action( 'amp_customizer_init' ) );
 		$this->assertFalse( has_action( 'customize_save_after', [ $instance, 'store_modified_theme_mod_setting_timestamps' ] ) );
 		$this->assertFalse( has_action( 'customize_controls_enqueue_scripts', [ $instance, 'add_customizer_scripts' ] ) );
@@ -127,6 +129,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		}
 
 		$instance = AMP_Template_Customizer::init( $wp_customize );
+		$this->assertEquals( 10, has_action( 'customize_controls_init', [ $instance, 'set_reader_preview_url' ] ) );
 		$this->assertFalse( has_action( 'customize_save_after', [ $instance, 'store_modified_theme_mod_setting_timestamps' ] ) );
 		$this->assertFalse( has_action( 'customize_controls_enqueue_scripts', [ $instance, 'add_customizer_scripts' ] ) );
 		$this->assertEquals( 1, did_action( 'amp_customizer_init' ) );
@@ -181,6 +184,7 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		}
 
 		$instance = AMP_Template_Customizer::init( $wp_customize );
+		$this->assertEquals( 10, has_action( 'customize_controls_init', [ $instance, 'set_reader_preview_url' ] ) );
 		$this->assertEquals( 10, has_action( 'customize_save_after', [ $instance, 'store_modified_theme_mod_setting_timestamps' ] ) );
 		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', [ $instance, 'add_customizer_scripts' ] ) );
 		$this->assertEquals( 10, has_action( 'customize_controls_print_footer_scripts', [ $instance, 'render_setting_import_section_template' ] ) );

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -72,12 +72,95 @@ class Test_AMP_Admin_Includes_Functions extends WP_UnitTestCase {
 
 	/** @covers ::amp_admin_get_preview_permalink() */
 	public function test_amp_admin_get_preview_permalink() {
-		$this->markTestIncomplete();
+		$page_id = self::factory()->post->create(
+			[
+				'post_type' => 'page',
+				'post_date' => '2020-01-01',
+			]
+		);
+		$post_id = self::factory()->post->create(
+			[
+				'post_type' => 'post',
+				'post_date' => '2021-01-01',
+			]
+		);
+
+		// Default case.
+		$this->assertEquals( amp_get_permalink( $post_id ), amp_admin_get_preview_permalink() );
+
+		// Only get a page if it is the only supported post type.
+		AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, [ 'page' ] );
+		add_filter(
+			'amp_customizer_post_type',
+			static function () {
+				return 'page';
+			}
+		);
+		$this->assertEquals( amp_get_permalink( $page_id ), amp_admin_get_preview_permalink() );
+
+		// Nothing returned if supported post types exist.
+		AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, [ 'book' ] );
+		$this->assertNull( amp_admin_get_preview_permalink() );
+
+		// If is_singular is not a supported template, then no URL will be returned (currently).
+		AMP_Options_Manager::update_options(
+			[
+				Option::THEME_SUPPORT           => AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+				Option::SUPPORTED_POST_TYPES    => [ 'post', 'page' ],
+				Option::SUPPORTED_TEMPLATES     => [ 'is_archive' ],
+				Option::ALL_TEMPLATES_SUPPORTED => false,
+			]
+		);
+		$this->assertNull( amp_admin_get_preview_permalink() );
 	}
 
-	/** @covers ::amp_get_customizer_url() */
-	public function test_amp_get_customizer_url() {
-		$this->markTestIncomplete();
+	/** @return array */
+	public function get_data_for_test_amp_get_customizer_url() {
+		return [
+			'legacy_reader' => [
+				'options' => [
+					Option::THEME_SUPPORT => AMP_Theme_Support::READER_MODE_SLUG,
+					Option::READER_THEME  => ReaderThemes::DEFAULT_READER_THEME,
+				],
+				function () {
+					$this->assertTrue( amp_is_legacy() );
+					$this->assertEquals( 'customize.php?amp_preview=1&autofocus[panel]=amp_panel', amp_get_customizer_url() );
+
+					add_filter( 'amp_customizer_is_enabled', '__return_false' );
+					$this->assertEquals( '', amp_get_customizer_url() );
+				},
+			],
+			'reader_theme'  => [
+				'options' => [
+					Option::THEME_SUPPORT => AMP_Theme_Support::READER_MODE_SLUG,
+					Option::READER_THEME  => 'twentynineteen',
+				],
+				function () {
+					$this->assertFalse( amp_is_legacy() );
+					$this->assertEquals( 'customize.php?amp_preview=1&amp=1', amp_get_customizer_url() );
+				},
+			],
+			'transitional'  => [
+				'options' => [
+					Option::THEME_SUPPORT => AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+				],
+				function () {
+					$this->assertEquals( '', amp_get_customizer_url() );
+				},
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_for_test_amp_get_customizer_url
+	 * @covers ::amp_get_customizer_url()
+	 *
+	 * @param array    $options Options.
+	 * @param callable $assert  Assert.
+	 */
+	public function test_amp_get_customizer_url( $options, $assert ) {
+		AMP_Options_Manager::update_options( $options );
+		$assert();
 	}
 
 	/** @covers ::amp_add_customizer_link() */

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -70,6 +70,16 @@ class Test_AMP_Admin_Includes_Functions extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'admin_menu', 'amp_add_customizer_link' ) );
 	}
 
+	/** @covers ::amp_admin_get_preview_permalink() */
+	public function test_amp_admin_get_preview_permalink() {
+		$this->markTestIncomplete();
+	}
+
+	/** @covers ::amp_get_customizer_url() */
+	public function test_amp_get_customizer_url() {
+		$this->markTestIncomplete();
+	}
+
 	/** @covers ::amp_add_customizer_link() */
 	public function test_amp_add_customizer_link_legacy() {
 		global $submenu;
@@ -112,5 +122,6 @@ class Test_AMP_Admin_Includes_Functions extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'themes.php', $submenu );
 		$this->assertEquals( 'AMP', $submenu['themes.php'][0][0] );
+		$this->assertEquals( 'customize.php?amp_preview=1&amp=1', $submenu['themes.php'][0][2] );
 	}
 }

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -72,6 +72,9 @@ class Test_AMP_Admin_Includes_Functions extends WP_UnitTestCase {
 
 	/** @covers ::amp_admin_get_preview_permalink() */
 	public function test_amp_admin_get_preview_permalink() {
+		// No posts exist yet.
+		$this->assertNull( amp_admin_get_preview_permalink() );
+
 		$page_id = self::factory()->post->create(
 			[
 				'post_type' => 'page',
@@ -223,5 +226,30 @@ class Test_AMP_Admin_Includes_Functions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'themes.php', $submenu );
 		$this->assertEquals( 'AMP', $submenu['themes.php'][0][0] );
 		$this->assertEquals( 'customize.php?amp_preview=1&amp=1', $submenu['themes.php'][0][2] );
+	}
+
+	/** @covers ::amp_editor_core_blocks() */
+	public function test_amp_editor_core_blocks() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			$this->markTestSkipped( 'Requires block editor.' );
+		}
+
+		remove_all_filters( 'wp_kses_allowed_html' );
+		amp_editor_core_blocks();
+		$this->assertTrue( has_filter( 'wp_kses_allowed_html' ) );
+	}
+
+	/** @covers ::amp_bootstrap_admin() */
+	public function test_amp_bootstrap_admin() {
+		remove_all_actions( 'admin_enqueue_scripts' );
+		remove_all_actions( 'post_submitbox_misc_actions' );
+		amp_bootstrap_admin();
+		$this->assertTrue( has_action( 'admin_enqueue_scripts' ) );
+		$this->assertTrue( has_action( 'post_submitbox_misc_actions' ) );
+	}
+
+	/** @covers ::amp_should_use_new_onboarding() */
+	public function test_amp_should_use_new_onboarding() {
+		$this->markTestIncomplete( 'This function may be eliminated as of https://github.com/ampproject/amp-wp/pull/6225' );
 	}
 }


### PR DESCRIPTION
## Summary

This addresses a [support forum topic](https://wordpress.org/support/topic/wp_query-get_posts-slow-query-when-add-edit-post/):

> When working in the backend using the Classic Editor, we have noticed significant slow queries from the following call related to the AMP plugin.
>
> We have 20k posts and 500k comments.
>
> ![image](https://user-images.githubusercontent.com/134745/117923728-6d6cdc00-b2a9-11eb-99b2-6b67522d20a8.png)
>
> After reviewing previous threads I can confirm AMP developer tools is deactivated. Any other thoughts on how to reduce or eliminate this call on the admin backend? We don’t need to use any of the settings or meta boxes for AMP on a per-post basis, is there an option to not load this call at all?

The issue here is the AMP Customizer link which is added under the Appearance menu when Reader mode is selected:

> ![image](https://user-images.githubusercontent.com/134745/117923852-a442f200-b2a9-11eb-813f-07a137fb99bb.png)

In order to have the Customizer open with an AMP page in the preview, we do a query to find an AMP page and then supply it in the `url` parameter to `customize.php`. However, we don't have to supply this URL at this point. We can defer lookup up the URL until the Customizer is actually accessed. We can omit the `url` parameter and instead supply a custom one like `amp_preview`. When that is supplied when accessing `customize.php` and Reader mode is active, in the `customize_controls_init` action we can at that point do the lookup for an AMP page and pass it to `WP_Customize_Manager::set_preview_url()`. In this way the preview URL will be determined just in time. 

This only applies in Reader mode to the aforementioned AMP admin menu item under Appearance and also to the “Customize Reader Theme” link on the AMP Settings screen:

> ![image](https://user-images.githubusercontent.com/134745/117924247-4bc02480-b2aa-11eb-829c-aa9aaf183610.png)

----

This PR also fixes a deprecation notice which was something I missed in #5793.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
