### PR TITLE
Remove dependency approve list from `auto-merge` workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,14 +2,15 @@ name: Auto-merge
 
 on:
   pull_request:
-    # Only run workflow when a PR is opened.
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   automerge-dependencies:
     name: Automerge dependencies
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.auto_merge == null
     steps:
       - name: Enable auto-merge for the PR
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,9 +12,6 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for the PR
-        if: >
-          # Auto merge `@wordpress/` dependency PRs
-          startsWith( ${{ github.event.pull_request.title }}, 'Bump @wordpress' )
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

This PR enables auto-merging for all dependabot PRs. We can configure a deny list later if needed.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
