### PR TITLE
Fix time offset in schema.org metadata when site timezone is configured

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1672,10 +1672,10 @@ function amp_get_schemaorg_metadata() {
 	if ( $queried_object instanceof WP_Post ) {
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.3', '>=' ) ) {
 			$date_published = mysql2date( 'c', $queried_object->post_date, false );
-			$date_modified   = mysql2date( 'c', $queried_object->post_modified, false );
+			$date_modified  = mysql2date( 'c', $queried_object->post_modified, false );
 		} else {
 			$date_published = mysql2date( 'c', $queried_object->post_date_gmt, false );
-			$date_modified   = mysql2date( 'c', $queried_object->post_modified_gmt, false );
+			$date_modified  = mysql2date( 'c', $queried_object->post_modified_gmt, false );
 		}
 
 		$metadata = array_merge(
@@ -1685,7 +1685,7 @@ function amp_get_schemaorg_metadata() {
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
 				'datePublished'    => $date_published,
-				'dateModified'      => $date_modified,
+				'dateModified'     => $date_modified,
 			]
 		);
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1670,14 +1670,22 @@ function amp_get_schemaorg_metadata() {
 
 	$queried_object = get_queried_object();
 	if ( $queried_object instanceof WP_Post ) {
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.3', '>=' ) ) {
+			$date_published = mysql2date( 'c', $queried_object->post_date, false );
+			$date_modified   = mysql2date( 'c', $queried_object->post_modified, false );
+		} else {
+			$date_published = mysql2date( 'c', $queried_object->post_date_gmt, false );
+			$date_modified   = mysql2date( 'c', $queried_object->post_modified_gmt, false );
+		}
+
 		$metadata = array_merge(
 			$metadata,
 			[
 				'@type'            => is_page() ? 'WebPage' : 'BlogPosting',
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
-				'datePublished'    => mysql2date( 'c', $queried_object->post_date_gmt, false ),
-				'dateModified'     => mysql2date( 'c', $queried_object->post_modified_gmt, false ),
+				'datePublished'    => $date_published,
+				'dateModified'      => $date_modified,
 			]
 		);
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -843,6 +843,7 @@ class AMP_Theme_Support {
 			remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 			remove_action( 'wp_print_styles', 'print_emoji_styles' );
 			remove_action( 'wp_footer', 'gutenberg_the_skip_link' ); // Temporary workaround for <https://github.com/ampproject/amp-wp/issues/6115>.
+			remove_action( 'wp_footer', 'the_block_template_skip_link' ); // Temporary workaround for <https://github.com/ampproject/amp-wp/issues/6115>.
 			add_action( 'wp_print_styles', [ __CLASS__, 'print_emoji_styles' ] );
 			add_filter( 'the_title', 'wp_staticize_emoji' );
 			add_filter( 'the_excerpt', 'wp_staticize_emoji' );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1762,6 +1762,29 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->assertEquals( $metadata['publisher']['logo']['url'], amp_get_publisher_logo() );
 	}
 
+	/** @covers ::amp_get_schemaorg_metadata() */
+	public function test_amp_get_schemaorg_metadata_time_offset() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_date'     => '2021-02-18 12:55:00',
+				'post_date_gmt' => '2021-02-18 19:55:00'
+			]
+		);
+
+		add_filter(
+			'pre_option_gmt_offset',
+			static function () {
+				return '-7';
+			}
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+		$metadata = amp_get_schemaorg_metadata();
+
+		$this->assertSame( '2021-02-18T12:55:00-07:00', $metadata[ 'datePublished' ] );
+		$this->assertSame( '2021-02-18T12:55:00-07:00', $metadata[ 'dateModified' ] );
+	}
+
 	/**
 	 * Test amp_print_schemaorg_metadata().
 	 *

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1767,7 +1767,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$post_id = self::factory()->post->create(
 			[
 				'post_date'     => '2021-02-18 12:55:00',
-				'post_date_gmt' => '2021-02-18 19:55:00'
+				'post_date_gmt' => '2021-02-18 19:55:00',
 			]
 		);
 
@@ -1781,8 +1781,10 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 		$metadata = amp_get_schemaorg_metadata();
 
-		$this->assertSame( '2021-02-18T12:55:00-07:00', $metadata[ 'datePublished' ] );
-		$this->assertSame( '2021-02-18T12:55:00-07:00', $metadata[ 'dateModified' ] );
+		$expected = version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ? '2021-02-18T19:55:00+00:00' : '2021-02-18T12:55:00-07:00';
+
+		$this->assertSame( $expected, $metadata['datePublished'] );
+		$this->assertSame( $expected, $metadata['dateModified'] );
 	}
 
 	/**

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1764,11 +1764,29 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 
 	/** @covers ::amp_get_schemaorg_metadata() */
 	public function test_amp_get_schemaorg_metadata_time_offset() {
-		$post_id = self::factory()->post->create(
+
+		add_filter(
+			'wp_insert_post_data',
+			function ( $data ) {
+				return array_merge(
+					$data,
+					[
+						'post_modified'     => '2021-02-19 12:55:00',
+						'post_modified_gmt' => '2021-02-19 19:55:00',
+					]
+				);
+			}
+		);
+		$post_id = wp_insert_post(
 			[
+				'post_title'    => 'Test',
+				'post_content'  => 'Test',
+				'post_type'     => 'post',
+				'post_status'   => 'publish',
 				'post_date'     => '2021-02-18 12:55:00',
 				'post_date_gmt' => '2021-02-18 19:55:00',
-			]
+			],
+			true
 		);
 
 		add_filter(
@@ -1779,12 +1797,12 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		);
 
 		$this->go_to( get_permalink( $post_id ) );
-		$metadata = amp_get_schemaorg_metadata();
+		$metadata           = amp_get_schemaorg_metadata();
+		$expected_published = version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ? '2021-02-18T19:55:00+00:00' : '2021-02-18T12:55:00-07:00';
+		$expected_modified  = version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ? '2021-02-19T19:55:00+00:00' : '2021-02-19T12:55:00-07:00';
 
-		$expected = version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ? '2021-02-18T19:55:00+00:00' : '2021-02-18T12:55:00-07:00';
-
-		$this->assertSame( $expected, $metadata['datePublished'] );
-		$this->assertSame( $expected, $metadata['dateModified'] );
+		$this->assertSame( $expected_published, $metadata['datePublished'] );
+		$this->assertSame( $expected_modified, $metadata['dateModified'] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -75,6 +75,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$wp_styles    = null;
 		$wp_admin_bar = null;
 
+		$this->set_private_property( AMP_Theme_Support::class, 'metadata', null );
+
 		parent::tearDown();
 		unset( $GLOBALS['show_admin_bar'] );
 		AMP_Validation_Manager::$is_validate_request = false;
@@ -1631,6 +1633,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$original_html = $this->get_original_html();
+
+		$this->set_private_property( AMP_Theme_Support::class, 'metadata', amp_get_schemaorg_metadata() );
 
 		$call_prepare_response = static function() use ( $original_html ) {
 			AMP_HTTP::$headers_sent                     = [];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6316

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
