### PR TITLE
Trigger CI jobs when a dependency file is modified

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -52,9 +52,9 @@ jobs:
           echo -e "Modified files:\n$MODIFIED_FILES\n"
 
           FILE_COUNT=$(php -f bin/determine-modified-files-count.php "$IGNORE_PATH_REGEX" "$MODIFIED_FILES" --invert)
-          PHP_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.php" "$MODIFIED_FILES")
+          PHP_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.php|composer\.(json|lock)" "$MODIFIED_FILES")
           CSS_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.s?css" "$MODIFIED_FILES")
-          JS_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.(js|snap)" "$MODIFIED_FILES")
+          JS_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.(js|snap)|package\.(json|lock)" "$MODIFIED_FILES")
 
           echo "Changed file count: $FILE_COUNT"
           echo "Changed PHP file count: $PHP_FILE_COUNT"

--- a/.github/workflows/qa-integrate.yml
+++ b/.github/workflows/qa-integrate.yml
@@ -56,9 +56,9 @@ jobs:
           echo -e "Modified files:\n$MODIFIED_FILES\n"
 
           FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "$IGNORE_PATH_REGEX" "$MODIFIED_FILES")
-          PHP_FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "qa-tester\/.+\.php" "$MODIFIED_FILES")
+          PHP_FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "qa-tester\/(.+\.php|composer\.(json|lock))" "$MODIFIED_FILES")
           CSS_FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "qa-tester\/.+\.s?css" "$MODIFIED_FILES")
-          JS_FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "qa-tester\/.+\.(js|snap)" "$MODIFIED_FILES")
+          JS_FILE_COUNT=$(php -f ../bin/determine-modified-files-count.php "qa-tester\/(.+\.(js|snap)|package\.(json|lock))" "$MODIFIED_FILES")
 
           echo "Changed file count: $FILE_COUNT"
           echo "Changed PHP file count: $PHP_FILE_COUNT"


### PR DESCRIPTION
## Summary

Trigger necessary CI jobs when a JS or PHP dependency file is modified.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
