### PR TITLE
Fix `lint-js` job failure for dependabot PRs

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -109,7 +109,7 @@ jobs:
         run: npm run lint:js
 
       - name: Generate ESLint coding standard violations report
-        # Prevent generating the ESLint report if run from a PR fork
+        # Prevent generating the ESLint report if PR is from a fork or authored by Dependabot.
         if: >
           github.event.pull_request.head.repo.fork == false &&
           github.event.pull_request.user.login != 'dependabot'
@@ -117,7 +117,7 @@ jobs:
         continue-on-error: true
 
       - name: Annotate code linting results
-        # The action cannot annotate the PR diff when run from a PR fork
+        # The action cannot annotate the PR when run from a PR fork or was authored by Dependabot.
         if: >
           github.event.pull_request.head.repo.fork == false &&
           github.event.pull_request.user.login != 'dependabot'
@@ -663,7 +663,7 @@ jobs:
 
   build-zip:
     name: 'Build: ${{ matrix.build }} build ZIP'
-    # Only run if it is not a draft PR and the PR is not from a forked repository.
+    # Only run if the PR was not authored by Dependabot and it is not a draft or not from a fork.
     if: >
       ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false &&
       github.event.pull_request.user.login != 'dependabot'

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -111,16 +111,16 @@ jobs:
       - name: Generate ESLint coding standard violations report
         # Prevent generating the ESLint report if PR is from a fork or authored by Dependabot.
         if: >
-          github.event.pull_request.head.repo.fork == false &&
-          github.event.pull_request.user.login != 'dependabot'
+          ! ( github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot' )
         run: npm run lint:js:report
         continue-on-error: true
 
       - name: Annotate code linting results
         # The action cannot annotate the PR when run from a PR fork or was authored by Dependabot.
         if: >
-          github.event.pull_request.head.repo.fork == false &&
-          github.event.pull_request.user.login != 'dependabot'
+          ! ( github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot' )
         uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -665,7 +665,8 @@ jobs:
     name: 'Build: ${{ matrix.build }} build ZIP'
     # Only run if the PR was not authored by Dependabot and it is not a draft or not from a fork.
     if: >
-      ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot'
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -103,18 +103,24 @@ jobs:
         run: npm run lint:pkg-json
 
       - name: Detect ESLint coding standard violations
-        if: github.event.pull_request.head.repo.fork == true
+        if: >
+          github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot'
         run: npm run lint:js
 
       - name: Generate ESLint coding standard violations report
         # Prevent generating the ESLint report if run from a PR fork
-        if: github.event.pull_request.head.repo.fork == false
+        if: >
+          github.event.pull_request.head.repo.fork == false &&
+          github.event.pull_request.user.login != 'dependabot'
         run: npm run lint:js:report
         continue-on-error: true
 
       - name: Annotate code linting results
         # The action cannot annotate the PR diff when run from a PR fork
-        if: github.event.pull_request.head.repo.fork == false
+        if: >
+          github.event.pull_request.head.repo.fork == false &&
+          github.event.pull_request.user.login != 'dependabot'
         uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -658,7 +664,9 @@ jobs:
   build-zip:
     name: 'Build: ${{ matrix.build }} build ZIP'
     # Only run if it is not a draft PR and the PR is not from a forked repository.
-    if: ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false
+    if: >
+      ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false &&
+      github.event.pull_request.user.login != 'dependabot'
     runs-on: ubuntu-latest
     needs:
       - lint-css

--- a/.github/workflows/qa-integrate.yml
+++ b/.github/workflows/qa-integrate.yml
@@ -80,16 +80,16 @@ jobs:
       - name: Generate ESLint coding standard violations report
         # Prevent generating the ESLint report if PR is from a fork or authored by Dependabot.
         if: >
-          github.event.pull_request.head.repo.fork == false &&
-          github.event.pull_request.user.login != 'dependabot'
+          ! ( github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot' )
         run: npm run lint:js:report
         continue-on-error: true
 
       - name: Annotate code linting results
         # The action cannot annotate the PR when run from a PR fork or was authored by Dependabot.
         if: >
-          github.event.pull_request.head.repo.fork == false &&
-          github.event.pull_request.user.login != 'dependabot'
+          ! ( github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot' )
         uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -211,7 +211,8 @@ jobs:
     needs: [unit-test-php]
     # Only run if the PR was not authored by Dependabot and it is not a draft or not from a fork.
     if: >
-      ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/qa-integrate.yml
+++ b/.github/workflows/qa-integrate.yml
@@ -71,12 +71,26 @@ jobs:
       - name: Validate package.json
         run: npm run lint:pkg-json
 
-      - name: Detect coding standard violations (ESLint)
+      - name: Detect ESLint coding standard violations
+        if: >
+          github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.user.login == 'dependabot'
+        run: npm run lint:js
+
+      - name: Generate ESLint coding standard violations report
+        # Prevent generating the ESLint report if PR is from a fork or authored by Dependabot.
+        if: >
+          github.event.pull_request.head.repo.fork == false &&
+          github.event.pull_request.user.login != 'dependabot'
         run: npm run lint:js:report
         continue-on-error: true
 
       - name: Annotate code linting results
-        uses: ataylorme/eslint-annotate-action@1.0.4
+        # The action cannot annotate the PR when run from a PR fork or was authored by Dependabot.
+        if: >
+          github.event.pull_request.head.repo.fork == false &&
+          github.event.pull_request.user.login != 'dependabot'
+        uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'qa-tester/lint-js-report.json'
@@ -195,7 +209,10 @@ jobs:
   release-zip:
     name: Build release build ZIP and upload as GHA artifact
     needs: [unit-test-php]
-    if: github.event.pull_request.draft == false
+    # Only run if the PR was not authored by Dependabot and it is not a draft or not from a fork.
+    if: >
+      ( github.event.pull_request.draft || github.event.pull_request.head.repo.fork ) == false &&
+      github.event.pull_request.user.login != 'dependabot'
     runs-on: ubuntu-latest
     outputs:
       branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Skips GHA jobs that require a `GITHUB_TOKEN` with write access to function if the PR was created by @dependabot.

As noted in this [GitHub blog post](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), @dependabot no longer has write access to PRs it creates when the workflow is triggered via the `pull_request` event.

An alternative to skipping the `eslint` annotation job could be to continue generating the `eslint` report and pass on the report to another workflow that has the right permissions to modify the PR.

As for the jobs that upload the plugin build to GCS, I think those can continue to be skipped as we don't want to be hosting potentially malicious code created via PRs from forks or a malicious npm package, for example.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
