### PR TITLE
Add `data-ampdevmode` attribute to `regenerator-runtime` script when enqueueing Paired Browsing scripts

### DIFF
--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -196,7 +196,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional {
 		// Mark enqueued script for AMP dev mode so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
 		$dev_mode_handles = array_merge(
-			[ $handle, 'wp-i18n', 'wp-hooks' ],
+			[ $handle, 'wp-i18n', 'wp-hooks', 'regenerator-runtime' ],
 			$dependencies
 		);
 		add_filter(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6416

The `regenerator-runtime` script is now a dependency of the `wp-polyfill` script, and is thus being enqueued along with the Paired Browsing client script. This PR adds the `data-ampdevmode` attribute to the `regenerator-runtime` script so that a validation error is not raised for it.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
