### PR TITLE
Check for `conflicts.user` property before rendering list item

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -732,6 +732,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: pre-run
     runs-on: ubuntu-latest
     outputs:
       branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -164,25 +164,29 @@ function SlugConflictsNotice( { slug, conflicts } ) {
 					) )
 				) }
 
-				<li>
-					{
-						conflicts.user.edit_link ? (
-							<a href={ conflicts.user.edit_link } target="_blank" rel="noreferrer">
-								{ __( 'User', 'amp' ) }
-							</a>
-						) : (
-							__( 'User', 'amp' )
-						)
-					}
-					{ ': ' + conflicts.user.name }
-					{ ' ' }
-					<small>
-						{
-							/* translators: %d is entity ID */
-							sprintf( __( '(ID: %d)', 'amp' ), conflicts.user.id )
-						}
-					</small>
-				</li>
+				{
+					conflicts.user && (
+						<li>
+							{
+								conflicts.user.edit_link ? (
+									<a href={ conflicts.user.edit_link } target="_blank" rel="noreferrer">
+										{ __( 'User', 'amp' ) }
+									</a>
+								) : (
+									__( 'User', 'amp' )
+								)
+							}
+							{ ': ' + conflicts.user.name }
+							{ ' ' }
+							<small>
+								{
+									/* translators: %d is entity ID */
+									sprintf( __( '(ID: %d)', 'amp' ), conflicts.user.id )
+								}
+							</small>
+						</li>
+					)
+				}
 
 				{
 					conflicts.post_type && (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Amends #6374.

If there isn't a user with the same slug as the AMP slug, the settings screen crashes.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
