### PR TITLE
Indicate what entity(s) are blocking the use of the paired endpoint suffix

### DIFF
--- a/assets/src/block-editor/components/layout-controls.js
+++ b/assets/src/block-editor/components/layout-controls.js
@@ -17,7 +17,6 @@ import { __, sprintf } from '@wordpress/i18n';
  * @param {Object}   props.attributes           Block attributes.
  * @param {Function} props.setAttributes        Callback to update block attributes.
  * @param {Array}    props.ampLayoutOptions     Layout options.
- *
  * @return {ReactElement} Controls.
  */
 const LayoutControls = ( { attributes, setAttributes, ampLayoutOptions } ) => {

--- a/assets/src/block-editor/components/media-placeholder.js
+++ b/assets/src/block-editor/components/media-placeholder.js
@@ -16,7 +16,6 @@ import { __ } from '@wordpress/i18n';
  * @param {Object} props Component props.
  * @param {string} props.name Block's name.
  * @param {string} props.url URL.
- *
  * @return {ReactElement} Placeholder.
  */
 const MediaPlaceholder = ( { name, url } ) => {

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -86,7 +86,6 @@ const ampLayoutOptions = [
  *
  * @param {Object} settings Block settings.
  * @param {string} name     Block name.
- *
  * @return {Object} Modified block settings.
  */
 export const addAMPAttributes = ( settings, name ) => {
@@ -140,7 +139,6 @@ export const addAMPAttributes = ( settings, name ) => {
  *
  * @param {Object} settings Block settings.
  * @param {string} name     Block name.
- *
  * @return {Object} Modified block settings.
  */
 export const removeAmpFitTextFromBlocks = ( settings, name ) => {
@@ -223,9 +221,7 @@ export const removeAmpFitTextFromBlocks = ( settings, name ) => {
  * removed and the deprecation of the block and proceed without error.
  *
  * @see removeAmpFitTextFromBlocks
- *
  * @param {ReactElement} element Block save result.
- *
  * @return {ReactElement} Modified block if it is of `amp-fit-text` type, otherwise the  original element is returned.
  */
 export const removeClassFromAmpFitTextBlocks = ( element ) => {
@@ -242,7 +238,6 @@ export const removeClassFromAmpFitTextBlocks = ( element ) => {
  * Get layout options depending on the block.
  *
  * @param {string} block Block name.
- *
  * @return {Object[]} Options.
  */
 export const getLayoutOptions = ( block ) => {
@@ -271,7 +266,6 @@ export const getLayoutOptions = ( block ) => {
  * Filters blocks edit function of all blocks.
  *
  * @param {Function} BlockEdit function.
- *
  * @return {Function} Edit function.
  */
 export const filterBlocksEdit = ( BlockEdit ) => {
@@ -358,7 +352,6 @@ export const setImageBlockLayoutAttributes = ( props, layout ) => {
  * Default setup for inspector controls.
  *
  * @param {Object} props Props.
- *
  * @return {ReactElement} Inspector Controls.
  */
 export const setUpInspectorControls = ( props ) => {
@@ -386,9 +379,7 @@ setUpInspectorControls.propTypes = {
  * Get AMP Layout select control.
  *
  * @deprecated As of v2.1. Blocks with the `ampLayout` attribute will still be able to use the control.
- *
  * @param {Object} props Props.
- *
  * @return {ReactElement} Element.
  */
 export const AmpLayoutControl = ( props ) => {
@@ -446,9 +437,7 @@ AmpLayoutControl.propTypes = {
  * Get AMP Noloading toggle control.
  *
  * @deprecated As of v2.1. Blocks with the `ampNoLoading` attribute will still be able to use the control.
- *
  * @param {Object} props Props.
- *
  * @return {ReactElement} Element.
  */
 export const AmpNoloadingToggle = ( props ) => {
@@ -495,7 +484,6 @@ AmpNoloadingToggle.propTypes = {
  * Get AMP Lightbox toggle control.
  *
  * @param {Object} props Props.
- *
  * @return {ReactElement} Element.
  */
 const AmpLightboxToggle = ( props ) => {
@@ -538,7 +526,6 @@ AmpLightboxToggle.propTypes = {
  * @param {Object}   props.attributes             Block attributes.
  * @param {Object}   props.attributes.ampCarousel AMP Carousel toggle value.
  * @param {Function} props.setAttributes          Callback to update attributes.
- *
  * @return {Object} Element.
  */
 const AmpCarouselToggle = ( props ) => {
@@ -565,7 +552,6 @@ AmpCarouselToggle.propTypes = {
  *
  * @param {Object}  props            Props.
  * @param {boolean} props.isSelected Whether the current block has been selected or not.
- *
  * @return {Object} Inspector Controls.
  */
 const setUpImageInspectorControls = ( props ) => {
@@ -596,7 +582,6 @@ setUpImageInspectorControls.propTypes = {
  *
  * @param {Object}  props            Props.
  * @param {boolean} props.isSelected Whether the current block has been selected or not.
- *
  * @return {Object} Inspector controls.
  */
 const setUpGalleryInspectorControls = ( props ) => {

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -2,7 +2,6 @@
  * Returns whether the current theme has AMP support.
  *
  * @param {Object} state Editor state.
- *
  * @return {boolean} Whether the current theme has AMP support.
  */
 export function hasThemeSupport( state ) {
@@ -13,7 +12,6 @@ export function hasThemeSupport( state ) {
  * Returns whether the current user has the AMP DevTools enabled.
  *
  * @param {Object} state The editor state.
- *
  * @return {boolean} Whether the DevTools are enabled.
  */
 export function isDevToolsEnabled( state ) {
@@ -24,7 +22,6 @@ export function isDevToolsEnabled( state ) {
  * Returns whether the current site is in Standard mode (AMP-first) as opposed to Transitional (paired).
  *
  * @param {Object} state Editor state.
- *
  * @return {boolean} Whether the current site is AMP-first.
  */
 export function isStandardMode( state ) {
@@ -35,7 +32,6 @@ export function isStandardMode( state ) {
  * Returns the AMP validation error messages.
  *
  * @param {Object} state The editor state.
- *
  * @return {string[]} The validation error messages.
  */
 export function getErrorMessages( state ) {
@@ -46,7 +42,6 @@ export function getErrorMessages( state ) {
  * Returns the AMP preview link (URL).
  *
  * @param {Object} state The editor state.
- *
  * @return {string} The AMP preview link URL.
  */
 export function getAmpPreviewLink( state ) {
@@ -57,7 +52,6 @@ export function getAmpPreviewLink( state ) {
  * Returns the AMP URL.
  *
  * @param {Object} state The editor state.
- *
  * @return {string} The AMP URL.
  */
 export function getAmpUrl( state ) {
@@ -68,7 +62,6 @@ export function getAmpUrl( state ) {
  * Returns the list of AMP blocks found in the post.
  *
  * @param {Object} state The editor state.
- *
  * @return {string[]} The list of AMP blocks in post.
  */
 export function getAmpBlocksInUse( state ) {

--- a/assets/src/classic-editor/amp-post-meta-box.js
+++ b/assets/src/classic-editor/amp-post-meta-box.js
@@ -7,7 +7,6 @@ import jQuery from 'jquery';
  * AMP Post Meta Box.
  *
  * @todo Rename this to be just the ampEditPostScreen?
- *
  * @since 0.6
  */
 window.ampPostMetaBox = ( function( $ ) {

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -23,7 +23,6 @@ import { validateFeaturedImage } from '../helpers';
  * @param {Object} props.featuredMedia Media object.
  * @param {Array} props.dimensions Required image dimensions.
  * @param {boolean} props.required Whether selecting a featured image is required.
- *
  * @return {Function} Either a plain pre-publish panel, or the panel with a featured image notice.
  */
 const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -27,7 +27,6 @@ import {
  * @param {Object} dimensions        An object with minimum required width and height values.
  * @param {number} dimensions.width  Required media width in pixels.
  * @param {number} dimensions.height Required media height in pixels.
- *
  * @return {boolean} Whether the media has the minimum dimensions.
  */
 export const hasMinimumDimensions = ( media, dimensions ) => {
@@ -46,8 +45,6 @@ export const hasMinimumDimensions = ( media, dimensions ) => {
 /**
  * Get minimum dimensions for a featured image.
  *
- * @see https://developers.google.com/search/docs/data-types/article#article_types
- *
  * "Images should be at least 1200 pixels wide.
  * For best results, provide multiple high-resolution images (minimum of 800,000 pixels when multiplying width and height)
  * with the following aspect ratios: 16x9, 4x3, and 1x1."
@@ -55,6 +52,7 @@ export const hasMinimumDimensions = ( media, dimensions ) => {
  * Given this requirement, this function ensures the right aspect ratio.
  * The 16/9 aspect ratio is chosen because it has the smallest height for the given width.
  *
+ * @see https://developers.google.com/search/docs/data-types/article#article_types
  * @return {Object} Minimum dimensions including width and height.
  */
 export const getMinimumFeaturedImageDimensions = () => {
@@ -76,7 +74,6 @@ export const getMinimumFeaturedImageDimensions = () => {
  * @param {number}  dimensions.width           Minimum required width value.
  * @param {number}  dimensions.height          Minimum required height value.
  * @param {boolean} required                   Whether the image is required or not.
- *
  * @return {string[]|null} Validation errors, or null if there were no errors.
  */
 export const validateFeaturedImage = ( media, dimensions, required ) => {

--- a/assets/src/components/carousel/index.js
+++ b/assets/src/components/carousel/index.js
@@ -165,7 +165,6 @@ Carousel.propTypes = {
  * Styles for the carousel component, rendered as a string in JSX to facilitate dynamic rules.
  *
  * @todo Installing a styled components library would provide better tooling for this.
- *
  * @param {Object} props Component props.
  * @param {number} props.gutterWidth The amount of space between items.
  * @param {number} props.itemWidth The width of items.

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -167,26 +167,25 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 				{
 					conflicts.user && (
 						[ conflicts.user ].map( ( entity ) => (
-							<li key={ `user-${ entity.id }` }>
+					<li>
+							{
+								conflicts.user.edit_link ? (
+									<a href={ conflicts.user.edit_link } target="_blank" rel="noreferrer">
+										{ __( 'User', 'amp' ) }
+									</a>
+								) : (
+									__( 'User', 'amp' )
+								)
+							}
+							{ ': ' + conflicts.user.name }
+							{ ' ' }
+							<small>
 								{
-									entity.edit_link ? (
-										<a href={ entity.edit_link } target="_blank" rel="noreferrer">
-											{ __( 'User', 'amp' ) }
-										</a>
-									) : (
-										__( 'User', 'amp' )
-									)
+									/* translators: %d is entity ID */
+									sprintf( __( '(ID: %d)', 'amp' ), conflicts.user.id )
 								}
-								{ ': ' + entity.name }
-								{ ' ' }
-								<small>
-									{
-										/* translators: %d is entity ID */
-										sprintf( __( '(ID: %d)', 'amp' ), entity.id )
-									}
-								</small>
-							</li>
-						) )
+							</small>
+						</li>
 					)
 				}
 

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -192,7 +192,7 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 
 				{
 					conflicts.post_type && (
-						<li key="post_type">
+						<li>
 							{
 								sprintf(
 									/* translators: %s is post type label */
@@ -213,7 +213,7 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 
 				{
 					conflicts.taxonomy && (
-						<li key="taxonomy">
+						<li>
 							{
 								sprintf(
 									/* translators: %s is taxonomy label */
@@ -233,7 +233,7 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 				}
 
 				{ conflicts.rewrite && (
-					<li key="rewrite">
+					<li>
 						{ __( 'Rewrite rules: ', 'amp' ) }
 						{
 							conflicts.rewrite

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -251,8 +251,8 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 	);
 }
 SlugConflictsNotice.propTypes = {
-	slug: PropTypes.string,
-	conflicts: PropTypes.object,
+	slug: PropTypes.string.isRequired,
+	conflicts: PropTypes.object.isRequired,
 };
 
 /**
@@ -276,7 +276,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 
 	const isCustom = 'custom' === editedOptions.paired_url_structure;
 
-	const endpointSuffixAvailable = editedOptions.endpoint_path_slug_conflicts.length === 0;
+	const endpointSuffixAvailable = editedOptions.endpoint_path_slug_conflicts === null;
 
 	return (
 		<AMPDrawer
@@ -313,7 +313,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 			/>
 
 			{ ! endpointSuffixAvailable && (
-				<SlugConflictsNotice conflicts={ editedOptions.endpoint_path_slug_conflicts } />
+				<SlugConflictsNotice slug={ slug } conflicts={ editedOptions.endpoint_path_slug_conflicts } />
 			) }
 
 			<ul>

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -142,10 +142,10 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 							{
 								entity.edit_link ? (
 									<a href={ entity.edit_link } target="_blank" rel="noreferrer">
-										{ entity.label || entity.post_type }
+										{ entity.label || entity.taxonomy }
 									</a>
 								) : (
-									entity.label || entity.post_type
+									entity.label || entity.taxonomy
 								)
 							}
 							{
@@ -191,7 +191,7 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 								sprintf(
 									/* translators: %s is post type label */
 									__( 'Post type: %s', 'amp' ),
-									conflicts.post_type.label,
+									conflicts.post_type.label || '--',
 								)
 							}
 							{ ' ' }
@@ -212,7 +212,7 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 								sprintf(
 									/* translators: %s is taxonomy label */
 									__( 'Taxonomy: %s', 'amp' ),
-									conflicts.taxonomy.label,
+									conflicts.taxonomy.label || '--',
 								)
 							}
 							{ ' ' }
@@ -247,12 +247,34 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 SlugConflictsNotice.propTypes = {
 	slug: PropTypes.string.isRequired,
 	conflicts: PropTypes.shape( {
-		post_type: PropTypes.object,
-		posts: PropTypes.arrayOf( PropTypes.object ),
+		post_type: PropTypes.shape( {
+			name: PropTypes.string.isRequired,
+			label: PropTypes.string,
+		} ),
+		posts: PropTypes.arrayOf( PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+			edit_link: PropTypes.string,
+			label: PropTypes.string,
+			post_type: PropTypes.string.isRequired,
+			title: PropTypes.string,
+		} ) ),
 		rewrite: PropTypes.arrayOf( PropTypes.string ),
-		taxonomy: PropTypes.object,
-		terms: PropTypes.arrayOf( PropTypes.object ),
-		user: PropTypes.object,
+		taxonomy: PropTypes.shape( {
+			name: PropTypes.string.isRequired,
+			label: PropTypes.string,
+		} ),
+		terms: PropTypes.arrayOf( PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+			edit_link: PropTypes.string,
+			label: PropTypes.string,
+			taxonomy: PropTypes.string.isRequired,
+			name: PropTypes.string,
+		} ) ),
+		user: PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+			edit_link: PropTypes.string,
+			name: PropTypes.string.isRequired,
+		} ),
 	} ).isRequired,
 };
 

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -89,6 +89,173 @@ function getCustomPairedStructureSources( sources ) {
 }
 
 /**
+ * Slug conflicts notice.
+ *
+ * @param {Object} props           Component props.
+ * @param {string} props.slug      Slug.
+ * @param {Object} props.conflicts Conflicts.
+ */
+function SlugConflictsNotice( { slug, conflicts } ) {
+	return (
+		<AMPNotice size={ NOTICE_SIZE_LARGE } type={ NOTICE_TYPE_INFO }>
+			<p>
+				{
+					sprintf(
+						/* translators: %s is the AMP slug */
+						__( 'There are one or more entities that are already using the “%s” URL slug. For this reason, you cannot currently use the path suffix or legacy reader paired URL structures. See below for the source of the slug conflict(s):', 'amp' ),
+						slug,
+					)
+				}
+			</p>
+			<ul>
+				{ conflicts.posts && (
+					conflicts.posts.map( ( entity ) => (
+						<li key={ `post-${ entity.id }` }>
+							{
+								entity.edit_link ? (
+									<a href={ entity.edit_link } target="_blank" rel="noreferrer">
+										{ entity.label || entity.post_type }
+									</a>
+								) : (
+									entity.label || entity.post_type
+								)
+							}
+							{
+								entity.title && (
+									': ' + entity.title
+								)
+							}
+							{ ' ' }
+							<small>
+								{
+									/* translators: %d is entity ID */
+									sprintf( __( '(ID: %d)', 'amp' ), entity.id )
+								}
+							</small>
+						</li>
+					) )
+				) }
+
+				{ conflicts.terms && (
+					conflicts.terms.map( ( entity ) => (
+						<li key={ `term-${ entity.id }` }>
+							{
+								entity.edit_link ? (
+									<a href={ entity.edit_link } target="_blank" rel="noreferrer">
+										{ entity.label || entity.post_type }
+									</a>
+								) : (
+									entity.label || entity.post_type
+								)
+							}
+							{
+								entity.name && (
+									': ' + entity.name
+								)
+							}
+							{ ' ' }
+							<small>
+								{
+									/* translators: %d is entity ID */
+									sprintf( __( '(ID: %d)', 'amp' ), entity.id )
+								}
+							</small>
+						</li>
+					) )
+				) }
+
+				{
+					conflicts.user && (
+						[ conflicts.user ].map( ( entity ) => (
+							<li key={ `user-${ entity.id }` }>
+								{
+									entity.edit_link ? (
+										<a href={ entity.edit_link } target="_blank" rel="noreferrer">
+											{ __( 'User', 'amp' ) }
+										</a>
+									) : (
+										__( 'User', 'amp' )
+									)
+								}
+								{ ': ' + entity.name }
+								{ ' ' }
+								<small>
+									{
+										/* translators: %d is entity ID */
+										sprintf( __( '(ID: %d)', 'amp' ), entity.id )
+									}
+								</small>
+							</li>
+						) )
+					)
+				}
+
+				{
+					conflicts.post_type && (
+						<li key="post_type">
+							{
+								sprintf(
+									/* translators: %s is post type label */
+									__( 'Post type: %s', 'amp' ),
+									conflicts.post_type.label,
+								)
+							}
+							{ ' ' }
+							<small>
+								{
+									/* translators: %s is entity name */
+									sprintf( __( '(name: %s)', 'amp' ), conflicts.post_type.name )
+								}
+							</small>
+						</li>
+					)
+				}
+
+				{
+					conflicts.taxonomy && (
+						<li key="taxonomy">
+							{
+								sprintf(
+									/* translators: %s is taxonomy label */
+									__( 'Taxonomy: %s', 'amp' ),
+									conflicts.taxonomy.label,
+								)
+							}
+							{ ' ' }
+							<small>
+								{
+									/* translators: %s is entity name */
+									sprintf( __( '(name: %s)', 'amp' ), conflicts.taxonomy.name )
+								}
+							</small>
+						</li>
+					)
+				}
+
+				{ conflicts.rewrite && (
+					<li key="rewrite">
+						{ __( 'Rewrite rules: ', 'amp' ) }
+						{
+							conflicts.rewrite
+								.map( ( entity ) => (
+									<code key={ entity }>
+										{ entity }
+									</code>
+								) )
+								.reduce( ( prev, curr ) => [ prev, ', ', curr ] )
+						}
+					</li>
+				) }
+			</ul>
+		</AMPNotice>
+	);
+}
+SlugConflictsNotice.propTypes = {
+	slug: PropTypes.string,
+	conflicts: PropTypes.object,
+};
+
+/**
  * Component rendering the paired URL structure.
  *
  * @param {Object} props Component props.
@@ -146,17 +313,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 			/>
 
 			{ ! endpointSuffixAvailable && (
-				<AMPNotice size={ NOTICE_SIZE_LARGE } type={ NOTICE_TYPE_INFO }>
-					<p>
-						{
-							sprintf(
-								/* translators: %s is the AMP slug */
-								__( 'There is a post, term, user, or some other entity that is already using the “%s” URL slug. For this reason, you cannot currently use the path suffix or legacy reader paired URL structures.', 'amp' ),
-								slug,
-							)
-						}
-					</p>
-				</AMPNotice>
+				<SlugConflictsNotice conflicts={ editedOptions.endpoint_path_slug_conflicts } />
 			) }
 
 			<ul>
@@ -201,7 +358,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 						</code>
 						{ ! endpointSuffixAvailable && (
 							<em>
-								{ ' ' + __( '(unavailable due to slug conflict)', 'amp' ) }
+								{ ' ' + __( '(unavailable due to slug conflict per above)', 'amp' ) }
 							</em>
 						) }
 						{ ! editedOptions.rewrite_using_permalinks && (
@@ -253,7 +410,7 @@ export function PairedUrlStructure( { focusedSection } ) {
 						</code>
 						{ ! endpointSuffixAvailable && (
 							<em>
-								{ ' ' + __( '(unavailable due to slug conflict)', 'amp' ) }
+								{ ' ' + __( '(unavailable due to slug conflict per above)', 'amp' ) }
 							</em>
 						) }
 						{ ! editedOptions.rewrite_using_permalinks && (

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -252,7 +252,14 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 }
 SlugConflictsNotice.propTypes = {
 	slug: PropTypes.string.isRequired,
-	conflicts: PropTypes.object.isRequired,
+	conflicts: PropTypes.shape( {
+		post_type: PropTypes.object,
+		posts: PropTypes.arrayOf( PropTypes.object ),
+		rewrite: PropTypes.arrayOf( PropTypes.string ),
+		taxonomy: PropTypes.object,
+		terms: PropTypes.arrayOf( PropTypes.object ),
+		user: PropTypes.object,
+	} ).isRequired,
 };
 
 /**

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -164,30 +164,25 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 					) )
 				) }
 
-				{
-					conflicts.user && (
-						[ conflicts.user ].map( ( entity ) => (
-					<li>
-							{
-								conflicts.user.edit_link ? (
-									<a href={ conflicts.user.edit_link } target="_blank" rel="noreferrer">
-										{ __( 'User', 'amp' ) }
-									</a>
-								) : (
-									__( 'User', 'amp' )
-								)
-							}
-							{ ': ' + conflicts.user.name }
-							{ ' ' }
-							<small>
-								{
-									/* translators: %d is entity ID */
-									sprintf( __( '(ID: %d)', 'amp' ), conflicts.user.id )
-								}
-							</small>
-						</li>
-					)
-				}
+				<li>
+					{
+						conflicts.user.edit_link ? (
+							<a href={ conflicts.user.edit_link } target="_blank" rel="noreferrer">
+								{ __( 'User', 'amp' ) }
+							</a>
+						) : (
+							__( 'User', 'amp' )
+						)
+					}
+					{ ': ' + conflicts.user.name }
+					{ ' ' }
+					<small>
+						{
+							/* translators: %d is entity ID */
+							sprintf( __( '(ID: %d)', 'amp' ), conflicts.user.id )
+						}
+					</small>
+				</li>
 
 				{
 					conflicts.post_type && (

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -389,6 +389,15 @@ li.error-kept {
 	margin-bottom: 1em;
 }
 
+#paired-url-structure .amp-drawer__panel-body-inner .amp-notice ul {
+	margin-top: 1rem;
+}
+
+#paired-url-structure .amp-drawer__panel-body-inner .amp-notice li {
+	list-style: disc;
+	margin: 0;
+}
+
 .amp-drawer__panel-body-inner .amp-paired-url-examples {
 	margin-top: 0.5em;
 	margin-bottom: 0;

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -23,7 +23,10 @@ use WP_Query;
 use WP_Rewrite;
 use WP;
 use WP_Hook;
+use WP_Post;
+use WP_Term;
 use WP_Term_Query;
+use WP_User;
 
 /**
  * Service for routing users to and from paired AMP URLs.
@@ -345,28 +348,56 @@ final class PairedRouting implements Service, Registerable {
 			[
 				'post_type'      => 'any',
 				'name'           => $amp_slug,
-				'fields'         => 'ids',
 				'posts_per_page' => 100,
 			]
 		);
 		if ( $post_query->post_count > 0 ) {
-			$conflicts['posts'] = $post_query->posts;
+			$conflicts['posts'] = array_map(
+				static function ( WP_Post $post ) {
+					$post_type = get_post_type_object( $post->post_type );
+					return [
+						'id'        => $post->ID,
+						'edit_link' => get_edit_post_link( $post->ID, 'raw' ),
+						'post_type' => $post->post_type,
+						'label'     => isset( $post_type->labels->singular_name )
+									? $post_type->labels->singular_name
+									: null,
+					];
+				},
+				$post_query->posts
+			);
 		}
 
 		$term_query = new WP_Term_Query(
 			[
 				'slug'       => $amp_slug,
-				'fields'     => 'ids',
 				'hide_empty' => false,
 			]
 		);
 		if ( $term_query->terms ) {
-			$conflicts['terms'] = $term_query->terms;
+			$conflicts['terms'] = array_map(
+				static function ( WP_Term $term ) {
+					$taxonomy = get_taxonomy( $term->taxonomy );
+					return [
+						'id'        => $term->term_id,
+						'edit_link' => get_edit_term_link( $term->term_id, $term->taxonomy ),
+						'taxonomy'  => $term->taxonomy,
+						'label'     => isset( $taxonomy->labels->singular_name )
+									? $taxonomy->labels->singular_name
+									: null,
+					];
+				},
+				$term_query->terms
+			);
 		}
 
 		$user = get_user_by( 'slug', $amp_slug );
-		if ( $user ) {
-			$conflicts['users'] = [ $user->ID ];
+		if ( $user instanceof WP_User ) {
+			$conflicts['user'] = [
+				'id'        => $user->ID,
+				'edit_link' => get_edit_user_link( $user->ID ),
+				'label'     => $user->display_name,
+			];
 		}
 
 		foreach ( get_post_types( [], 'objects' ) as $post_type ) {
@@ -375,7 +406,13 @@ final class PairedRouting implements Service, Registerable {
 				||
 				isset( $post_type->rewrite['slug'] ) && $post_type->rewrite['slug'] === $amp_slug
 			) {
-				$conflicts['post_types'][] = $post_type->name;
+				$conflicts['post_type'] = [
+					'name'  => $post_type->name,
+					'label' => isset( $post_type->labels->name )
+							? $post_type->labels->name
+							: null,
+				];
+				break;
 			}
 		}
 
@@ -385,7 +422,14 @@ final class PairedRouting implements Service, Registerable {
 				||
 				isset( $taxonomy->rewrite['slug'] ) && $taxonomy->rewrite['slug'] === $amp_slug
 			) {
-				$conflicts['taxonomies'][] = $taxonomy->name;
+				$conflicts['taxonomy'] = [
+					'name'  => $taxonomy->name,
+					'label' => isset( $taxonomy->labels->name )
+							? $taxonomy->labels->name
+							: null,
+
+				];
+				break;
 			}
 		}
 

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -358,6 +358,7 @@ final class PairedRouting implements Service, Registerable {
 					return [
 						'id'        => $post->ID,
 						'edit_link' => get_edit_post_link( $post->ID, 'raw' ),
+						'title'     => $post->post_title,
 						'post_type' => $post->post_type,
 						'label'     => isset( $post_type->labels->singular_name )
 									? $post_type->labels->singular_name
@@ -382,6 +383,7 @@ final class PairedRouting implements Service, Registerable {
 						'id'        => $term->term_id,
 						'edit_link' => get_edit_term_link( $term->term_id, $term->taxonomy ),
 						'taxonomy'  => $term->taxonomy,
+						'name'      => $term->name,
 						'label'     => isset( $taxonomy->labels->singular_name )
 									? $taxonomy->labels->singular_name
 									: null,
@@ -396,7 +398,7 @@ final class PairedRouting implements Service, Registerable {
 			$conflicts['user'] = [
 				'id'        => $user->ID,
 				'edit_link' => get_edit_user_link( $user->ID ),
-				'label'     => $user->display_name,
+				'name'      => $user->display_name,
 			];
 		}
 

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -333,8 +333,11 @@ final class PairedRouting implements Service, Registerable {
 	 * Get the entities that are already using the AMP slug.
 	 *
 	 * @return array Conflict data.
+	 * @global WP_Rewrite $wp_rewrite
 	 */
 	public function get_endpoint_path_slug_conflicts() {
+		global $wp_rewrite;
+
 		$conflicts = [];
 		$amp_slug  = amp_get_slug();
 
@@ -383,6 +386,29 @@ final class PairedRouting implements Service, Registerable {
 				isset( $taxonomy->rewrite['slug'] ) && $taxonomy->rewrite['slug'] === $amp_slug
 			) {
 				$conflicts['taxonomies'][] = $taxonomy->name;
+			}
+		}
+
+		foreach ( $wp_rewrite->endpoints as $endpoint ) {
+			if ( isset( $endpoint[1] ) && $amp_slug === $endpoint[1] ) {
+				$conflicts['rewrite'][] = 'endpoint';
+				break;
+			}
+		}
+		foreach (
+			[
+				'author_base',
+				'comments_base',
+				'search_base',
+				'pagination_base',
+				'feed_base',
+				'comments_pagination_base',
+			]
+			as
+			$key
+		) {
+			if ( isset( $wp_rewrite->$key ) && $amp_slug === $wp_rewrite->$key ) {
+				$conflicts['rewrite'][] = $key;
 			}
 		}
 

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -288,7 +288,7 @@ final class PairedRouting implements Service, Registerable {
 					'readonly' => true,
 				],
 				self::ENDPOINT_PATH_SLUG_CONFLICTS => [
-					'type'     => 'array',
+					'type'     => 'object',
 					'readonly' => true,
 				],
 				self::REWRITE_USING_PERMALINKS     => [
@@ -335,7 +335,7 @@ final class PairedRouting implements Service, Registerable {
 	/**
 	 * Get the entities that are already using the AMP slug.
 	 *
-	 * @return array Conflict data.
+	 * @return array|null Conflict data or null if there are no conflicts.
 	 * @global WP_Rewrite $wp_rewrite
 	 */
 	public function get_endpoint_path_slug_conflicts() {
@@ -456,6 +456,10 @@ final class PairedRouting implements Service, Registerable {
 			if ( isset( $wp_rewrite->$key ) && $amp_slug === $wp_rewrite->$key ) {
 				$conflicts['rewrite'][] = $key;
 			}
+		}
+
+		if ( empty( $conflicts ) ) {
+			return null;
 		}
 
 		return $conflicts;

--- a/src/PairedRouting.php
+++ b/src/PairedRouting.php
@@ -406,7 +406,7 @@ final class PairedRouting implements Service, Registerable {
 			if (
 				$amp_slug === $post_type->query_var
 				||
-				isset( $post_type->rewrite['slug'] ) && $post_type->rewrite['slug'] === $amp_slug
+				( isset( $post_type->rewrite['slug'] ) && $post_type->rewrite['slug'] === $amp_slug )
 			) {
 				$conflicts['post_type'] = [
 					'name'  => $post_type->name,
@@ -422,7 +422,7 @@ final class PairedRouting implements Service, Registerable {
 			if (
 				$amp_slug === $taxonomy->query_var
 				||
-				isset( $taxonomy->rewrite['slug'] ) && $taxonomy->rewrite['slug'] === $amp_slug
+				( isset( $taxonomy->rewrite['slug'] ) && $taxonomy->rewrite['slug'] === $amp_slug )
 			) {
 				$conflicts['taxonomy'] = [
 					'name'  => $taxonomy->name,

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -293,6 +293,13 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 			[ 'posts', 'terms', 'users', 'post_types', 'taxonomies' ],
 			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
 		);
+
+		// Rewrite endpoint.
+		add_rewrite_endpoint( 'amp', E_ALL );
+		$this->assertEquals(
+			[ 'posts', 'terms', 'users', 'post_types', 'taxonomies', 'rewrite' ],
+			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
+		);
 	}
 
 	/** @return array */

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -248,7 +248,7 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 
 	/** @covers ::get_endpoint_path_slug_conflicts() */
 	public function test_get_endpoint_path_slug_conflicts() {
-		$this->assertCount( 0, $this->instance->get_endpoint_path_slug_conflicts() );
+		$this->assertNull( $this->instance->get_endpoint_path_slug_conflicts() );
 
 		// Posts.
 		self::factory()->post->create( [ 'post_name' => amp_get_slug() ] );

--- a/tests/php/src/PairedRoutingTest.php
+++ b/tests/php/src/PairedRoutingTest.php
@@ -276,28 +276,28 @@ class PairedRoutingTest extends DependencyInjectedTestCase {
 			]
 		);
 		$this->assertEquals(
-			[ 'posts', 'terms', 'users' ],
+			[ 'posts', 'terms', 'user' ],
 			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
 		);
 
 		// Post types.
 		register_post_type( amp_get_slug() );
 		$this->assertEquals(
-			[ 'posts', 'terms', 'users', 'post_types' ],
+			[ 'posts', 'terms', 'user', 'post_type' ],
 			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
 		);
 
 		// Taxonomies.
 		register_taxonomy( amp_get_slug(), 'post' );
 		$this->assertEquals(
-			[ 'posts', 'terms', 'users', 'post_types', 'taxonomies' ],
+			[ 'posts', 'terms', 'user', 'post_type', 'taxonomy' ],
 			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
 		);
 
 		// Rewrite endpoint.
 		add_rewrite_endpoint( 'amp', E_ALL );
 		$this->assertEquals(
-			[ 'posts', 'terms', 'users', 'post_types', 'taxonomies', 'rewrite' ],
+			[ 'posts', 'terms', 'user', 'post_type', 'taxonomy', 'rewrite' ],
 			array_keys( $this->instance->get_endpoint_path_slug_conflicts() )
 		);
 	}


### PR DESCRIPTION
## Summary

Fixes #6339

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/121753177-b2fa1000-cac6-11eb-8bf7-f016a2c4f1a4.png) | ![image](https://user-images.githubusercontent.com/134745/121753163-a2499a00-cac6-11eb-8b7c-7177754e0820.png)

### Testing

To test the functionality:

* Create a post with the slug `amp`.
* Create a page with the slug `amp`.
* Create a post tag with the slug `amp`.
* Create a category with the slug `amp`.
* Create a user with the username of `amp`.

Then:

* Register a post type with `amp` as the rewrite slug.
* Register a taxonomy with `amp` as the rewrite slug.
* Register an `amp` rewrite endpoint.

These can be achieved with this plugin code:

```php
add_action(
	'init',
	function () {
		add_rewrite_endpoint( 'amp', E_ALL );
		register_post_type( 'amp-post',
			[
				'labels' => [
					'name'          => 'AMP Posts',
					'singular_name' => 'AMP Post',
				],
				'rewrite' => [
					'slug' => 'amp'
				],
			]
		);
		register_taxonomy( 'amp-tax', 'post', [
			'labels' => [
				'name'          => 'AMP Taxes',
				'singular_name' => 'AMP Tax',
			],
			'rewrite' => [
				'slug' => 'amp'
			],
		] );
	}
);
```



## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
