### PR TITLE
Close latest Gutenberg packages update PR if it is outdated

### DIFF
--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest-version: ${{ steps.latest-release.outputs.version }}
+      latest-pr-num: ${{ steps.last-release.outputs.pr-num }}
       should-update: ${{ steps.release-status.outputs.outdated }}
     steps:
       - name: Get latest release version
@@ -24,11 +25,15 @@ jobs:
       - name: Get release version from last PR
         id: last-release
         run: |
-          PR_TITLE=$(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[].title' | head -n 1)
+          RESULT=$(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0]|[.number, .title]|join("\n")')
+          PR_NUM=${RESULT[0]}
+          PR_TITLE=${RESULT[1]}
+
           LAST_VERSION=$(sed -r 's/.+ v(.+) .+/\1/' <<< "$PR_TITLE")
           if ! egrep -q '^[0-9][0-9]*(\.[0-9][0-9]*)*$' <<< "$LAST_VERSION"; then
             LAST_VERSION='0.0.0'
           fi
+          echo "::set-output name=pr-num::$(echo "$PR_NUM")"
           echo "::set-output name=version::$(echo "$LAST_VERSION")"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,6 +48,18 @@ jobs:
         env:
           LAST_VER: ${{ steps.last-release.outputs.version }}
           LATEST_VER: ${{ steps.latest-release.outputs.version }}
+
+  close-latest-pr:
+    name: Close latest PR if one exists
+    if: needs.check-gutenberg-release.outputs.latest-pr-num != ''
+    runs-on: ubuntu-latest
+    needs: check-gutenberg-release
+    steps:
+      - name: Close latest PR
+        run: gh pr close ${{ env.PR_NUM }} --delete-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ needs.check-gutenberg-release.outputs.latest-pr-num }}
 
   update-packages:
     name: Update Gutenberg npm dependencies

--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get release version from last PR
         id: last-release
         run: |
-          RESULT=$(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0]|[.number, .title]|join("\n")')
+          readarray -t RESULT < <(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0]|[.number, .title]|join("\n")')
           PR_NUM=${RESULT[0]}
           PR_TITLE=${RESULT[1]}
 


### PR DESCRIPTION
## Summary

Closes most recent Gutenberg packages update PR if one exists.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
