### PR TITLE
Clarify what Paired URL Structures are and when to change them

### DIFF
--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -135,6 +135,16 @@ export function PairedUrlStructure( { focusedSection } ) {
 				</AMPNotice>
 			) }
 
+			<p dangerouslySetInnerHTML={
+				{ __html:
+					sprintf(
+						/* translators: 1: AMP Analytics docs URL */
+						__( 'When using Transitional or Reader template modes, your site is is in a “Paired AMP” configuration where your canonical URLs are non-AMP and then you have separate AMP versions of your pages with AMP-specific URLs. The structure of the paired AMP URL is not important, whether using a query parameter or path suffix. The use of a query parameter is the most compatible across various sites and it has the benefit of not resulting in a 404 if the AMP plugin is deactivated, so that is why it is the default. <em>Please note that changing the paired URL structure can cause AMP pages to disappear from search results until your site has been re-indexed.</em> So if the current structure of your paired AMP URLs works for you, there is no need to change. If you\'re migrating from another AMP plugin that used a different paired URL structure than the default, then you may want to change this setting. <a href="%1$s" target="_blank">Learn more</a>.', 'amp' ),
+						__( 'https://amp-wp.org/?p=10004', 'amp' ),
+					),
+				} }
+			/>
+
 			{ ! endpointSuffixAvailable && (
 				<AMPNotice size={ NOTICE_SIZE_LARGE } type={ NOTICE_TYPE_INFO }>
 					<p>
@@ -168,7 +178,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 						</code>
 						{ ' ' }
 						<em>
-							{ __( '(recommended)', 'amp' ) }
+							{ __( '(default)', 'amp' ) }
 						</em>
 					</label>
 					<PairedUrlExamples pairedUrls={ editedOptions.paired_url_examples.query_var } />

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -374,6 +374,7 @@ li.error-kept {
 }
 
 #plugin-suppression .amp-drawer__panel-body-inner > p,
+#paired-url-structure .amp-drawer__panel-body-inner > p,
 .amp-analytics .amp-drawer__panel-body-inner p,
 #paired-url-structure .amp-drawer__panel-body-inner {
 	margin-top: 0;
@@ -393,6 +394,10 @@ li.error-kept {
 	margin-top: 5px;
 	margin-bottom: 5px;
 	line-height: 1.5;
+}
+
+#paired-url-structure ul {
+	margin-top: 1.5rem;
 }
 
 #paired-url-structure .amp-notice--large {


### PR DESCRIPTION
## Summary

I've seen some users ask about the Paired URL Structures and when/why they would change them. In particular, users are not currently told that changing the paired URL structure can cause their paired AMP pages to disappear from search results until they are re-crawled. This should clarify why and why not to change the setting.

Before | After
-------|-----
<img width="972" alt="Screen Shot 2021-05-13 at 11 12 47" src="https://user-images.githubusercontent.com/134745/118171797-7ad8b200-b3e0-11eb-959e-a1d5472e09c7.png"> | <img width="972" alt="Screen Shot 2021-05-13 at 11 43 36" src="https://user-images.githubusercontent.com/134745/118171821-8330ed00-b3e0-11eb-9bcf-5a98b55b13c2.png">

The Learn More link goes to the pending docs page: https://amp-wp.org/documentation/getting-started/paired-url-structures/

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
