### PR TITLE
Fix `test_amp_get_schemaorg_metadata` and `test_wrap_widget_callbacks` in Gutenberg v10.8 and WP 5.8

### DIFF
--- a/tests/php/src/PluginSuppressionTest.php
+++ b/tests/php/src/PluginSuppressionTest.php
@@ -271,7 +271,10 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$this->assertEquals( 10, has_filter( 'amp_default_options', [ $this->instance, 'filter_default_options' ] ) );
 	}
 
-	/** @covers ::maybe_suppress_plugins() */
+	/**
+	 * @group widgets
+	 * @covers ::maybe_suppress_plugins()
+	 */
 	public function test_maybe_suppress_plugins_not_amp_endpoint() {
 		$url = home_url( '/' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
@@ -287,7 +290,10 @@ final class PluginSuppressionTest extends DependencyInjectedTestCase {
 		$this->assert_plugin_suppressed_state( false, $bad_plugin_file_slugs );
 	}
 
-	/** @covers ::maybe_suppress_plugins() */
+	/**
+	 * @group widgets
+	 * @covers ::maybe_suppress_plugins()
+	 */
 	public function test_maybe_suppress_plugins_yes_amp_endpoint() {
 		$url = home_url( '/' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1693,6 +1693,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		remove_filter( 'amp_site_icon_url', [ __CLASS__, 'mock_site_icon' ] );
 		delete_option( 'site_icon' );
 		remove_theme_mod( 'custom_logo' );
+		delete_option( 'site_logo' ); // As of Gutenberg v10.8.0.
 
 		// Test page.
 		$this->go_to( get_permalink( $page_id ) );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -97,6 +97,13 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	protected $original_wp_registered_widgets;
 
 	/**
+	 * Backed up $wp_widget_factory.
+	 *
+	 * @var WP_Widget_Factory
+	 */
+	protected $original_wp_widget_factory;
+
+	/**
 	 * Setup.
 	 *
 	 * @inheritdoc
@@ -111,6 +118,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		$dom_document->appendChild( $this->node );
 		AMP_Validation_Manager::reset_validation_results();
 		$this->original_wp_registered_widgets = $GLOBALS['wp_registered_widgets'];
+		$this->original_wp_widget_factory     = $GLOBALS['wp_widget_factory'];
 
 		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
 			foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $block ) {
@@ -127,6 +135,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 */
 	public function tearDown() {
 		$GLOBALS['wp_registered_widgets'] = $this->original_wp_registered_widgets;
+		$GLOBALS['wp_widget_factory']     = $this->original_wp_widget_factory;
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Validation_Manager::$validation_error_status_overrides = [];
 		$_REQUEST = [];
@@ -1224,6 +1233,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	/**
 	 * Test wrap_widget_callbacks.
 	 *
+	 * @group widgets
 	 * @covers AMP_Validation_Manager::wrap_widget_callbacks()
 	 */
 	public function test_wrap_widget_callbacks() {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1227,8 +1227,31 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 * @covers AMP_Validation_Manager::wrap_widget_callbacks()
 	 */
 	public function test_wrap_widget_callbacks() {
-		global $wp_registered_widgets, $_wp_sidebars_widgets;
+		global $wp_registered_widgets, $_wp_sidebars_widgets, $wp_widget_factory;
 		$this->go_to( amp_get_permalink( self::factory()->post->create() ) );
+
+		update_option(
+			'widget_search',
+			[
+				2               => [
+					'title' => '',
+				],
+				'_multi_widget' => 1,
+			]
+		);
+		update_option(
+			'widget_archives',
+			[
+				2               => [
+					'title' => '',
+				],
+				'_multi_widget' => 1,
+			]
+		);
+
+		$wp_registered_widgets = [];
+		$wp_widget_factory     = new WP_Widget_Factory();
+		wp_widgets_init();
 
 		$search_widget_id = 'search-2';
 		$this->assertArrayHasKey( $search_widget_id, $wp_registered_widgets );


### PR DESCRIPTION
## Summary

This fixes tests which were broken with Gutenberg v10.8.0 (and WP Core 5.8-beta1) due to https://github.com/WordPress/gutenberg/pull/32370 and https://github.com/WordPress/wordpress-develop/pull/1275, accounting for Custom Logo now being stored in an option in addition to a theme mod.

Also fixes `test_wrap_widget_callbacks` after changes to default widgets registered. See https://github.com/WordPress/wordpress-develop/commit/8add05ff150f148d3a5b9f88ce12c05d5cc48897 in https://core.trac.wordpress.org/ticket/53324.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
