### PR TITLE
Try deferring output buffer processing until shutdown hook

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1650,49 +1650,54 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_output_buffering( $response ) {
 		self::$is_output_buffering = false;
+		register_shutdown_function(
+			function () use ( $response ) {
+				try {
+					$response = self::prepare_response( $response );
+				} catch ( Exception $exception ) {
+					$title   = __( 'Failed to prepare AMP page', 'amp' );
+					$message = __( 'A PHP error occurred while trying to prepare the AMP response. This may not be caused by the AMP plugin but by some other active plugin or the current theme. You will need to review the error details to determine the source of the error.', 'amp' );
 
-		try {
-			$response = self::prepare_response( $response );
-		} catch ( Exception $exception ) {
-			$title   = __( 'Failed to prepare AMP page', 'amp' );
-			$message = __( 'A PHP error occurred while trying to prepare the AMP response. This may not be caused by the AMP plugin but by some other active plugin or the current theme. You will need to review the error details to determine the source of the error.', 'amp' );
+					$error_page = Services::get( 'dev_tools.error_page' );
 
-			$error_page = Services::get( 'dev_tools.error_page' );
+					$error_page
+							->with_title( $title )
+							->with_message( $message )
+							->with_exception( $exception )
+							->with_response_code( 500 );
 
-			$error_page
-				->with_title( $title )
-				->with_message( $message )
-				->with_exception( $exception )
-				->with_response_code( 500 );
+					// Add link to non-AMP version if not canonical.
+					if ( ! amp_is_canonical() ) {
+						$non_amp_url = amp_remove_paired_endpoint( amp_get_current_url() );
 
-			// Add link to non-AMP version if not canonical.
-			if ( ! amp_is_canonical() ) {
-				$non_amp_url = amp_remove_paired_endpoint( amp_get_current_url() );
+						// Prevent user from being redirected back to AMP version.
+						if ( true === AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
+							$non_amp_url = add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, $non_amp_url );
+						}
 
-				// Prevent user from being redirected back to AMP version.
-				if ( true === AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT ) ) {
-					$non_amp_url = add_query_arg( QueryVar::NOAMP, QueryVar::NOAMP_MOBILE, $non_amp_url );
+						$error_page->with_back_link(
+							$non_amp_url,
+							__( 'Go to non-AMP version', 'amp' )
+						);
+					}
+
+					$response = $error_page->render();
 				}
 
-				$error_page->with_back_link(
-					$non_amp_url,
-					__( 'Go to non-AMP version', 'amp' )
-				);
+				/**
+				 * Fires when server timings should be sent.
+				 *
+				 * This is immediately before the processed output buffer is sent to the client.
+				 *
+				 * @since 2.0
+				 * @internal
+				 */
+				do_action( 'amp_server_timing_send' );
+
+				echo $response; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
-
-			$response = $error_page->render();
-		}
-
-		/**
-		 * Fires when server timings should be sent.
-		 *
-		 * This is immediately before the processed output buffer is sent to the client.
-		 *
-		 * @since 2.0
-		 * @internal
-		 */
-		do_action( 'amp_server_timing_send' );
-		return $response;
+		);
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This is an alternative approach to #6233 based on @schlessera's idea in https://github.com/ampproject/amp-wp/issues/6232#issuecomment-841038092:

> Not yet sure whether this is technically possible, but another way to solve this would be to exit the output buffering callback as soon as possible and defer the processing to another method outside of that callback.
> 
> What happens if you add another shutdown handler while within the output buffering callback?

See #6232

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
