### PR TITLE
Call `amp_get_schemaorg_metadata()` before output buffer processing

### DIFF
--- a/src/Optimizer/Transformer/AmpSchemaOrgMetadataConfiguration.php
+++ b/src/Optimizer/Transformer/AmpSchemaOrgMetadataConfiguration.php
@@ -46,7 +46,7 @@ final class AmpSchemaOrgMetadataConfiguration extends BaseTransformerConfigurati
 		}
 
 		return [
-			self::METADATA => (array) amp_get_schemaorg_metadata(),
+			self::METADATA => [],
 		];
 	}
 

--- a/tests/php/test-class-amp-schema-org-metadata.php
+++ b/tests/php/test-class-amp-schema-org-metadata.php
@@ -86,7 +86,5 @@ class AmpSchemaOrgMetadataTest extends WP_UnitTestCase {
 
 		$xpath_query = '//script[ @type = "application/ld+json" ]';
 		$this->assertEquals( 0, $dom->xpath->query( $xpath_query )->length );
-
-		remove_filter( 'amp_schemaorg_metadata', '__return_empty_array' );
 	}
 }

--- a/tests/php/test-class-amp-schema-org-metadata.php
+++ b/tests/php/test-class-amp-schema-org-metadata.php
@@ -55,10 +55,21 @@ class AmpSchemaOrgMetadataTest extends WP_UnitTestCase {
 	 * @param int    $expected Expected count of valid JSON+LD schema.
 	 */
 	public function test_transform( $json, $expected ) {
-		$html        = '<html><head><script type="application/ld+json">%s</script></head><body>Test</body></html>';
-		$dom         = Document::fromHtml( sprintf( $html, $json ), Options::DEFAULTS );
-		$transformer = new AmpSchemaOrgMetadata( new AmpSchemaOrgMetadataConfiguration() );
-		$errors      = new ErrorCollection();
+		$html          = '<html><head><script type="application/ld+json">%s</script></head><body>Test</body></html>';
+		$dom           = Document::fromHtml( sprintf( $html, $json ), Options::DEFAULTS );
+		$configuration = new AmpSchemaOrgMetadataConfiguration(
+			[
+				AmpSchemaOrgMetadataConfiguration::METADATA => [
+					'@context'  => 'http://schema.org',
+					'publisher' => [
+						'@type' => 'Organization',
+						'name'  => 'Acme',
+					],
+				],
+			]
+		);
+		$transformer   = new AmpSchemaOrgMetadata( $configuration );
+		$errors        = new ErrorCollection();
 		$transformer->transform( $dom, $errors );
 		$this->assertEquals( $expected, substr_count( $dom->saveHTML(), 'schema.org' ) );
 	}
@@ -69,8 +80,6 @@ class AmpSchemaOrgMetadataTest extends WP_UnitTestCase {
 	 * @covers ::transform
 	 */
 	public function test_empty_metadata_configuration() {
-		add_filter( 'amp_schemaorg_metadata', '__return_empty_array' );
-
 		$dom         = new Document();
 		$transformer = new AmpSchemaOrgMetadata( new AmpSchemaOrgMetadataConfiguration() );
 		$transformer->transform( $dom, new ErrorCollection() );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1982,7 +1982,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 
 		add_filter(
-			'amp_schemaorg_metadata',
+			'amp_enable_optimizer',
 			static function () {
 				throw new RuntimeException( 'FAILURE', 42 );
 			}


### PR DESCRIPTION
## Summary

Fixes #6232

This moves up the `amp_get_schemaorg_metadata()` call to just before output buffering starts rather than calling it after output buffering has finished. This avoids many filters/actions from being invoked which are liable to call `ob_start()`.

👉  There is the possibility of a breaking change here. Namely, if a theme/plugin adds a `amp_schemaorg_metadata` filter or `amp_post_template_metadata` filter _after_ the `template_redirect` action then their function will not apply. Previously a site could add that filter at any point during template rendering. Nevertheless, it is not expected that this will be a problem.

### Deduplicated hooks fired before (count 173)

* `add_option`
* `add_option__transient_amp-parsed-stylesheet-v36-*`
* `add_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `added_option`
* `admin_url`
* `alloptions`
* `amp_default_options`
* `amp_enable_optimizer`
* `amp_enable_ssr`
* `amp_extract_image_dimensions_batch`
* `amp_extract_image_dimensions_batch_callbacks_registered`
* `amp_extract_image_dimensions_get_user_agent`
* `amp_optimizer_config`
* `amp_post_template_metadata`
* `amp_query_var`
* `amp_schemaorg_metadata`
* `amp_server_timing_log`
* `amp_server_timing_start`
* `amp_server_timing_stop`
* `amp_site_icon_url`
* `amp_to_amp_linking_element_excluded`
* `amp_to_amp_linking_element_query_vars`
* `amp_validation_error`
* `amp_validation_error_sanitized`
* `block_parser_class`
* `content_url`
* `default_option__transient_amp-parsed-stylesheet-v36-*`
* `default_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `default_option_site_logo`
* `default_post_metadata`
* `determine_locale`
* `editor_max_image_size`
* `expiration_of_transient_amp-parsed-stylesheet-v36-*`
* `get_amp_validation_error`
* `get_attached_file`
* `get_avatar_data`
* `get_avatar_url`
* `get_meta_sql`
* `get_post_metadata`
* `get_post_status`
* `get_site_icon_url`
* `get_term`
* `get_terms_args`
* `get_terms_defaults`
* `get_terms_fields`
* `get_terms_orderby`
* `get_user_metadata`
* `gettext`
* `gettext_amp`
* `gettext_default`
* `has_post_thumbnail`
* `home_url`
* `image_downsize`
* `includes_url`
* `infinite_scroll_archive_supported`
* `infinite_scroll_settings`
* `jetpack_images_get_images`
* `jetpack_images_pre_get_images`
* `jetpack_postimages_post_get_image`
* `jetpack_postimages_pre_get_image`
* `list_terms_exclusions`
* `locale`
* `log_query_custom_data`
* `map_meta_cap`
* `no_texturize_shortcodes`
* `no_texturize_tags`
* `option__transient_amp-parsed-stylesheet-v36-*`
* `option__transient_amp_remote_request_*`
* `option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `option__transient_timeout_amp_remote_request_*`
* `option_amp-options`
* `option_avatar_default`
* `option_avatar_rating`
* `option_blog_charset`
* `option_blogname`
* `option_comments_per_page`
* `option_home`
* `option_page_on_front`
* `option_permalink_structure`
* `option_show_on_front`
* `option_site_icon`
* `option_siteurl`
* `option_stylesheet`
* `option_stylesheet_root`
* `option_template`
* `option_theme_mods_twentytwentyone`
* `option_timezone_string`
* `parse_query`
* `parse_tax_query`
* `parse_term_query`
* `post_limits`
* `post_limits_request`
* `post_link`
* `posts_clauses`
* `posts_clauses_request`
* `posts_distinct`
* `posts_distinct_request`
* `posts_fields`
* `posts_fields_request`
* `posts_groupby`
* `posts_groupby_request`
* `posts_join`
* `posts_join_paged`
* `posts_join_request`
* `posts_orderby`
* `posts_orderby_request`
* `posts_pre_query`
* `posts_request`
* `posts_search`
* `posts_selection`
* `posts_where`
* `posts_where_paged`
* `posts_where_request`
* `pre_determine_locale`
* `pre_get_avatar_data`
* `pre_get_posts`
* `pre_get_table_charset`
* `pre_get_terms`
* `pre_option__transient_amp-parsed-stylesheet-v36-*`
* `pre_option__transient_amp_remote_request_*`
* `pre_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `pre_option__transient_timeout_amp_remote_request_*`
* `pre_option_amp-options`
* `pre_option_avatar_default`
* `pre_option_avatar_rating`
* `pre_option_blog_charset`
* `pre_option_blogname`
* `pre_option_comments_per_page`
* `pre_option_home`
* `pre_option_page_on_front`
* `pre_option_permalink_structure`
* `pre_option_show_on_front`
* `pre_option_site_icon`
* `pre_option_site_logo`
* `pre_option_siteurl`
* `pre_option_stylesheet`
* `pre_option_stylesheet_root`
* `pre_option_template`
* `pre_option_theme_mods_twentytwentyone`
* `pre_option_timezone_string`
* `pre_post_link`
* `pre_set_transient_amp-parsed-stylesheet-v36-*`
* `pre_transient_amp-parsed-stylesheet-v36-*`
* `pre_transient_amp_remote_request_*`
* `query`
* `sanitize_key`
* `sanitize_option__transient_amp-parsed-stylesheet-v36-*`
* `sanitize_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `sanitize_title`
* `set_transient_amp-parsed-stylesheet-v36-*`
* `set_url_scheme`
* `setted_transient`
* `show_admin_bar`
* `site_url`
* `stylesheet`
* `stylesheet_directory_uri`
* `template`
* `template_directory_uri`
* `terms_clauses`
* `terms_pre_query`
* `the_title`
* `theme_mod_custom_logo`
* `theme_root_uri`
* `transient_amp-parsed-stylesheet-v36-*`
* `transient_amp_remote_request_*`
* `upload_dir`
* `user_has_cap`
* `user_trailingslashit`
* `wp_constrain_dimensions`
* `wp_get_attachment_image_src`
* `wp_get_attachment_metadata`
* `wp_get_attachment_url`
* `wp_parse_str`

### Deduplicated hooks fired after (count 91)

* `add_option`
* `add_option__transient_amp-parsed-stylesheet-v36-*`
* `add_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `added_option`
* `admin_url`
* `alloptions`
* `amp_default_options`
* `amp_enable_optimizer`
* `amp_enable_ssr`
* `amp_extract_image_dimensions_batch`
* `amp_extract_image_dimensions_batch_callbacks_registered`
* `amp_extract_image_dimensions_get_user_agent`
* `amp_optimizer_config`
* `amp_query_var`
* `amp_server_timing_log`
* `amp_server_timing_start`
* `amp_server_timing_stop`
* `amp_to_amp_linking_element_excluded`
* `amp_to_amp_linking_element_query_vars`
* `amp_validation_error`
* `amp_validation_error_sanitized`
* `content_url`
* `default_option__transient_amp-parsed-stylesheet-v36-*`
* `default_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `determine_locale`
* `expiration_of_transient_amp-parsed-stylesheet-v36-*`
* `get_amp_validation_error`
* `get_meta_sql`
* `get_term`
* `get_terms_args`
* `get_terms_defaults`
* `get_terms_fields`
* `get_terms_orderby`
* `gettext`
* `gettext_amp`
* `gettext_default`
* `home_url`
* `includes_url`
* `list_terms_exclusions`
* `locale`
* `log_query_custom_data`
* `map_meta_cap`
* `option__transient_amp-parsed-stylesheet-v36-*`
* `option__transient_amp_remote_request_*`
* `option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `option__transient_timeout_amp_remote_request_*`
* `option_amp-options`
* `option_home`
* `option_siteurl`
* `option_stylesheet`
* `option_stylesheet_root`
* `option_template`
* `parse_term_query`
* `pre_determine_locale`
* `pre_get_table_charset`
* `pre_get_terms`
* `pre_option__transient_amp-parsed-stylesheet-v36-*`
* `pre_option__transient_amp_remote_request_*`
* `pre_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `pre_option__transient_timeout_amp_remote_request_*`
* `pre_option_amp-options`
* `pre_option_home`
* `pre_option_siteurl`
* `pre_option_stylesheet`
* `pre_option_stylesheet_root`
* `pre_option_template`
* `pre_set_transient_amp-parsed-stylesheet-v36-*`
* `pre_transient_amp-parsed-stylesheet-v36-*`
* `pre_transient_amp_remote_request_*`
* `query`
* `sanitize_key`
* `sanitize_option__transient_amp-parsed-stylesheet-v36-*`
* `sanitize_option__transient_timeout_amp-parsed-stylesheet-v36-*`
* `sanitize_title`
* `set_transient_amp-parsed-stylesheet-v36-*`
* `set_url_scheme`
* `setted_transient`
* `show_admin_bar`
* `site_url`
* `stylesheet`
* `stylesheet_directory_uri`
* `template`
* `template_directory_uri`
* `terms_clauses`
* `terms_pre_query`
* `theme_root_uri`
* `transient_amp-parsed-stylesheet-v36-*`
* `transient_amp_remote_request_*`
* `user_has_cap`
* `user_trailingslashit`
* `wp_parse_str`

### Diff (removed count: 91 or 47%)

173 - 91 = 82 unique hooks prevented from running during output buffer processing:

```diff
14d13
< amp_post_template_metadata
16d14
< amp_schemaorg_metadata
20d17
< amp_site_icon_url
25d21
< block_parser_class
29,30d24
< default_option_site_logo
< default_post_metadata
32d25
< editor_max_image_size
35,37d27
< get_attached_file
< get_avatar_data
< get_avatar_url
39,41d28
< get_post_metadata
< get_post_status
< get_site_icon_url
47d33
< get_user_metadata
51d36
< has_post_thumbnail
53d37
< image_downsize
55,60d38
< infinite_scroll_archive_supported
< infinite_scroll_settings
< jetpack_images_get_images
< jetpack_images_pre_get_images
< jetpack_postimages_post_get_image
< jetpack_postimages_pre_get_image
65,66d42
< no_texturize_shortcodes
< no_texturize_tags
72,76d47
< option_avatar_default
< option_avatar_rating
< option_blog_charset
< option_blogname
< option_comments_per_page
78,81d48
< option_page_on_front
< option_permalink_structure
< option_show_on_front
< option_site_icon
86,89d52
< option_theme_mods_twentytwentyone
< option_timezone_string
< parse_query
< parse_tax_query
91,113d53
< post_limits
< post_limits_request
< post_link
< posts_clauses
< posts_clauses_request
< posts_distinct
< posts_distinct_request
< posts_fields
< posts_fields_request
< posts_groupby
< posts_groupby_request
< posts_join
< posts_join_paged
< posts_join_request
< posts_orderby
< posts_orderby_request
< posts_pre_query
< posts_request
< posts_search
< posts_selection
< posts_where
< posts_where_paged
< posts_where_request
115,116d54
< pre_get_avatar_data
< pre_get_posts
124,128d61
< pre_option_avatar_default
< pre_option_avatar_rating
< pre_option_blog_charset
< pre_option_blogname
< pre_option_comments_per_page
130,134d62
< pre_option_page_on_front
< pre_option_permalink_structure
< pre_option_show_on_front
< pre_option_site_icon
< pre_option_site_logo
139,141d66
< pre_option_theme_mods_twentytwentyone
< pre_option_timezone_string
< pre_post_link
161,162d85
< the_title
< theme_mod_custom_logo
166d88
< upload_dir
169,172d90
< wp_constrain_dimensions
< wp_get_attachment_image_src
< wp_get_attachment_metadata
< wp_get_attachment_url
```

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
