### PR TITLE
Ensure site icon in legacy template is identified as a hero image

### DIFF
--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -24,7 +24,7 @@
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
-				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon"></amp-img>
+				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon" data-hero-candidate></amp-img>
 			<?php endif; ?>
 			<span class="amp-site-title">
 				<?php echo esc_html( wptexturize( $this->get( 'blog_name' ) ) ); ?>

--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -24,7 +24,7 @@
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
-				<img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon" data-hero-candidate>
+				<img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon" data-hero-candidate alt="<?php esc_attr_e( 'Site icon', 'amp' ); ?>">
 			<?php endif; ?>
 			<span class="amp-site-title">
 				<?php echo esc_html( wptexturize( $this->get( 'blog_name' ) ) ); ?>

--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -24,7 +24,7 @@
 		<a href="<?php echo esc_url( $this->get( 'home_url' ) ); ?>">
 			<?php $site_icon_url = $this->get( 'site_icon_url' ); ?>
 			<?php if ( $site_icon_url ) : ?>
-				<amp-img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon" data-hero-candidate></amp-img>
+				<img src="<?php echo esc_url( $site_icon_url ); ?>" width="32" height="32" class="amp-wp-site-icon" data-hero-candidate>
 			<?php endif; ?>
 			<span class="amp-site-title">
 				<?php echo esc_html( wptexturize( $this->get( 'blog_name' ) ) ); ?>


### PR DESCRIPTION
## Summary

Discovered when testing #6402.

* Add `data-hero-candidate` to `.amp-wp-site-icon`.
* Let `.amp-wp-site-icon` be `img` in template so it can convert to `amp-img`.
* Add `alt` attribute to `.amp-wp-site-icon`.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
