### PR TITLE
Show HTTP error code when failing to fetch

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1508,8 +1508,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$status = $response->getStatusCode();
 
 		if ( $status < 200 || $status >= 300 ) {
-			/* translators: %s: the fetched URL */
-			return new WP_Error( "http_{$status}", sprintf( __( 'Failed to fetch: %s', 'amp' ), $url ) );
+			/* translators: %1$s: the URL, %2$d: the HTTP status code, %3$s: the HTTP status message */
+			return new WP_Error( "http_{$status}", sprintf( __( 'Failed to fetch: %1$s (HTTP %2$d: %3$s)', 'amp' ), $url, $status, get_status_header_desc( $status ) ) );
 		}
 
 		$content_type = (array) $response->getHeader( 'content-type' );


### PR DESCRIPTION
## Summary

In a [support topic](https://wordpress.org/support/topic/stylesheet-wont-be-fetched-yet-seems-compatible-and-fetch-able/) I discovered that the HTTP status code is not revealed when a stylesheet fetch fails. This PR shows the status code and its corresponding message.

Before | After
-------|-----
![image](https://user-images.githubusercontent.com/134745/118373859-d08e9500-b56d-11eb-9019-8a858bad9dba.png) | ![image](https://user-images.githubusercontent.com/134745/118373875-ddab8400-b56d-11eb-9115-cd7d4290d89b.png)

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
