### PR TITLE
Remove newlines from package list before setting step output

### DIFF
--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -121,12 +121,12 @@ jobs:
         id: packages
         run: |
           # Get list of latest package versions.
-          PACKAGES=$(npm outdated --parseable | cut -d':' -f 4 | grep @wordpress || echo 0)
+          PACKAGES=$(npm outdated --parseable | cut -d':' -f 4 | grep @wordpress | paste -s -d' ' || echo 0)
           echo "::set-output name=list::$(echo "$PACKAGES")"
 
       - name: Update packages
         if: steps.packages.outputs.list != 0
-        run: npm i $(echo "$PACKAGES" | paste -s -d' ')
+        run: npm i $(echo "$PACKAGES")
         env:
           PACKAGES: ${{ steps.packages.outputs.list }}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Amends #6302

The package list was not being serialized correctly and so only the first package in the list was set as the step output.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
