### PR TITLE
Reduce length of specificity-hacked CSS selectors

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1645,7 +1645,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function get_parsed_stylesheet( $stylesheet, $options = [] ) {
 		$cached         = true;
-		$cache_group    = 'amp-parsed-stylesheet-v38'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group    = 'amp-parsed-stylesheet-v39'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 		$use_transients = $this->should_use_transient_caching();
 
 		// @todo If ValidationExemption::is_px_verified_for_node( $this->current_node ) then keep !important.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2917,16 +2917,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					if ( $old_selector->getSpecificity() % 10 > 0 ) {
 						$specificity_multiplier++;
 					}
-					$selector_mod = str_repeat( ':not(#_)', $specificity_multiplier ); // Here "_" is just a short single-char ID.
 
-					$new_selector = $old_selector->getSelector();
+					$new_selector  = $old_selector->getSelector();
+					$new_selector .= ':not(' . str_repeat( '#_', $specificity_multiplier ) . ')'; // Here "_" is just a short single-char ID.
 
-					// Amend the selector mod to the first element in selector if it is already the root; otherwise add new root ancestor.
-					if ( preg_match( '/^\s*(html|:root)\b/i', $new_selector, $matches ) ) {
-						$new_selector = substr( $new_selector, 0, strlen( $matches[0] ) ) . $selector_mod . substr( $new_selector, strlen( $matches[0] ) );
-					} else {
-						$new_selector = sprintf( ':root%s %s', $selector_mod, $new_selector );
-					}
 					return new Selector( $new_selector );
 				},
 				$ruleset->getSelectors()
@@ -2975,9 +2969,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$class = 'amp-wp-' . substr( md5( $value ), 0, 7 );
-		$root  = ':root' . str_repeat( ':not(#_)', self::INLINE_SPECIFICITY_MULTIPLIER );
-		$rule  = sprintf( '%s .%s { %s }', $root, $class, $value );
+		$class       = 'amp' . substr( md5( $value ), 0, 7 );
+		$specificity = ':not(' . str_repeat( '#_', self::INLINE_SPECIFICITY_MULTIPLIER ) . ')';
+		$rule        = sprintf( '.%s%s{%s}', $class, $specificity, $value );
 
 		$this->set_current_node( $element ); // And sources when needing to be located.
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2918,8 +2918,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						$specificity_multiplier++;
 					}
 
-					$new_selector  = $old_selector->getSelector();
-					$new_selector .= ':not(' . str_repeat( '#_', $specificity_multiplier ) . ')'; // Here "_" is just a short single-char ID.
+					$new_selector = $old_selector->getSelector();
+
+					if ( '#_)' === substr( $new_selector, -3 ) ) {
+						$new_selector = rtrim( $new_selector, ')' ) . str_repeat( '#_', $specificity_multiplier ) . ')';
+					} else {
+						$new_selector .= ':not(' . str_repeat( '#_', $specificity_multiplier ) . ')'; // Here "_" is just a short single-char ID.
+					}
 
 					return new Selector( $new_selector );
 				},

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2974,7 +2974,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$class       = 'amp' . substr( md5( $value ), 0, 7 );
+		$class       = 'amp-wp-' . substr( md5( $value ), 0, 7 );
 		$specificity = ':not(' . str_repeat( '#_', self::INLINE_SPECIFICITY_MULTIPLIER ) . ')';
 		$rule        = sprintf( '.%s%s{%s}', $class, $specificity, $value );
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2812,6 +2812,14 @@ class AMP_Validated_URL_Post_Type {
 													$selector_html
 												);
 											}
+											$selector_html = preg_replace(
+												'/:not\((#_)+\)/',
+												sprintf(
+													'<abbr title="%s">$0</abbr>',
+													esc_attr__( 'Pseudo-class selector used to increase specificity for rule extracted from inline styles and/or properties with !important qualifiers.', 'amp' )
+												),
+												$selector_html
+											);
 
 											echo $selector_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/tests/php/test-amp-bento-sanitizer.php
+++ b/tests/php/test-amp-bento-sanitizer.php
@@ -80,7 +80,7 @@ class AMP_Bento_Sanitizer_Test extends TestCase {
 					<html>
 						<head>
 							<meta charset="utf-8">
-							<style amp-custom>#my-accordion{display:block;outline:solid 2px red}amp-accordion#my-accordion{outline:solid 2px green}amp-accordion h2{text-transform:uppercase}:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-a33452e{border:solid 1px black}
+							<style amp-custom>#my-accordion{display:block;outline:solid 2px red}amp-accordion#my-accordion{outline:solid 2px green}amp-accordion h2{text-transform:uppercase}.amp-wp-a33452e:not(#_#_#_#_#_){border:solid 1px black}
 
 							/*# sourceURL="amp-custom.css" */</style>
 						</head>
@@ -245,7 +245,7 @@ class AMP_Bento_Sanitizer_Test extends TestCase {
 							<script type="module" async="" src="https://cdn.ampproject.org/v0/bento-marquee-1.0.mjs" data-px-verified-tag></script>
 							<script nomodule="" async="" src="https://cdn.ampproject.org/v0/bento-marquee-1.0.js" data-px-verified-tag></script>
 							<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/bento-marquee-1.0.css" data-px-verified-tag data-px-verified-attrs="href">
-							<style amp-custom>#timeago{color:red}amp-timeago#timeago{color:blue}#marquee{display:block;outline:solid 2px red}bento-marquee#marquee{outline:solid 2px green}bento-marquee h2{text-transform:uppercase}:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c437205{border:solid 1px green}:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-4d7586b{max-width:50vw}:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-4ce7767{position:relative;width:100%;height:400px}
+							<style amp-custom>#timeago{color:red}amp-timeago#timeago{color:blue}#marquee{display:block;outline:solid 2px red}bento-marquee#marquee{outline:solid 2px green}bento-marquee h2{text-transform:uppercase}.amp-wp-c437205:not(#_#_#_#_#_){border:solid 1px green}.amp-wp-4d7586b:not(#_#_#_#_#_){max-width:50vw}.amp-wp-4ce7767:not(#_#_#_#_#_){position:relative;width:100%;height:400px}
 
 							/*# sourceURL="amp-custom.css" */</style>
 						</head>
@@ -415,7 +415,7 @@ class AMP_Bento_Sanitizer_Test extends TestCase {
 					<html>
 						<head>
 							<meta charset="utf-8">
-							<style amp-custom>:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-3ef80bd{height:40px}:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-120213e{height:40px;width:147px}
+							<style amp-custom>.amp-wp-3ef80bd:not(#_#_#_#_#_){height:40px}.amp-wp-120213e:not(#_#_#_#_#_){height:40px;width:147px}
 
 							/*# sourceURL="amp-custom.css" */</style>
 						</head>

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -594,7 +594,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				$this->assertStringContainsString( '}amp-audio{', $css_text );
 				break;
 			case 3:
-				$this->assertStringContainsString( ':not(#_) amp-audio{', $css_text );
+				$this->assertStringContainsString( '}amp-audio:not(#_', $css_text );
 				break;
 		}
 

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -72,7 +72,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color: #00ff00;">This is green.</span>',
 				'<span data-amp-original-style="color: #00ff00;" class="amp-wp-bb01159">This is green.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
+					'.amp-wp-bb01159:not(#_#_#_#_#_){color:#0f0}',
 				],
 			],
 
@@ -86,7 +86,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color  :   #00ff00">This is green.</span>',
 				'<span data-amp-original-style="color  :   #00ff00" class="amp-wp-0837823">This is green.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-0837823{color:#0f0}',
+					'.amp-wp-0837823:not(#_#_#_#_#_){color:#0f0}',
 				],
 			],
 
@@ -94,7 +94,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color: #00ff00; background-color: #000;">This is green.</span>',
 				'<span data-amp-original-style="color: #00ff00; background-color: #000;" class="amp-wp-be0c539">This is green.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-be0c539{color:#0f0;background-color:#000}',
+					'.amp-wp-be0c539:not(#_#_#_#_#_){color:#0f0;background-color:#000}',
 				],
 			],
 
@@ -102,7 +102,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				'<span data-amp-original-style="display: none;" class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
+					'.amp-wp-224b51a:not(#_#_#_#_#_){display:none}',
 				],
 			],
 
@@ -110,7 +110,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="padding:1px; margin: 2px !important; outline: 3px;">!important is converted.</span>',
 				'<span data-amp-original-style="padding:1px; margin: 2px !important; outline: 3px;" class="amp-wp-6a75598">!important is converted.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{padding:1px;outline:3px}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{margin:2px}',
+					'.amp-wp-6a75598:not(#_#_#_#_#_){padding:1px;outline:3px}.amp-wp-6a75598:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_){margin:2px}',
 				],
 			],
 
@@ -118,7 +118,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color: red  !  important;">!important is converted.</span>',
 				'<span data-amp-original-style="color: red  !  important;" class="amp-wp-952600b">!important is converted.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-952600b{color:red}',
+					'.amp-wp-952600b:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_){color:red}',
 				],
 			],
 
@@ -126,7 +126,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color: red !important; background: blue!important;">!important is converted.</span>',
 				'<span data-amp-original-style="color: red !important; background: blue!important;" class="amp-wp-1e2bfaa">!important is converted.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-1e2bfaa{color:red;background:blue}',
+					'.amp-wp-1e2bfaa:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_){color:red;background:blue}',
 				],
 			],
 
@@ -134,8 +134,8 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<header id="header" style="display: none;"><h1>This is the header.</h1></header><style>#header { display: block !important;width: 100%;background: #fff; }',
 				'<header id="header" data-amp-original-style="display: none;" class="amp-wp-224b51a"><h1>This is the header.</h1></header>',
 				[
-					'#header{width:100%;background:#fff}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #header{display:block}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
+					'#header{width:100%;background:#fff}#header:not(#_#_#_#_#_#_#_){display:block}',
+					'.amp-wp-224b51a:not(#_#_#_#_#_){display:none}',
 				],
 			],
 
@@ -143,8 +143,8 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
 				'<span data-amp-original-style="color: #00ff00;" class="amp-wp-bb01159"><span data-amp-original-style="color: #ff0000;" class="amp-wp-cc68ddc">This is red.</span></span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cc68ddc{color:#f00}',
+					'.amp-wp-bb01159:not(#_#_#_#_#_){color:#0f0}',
+					'.amp-wp-cc68ddc:not(#_#_#_#_#_){color:#f00}',
 				],
 			],
 
@@ -152,7 +152,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<figure class="alignleft" style="background: #000"></figure>',
 				'<figure class="alignleft amp-wp-2864855" data-amp-original-style="background: #000"></figure>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-2864855{background:#000}',
+					'.amp-wp-2864855:not(#_#_#_#_#_){background:#000}',
 				],
 			],
 
@@ -160,7 +160,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<style>div > span { font-weight:bold !important; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
 				[
-					'div > span{font-style:italic}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) div > span{font-weight:bold}@media screen and ( max-width: 640px ){div > span{font-style:normal}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) div > span{font-weight:normal}}',
+					'div > span{font-style:italic}div > span:not(#_#_#_#_#_#_#_#_){font-weight:bold}@media screen and ( max-width: 640px ){div > span{font-style:normal}div > span:not(#_#_#_#_#_#_#_#_){font-weight:normal}}',
 				],
 			],
 
@@ -178,7 +178,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<span style="color:brown; @media screen { color:green }">invalid @-rule omitted.</span>',
 				'<span data-amp-original-style="color:brown; @media screen { color:green }" class="amp-wp-481af57">invalid @-rule omitted.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-481af57{color:brown}',
+					'.amp-wp-481af57:not(#_#_#_#_#_){color:brown}',
 				],
 				[],
 			],
@@ -247,9 +247,9 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<style>#child {color:red !important} #parent #child {color:pink !important} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div><div id="me"><span class="foo"></span></div>',
 				'<div id="parent"><span id="child" class="foo bar baz">one</span><span data-amp-original-style="color: yellow;" class="amp-wp-64b4fd4">two</span><span data-amp-original-style="color: purple !important;" class="amp-wp-ab79d9e">three</span></div><div id="me"><span class="foo"></span></div>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #child{color:red}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #parent #child{color:pink}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo{color:blue}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #me .foo{color:green}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-ab79d9e{color:purple}',
+					'#child:not(#_#_#_#_#_#_#_){color:red}#parent #child:not(#_#_#_#_#_#_#_#_){color:pink}.foo:not(#_#_#_#_#_#_#_){color:blue}#me .foo:not(#_#_#_#_#_#_#_#_){color:green}',
+					'.amp-wp-64b4fd4:not(#_#_#_#_#_){color:yellow}',
+					'.amp-wp-ab79d9e:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_){color:purple}',
 				],
 			],
 
@@ -265,7 +265,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<table><colgroup><col width="253"/></colgroup></table>',
 				'<table><colgroup><col data-amp-original-style="width: 253px" class="amp-wp-cbcb5c2"></colgroup></table>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cbcb5c2{width:253px}',
+					'.amp-wp-cbcb5c2:not(#_#_#_#_#_){width:253px}',
 				],
 			],
 
@@ -273,7 +273,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<table><colgroup><col width="50%"/></colgroup></table>',
 				'<table><colgroup><col data-amp-original-style="width: 50%" class="amp-wp-cd7753e"></colgroup></table>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cd7753e{width:50%}',
+					'.amp-wp-cd7753e:not(#_#_#_#_#_){width:50%}',
 				],
 			],
 
@@ -288,7 +288,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'<table><colgroup><col width="50" style="background-color: red; width: 60px"/></colgroup></table>',
 				'<table><colgroup><col data-amp-original-style="width: 50px;background-color: red; width: 60px" class="amp-wp-c8aa9e9"></colgroup></table>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c8aa9e9{width:50px;width:60px;background-color:red}',
+					'.amp-wp-c8aa9e9:not(#_#_#_#_#_){width:50px;width:60px;background-color:red}',
 				],
 			],
 
@@ -352,8 +352,8 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				',
 				[
 					'.custom-population{color:red}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-f2a1aff{color:blue}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-d4ea4c7{outline:solid 1px black}',
+					'.amp-wp-f2a1aff:not(#_#_#_#_#_){color:blue}',
+					'.amp-wp-d4ea4c7:not(#_#_#_#_#_){outline:solid 1px black}',
 				],
 			],
 			'with_mustache_template_script' => [
@@ -386,8 +386,8 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				',
 				[
 					'.custom-population{color:red}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-f2a1aff{color:blue}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-d4ea4c7{outline:solid 1px black}',
+					'.amp-wp-f2a1aff:not(#_#_#_#_#_){color:blue}',
+					'.amp-wp-d4ea4c7:not(#_#_#_#_#_){outline:solid 1px black}',
 				],
 			],
 			'with_internal_amp_selectors_and_class_names' => [
@@ -531,9 +531,9 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 			'multiple_amp_custom_and_other_styles' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>b {color:red !important}</style><style amp-custom>i {color:blue}</style><style type="text/css">u {color:green; text-decoration: underline !important}</style></head><body><style>s {color:yellow} /* So !important! */</style><b>1</b><i>i</i><u>u</u><s>s</s></body></html>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) b{color:red}',
+					'b:not(#_#_#_#_#_#_#_#_){color:red}',
 					'i{color:blue}',
-					'u{color:green}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) u{text-decoration:underline}',
+					'u{color:green}u:not(#_#_#_#_#_#_#_#_){text-decoration:underline}',
 					's{color:yellow}',
 				],
 				[],
@@ -547,7 +547,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 					'strong.before-dashicon',
 					'.dashicons-dashboard:before',
 					'strong.after-dashicon',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) s{color:yellow}',
+					's:not(#_#_#_#_#_#_#_#_){color:yellow}',
 				],
 				[],
 			],
@@ -575,8 +575,8 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 			'style_on_root_element' => [
 				'<html amp style="color:red;"><head><meta charset="utf-8"><style amp-custom>html { background-color: blue !important; }</style></head><body>Hi</body></html>',
 				[
-					'html:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_){background-color:blue}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-10b06ba{color:red}',
+					'html:not(#_#_#_#_#_#_#_#_){background-color:blue}',
+					'.amp-wp-10b06ba:not(#_#_#_#_#_){color:red}',
 				],
 				[],
 			],
@@ -1099,10 +1099,10 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				true, // should_sanitize
 				$html,
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo{color:red}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo[data-amp-original-style*="blue"]{outline:solid 2px green}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-9605c4d{background:blue}',
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-32bb249{background:red}',
+					'.foo:not(#_#_#_#_#_#_#_){color:red}',
+					'.foo[data-amp-original-style*="blue"]:not(#_#_#_#_#_#_#_){outline:solid 2px green}',
+					'.amp-wp-9605c4d:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_){background:blue}',
+					'.amp-wp-32bb249:not(#_#_#_#_#_){background:red}',
 				],
 				'<style amp-custom>',
 				'

--- a/tests/php/test-class-amp-content-sanitizer.php
+++ b/tests/php/test-class-amp-content-sanitizer.php
@@ -38,7 +38,7 @@ class Test_AMP_Content_Sanitizer extends TestCase {
 			$sanitize_results['scripts']
 		);
 		$this->assertEquals(
-			[ ':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-9f6e771{outline:solid 1px red}' ],
+			[ '.amp-wp-9f6e771:not(#_#_#_#_#_){outline:solid 1px red}' ],
 			$sanitize_results['stylesheets']
 		);
 		$this->assertEmpty( $sanitize_results['styles'] );
@@ -74,7 +74,7 @@ class Test_AMP_Content_Sanitizer extends TestCase {
 		$expected_return = [
 			'<amp-video src="https://example.com/foo.mp4" width="100" height="200" layout="intrinsic" data-amp-original-style="outline: solid 1px red;" class="amp-wp-9f6e771"><a href="https://example.com/foo.mp4" fallback="">https://example.com/foo.mp4</a><noscript><video src="https://example.com/foo.mp4" width="100" height="200"></video></noscript></amp-video>',
 			[ 'amp-video' => true ],
-			[ ':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-9f6e771{outline:solid 1px red}' ],
+			[ '.amp-wp-9f6e771:not(#_#_#_#_#_){outline:solid 1px red}' ],
 		];
 
 		$actual_return = AMP_Content_Sanitizer::sanitize(

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1660,7 +1660,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->assertStringContainsString( '<amp-img src="test.png"', $output );
 		$this->assertStringContainsString( '<style amp-custom-partial="">', $output );
 		$this->assertStringContainsString( 'amp-img{background:blue}', $output );
-		$this->assertStringContainsString( ':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-b123f72{border:solid 1px red}', $output );
+		$this->assertStringContainsString( '.amp-wp-b123f72:not(#_#_#_#_#_){border:solid 1px red}', $output );
 		$this->assertStringEndsWith( '/*# sourceURL=amp-custom-partial.css */</style>', $output );
 		$this->assertStringNotContainsString( '<script', $output );
 		$this->assertStringNotContainsString( '<html', $output );


### PR DESCRIPTION
## Summary

I realized that we can compress the size of our CSS specificity hacks quite a bit by eliminating the redundant `:not()` pseudo selectors. So instead of `:not(#_):not(#_):not(#_)` we can refactor this to be the equivalent specificity `:not(#_#_#_)`.

Additionally, instead of adding a `:root` ancestor selector, we can instead just appending the the `:not()` to the original selector. <del>Lastly, the prefix of `.amp-wp-` can be reduced down to just `.amp`.</del> <ins>This is kept as-is for now to prevent any unintentional regressions.</ins>

Given this example HTML from https://github.com/ampproject/amp-wp/issues/1313:

```html
<style>
p#para {
    color: red !important;
    font-weight: normal !important;
    text-decoration: underline;
}
</style>
<p id="para" style="color: green !important; font-weight: bold; text-decoration: overline;">I should still be green, not bold, and overlined!</p>
```

Before this would have resulted in the following which is **422 bytes** after minification:

```css
p#para {
	text-decoration: underline
}

:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) p#para {
	color: red;
	font-weight: normal
}

:root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-27ad0ad {
	font-weight: bold;
	text-decoration: overline
}

:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-27ad0ad {
	color: green
}
```

With the changes in this PR, the same CSS is reduced to **235 bytes** after minification:

```css
p#para {
	text-decoration: underline
}

p#para:not(#_#_#_#_#_#_#_#_#_) {
	color: red;
	font-weight: normal
}

.amp-wp-27ad0ad:not(#_#_#_#_#_) {
	font-weight: bold;
	text-decoration: overline
}

.amp-wp-27ad0ad:not(#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_#_) {
	color: green
}
```

This is a ~44% reduction in the resulting CSS.

This also fixes issues with `amp-next-page` for CSS selectors that are targeting elements in shadow DOM. Fixes #6909.

This also adds a tooltip to the `:not(#_…)` pesudo-class selectors in the stylesheets metabox:

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/134745/153664298-9b73548f-ab60-49a5-beb7-8789289612d9.png">

## Checklist

- [x] Esure specificities are maintained.
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).