### PR TITLE
Use last PR commit hash for plugin version code; add query param to cache bust plugin build downloads

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -684,6 +684,9 @@ jobs:
     steps:
       - name: Check out source files
         uses: actions/checkout@v2
+        with:
+          # By default, the fetch depth is 1. To get the last PR commit we'd need to increment that by 1.
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -745,6 +745,8 @@ jobs:
         run: |
           npm run build:${{ matrix.build }}
           mv amp.zip builds/${{ matrix.build }}/amp.zip
+        env:
+          LAST_PR_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieve branch name
         id: retrieve-branch-name

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -815,8 +815,8 @@ jobs:
         # Setting a multi-line output requires escaping line-feeds. See <https://github.community/t/set-output-truncates-multiline-strings/16852/3>.
         run: |
           body="Plugin builds for ${{ github.event.pull_request.head.sha }} are ready :bellhop_bell:!
-          - Download [development build](https://storage.googleapis.com/ampwp_github_artifacts/${{ github.ref }}/dev/amp.zip)
-          - Download [production build](https://storage.googleapis.com/ampwp_github_artifacts/${{ github.ref }}/prod/amp.zip)"
+          - Download [development build](https://storage.googleapis.com/ampwp_github_artifacts/${{ github.ref }}/dev/amp.zip?${{ github.sha }})
+          - Download [production build](https://storage.googleapis.com/ampwp_github_artifacts/${{ github.ref }}/prod/amp.zip?${{ github.sha }})"
           body="${body//$'\n'/'%0A'}"
           echo "::set-output name=body::$body"
 

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -684,9 +684,6 @@ jobs:
     steps:
       - name: Check out source files
         uses: actions/checkout@v2
-        with:
-          # By default, the fetch depth is 1. To get the last PR commit we'd need to increment that by 1.
-          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,10 +131,14 @@ module.exports = function( grunt ) {
 			},
 		);
 
-		// If the script is executed within a GHA job in a PR, use the commit hash from the parent of the merge
-		// commit (which would be the last commit of the PR).
-		if ( Boolean( process.env.GITHUB_HEAD_REF ) ) {
-			spawnQueue[ 0 ].args.push( 'HEAD~' );
+		// If the script is executed within a GHA job in a PR, use the last PR commit hash instead of the one from the
+		// currently checked out merge commit.
+		if ( Boolean( process.env.LAST_PR_COMMIT_HASH ) ) {
+			spawnQueue[ 0 ] = {
+				cmd: 'echo',
+				// eslint-disable-next-line no-template-curly-in-string
+				args: [ `${ process.env.LAST_PR_COMMIT_HASH.slice( 0, 9 ) }` ],
+			};
 		}
 
 		function finalize() {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,7 +131,8 @@ module.exports = function( grunt ) {
 			},
 		);
 
-		// Use the parent commit hash instead of the one of the merge commit when the script is run via a GHA PR event.
+		// If the script is executed within a GHA job in a PR, use the commit hash from the parent of the merge
+		// commit (which would be the last commit of the PR).
 		if ( Boolean( process.env.GITHUB_HEAD_REF ) ) {
 			spawnQueue[ 0 ].args.push( 'HEAD~' );
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,19 +131,9 @@ module.exports = function( grunt ) {
 			},
 		);
 
-		// If the script is executed within a GHA job in a PR, use the last PR commit hash instead of the one from the
-		// currently checked out merge commit.
-		if ( Boolean( process.env.LAST_PR_COMMIT_HASH ) ) {
-			spawnQueue[ 0 ] = {
-				cmd: 'echo',
-				// eslint-disable-next-line no-template-curly-in-string
-				args: [ `${ process.env.LAST_PR_COMMIT_HASH.slice( 0, 9 ) }` ],
-			};
-		}
-
 		function finalize() {
-			const commitHash = stdout.shift();
-			const lsOutput = stdout.shift();
+			const commitHash = process.env.LAST_PR_COMMIT_HASH ? process.env.LAST_PR_COMMIT_HASH.slice( 0, 9 ) : stdout.shift();
+			const lsOutput = process.env.LAST_PR_COMMIT_HASH ? stdout[ 1 ] : stdout.shift();
 			const versionAppend = new Date().toISOString().replace( /\.\d+/, '' ).replace( /-|:/g, '' ) + '-' + commitHash;
 
 			const paths = lsOutput.trim().split( /\n/ ).filter( function( file ) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,11 @@ module.exports = function( grunt ) {
 			},
 		);
 
+		// Use the parent commit hash instead of the one of the merge commit when the script is run via a GHA PR event.
+		if ( Boolean( process.env.GITHUB_HEAD_REF ) ) {
+			spawnQueue[ 0 ].args.push( 'HEAD~' );
+		}
+
 		function finalize() {
 			const commitHash = stdout.shift();
 			const lsOutput = stdout.shift();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
- Use the last PR commit hash instead of the one from the merge commit as apart of the built plugin version code
- Use hash of currently checked out commit as a query param to cache bust downloads for plugin builds

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
