### PR TITLE
Fix GHA job that closes stale Gutenberg update PRs

### DIFF
--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest-version: ${{ steps.latest-release.outputs.version }}
-      latest-pr-num: ${{ steps.last-release.outputs.pr-num }}
       should-update: ${{ steps.release-status.outputs.outdated }}
     steps:
       - name: Get latest release version
@@ -25,15 +24,11 @@ jobs:
       - name: Get release version from last PR
         id: last-release
         run: |
-          readarray -t RESULT < <(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0]|[.number, .title]|join("\n")')
-          PR_NUM=${RESULT[0]}
-          PR_TITLE=${RESULT[1]}
-
+          PR_TITLE=$(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0].title')
           LAST_VERSION=$(sed -r 's/.+ v(.+) .+/\1/' <<< "$PR_TITLE")
           if ! egrep -q '^[0-9][0-9]*(\.[0-9][0-9]*)*$' <<< "$LAST_VERSION"; then
             LAST_VERSION='0.0.0'
           fi
-          echo "::set-output name=pr-num::$(echo "$PR_NUM")"
           echo "::set-output name=version::$(echo "$LAST_VERSION")"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,19 +45,32 @@ jobs:
           LATEST_VER: ${{ steps.latest-release.outputs.version }}
 
   close-latest-pr:
-    name: Close latest PR if one exists
-    if: needs.check-gutenberg-release.outputs.latest-pr-num != ''
+    name: Close latest open PR if one exists
+    # Run job if there is a new Gutenberg release.
+    if: needs.check-gutenberg-release.outputs.should-update == 'true'
     runs-on: ubuntu-latest
     needs: check-gutenberg-release
     steps:
-      - name: Checkout
+      - name: Get latest open PR
+        id: latest-pr
+        run: |
+          PR_NUM=$(gh api -X GET search/issues -f q='${{ env.QUERY }}' -f sort='created' -f order='desc' --jq '.items.[0].number')
+          echo "::set-output name=num::$(echo $PR_NUM)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUERY: 'repo:ampproject/amp-wp is:pr author:app/github-actions is:open in:title Update Gutenberg packages after'
+
+      # Needed to later close PR.
+      - name: Checkout repo
+        if: ${{ steps.latest-pr.num != '' }}
         uses: actions/checkout@v2
 
-      - name: Close latest PR
+      - name: Close latest open PR
+        if: ${{ steps.latest-pr.num != '' }}
         run: gh pr close ${{ env.PR_NUM }} --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ needs.check-gutenberg-release.outputs.latest-pr-num }}
+          PR_NUM: ${{ steps.latest-pr.num }}
 
   update-packages:
     name: Update Gutenberg npm dependencies

--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -55,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-gutenberg-release
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Close latest PR
         run: gh pr close ${{ env.PR_NUM }} --delete-branch
         env:


### PR DESCRIPTION
## Summary

- Checks out the repo before attempting to close PR. The GitHub CLI needs to know the base repo before executing the command. Otherwise the job [fails](https://github.com/ampproject/amp-wp/runs/2862569649?check_suite_focus=true#step:2:7) with:

    > could not determine base repo: fatal: not a git repository (or any of the parent directories): .git
/usr/bin/git: exit status 128

- Only run the 'close PR' step when there is an open PR. Previously it was only doing this for merged PRs, which would have no effect.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
