### PR TITLE
Add error boundary to the Settings page

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -52,6 +52,7 @@ namespace PHPSTORM_META {
 			'background_task_deactivator'        => \AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator::class,
 			'paired_routing'                     => \AmpProject\AmpWP\PairedRouting::class,
 			'paired_url'                         => \AmpProject\AmpWP\PairedUrl::class,
+			'loading_error'                      => \AmpProject\AmpWP\LoadingError::class,
 		] )
 	);
 

--- a/assets/src/amp-validation/counts/index.js
+++ b/assets/src/amp-validation/counts/index.js
@@ -20,9 +20,8 @@ import './style.css';
  */
 function updateMenuItem( itemEl, count ) {
 	if ( isNaN( count ) || count === 0 ) {
-		itemEl.parentNode.parentNode.removeChild( itemEl.parentNode );
+		itemEl.parentNode.removeChild( itemEl );
 	} else {
-		itemEl.classList.remove( 'amp-count-loading' );
 		itemEl.textContent = count.toLocaleString();
 	}
 }

--- a/assets/src/amp-validation/counts/style.css
+++ b/assets/src/amp-validation/counts/style.css
@@ -22,3 +22,8 @@
 	border-radius: 50%;
 	display: inline-block;
 }
+
+body.no-js #new-validation-url-count,
+body.no-js #new-error-index-count {
+	display: none;
+}

--- a/assets/src/components/clipboard-button/index.js
+++ b/assets/src/components/clipboard-button/index.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { Button } from '@wordpress/components';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+const TIMEOUT = 4000;
+
+// Migrated from @wordpress/components.
+export default function ClipboardButton( {
+	children,
+	onCopy,
+	onFinishCopy,
+	text,
+	...buttonProps
+} ) {
+	const timeoutId = useRef();
+	const ref = useCopyToClipboard( text, () => {
+		if ( onCopy ) {
+			onCopy();
+		}
+
+		clearTimeout( timeoutId.current );
+
+		if ( onFinishCopy ) {
+			timeoutId.current = setTimeout( () => onFinishCopy(), TIMEOUT );
+		}
+	} );
+
+	useEffect( () => {
+		clearTimeout( timeoutId.current );
+	}, [] );
+
+	// Workaround for inconsistent behavior in Safari, where <textarea> is not
+	// the document.activeElement at the moment when the copy event fires.
+	// This causes documentHasSelection() in the copy-handler component to
+	// mistakenly override the ClipboardButton, and copy a serialized string
+	// of the current block instead.
+	const focusOnCopyEventTarget = ( event ) => {
+		event.target.focus();
+	};
+
+	return (
+		<Button
+			{ ...buttonProps }
+			className="components-clipboard-button"
+			ref={ ref }
+			onCopy={ focusOnCopyEventTarget }
+		>
+			{ children }
+		</Button>
+	);
+}
+
+ClipboardButton.propTypes = {
+	children: PropTypes.any,
+	onCopy: PropTypes.func,
+	onFinishCopy: PropTypes.func,
+	text: PropTypes.string.isRequired,
+};

--- a/assets/src/components/clipboard-button/index.js
+++ b/assets/src/components/clipboard-button/index.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 const TIMEOUT = 4000;
 
-// Migrated from @wordpress/components.
+// Adapted from @wordpress/components: <https://github.com/WordPress/gutenberg/blob/3c00d85/packages/components/src/clipboard-button/index.js#L18-L69>.
 export default function ClipboardButton( {
 	children,
 	onCopy,

--- a/assets/src/components/clipboard-button/index.js
+++ b/assets/src/components/clipboard-button/index.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 const TIMEOUT = 4000;
 
-// Adapted from @wordpress/components: <https://github.com/WordPress/gutenberg/blob/3c00d85/packages/components/src/clipboard-button/index.js#L18-L69>.
+// Adapted from @wordpress/components: <https://github.com/WordPress/gutenberg/blob/3c00d85b12ee45365e3ab329301a07312d99ffdf/packages/components/src/clipboard-button/index.js#L18-L69>.
 export default function ClipboardButton( {
 	children,
 	onCopy,

--- a/assets/src/components/clipboard-button/test/__snapshots__/index.js.snap
+++ b/assets/src/components/clipboard-button/test/__snapshots__/index.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClipboardButton matches snapshot 1`] = `
+<button
+  aria-describedby={null}
+  className="components-button components-clipboard-button"
+  onCopy={[Function]}
+  type="button"
+/>
+`;

--- a/assets/src/components/clipboard-button/test/index.js
+++ b/assets/src/components/clipboard-button/test/index.js
@@ -1,0 +1,19 @@
+
+/**
+ * External dependencies
+ */
+import { create } from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import ClipboardButton from '..';
+
+describe( 'ClipboardButton', () => {
+	it( 'matches snapshot', () => {
+		const wrapper = create(
+			<ClipboardButton text="Sample text" />,
+		);
+		expect( wrapper.toJSON() ).toMatchSnapshot();
+	} );
+} );

--- a/assets/src/components/error-boundary/index.js
+++ b/assets/src/components/error-boundary/index.js
@@ -21,7 +21,8 @@ import { ErrorScreen } from '../error-screen';
 export class ErrorBoundary extends Component {
 	static propTypes = {
 		children: PropTypes.any,
-		exitLink: PropTypes.string,
+		exitLinkLabel: PropTypes.string,
+		exitLinkUrl: PropTypes.string,
 		title: PropTypes.string,
 	}
 
@@ -46,13 +47,14 @@ export class ErrorBoundary extends Component {
 
 	render() {
 		const { error } = this.state;
-		const { children, exitLink, title } = this.props;
+		const { children, exitLinkLabel, exitLinkUrl, title } = this.props;
 
 		if ( error ) {
 			return (
 				<ErrorScreen
 					error={ error }
-					finishLink={ exitLink }
+					finishLinkLabel={ exitLinkLabel }
+					finishLinkUrl={ exitLinkUrl }
 					title={ title }
 				/>
 			);

--- a/assets/src/components/error-boundary/index.js
+++ b/assets/src/components/error-boundary/index.js
@@ -22,6 +22,7 @@ export class ErrorBoundary extends Component {
 	static propTypes = {
 		children: PropTypes.any,
 		exitLink: PropTypes.string,
+		title: PropTypes.string,
 	}
 
 	constructor( props ) {
@@ -45,11 +46,15 @@ export class ErrorBoundary extends Component {
 
 	render() {
 		const { error } = this.state;
-		const { children, exitLink } = this.props;
+		const { children, exitLink, title } = this.props;
 
 		if ( error ) {
 			return (
-				<ErrorScreen error={ error } finishLink={ exitLink } />
+				<ErrorScreen
+					error={ error }
+					finishLink={ exitLink }
+					title={ title }
+				/>
 			);
 		}
 

--- a/assets/src/components/error-boundary/index.js
+++ b/assets/src/components/error-boundary/index.js
@@ -22,7 +22,6 @@ export class ErrorBoundary extends Component {
 	static propTypes = {
 		children: PropTypes.any,
 		exitLink: PropTypes.string,
-		fullScreen: PropTypes.bool,
 	}
 
 	constructor( props ) {
@@ -46,9 +45,9 @@ export class ErrorBoundary extends Component {
 
 	render() {
 		const { error } = this.state;
-		const { children, exitLink, fullScreen } = this.props;
+		const { children, exitLink } = this.props;
 
-		if ( error && fullScreen ) {
+		if ( error ) {
 			return (
 				<ErrorScreen error={ error } finishLink={ exitLink } />
 			);

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Panel } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
@@ -39,6 +39,15 @@ export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) 
 				{ /* dangerouslySetInnerHTML reason: WordPress sometimes sends back HTML in error messages. */ }
 				<p dangerouslySetInnerHTML={ {
 					__html: message || __( 'There was an error loading the page.', 'amp' ),
+				} } />
+
+				{ /* dangerouslySetInnerHTML reason: The message contains a link to the AMP support forum. */ }
+				<p dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						// translators: %s is the AMP support forum URL.
+						__( 'Please submit details to our <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
+						__( 'https://wordpress.org/support/plugin/amp/', 'amp' ),
+					),
 				} } />
 
 				{ stack && (

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -45,7 +45,9 @@ export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) 
 						<summary>
 							{ __( 'Details', 'amp' ) }
 						</summary>
-						<pre dangerouslySetInnerHTML={ { __html: error.stack } } />
+						<pre>
+							{ error.stack }
+						</pre>
 						<ClipboardButton
 							isSmall={ true }
 							isSecondary={ true }

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -27,6 +27,7 @@ import './style.css';
  */
 export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) {
 	const [ hasCopied, setHasCopied ] = useState( false );
+	const { message, stack } = error;
 
 	return (
 		<div className="error-screen-container">
@@ -37,21 +38,21 @@ export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) 
 
 				{ /* dangerouslySetInnerHTML reason: WordPress sometimes sends back HTML in error messages. */ }
 				<p dangerouslySetInnerHTML={ {
-					__html: error.message || __( 'There was an error loading the page.', 'amp' ),
+					__html: message || __( 'There was an error loading the page.', 'amp' ),
 				} } />
 
-				{ error?.stack && (
+				{ stack && (
 					<details>
 						<summary>
 							{ __( 'Details', 'amp' ) }
 						</summary>
 						<pre>
-							{ error.stack }
+							{ stack }
 						</pre>
 						<ClipboardButton
 							isSmall={ true }
 							isSecondary={ true }
-							text={ error.stack }
+							text={ JSON.stringify( { message, stack }, null, 2 ) }
 							onCopy={ () => setHasCopied( true ) }
 							onFinishCopy={ () => setHasCopied( false ) }
 						>

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Panel } from '@wordpress/components';
+import { ClipboardButton, Panel } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -24,6 +25,8 @@ import './style.css';
  * @param {string} props.title Custom message title.
  */
 export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) {
+	const [ hasCopied, setHasCopied ] = useState( false );
+
 	return (
 		<div className="error-screen-container">
 			<Panel className="error-screen">
@@ -42,6 +45,15 @@ export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) 
 							{ __( 'Details', 'amp' ) }
 						</summary>
 						<pre dangerouslySetInnerHTML={ { __html: error.stack } } />
+						<ClipboardButton
+							isSmall={ true }
+							isSecondary={ true }
+							text={ error.stack }
+							onCopy={ () => setHasCopied( true ) }
+							onFinishCopy={ () => setHasCopied( false ) }
+						>
+							{ hasCopied ? __( 'Copied!', 'amp' ) : __( 'Copy Error', 'amp' ) }
+						</ClipboardButton>
 					</details>
 				) }
 

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -19,24 +19,25 @@ import './style.css';
  *
  * @param {Object} props Component props.
  * @param {Object} props.error Error object containing a message string.
- * @param {string} props.finishLink The link to return to the admin.
+ * @param {Object} props.finishLink The link to return to the admin.
+ * @param {string} props.title Custom message title.
  */
-export function ErrorScreen( { error, finishLink } ) {
+export function ErrorScreen( { error, finishLink, title } ) {
 	return (
 		<div className="error-screen-container">
 			<Panel className="error-screen">
 				<h1>
-					{ __( 'The setup wizard has experienced an error.', 'amp' ) }
+					{ title || __( 'Something went wrong.', 'amp' ) }
 				</h1>
 				<p>
 					{ /* dangerouslySetInnerHTML reason: WordPress sometimes sends back HTML in error messages. */ }
 					<span
-						dangerouslySetInnerHTML={ { __html: error.message || __( 'There was an error loading the setup wizard.', 'amp' ) } }
+						dangerouslySetInnerHTML={ { __html: error.message || __( 'There was an error loading the page.', 'amp' ) } }
 					/>
 					{ ' ' }
-					{ finishLink && (
-						<a href={ finishLink }>
-							{ __( 'Return to AMP settings.', 'amp' ) }
+					{ finishLink?.url && finishLink?.label && (
+						<a href={ finishLink.url }>
+							{ finishLink.label }
 						</a>
 					) }
 				</p>
@@ -49,5 +50,9 @@ ErrorScreen.propTypes = {
 	error: PropTypes.shape( {
 		message: PropTypes.string,
 	} ).isRequired,
-	finishLink: PropTypes.string.isRequired,
+	finishLink: PropTypes.shape( {
+		label: PropTypes.string.isRequired,
+		url: PropTypes.string.isRequired,
+	} ),
+	title: PropTypes.string,
 };

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -29,18 +29,28 @@ export function ErrorScreen( { error, finishLink, title } ) {
 				<h1>
 					{ title || __( 'Something went wrong.', 'amp' ) }
 				</h1>
-				<p>
-					{ /* dangerouslySetInnerHTML reason: WordPress sometimes sends back HTML in error messages. */ }
-					<span
-						dangerouslySetInnerHTML={ { __html: error.message || __( 'There was an error loading the page.', 'amp' ) } }
-					/>
-					{ ' ' }
-					{ finishLink?.url && finishLink?.label && (
+
+				{ /* dangerouslySetInnerHTML reason: WordPress sometimes sends back HTML in error messages. */ }
+				<p dangerouslySetInnerHTML={ {
+					__html: error.message || __( 'There was an error loading the page.', 'amp' ),
+				} } />
+
+				{ error?.stack && (
+					<details>
+						<summary>
+							{ __( 'Details', 'amp' ) }
+						</summary>
+						<pre dangerouslySetInnerHTML={ { __html: error.stack } } />
+					</details>
+				) }
+
+				{ finishLink?.url && finishLink?.label && (
+					<p>
 						<a href={ finishLink.url }>
 							{ finishLink.label }
 						</a>
-					) }
-				</p>
+					</p>
+				) }
 			</Panel>
 		</div>
 	);
@@ -49,6 +59,7 @@ export function ErrorScreen( { error, finishLink, title } ) {
 ErrorScreen.propTypes = {
 	error: PropTypes.shape( {
 		message: PropTypes.string,
+		stack: PropTypes.string,
 	} ).isRequired,
 	finishLink: PropTypes.shape( {
 		label: PropTypes.string.isRequired,

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ClipboardButton, Panel } from '@wordpress/components';
+import { Panel } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import ClipboardButton from '../clipboard-button';
 import './style.css';
 
 /**

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -19,10 +19,11 @@ import './style.css';
  *
  * @param {Object} props Component props.
  * @param {Object} props.error Error object containing a message string.
- * @param {Object} props.finishLink The link to return to the admin.
+ * @param {string} props.finishLinkLabel Label of a link to return to the admin.
+ * @param {string} props.finishLinkUrl Url of a link to return to the admin.
  * @param {string} props.title Custom message title.
  */
-export function ErrorScreen( { error, finishLink, title } ) {
+export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) {
 	return (
 		<div className="error-screen-container">
 			<Panel className="error-screen">
@@ -44,10 +45,10 @@ export function ErrorScreen( { error, finishLink, title } ) {
 					</details>
 				) }
 
-				{ finishLink?.url && finishLink?.label && (
+				{ finishLinkUrl && finishLinkLabel && (
 					<p>
-						<a href={ finishLink.url }>
-							{ finishLink.label }
+						<a href={ finishLinkUrl }>
+							{ finishLinkLabel }
 						</a>
 					</p>
 				) }
@@ -61,9 +62,7 @@ ErrorScreen.propTypes = {
 		message: PropTypes.string,
 		stack: PropTypes.string,
 	} ).isRequired,
-	finishLink: PropTypes.shape( {
-		label: PropTypes.string.isRequired,
-		url: PropTypes.string.isRequired,
-	} ),
+	finishLinkLabel: PropTypes.string,
+	finishLinkUrl: PropTypes.string,
 	title: PropTypes.string,
 };

--- a/assets/src/components/error-screen/style.css
+++ b/assets/src/components/error-screen/style.css
@@ -13,8 +13,30 @@
 .error-screen {
 	padding: 2.25rem;
 	width: 100%;
+	background-color: #fff;
+	border-left: 4px solid #d54e21;
 }
 
 .error-screen h1 {
-	line-height: 1.19;
+	line-height: 1.4;
+	font-size: 1.5rem;
+	font-family: var(--font-poppins);
+	margin: 0 0 1rem;
+	font-weight: 600;
+}
+
+.error-screen p {
+	margin: 1rem 0;
+	font-family: var(--font-noto);
+	font-size: 1rem;
+	line-height: 1.5;
+}
+
+.error-screen pre {
+	overflow: auto;
+	padding: 3px 5px 2px 5px;
+	margin: 0 1px;
+	background: #f0f0f1;
+	background: rgba(0,0,0,.07);
+	font-size: 13px;
 }

--- a/assets/src/components/error-screen/style.css
+++ b/assets/src/components/error-screen/style.css
@@ -1,7 +1,7 @@
-* {
+.error-screen-container,
+.error-screen-container * {
 	box-sizing: border-box;
 }
-
 
 .error-screen-container {
 	margin: 3rem auto;

--- a/assets/src/components/error-screen/style.css
+++ b/assets/src/components/error-screen/style.css
@@ -37,6 +37,6 @@
 	padding: 3px 5px 2px 5px;
 	margin: 0 1px;
 	background: #f0f0f1;
-	background: rgba(0,0,0,.07);
+	background: rgba(0, 0, 0, .07);
 	font-size: 13px;
 }

--- a/assets/src/components/error-screen/style.css
+++ b/assets/src/components/error-screen/style.css
@@ -30,6 +30,7 @@
 	font-family: var(--font-noto);
 	font-size: 1rem;
 	line-height: 1.5;
+	word-break: break-word;
 }
 
 .error-screen pre {

--- a/assets/src/components/error-screen/style.css
+++ b/assets/src/components/error-screen/style.css
@@ -35,7 +35,7 @@
 .error-screen pre {
 	overflow: auto;
 	padding: 3px 5px 2px 5px;
-	margin: 0 1px;
+	margin: 1rem 1px;
 	background: #f0f0f1;
 	background: rgba(0, 0, 0, .07);
 	font-size: 13px;

--- a/assets/src/components/error-screen/test/__snapshots__/index.js.snap
+++ b/assets/src/components/error-screen/test/__snapshots__/index.js.snap
@@ -17,6 +17,13 @@ exports[`ErrorScreen matches snapshot 1`] = `
         }
       }
     />
+    <p
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Please submit details to our <a href=\\"https://wordpress.org/support/plugin/amp/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">support forum</a>.",
+        }
+      }
+    />
     <details>
       <summary>
         Details

--- a/assets/src/components/error-screen/test/__snapshots__/index.js.snap
+++ b/assets/src/components/error-screen/test/__snapshots__/index.js.snap
@@ -8,21 +8,32 @@ exports[`ErrorScreen matches snapshot 1`] = `
     className="error-screen components-panel"
   >
     <h1>
-      The setup wizard has experienced an error.
+      Something went wrong.
     </h1>
-    <p>
-      <span
+    <p
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "The application failed",
+        }
+      }
+    />
+    <details>
+      <summary>
+        Details
+      </summary>
+      <pre
         dangerouslySetInnerHTML={
           Object {
-            "__html": "The application failed",
+            "__html": "ReferenceError: foo is not defined",
           }
         }
       />
-       
+    </details>
+    <p>
       <a
         href="http://my-exit-link.com"
       >
-        Return to AMP settings.
+        Go to homepage
       </a>
     </p>
   </div>

--- a/assets/src/components/error-screen/test/__snapshots__/index.js.snap
+++ b/assets/src/components/error-screen/test/__snapshots__/index.js.snap
@@ -21,13 +21,9 @@ exports[`ErrorScreen matches snapshot 1`] = `
       <summary>
         Details
       </summary>
-      <pre
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "ReferenceError: foo is not defined",
-          }
-        }
-      />
+      <pre>
+        ReferenceError: foo is not defined
+      </pre>
       <button
         aria-describedby={null}
         className="components-button components-clipboard-button is-secondary is-small"

--- a/assets/src/components/error-screen/test/__snapshots__/index.js.snap
+++ b/assets/src/components/error-screen/test/__snapshots__/index.js.snap
@@ -28,6 +28,14 @@ exports[`ErrorScreen matches snapshot 1`] = `
           }
         }
       />
+      <button
+        aria-describedby={null}
+        className="components-button components-clipboard-button is-secondary is-small"
+        onCopy={[Function]}
+        type="button"
+      >
+        Copy Error
+      </button>
     </details>
     <p>
       <a

--- a/assets/src/components/error-screen/test/index.js
+++ b/assets/src/components/error-screen/test/index.js
@@ -13,10 +13,8 @@ describe( 'ErrorScreen', () => {
 	it( 'matches snapshot', () => {
 		const wrapper = create(
 			<ErrorScreen
-				finishLink={ {
-					url: 'http://my-exit-link.com',
-					label: 'Go to homepage',
-				} }
+				finishLinkLabel="Go to homepage"
+				finishLinkUrl="http://my-exit-link.com"
 				error={ {
 					message: 'The application failed',
 					stack: 'ReferenceError: foo is not defined',

--- a/assets/src/components/error-screen/test/index.js
+++ b/assets/src/components/error-screen/test/index.js
@@ -12,7 +12,15 @@ import { ErrorScreen } from '..';
 describe( 'ErrorScreen', () => {
 	it( 'matches snapshot', () => {
 		const wrapper = create(
-			<ErrorScreen finishLink={ 'http://my-exit-link.com' } error={ { message: 'The application failed' } } />,
+			<ErrorScreen
+				finishLink={ {
+					url: 'http://my-exit-link.com',
+					label: 'Go to homepage',
+				} }
+				error={ {
+					message: 'The application failed',
+					stack: 'ReferenceError: foo is not defined',
+				} } />,
 		);
 		expect( wrapper.toJSON() ).toMatchSnapshot();
 	} );

--- a/assets/src/components/error-screen/test/index.js
+++ b/assets/src/components/error-screen/test/index.js
@@ -20,7 +20,8 @@ describe( 'ErrorScreen', () => {
 				error={ {
 					message: 'The application failed',
 					stack: 'ReferenceError: foo is not defined',
-				} } />,
+				} }
+			/>,
 		);
 		expect( wrapper.toJSON() ).toMatchSnapshot();
 	} );

--- a/assets/src/components/site-settings-provider/index.js
+++ b/assets/src/components/site-settings-provider/index.js
@@ -13,6 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { ErrorContext } from '../error-context-provider';
+import { useAsyncError } from '../../utils/use-async-error';
 
 export const SiteSettings = createContext();
 
@@ -21,12 +22,14 @@ export const SiteSettings = createContext();
  *
  * @param {Object} props Component props.
  * @param {any} props.children Component children.
+ * @param {boolean} props.hasErrorBoundary Whether the component is wrapped in an error boundary.
  */
-export function SiteSettingsProvider( { children } ) {
+export function SiteSettingsProvider( { children, hasErrorBoundary = false } ) {
 	const [ settings, setSettings ] = useState( {} );
 	const [ fetchingSiteSettings, setFetchingSiteSettings ] = useState( false );
 
 	const { error, setError } = useContext( ErrorContext );
+	const { setAsyncError } = useAsyncError();
 
 	useEffect( () => {
 		if ( error || Object.keys( settings ).length || fetchingSiteSettings ) {
@@ -50,6 +53,10 @@ export function SiteSettingsProvider( { children } ) {
 				}
 
 				setError( e );
+
+				if ( hasErrorBoundary ) {
+					setAsyncError( e );
+				}
 				return;
 			}
 
@@ -59,7 +66,7 @@ export function SiteSettingsProvider( { children } ) {
 		return () => {
 			unmounted = true;
 		};
-	}, [ error, settings, fetchingSiteSettings, setError ] );
+	}, [ error, settings, fetchingSiteSettings, setError, hasErrorBoundary, setAsyncError ] );
 
 	return (
 		<SiteSettings.Provider value={ { settings, fetchingSiteSettings } }>
@@ -70,4 +77,5 @@ export function SiteSettingsProvider( { children } ) {
 
 SiteSettingsProvider.propTypes = {
 	children: PropTypes.any,
+	hasErrorBoundary: PropTypes.bool,
 };

--- a/assets/src/css/core-components.css
+++ b/assets/src/css/core-components.css
@@ -86,6 +86,10 @@
 	flex-wrap: wrap;
 }
 
+.amp .components-button.is-small {
+	font-size: 0.875rem;
+}
+
 
 .amp .components-toggle-control .components-base-control__field {
 	align-items: center;

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -51,10 +51,8 @@ export function Providers( { children } ) {
 	return (
 		<ErrorContextProvider>
 			<ErrorBoundary
-				exitLink={ {
-					label: __( 'Return to AMP settings.', 'amp' ),
-					url: FINISH_LINK,
-				} }
+				exitLinkLabel={ __( 'Return to AMP settings.', 'amp' ) }
+				exitLinkUrl={ FINISH_LINK }
 				title={ __( 'The setup wizard has experienced an error.', 'amp' ) }
 			>
 				<OptionsContextProvider

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -49,8 +49,7 @@ const { ajaxurl: wpAjaxUrl } = global;
 export function Providers( { children } ) {
 	return (
 		<ErrorContextProvider>
-			<ErrorBoundary exitLink={ FINISH_LINK } fullScreen={ true }>
-
+			<ErrorBoundary exitLink={ FINISH_LINK }>
 				<OptionsContextProvider
 					delaySave={ true }
 					hasErrorBoundary={ true }

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -42,6 +42,8 @@ import { TemplateModeOverrideContextProvider } from './components/template-mode-
 
 const { ajaxurl: wpAjaxUrl } = global;
 
+let errorHandler;
+
 /**
  * Context providers for the application.
  *
@@ -49,6 +51,8 @@ const { ajaxurl: wpAjaxUrl } = global;
  * @param {any} props.children Component children.
  */
 export function Providers( { children } ) {
+	global.removeEventListener( 'error', errorHandler );
+
 	return (
 		<ErrorContextProvider>
 			<ErrorBoundary
@@ -99,10 +103,10 @@ domReady( () => {
 		return;
 	}
 
-	const errorHandler = ( error ) => {
+	errorHandler = ( event ) => {
 		// Handle only own errors.
-		if ( error?.filename?.match( /amp-onboarding-wizard(\.min)?\.js/ ) ) {
-			render( <ErrorScreen error={ error } />, root );
+		if ( /amp-onboarding-wizard(\.min)?\.js/.test( event?.filename ) ) {
+			render( <ErrorScreen error={ event.error } />, root );
 		}
 	};
 
@@ -113,6 +117,5 @@ domReady( () => {
 			<SetupWizard closeLink={ CLOSE_LINK } finishLink={ FINISH_LINK } appRoot={ root } />
 		</Providers>,
 		root,
-		() => global.removeEventListener( 'error', errorHandler ),
 	);
 } );

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -32,6 +32,7 @@ import { OptionsContextProvider } from '../components/options-context-provider';
 import { ReaderThemesContextProvider } from '../components/reader-themes-context-provider';
 import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorContextProvider } from '../components/error-context-provider';
+import { ErrorScreen } from '../components/error-screen';
 import { PAGES } from './pages';
 import { SetupWizard } from './setup-wizard';
 import { NavigationContextProvider } from './components/navigation-context-provider';
@@ -94,13 +95,24 @@ Providers.propTypes = {
 domReady( () => {
 	const root = document.getElementById( APP_ROOT_ID );
 
-	if ( root ) {
-		render(
-
-			<Providers>
-				<SetupWizard closeLink={ CLOSE_LINK } finishLink={ FINISH_LINK } appRoot={ root } />
-			</Providers>,
-			root,
-		);
+	if ( ! root ) {
+		return;
 	}
+
+	const errorHandler = ( error ) => {
+		// Handle only own errors.
+		if ( error?.filename?.match( /amp-onboarding-wizard(\.min)?\.js/ ) ) {
+			render( <ErrorScreen error={ error } />, root );
+		}
+	};
+
+	global.addEventListener( 'error', errorHandler );
+
+	render(
+		<Providers>
+			<SetupWizard closeLink={ CLOSE_LINK } finishLink={ FINISH_LINK } appRoot={ root } />
+		</Providers>,
+		root,
+		() => global.removeEventListener( 'error', errorHandler ),
+	);
 } );

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -3,6 +3,7 @@
  */
 import { render } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
+import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -49,7 +50,13 @@ const { ajaxurl: wpAjaxUrl } = global;
 export function Providers( { children } ) {
 	return (
 		<ErrorContextProvider>
-			<ErrorBoundary exitLink={ FINISH_LINK }>
+			<ErrorBoundary
+				exitLink={ {
+					label: __( 'Return to AMP settings.', 'amp' ),
+					url: FINISH_LINK,
+				} }
+				title={ __( 'The setup wizard has experienced an error.', 'amp' ) }
+			>
 				<OptionsContextProvider
 					delaySave={ true }
 					hasErrorBoundary={ true }

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -105,7 +105,7 @@ domReady( () => {
 
 	errorHandler = ( event ) => {
 		// Handle only own errors.
-		if ( /amp-onboarding-wizard(\.min)?\.js/.test( event?.filename ) ) {
+		if ( event.filename && /amp-onboarding-wizard(\.min)?\.js/.test( event.filename ) ) {
 			render( <ErrorScreen error={ event.error } />, root );
 		}
 	};

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -227,7 +227,7 @@ domReady( () => {
 
 	errorHandler = ( event ) => {
 		// Handle only own errors.
-		if ( /amp-settings(\.min)?\.js/.test( event?.filename ) ) {
+		if ( event.filename && /amp-settings(\.min)?\.js/.test( event.filename ) ) {
 			render( <ErrorScreen error={ event.error } />, root );
 		}
 	};

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -29,6 +29,7 @@ import { ReaderThemesContextProvider, ReaderThemes } from '../components/reader-
 import { SiteSettingsProvider } from '../components/site-settings-provider';
 import { Loading } from '../components/loading';
 import { UnsavedChangesWarning } from '../components/unsaved-changes-warning';
+import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorContextProvider } from '../components/error-context-provider';
 import { AMPDrawer } from '../components/amp-drawer';
 import { AMPNotice, NOTICE_SIZE_LARGE } from '../components/amp-notice';
@@ -51,19 +52,23 @@ const { ajaxurl: wpAjaxUrl } = global;
  */
 function Providers( { children } ) {
 	return (
-		<SiteSettingsProvider>
-			<OptionsContextProvider optionsRestPath={ OPTIONS_REST_PATH } populateDefaultValues={ true }>
-				<ReaderThemesContextProvider
-					currentTheme={ CURRENT_THEME }
-					readerThemesRestPath={ READER_THEMES_REST_PATH }
-					hideCurrentlyActiveTheme={ true }
-					updatesNonce={ UPDATES_NONCE }
-					wpAjaxUrl={ wpAjaxUrl }
-				>
-					{ children }
-				</ReaderThemesContextProvider>
-			</OptionsContextProvider>
-		</SiteSettingsProvider>
+		<ErrorContextProvider>
+			<ErrorBoundary fullScreen={ true }>
+				<SiteSettingsProvider>
+					<OptionsContextProvider optionsRestPath={ OPTIONS_REST_PATH } populateDefaultValues={ true }>
+						<ReaderThemesContextProvider
+							currentTheme={ CURRENT_THEME }
+							readerThemesRestPath={ READER_THEMES_REST_PATH }
+							hideCurrentlyActiveTheme={ true }
+							updatesNonce={ UPDATES_NONCE }
+							wpAjaxUrl={ wpAjaxUrl }
+						>
+							{ children }
+						</ReaderThemesContextProvider>
+					</OptionsContextProvider>
+				</SiteSettingsProvider>
+			</ErrorBoundary>
+		</ErrorContextProvider>
 	);
 }
 Providers.propTypes = {
@@ -213,11 +218,9 @@ domReady( () => {
 
 	if ( root ) {
 		render( (
-			<ErrorContextProvider>
-				<Providers>
-					<Root appRoot={ root } />
-				</Providers>
-			</ErrorContextProvider>
+			<Providers>
+				<Root appRoot={ root } />
+			</Providers>
 		), root );
 	}
 } );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -33,6 +33,7 @@ import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorContextProvider } from '../components/error-context-provider';
 import { AMPDrawer } from '../components/amp-drawer';
 import { AMPNotice, NOTICE_SIZE_LARGE } from '../components/amp-notice';
+import { ErrorScreen } from '../components/error-screen';
 import { Welcome } from './welcome';
 import { TemplateModes } from './template-modes';
 import { SupportedTemplates } from './supported-templates';
@@ -216,11 +217,24 @@ Root.propTypes = {
 domReady( () => {
 	const root = document.getElementById( 'amp-settings-root' );
 
-	if ( root ) {
-		render( (
-			<Providers>
-				<Root appRoot={ root } />
-			</Providers>
-		), root );
+	if ( ! root ) {
+		return;
 	}
+
+	const errorHandler = ( error ) => {
+		// Handle only own errors.
+		if ( error?.filename?.match( /amp-settings(\.min)?\.js/ ) ) {
+			render( <ErrorScreen error={ error } />, root );
+		}
+	};
+
+	global.addEventListener( 'error', errorHandler );
+
+	render(
+		<Providers>
+			<Root appRoot={ root } />
+		</Providers>,
+		root,
+		() => global.removeEventListener( 'error', errorHandler ),
+	);
 } );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -53,7 +53,7 @@ const { ajaxurl: wpAjaxUrl } = global;
 function Providers( { children } ) {
 	return (
 		<ErrorContextProvider>
-			<ErrorBoundary fullScreen={ true }>
+			<ErrorBoundary>
 				<SiteSettingsProvider>
 					<OptionsContextProvider optionsRestPath={ OPTIONS_REST_PATH } populateDefaultValues={ true }>
 						<ReaderThemesContextProvider

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -45,6 +45,8 @@ import { PairedUrlStructure } from './paired-url-structure';
 
 const { ajaxurl: wpAjaxUrl } = global;
 
+let errorHandler;
+
 /**
  * Context providers for the settings page.
  *
@@ -52,6 +54,8 @@ const { ajaxurl: wpAjaxUrl } = global;
  * @param {any} props.children Context consumers.
  */
 function Providers( { children } ) {
+	global.removeEventListener( 'error', errorHandler );
+
 	return (
 		<ErrorContextProvider>
 			<ErrorBoundary>
@@ -221,10 +225,10 @@ domReady( () => {
 		return;
 	}
 
-	const errorHandler = ( error ) => {
+	errorHandler = ( event ) => {
 		// Handle only own errors.
-		if ( error?.filename?.match( /amp-settings(\.min)?\.js/ ) ) {
-			render( <ErrorScreen error={ error } />, root );
+		if ( /amp-settings(\.min)?\.js/.test( event?.filename ) ) {
+			render( <ErrorScreen error={ event.error } />, root );
 		}
 	};
 
@@ -235,6 +239,5 @@ domReady( () => {
 			<Root appRoot={ root } />
 		</Providers>,
 		root,
-		() => global.removeEventListener( 'error', errorHandler ),
 	);
 } );

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -59,11 +59,16 @@ function Providers( { children } ) {
 	return (
 		<ErrorContextProvider>
 			<ErrorBoundary>
-				<SiteSettingsProvider>
-					<OptionsContextProvider optionsRestPath={ OPTIONS_REST_PATH } populateDefaultValues={ true }>
+				<SiteSettingsProvider hasErrorBoundary={ true }>
+					<OptionsContextProvider
+						hasErrorBoundary={ true }
+						optionsRestPath={ OPTIONS_REST_PATH }
+						populateDefaultValues={ true }
+					>
 						<ReaderThemesContextProvider
 							currentTheme={ CURRENT_THEME }
 							readerThemesRestPath={ READER_THEMES_REST_PATH }
+							hasErrorBoundary={ true }
 							hideCurrentlyActiveTheme={ true }
 							updatesNonce={ UPDATES_NONCE }
 							wpAjaxUrl={ wpAjaxUrl }

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -469,7 +469,7 @@ class AMP_Validated_URL_Post_Type {
 
 				if ( ValidationCounts::is_needed() ) {
 					// Append markup to display a loading spinner while the unreviewed count is being fetched.
-					$submenu_item[0] .= ' <span class="awaiting-mod"><span id="new-validation-url-count" class="amp-count-loading"></span></span>';
+					$submenu_item[0] .= ' <span id="new-validation-url-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
 				}
 
 				break;

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1745,7 +1745,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( ValidationCounts::is_needed() ) {
 			// Append markup to display a loading spinner while the unreviewed count is being fetched.
-			$menu_item_label .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
+			$menu_item_label .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
 		}
 
 		$post_menu_slug = 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -139,7 +139,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 			<div>
 			<div>
 			<div class="amp" id="<?php echo esc_attr( self::APP_ROOT_ID ); ?>">
-				<?php LoadingError::print(); ?>
+				<?php LoadingError::render(); ?>
 			</div>
 
 			<style>

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -133,7 +133,8 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 		// <head> tag was opened prior to this action and hasn't been closed.
 		?>
 		</head>
-		<body>
+		<body class="no-js">
+			<script>document.body.className = document.body.className.replace('no-js','js');</script>
 			<?php // The admin footer template closes three divs. ?>
 			<div>
 			<div>

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -13,6 +13,7 @@ use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\LoadingError;
 
 /**
  * AMP setup wizard submenu page class.
@@ -137,7 +138,9 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 			<div>
 			<div>
 			<div>
-			<div class="amp" id="<?php echo esc_attr( self::APP_ROOT_ID ); ?>"></div>
+			<div class="amp" id="<?php echo esc_attr( self::APP_ROOT_ID ); ?>">
+				<?php LoadingError::print(); ?>
+			</div>
 
 			<style>
 			#wpfooter { display:none; }

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -62,7 +62,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 	private $rest_preloader;
 
 	/**
-	 * RESTPreloader instance.
+	 * LoadingError instance.
 	 *
 	 * @var LoadingError
 	 */

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -62,16 +62,25 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 	private $rest_preloader;
 
 	/**
+	 * RESTPreloader instance.
+	 *
+	 * @var LoadingError
+	 */
+	private $loading_error;
+
+	/**
 	 * OnboardingWizardSubmenuPage constructor.
 	 *
-	 * @param GoogleFonts   $google_fonts  An instance of the GoogleFonts service.
-	 * @param ReaderThemes  $reader_themes An instance of the ReaderThemes class.
+	 * @param GoogleFonts   $google_fonts   An instance of the GoogleFonts service.
+	 * @param ReaderThemes  $reader_themes  An instance of the ReaderThemes class.
 	 * @param RESTPreloader $rest_preloader An instance of the RESTPreloader class.
+	 * @param LoadingError  $loading_error  An instance of the LoadingError class.
 	 */
-	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader ) {
+	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader, LoadingError $loading_error ) {
 		$this->google_fonts   = $google_fonts;
 		$this->reader_themes  = $reader_themes;
 		$this->rest_preloader = $rest_preloader;
+		$this->loading_error  = $loading_error;
 	}
 
 	/**
@@ -140,7 +149,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 			<div>
 			<div>
 			<div class="amp" id="<?php echo esc_attr( self::APP_ROOT_ID ); ?>">
-				<?php LoadingError::render(); ?>
+				<?php $this->loading_error->render(); ?>
 			</div>
 
 			<style>

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -60,6 +60,9 @@ class OptionsMenu implements Conditional, Service, Registerable {
 	 */
 	private $rest_preloader;
 
+	/** @var LoadingError */
+	private $loading_error;
+
 	/** @var DependencySupport */
 	private $dependency_support;
 
@@ -89,12 +92,14 @@ class OptionsMenu implements Conditional, Service, Registerable {
 	 * @param ReaderThemes      $reader_themes An instance of the ReaderThemes class.
 	 * @param RESTPreloader     $rest_preloader An instance of the RESTPreloader class.
 	 * @param DependencySupport $dependency_support An instance of the DependencySupport class.
+	 * @param LoadingError      $loading_error An instance of the LoadingError class.
 	 */
-	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader, DependencySupport $dependency_support ) {
+	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader, DependencySupport $dependency_support, LoadingError $loading_error ) {
 		$this->google_fonts       = $google_fonts;
 		$this->reader_themes      = $reader_themes;
 		$this->rest_preloader     = $rest_preloader;
 		$this->dependency_support = $dependency_support;
+		$this->loading_error      = $loading_error;
 	}
 
 	/**
@@ -278,7 +283,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 
 				<div class="amp amp-settings">
 					<div id="amp-settings-root">
-						<?php LoadingError::render(); ?>
+						<?php $this->loading_error->render(); ?>
 					</div>
 				</div>
 			</form>

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -14,6 +14,7 @@ use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\LoadingError;
 
 /**
  * OptionsMenu class.
@@ -276,7 +277,9 @@ class OptionsMenu implements Conditional, Service, Registerable {
 				<?php settings_errors(); ?>
 
 				<div class="amp amp-settings">
-					<div id="amp-settings-root"></div>
+					<div id="amp-settings-root">
+						<?php LoadingError::print(); ?>
+					</div>
 				</div>
 			</form>
 		</div>

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -278,7 +278,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 
 				<div class="amp amp-settings">
 					<div id="amp-settings-root">
-						<?php LoadingError::print(); ?>
+						<?php LoadingError::render(); ?>
 					</div>
 				</div>
 			</form>

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -112,6 +112,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 		'background_task_deactivator'        => BackgroundTaskDeactivator::class,
 		'paired_routing'                     => PairedRouting::class,
 		'paired_url'                         => PairedUrl::class,
+		'loading_error'                      => LoadingError::class,
 	];
 
 	/**
@@ -200,6 +201,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			ReaderThemeSupportFeatures::class,
 			BackgroundTask\BackgroundTaskDeactivator::class,
 			PairedRouting::class,
+			LoadingError::class,
 			Injector::class,
 		];
 	}

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -17,9 +17,9 @@ namespace AmpProject\AmpWP;
 final class LoadingError {
 
 	/**
-	 * Print error message along with necessary styles.
+	 * Render error message along with necessary styles.
 	 */
-	public static function print() {
+	public static function render() {
 		?>
 		<div id="amp-loading-failure" class="error-screen-container">
 			<div class="error-screen components-panel">

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -7,6 +7,8 @@
 
 namespace AmpProject\AmpWP;
 
+use AmpProject\AmpWP\Infrastructure\Service;
+
 /**
  * Client-side app loading error markup and styles.
  *
@@ -14,15 +16,15 @@ namespace AmpProject\AmpWP;
  * @since 2.1.3
  * @internal
  */
-final class LoadingError {
+final class LoadingError implements Service {
 
 	/**
 	 * Render error message along with necessary styles.
 	 */
-	public static function render() {
+	public function render() {
 		?>
 		<div id="amp-pre-loading-spinner" class="amp-spinner-container">
-			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="Loading" width="16" height="16">
+			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="<?php esc_html_e( 'Loading', 'amp' ); ?>" width="16" height="16" decoding="async">
 		</div>
 
 		<div id="amp-loading-failure" class="error-screen-container">

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -24,7 +24,7 @@ final class LoadingError implements Service {
 	public function render() {
 		?>
 		<div id="amp-pre-loading-spinner" class="amp-spinner-container">
-			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="<?php esc_html_e( 'Loading', 'amp' ); ?>" width="16" height="16" decoding="async">
+			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="<?php esc_attr_e( 'Loading', 'amp' ); ?>" width="16" height="16" decoding="async">
 		</div>
 
 		<div id="amp-loading-failure" class="error-screen-container">

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -124,7 +124,6 @@ final class LoadingError implements Service {
 				width: 18px;
 				height: 18px;
 				opacity: 0.7;
-				margin: 5px 11px 0;
 				border-radius: 100%;
 				position: relative;
 			}

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -21,6 +21,10 @@ final class LoadingError {
 	 */
 	public static function render() {
 		?>
+		<div id="amp-pre-loading-spinner" class="amp-spinner-container">
+			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="Loading" width="16" height="16">
+		</div>
+
 		<div id="amp-loading-failure" class="error-screen-container">
 			<div class="error-screen components-panel">
 				<h1>
@@ -29,11 +33,11 @@ final class LoadingError {
 
 				<?php
 				printf(
-					'<p>%s</p>',
+					'<p class="amp-loading-failure-script">%s</p>',
 					wp_kses(
 						sprintf(
 							/* translators: %s is the AMP support forum URL. */
-							__( 'Oops! Something went wrong. Please open your browser console to see the error messages and share them on the <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>', 'amp' ),
+							__( 'Oops! Something went wrong. Please open your browser console to see the error messages and share them on the <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
 							esc_url( __( 'https://wordpress.org/support/plugin/amp/', 'amp' ) )
 						),
 						[
@@ -48,23 +52,55 @@ final class LoadingError {
 				?>
 
 				<noscript>
-					<p><?php esc_html_e( 'You must have JavaScript enabled to use this page.', 'amp' ); ?></p>
+					<p class="amp-loading-failure-noscript"><?php esc_html_e( 'You must have JavaScript enabled to use this page.', 'amp' ); ?></p>
 				</noscript>
 			</div>
 		</div>
 		<style>
 			#amp-loading-failure {
 				visibility: hidden;
-				animation: amp-wp-show-error 5s steps(1, end) 0s 1 normal both;
+				animation: amp-wp-show-element 5s steps(1, end) 0s 1 normal both;
 			}
 
-			@keyframes amp-wp-show-error {
+			#amp-pre-loading-spinner {
+				visibility: visible;
+				animation: amp-wp-hide-element 5s steps(1, end) 0s 1 normal both; /* This could probably reuse amp-wp-show-element if reversed. */
+			}
+
+			.amp-loading-failure-noscript {
+				display: none;
+			}
+
+			@keyframes amp-wp-show-element {
 				from {
 					visibility: hidden;
 				}
 				to {
 					visibility: visible;
 				}
+			}
+
+			@keyframes amp-wp-hide-element {
+				from {
+					visibility: visible;
+				}
+				to {
+					visibility: hidden;
+				}
+			}
+
+			body.no-js #amp-loading-failure {
+				animation: none;
+				visibility: visible;
+			}
+
+			body.no-js .amp-loading-failure-noscript {
+				display: block;
+			}
+
+			body.no-js #amp-pre-loading-spinner,
+			body.no-js .amp-loading-failure-script {
+				display: none;
 			}
 		</style>
 		<?php

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -37,7 +37,7 @@ final class LoadingError {
 					wp_kses(
 						sprintf(
 							/* translators: %s is the AMP support forum URL. */
-							__( 'Oops! Something went wrong. Please open your browser console to see the error messages and share them on the <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
+							__( 'Check your connection and open your browser console to see if there are any error messages. You may share them on the <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
 							esc_url( __( 'https://wordpress.org/support/plugin/amp/', 'amp' ) )
 						),
 						[
@@ -59,12 +59,12 @@ final class LoadingError {
 		<style>
 			#amp-loading-failure {
 				visibility: hidden;
-				animation: amp-wp-show-element 5s steps(1, end) 0s 1 normal both;
+				animation: amp-wp-show-element 30s steps(1, end) 0s 1 normal both;
 			}
 
 			#amp-pre-loading-spinner {
 				visibility: visible;
-				animation: amp-wp-hide-element 5s steps(1, end) 0s 1 normal both; /* This could probably reuse amp-wp-show-element if reversed. */
+				animation: amp-wp-hide-element 30s steps(1, end) 0s 1 normal both; /* This could probably reuse amp-wp-show-element if reversed. */
 			}
 
 			.amp-loading-failure-noscript {

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Class LoadingError.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP;
+
+/**
+ * Client-side app loading error markup and styles.
+ *
+ * @package AmpProject\AmpWP
+ * @since 2.1.3
+ * @internal
+ */
+final class LoadingError {
+
+	/**
+	 * Print error message along with necessary styles.
+	 */
+	public static function print() {
+		?>
+		<div id="amp-loading-failure" class="error-screen-container">
+			<div class="error-screen components-panel">
+				<h1>
+					<?php esc_html_e( 'Something went wrong.', 'amp' ); ?>
+				</h1>
+
+				<?php
+				printf(
+					'<p>%s</p>',
+					wp_kses(
+						sprintf(
+							/* translators: %s is the AMP support forum URL. */
+							__( 'Oops! Something went wrong. Please open your browser console to see the error messages and share them on the <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>', 'amp' ),
+							esc_url( __( 'https://wordpress.org/support/plugin/amp/', 'amp' ) )
+						),
+						[
+							'a' => [
+								'href'   => true,
+								'target' => true,
+								'rel'    => true,
+							],
+						]
+					)
+				);
+				?>
+
+				<noscript>
+					<p><?php esc_html_e( 'You must have JavaScript enabled to use this page.', 'amp' ); ?></p>
+				</noscript>
+			</div>
+		</div>
+		<style>
+			#amp-loading-failure {
+				visibility: hidden;
+				animation: amp-wp-show-error 5s steps(1, end) 0s 1 normal both;
+			}
+
+			@keyframes amp-wp-show-error {
+				from {
+					visibility: hidden;
+				}
+				to {
+					visibility: visible;
+				}
+			}
+		</style>
+		<?php
+	}
+}

--- a/src/LoadingError.php
+++ b/src/LoadingError.php
@@ -24,7 +24,11 @@ final class LoadingError implements Service {
 	public function render() {
 		?>
 		<div id="amp-pre-loading-spinner" class="amp-spinner-container">
-			<img src="<?php echo esc_url( admin_url( 'images/loading.gif' ) ); ?>" alt="<?php esc_attr_e( 'Loading', 'amp' ); ?>" width="16" height="16" decoding="async">
+			<span class="amp-loading-spinner">
+				<span class="screen-reader-text">
+					<?php esc_html_e( 'Loading', 'amp' ); ?>
+				</span>
+			</span>
 		</div>
 
 		<div id="amp-loading-failure" class="error-screen-container">
@@ -91,6 +95,15 @@ final class LoadingError implements Service {
 				}
 			}
 
+			@keyframes amp-loading-spinner {
+				from {
+					transform: rotate(0deg);
+				}
+				to {
+					transform: rotate(360deg);
+				}
+			}
+
 			body.no-js #amp-loading-failure {
 				animation: none;
 				visibility: visible;
@@ -103,6 +116,30 @@ final class LoadingError implements Service {
 			body.no-js #amp-pre-loading-spinner,
 			body.no-js .amp-loading-failure-script {
 				display: none;
+			}
+
+			.amp-spinner-container .amp-loading-spinner {
+				display: inline-block;
+				background-color: #949494;
+				width: 18px;
+				height: 18px;
+				opacity: 0.7;
+				margin: 5px 11px 0;
+				border-radius: 100%;
+				position: relative;
+			}
+
+			.amp-spinner-container .amp-loading-spinner::before {
+				content: '';
+				position: absolute;
+				background-color: #fff;
+				width: calc(18px / 4.5);
+				height: calc(18px / 4.5);
+				border-radius: 100%;
+				transform-origin: calc(18px / 3) calc(18px / 3);
+				top: calc((18px - 18px * (2 / 3)) / 2);
+				left: calc((18px - 18px * (2 / 3)) / 2);
+				animation: amp-loading-spinner 1s infinite linear;
 			}
 		</style>
 		<?php

--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -13,6 +13,7 @@ use AmpProject\AmpWP\Admin\OptionsMenu;
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Admin\RESTPreloader;
 use AmpProject\AmpWP\DependencySupport;
+use AmpProject\AmpWP\LoadingError;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use WP_UnitTestCase;
 
@@ -52,7 +53,8 @@ class AnalyticsOptionsSubmenuTest extends WP_UnitTestCase {
 			new GoogleFonts(),
 			new ReaderThemes(),
 			new RESTPreloader(),
-			new DependencySupport()
+			new DependencySupport(),
+			new LoadingError()
 		);
 		$this->instance              = new AnalyticsOptionsSubmenu( $this->options_menu_instance );
 	}

--- a/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuPageTest.php
@@ -102,7 +102,7 @@ class OnboardingWizardSubmenuPageTest extends DependencyInjectedTestCase {
 
 		$this->onboarding_wizard_submenu_page->render();
 
-		$this->assertStringContains( '<div class="amp" id="amp-onboarding-wizard"></div>', ob_get_clean() );
+		$this->assertStringContains( '<div class="amp" id="amp-onboarding-wizard">', ob_get_clean() );
 	}
 
 	/**

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -15,6 +15,7 @@ use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\LoadingError;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use WP_UnitTestCase;
 
@@ -42,7 +43,7 @@ class OptionsMenuTest extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->instance = new OptionsMenu( new GoogleFonts(), new ReaderThemes(), new RESTPreloader(), new DependencySupport() );
+		$this->instance = new OptionsMenu( new GoogleFonts(), new ReaderThemes(), new RESTPreloader(), new DependencySupport(), new LoadingError() );
 	}
 
 	/** @covers ::__construct() */

--- a/tests/php/src/LoadingErrorTest.php
+++ b/tests/php/src/LoadingErrorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests;
+
+use AmpProject\AmpWP\LoadingError;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
+
+/** @coversDefaultClass \AmpProject\AmpWP\LoadingError */
+class LoadingErrorTest extends DependencyInjectedTestCase {
+
+	use AssertContainsCompatibility;
+
+	/** @var LoadingError */
+	private $instance;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = $this->injector->make( LoadingError::class );
+	}
+
+	public function test_it_can_be_initialized() {
+		$this->assertInstanceOf( Service::class, $this->instance );
+	}
+
+	/** @covers ::render() */
+	public function test_render() {
+		$output = get_echo( [ $this->instance, 'render' ] );
+		$this->assertStringContains( 'loading.gif', $output );
+		$this->assertStringContains( '<div id="amp-loading-failure"', $output );
+		$this->assertStringContains( '<p class="amp-loading-failure-script">', $output );
+		$this->assertStringContains( '<p class="amp-loading-failure-noscript">', $output );
+	}
+}

--- a/tests/php/src/LoadingErrorTest.php
+++ b/tests/php/src/LoadingErrorTest.php
@@ -27,7 +27,7 @@ class LoadingErrorTest extends DependencyInjectedTestCase {
 	/** @covers ::render() */
 	public function test_render() {
 		$output = get_echo( [ $this->instance, 'render' ] );
-		$this->assertStringContains( 'loading.gif', $output );
+		$this->assertStringContains( '<span class="amp-loading-spinner">', $output );
 		$this->assertStringContains( '<div id="amp-loading-failure"', $output );
 		$this->assertStringContains( '<p class="amp-loading-failure-script">', $output );
 		$this->assertStringContains( '<p class="amp-loading-failure-noscript">', $output );

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -162,7 +162,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$this->assertSame( 'Validated URLs <span class="awaiting-mod"><span id="new-validation-url-count" class="amp-count-loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+			$this->assertSame( 'Validated URLs <span id="new-validation-url-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		} else {
 			$this->assertSame( 'Validated URLs', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		}

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1031,8 +1031,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			'Error Index',
 		];
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$expected_submenu[0] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
-			$expected_submenu[3] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
+			$expected_submenu[0] .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
+			$expected_submenu[3] .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
 		}
 		$amp_options = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );


### PR DESCRIPTION
## Summary

This PR adds the error boundary and error screen components from the Onboarding Wizard to the AMP Settings page. The error screen is also extended. It now shows not only the error message but also the stack information. Some cosmetic updates to the look and feel of the error message have been done as well. 

| Onboarding Wizard | AMP Settings |
| --- | --- |
| ![Screenshot 2021-05-31 at 14 36 11](https://user-images.githubusercontent.com/478735/120196056-b3212280-c21f-11eb-8a84-a990d03ebf72.png) | ![Screenshot 2021-05-31 at 14 36 31](https://user-images.githubusercontent.com/478735/120196066-b7e5d680-c21f-11eb-86c0-993e3e013571.png) |

| Onboarding Wizard before | Onboarding Wizard after |
| --- | --- |
| ![Screenshot 2021-05-31 at 14 50 27](https://user-images.githubusercontent.com/478735/120196162-d3e97800-c21f-11eb-9a19-cbb35b2987a8.png) | ![Screenshot 2021-05-31 at 14 50 52](https://user-images.githubusercontent.com/478735/120196176-d8159580-c21f-11eb-903e-42d43370a028.png) |

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6230

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
