### PR TITLE
Update class name used to display a pending state when retrieving validation counts

### DIFF
--- a/assets/src/amp-validation/counts/index.js
+++ b/assets/src/amp-validation/counts/index.js
@@ -22,7 +22,7 @@ function updateMenuItem( itemEl, count ) {
 	if ( isNaN( count ) || count === 0 ) {
 		itemEl.parentNode.parentNode.removeChild( itemEl.parentNode );
 	} else {
-		itemEl.classList.remove( 'loading' );
+		itemEl.classList.remove( 'amp-count-loading' );
 		itemEl.textContent = count.toLocaleString();
 	}
 }

--- a/assets/src/amp-validation/counts/style.css
+++ b/assets/src/amp-validation/counts/style.css
@@ -9,7 +9,7 @@
 	}
 }
 
-#toplevel_page_amp-options > ul > li span.loading {
+#toplevel_page_amp-options .amp-count-loading {
 	animation-duration: 0.75s;
 	animation-iteration-count: infinite;
 	animation-name: rotate-forever;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -469,7 +469,7 @@ class AMP_Validated_URL_Post_Type {
 
 				if ( ValidationCounts::is_needed() ) {
 					// Append markup to display a loading spinner while the unreviewed count is being fetched.
-					$submenu_item[0] .= ' <span class="awaiting-mod"><span id="new-validation-url-count" class="loading"></span></span>';
+					$submenu_item[0] .= ' <span class="awaiting-mod"><span id="new-validation-url-count" class="amp-count-loading"></span></span>';
 				}
 
 				break;

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1745,7 +1745,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( ValidationCounts::is_needed() ) {
 			// Append markup to display a loading spinner while the unreviewed count is being fetched.
-			$menu_item_label .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>';
+			$menu_item_label .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
 		}
 
 		$post_menu_slug = 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -162,7 +162,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$this->assertSame( 'Validated URLs <span class="awaiting-mod"><span id="new-validation-url-count" class="loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+			$this->assertSame( 'Validated URLs <span class="awaiting-mod"><span id="new-validation-url-count" class="amp-count-loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		} else {
 			$this->assertSame( 'Validated URLs', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		}

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1031,8 +1031,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			'Error Index',
 		];
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$expected_submenu[0] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>';
-			$expected_submenu[3] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="loading"></span></span>';
+			$expected_submenu[0] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
+			$expected_submenu[3] .= ' <span class="awaiting-mod"><span id="new-error-index-count" class="amp-count-loading"></span></span>';
 		}
 		$amp_options = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );


### PR DESCRIPTION
## Summary

As reported in a [support forum topic](https://wordpress.org/support/topic/loading-spinner-bug/#post-14569326), the `loading` class name used for the validation counts can conflict with CSS from other plugins (or themes). This PR resolves that by making the class name more unique.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
