### PR TITLE
Prevent fatal error in HeroCandidateFiltering when attachment post is not available

### DIFF
--- a/src/Optimizer/HeroCandidateFiltering.php
+++ b/src/Optimizer/HeroCandidateFiltering.php
@@ -93,11 +93,11 @@ final class HeroCandidateFiltering implements Service, Delayed, Conditional, Reg
 	 *
 	 * Only the featured image for the singular queried object post or the first post in the loop will be identified.
 	 *
-	 * @param string[] $attrs      Array of attribute values for the image markup, keyed by attribute name.
-	 * @param WP_Post  $attachment Image attachment post.
+	 * @param string[]     $attrs      Array of attribute values for the image markup, keyed by attribute name.
+	 * @param WP_Post|null $attachment Image attachment post.
 	 * @return string[] Filtered attributes.
 	 */
-	public function filter_attachment_image_attributes( $attrs, WP_Post $attachment ) {
+	public function filter_attachment_image_attributes( $attrs, $attachment = null ) {
 		global $wp_query;
 
 		$post         = null;
@@ -110,6 +110,8 @@ final class HeroCandidateFiltering implements Service, Delayed, Conditional, Reg
 
 		if (
 			$post instanceof WP_Post
+			&&
+			$attachment instanceof WP_Post
 			&&
 			(int) get_post_thumbnail_id( $post ) === $attachment->ID
 		) {

--- a/tests/php/src/Optimizer/HeroCandidateFilteringTest.php
+++ b/tests/php/src/Optimizer/HeroCandidateFilteringTest.php
@@ -181,6 +181,15 @@ final class HeroCandidateFilteringTest extends DependencyInjectedTestCase {
 			$merged_attrs,
 			$this->instance->filter_attachment_image_attributes( $initial_attrs, $attachment )
 		);
+
+		// When no attachment is provided, then no filtering is done.
+		delete_post_thumbnail( $post_ids[1] );
+		set_post_thumbnail( $post_ids[0], $attachment->ID );
+		$this->go_to( get_permalink( $post_ids[0] ) );
+		$this->assertEquals(
+			$initial_attrs,
+			$this->instance->filter_attachment_image_attributes( $initial_attrs, null )
+		);
 	}
 
 	/** @covers ::add_data_hero_candidate_attribute()  */


### PR DESCRIPTION
## Summary

As discovered in a [support topic](https://wordpress.org/support/topic/amp-version-2-1-1-filter_attachment_image_attributes/), when a site is filtering `wp_get_attachment_image_src` to force an image to be supplied even when an invalid attachment ID was originally provided, the result is a fatal error in `HeroCandidateFiltering`. 

Consider this code:

```php
add_action( 'wp_body_open', function () {
	$faux_id = 999990000000001649;
	add_filter(
		'wp_get_attachment_image_src',
		function ( $image, $attachment_id ) use ( $faux_id ) {
			if ( $faux_id === $attachment_id ) {
				$image = [
					'https://amp.dev/static/img/icons/icon-512x512.png',
					512,
					512,
					false,
				];
			}
			return $image;
		},
		10,
		2
	);
	echo wp_get_attachment_image($faux_id, 'large', false, []);
} );
```

This results in:

<pre><b>Fatal error</b>:  Uncaught TypeError: Argument 2 passed to AmpProject\AmpWP\Optimizer\HeroCandidateFiltering::filter_attachment_image_attributes() must be an instance of WP_Post, null given, called in /app/public/core-dev/src/wp-includes/class-wp-hook.php on line 294 and defined in /app/public/content/plugins/amp/src/Optimizer/HeroCandidateFiltering.php:100
Stack trace:
#0 /app/public/core-dev/src/wp-includes/class-wp-hook.php(294): AmpProject\AmpWP\Optimizer\HeroCandidateFiltering-&gt;filter_attachment_image_attributes(Array, NULL)
#1 /app/public/core-dev/src/wp-includes/plugin.php(212): WP_Hook-&gt;apply_filters(Array, Array)
#2 /app/public/core-dev/src/wp-includes/media.php(1090): apply_filters('wp_get_attachme...', Array, NULL, 'large')
#3 /app/public/content/mu-plugins/scratch.php(25): wp_get_attachment_image(999990000000001649, 'large', false, Array)
#4 /app/public/core-dev/src/wp-includes/class-wp-hook.php(292): {closure}('')
#5 /app/public/core-dev/src/wp-includes/class-wp-hook.php(316): WP_Hook-&gt;apply_filters(NULL, Array)
# in <b>/app/public/content/plugins/amp/src/Optimizer/HeroCandidateFiltering.php</b> on line <b>100</b><br></pre>

I'm familiar with code like this being used to share media across a multisite network.

What is needed is to not enforce the data type of `$attachment` in the method param, but rather to check if if it is a `WP_Post` in the method body.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
