### PR TITLE
Update amp-toolbox-php to 0.6.0 (almost) and update error page to support fatal errors (in PHP 7+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.5.2",
+    "ampproject/amp-toolbox": "dev-main",
     "cweagans/composer-patches": "1.7.1",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "87317406a9dc6a575f3a5b23048eb5a8277a3048"
+                "reference": "eea2e2416a2d858a17d947fe978ac02e62abcda0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/87317406a9dc6a575f3a5b23048eb5a8277a3048",
-                "reference": "87317406a9dc6a575f3a5b23048eb5a8277a3048",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/eea2e2416a2d858a17d947fe978ac02e62abcda0",
+                "reference": "eea2e2416a2d858a17d947fe978ac02e62abcda0",
                 "shasum": ""
             },
             "require": {
@@ -73,7 +73,7 @@
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
                 "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2021-06-24T00:30:00+00:00"
+            "time": "2021-06-24T05:45:26+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d914bcf0ddd6b4470acad67de7d29256",
+    "content-hash": "fce79e8016e43fda3ee3335f06d46f88",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.5.2",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "062370f09366e91bec955b01520848f943d8d28a"
+                "reference": "87317406a9dc6a575f3a5b23048eb5a8277a3048"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/062370f09366e91bec955b01520848f943d8d28a",
-                "reference": "062370f09366e91bec955b01520848f943d8d28a",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/87317406a9dc6a575f3a5b23048eb5a8277a3048",
+                "reference": "87317406a9dc6a575f3a5b23048eb5a8277a3048",
                 "shasum": ""
             },
             "require": {
@@ -33,17 +33,19 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpcompatibility/phpcompatibility-wp": "2.1.1",
+                "phpcompatibility/php-compatibility": "^9",
                 "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
                 "roave/security-advisories": "dev-master",
-                "sirbrillig/phpcs-variable-analysis": "2.11.0",
+                "sirbrillig/phpcs-variable-analysis": "2.11.1",
                 "squizlabs/php_codesniffer": "^3",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0"
             },
             "suggest": {
                 "ext-json": "Provides native implementation of json_encode()/json_decode().",
-                "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed."
+                "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed.",
+                "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
+            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -69,9 +71,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.5.2"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2021-05-06T01:53:44+00:00"
+            "time": "2021-06-24T00:30:00+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -5967,6 +5969,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "ampproject/amp-toolbox": 20,
         "sabberworm/php-css-parser": 20,
         "roave/security-advisories": 20
     },
@@ -5987,5 +5990,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/sanitizers/class-amp-object-sanitizer.php
+++ b/includes/sanitizers/class-amp-object-sanitizer.php
@@ -9,7 +9,6 @@ use AmpProject\Attribute;
 use AmpProject\Dom\Element;
 use AmpProject\Extension;
 use AmpProject\Layout;
-use AmpProject\Tag;
 
 /**
  * Class AMP_Object_Sanitizer
@@ -35,7 +34,7 @@ class AMP_Object_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function get_selector_conversion_mapping() {
 		return [
-			Tag::OBJECT => [
+			'object' => [
 				Extension::GOOGLE_DOCUMENT_EMBED,
 			],
 		];
@@ -45,7 +44,7 @@ class AMP_Object_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize `object` elements from the HTML contained in this instance's Dom\Document.
 	 */
 	public function sanitize() {
-		$elements = $this->dom->getElementsByTagName( Tag::OBJECT );
+		$elements = $this->dom->getElementsByTagName( 'object' );
 
 		if ( 0 === $elements->length ) {
 			return;

--- a/includes/sanitizers/class-amp-object-sanitizer.php
+++ b/includes/sanitizers/class-amp-object-sanitizer.php
@@ -9,6 +9,7 @@ use AmpProject\Attribute;
 use AmpProject\Dom\Element;
 use AmpProject\Extension;
 use AmpProject\Layout;
+use AmpProject\Tag;
 
 /**
  * Class AMP_Object_Sanitizer
@@ -34,7 +35,7 @@ class AMP_Object_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function get_selector_conversion_mapping() {
 		return [
-			'object' => [
+			Tag::OBJECT => [
 				Extension::GOOGLE_DOCUMENT_EMBED,
 			],
 		];
@@ -44,7 +45,7 @@ class AMP_Object_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize `object` elements from the HTML contained in this instance's Dom\Document.
 	 */
 	public function sanitize() {
-		$elements = $this->dom->getElementsByTagName( 'object' );
+		$elements = $this->dom->getElementsByTagName( Tag::OBJECT );
 
 		if ( 0 === $elements->length ) {
 			return;

--- a/src/DevTools/ErrorPage.php
+++ b/src/DevTools/ErrorPage.php
@@ -236,8 +236,9 @@ final class ErrorPage implements Service {
 	</head>
 	<body id="error-page">
 		<h1>{$this->render_title()}</h1>
-		<p>{$this->render_message()}</p>
+		{$this->render_message()}
 		{$this->render_source()}
+		{$this->render_support_link()}
 		{$this->render_throwable()}
 		{$this->render_back_link()}
 	</body>
@@ -260,7 +261,29 @@ HTML;
 	 * @return string KSES-sanitized message.
 	 */
 	private function render_message() {
-		return wp_kses_post( $this->message );
+		return '<p>' . wp_kses_post( $this->message ) . '</p>';
+	}
+
+	/**
+	 * Render support link.
+	 *
+	 * @return string
+	 */
+	private function render_support_link() {
+		return '<p>' . wp_kses(
+			sprintf(
+				/* translators: %s is the AMP support forum URL. */
+				__( 'If you get stuck, you may want to share any details in a new topic on the plugin\'s <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
+				esc_url( __( 'https://wordpress.org/support/plugin/amp/', 'amp' ) )
+			),
+			[
+				'a' => [
+					'href'   => true,
+					'target' => true,
+					'rel'    => true,
+				],
+			]
+		) . '</p>';
 	}
 
 	/**

--- a/src/DevTools/LikelyCulpritDetector.php
+++ b/src/DevTools/LikelyCulpritDetector.php
@@ -8,7 +8,10 @@
 namespace AmpProject\AmpWP\DevTools;
 
 use AmpProject\AmpWP\Infrastructure\Service;
+use Error;
 use Exception;
+use InvalidArgumentException;
+use Throwable;
 
 /**
  * Go through a debug backtrace and detect the extension that is likely to have
@@ -54,7 +57,9 @@ final class LikelyCulpritDetector implements Service {
 	/**
 	 * Detect the themes and plugins responsible for causing the exception.
 	 *
-	 * @param Exception $exception Exception to analyze.
+	 * @param Throwable $throwable Exception or Error to analyze. The Throwable type does not exist in PHP 5,
+	 *                             which is why type is absent from the function parameter.
+	 * @throws InvalidArgumentException If $throwable is not an Exception or an Error.
 	 * @return array {
 	 *     Type and name of extension that is the likely culprit.
 	 *
@@ -62,9 +67,12 @@ final class LikelyCulpritDetector implements Service {
 	 *     @type string $name Name. Empty if none matched.
 	 * }
 	 */
-	public function analyze_exception( Exception $exception ) {
-		$trace = $exception->getTrace();
-		array_unshift( $trace, [ FileReflection::SOURCE_FILE => $exception->getFile() ] );
+	public function analyze_throwable( $throwable ) {
+		if ( ! ( $throwable instanceof Exception || $throwable instanceof Error ) ) {
+			throw new InvalidArgumentException( 'Parameter must be Throwable (Exception or Error).' );
+		}
+		$trace = $throwable->getTrace();
+		array_unshift( $trace, [ FileReflection::SOURCE_FILE => $throwable->getFile() ] );
 		return $this->analyze_trace( $trace );
 	}
 

--- a/tests/php/src/DevTools/ErrorPageTest.php
+++ b/tests/php/src/DevTools/ErrorPageTest.php
@@ -21,7 +21,7 @@ final class ErrorPageTest extends DependencyInjectedTestCase {
 		$output = $this->injector->make( ErrorPage::class )
 			->with_title( 'Error Page Title' )
 			->with_message( 'Error Page Message' )
-			->with_exception( new RuntimeException( 'FAILURE', 42 ) )
+			->with_throwable( new RuntimeException( 'FAILURE', 42 ) )
 			->with_response_code( 123 )
 			->with_back_link( 'https://back.example.com', 'Go Back' )
 			->render();

--- a/tests/php/src/DevTools/ErrorPageTest.php
+++ b/tests/php/src/DevTools/ErrorPageTest.php
@@ -44,6 +44,7 @@ final class ErrorPageTest extends DependencyInjectedTestCase {
 		$this->assertStringContains( '<meta name="viewport"', $output );
 		$this->assertStringContains( '<body id="error-page">', $output );
 		$this->assertStringContains( '<style type="text/css">', $output );
+		$this->assertStringContains( 'If you get stuck', $output );
 		$this->assertStringContains( 'button button-large', $output );
 		$this->assertStringContains( 'https://back.example.com', $output );
 		$this->assertStringContains( 'Go Back', $output );

--- a/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
+++ b/tests/php/src/DevTools/LikelyCulpritDetectorTest.php
@@ -217,7 +217,7 @@ class LikelyCulpritDetectorTest extends DependencyInjectedTestCase {
 	}
 
 	/**
-	 * Tests LikelyCulpritDetector::analyze_exception
+	 * Tests LikelyCulpritDetector::analyze_throwable
 	 *
 	 * @dataProvider single_step_trace_data()
 	 *
@@ -225,9 +225,9 @@ class LikelyCulpritDetectorTest extends DependencyInjectedTestCase {
 	 * @param string   $expected_type Expected source type.
 	 * @param string   $expected_name Expected source name.
 	 *
-	 * @covers ::analyze_exception
+	 * @covers ::analyze_throwable
 	 */
-	public function test_analyze_exception( $file_stack, $expected_type, $expected_name ) {
+	public function test_analyze_throwable( $file_stack, $expected_type, $expected_name ) {
 		$trace     = $this->get_trace_from_file_stack( $file_stack );
 		$exception = new RuntimeException();
 		$this->set_private_property(
@@ -240,7 +240,7 @@ class LikelyCulpritDetectorTest extends DependencyInjectedTestCase {
 		// method and not stored as a property. Therefore, we can only test
 		// the first "file" that is encountered.
 
-		$source = $this->likely_culprit_detector->analyze_exception( $exception );
+		$source = $this->likely_culprit_detector->analyze_throwable( $exception );
 
 		$this->assertEquals( $expected_type, $source['type'] );
 		$this->assertEquals( $expected_name, $source['name'] );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1988,6 +1988,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Test prepare_response for responses that throw an exception.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()
+	 * @covers AMP_Theme_Support::render_error_page()
 	 */
 	public function test_prepare_response_throwing_exception() {
 		// Set up temporary capture of error log to test error log output.
@@ -2020,6 +2021,49 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Verify that error log was properly populated.
 		$this->assertRegExp(
 			'/^\[[^\]]*\] A PHP error occurred while trying to prepare the AMP response\..*- FAILURE \(42\) \[RuntimeException\].*/',
+			stream_get_contents( $capture )
+		);
+
+		// Reset error log back to initial settings.
+		ini_set( 'error_log', $backup ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
+		$this->assertStringContains( 'Failed to prepare AMP page', $output );
+	}
+
+	/**
+	 * Test prepare_response for responses that throw a fatal error.
+	 *
+	 * @covers AMP_Theme_Support::prepare_response()
+	 * @covers AMP_Theme_Support::render_error_page()
+	 */
+	public function test_prepare_response_throwing_error() {
+		if ( PHP_MAJOR_VERSION < 7 ) {
+			$this->markTestSkipped( 'Requires PHP 7.' );
+		}
+
+		// Set up temporary capture of error log to test error log output.
+		$capture = tmpfile();
+		$backup  = ini_set( // phpcs:ignore WordPress.PHP.IniSet.Risky
+			'error_log',
+			stream_get_meta_data( $capture )['uri']
+		);
+
+		add_filter(
+			'amp_enable_optimizer',
+			static function ( $enabled ) {
+				if ( AMP_Theme_Support::DOES_NOT_EXIST === true ) { // phpcs:ignore
+					$enabled = true;
+				}
+				return $enabled;
+			}
+		);
+
+		wp();
+		$output = AMP_Theme_Support::finish_output_buffering( $this->get_original_html() );
+
+		// Verify that error log was properly populated.
+		$this->assertRegExp(
+			'/^\[[^\]]*\] A PHP error occurred while trying to prepare the AMP response\..*- Undefined class constant \'DOES_NOT_EXIST\' \(0\) \[Error\].*/',
 			stream_get_contents( $capture )
 		);
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1663,7 +1663,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'<html amp=""',
 			'<meta charset="' . Document\Encoding::AMP . '">',
 			'<meta name="viewport" content="width=device-width">',
-			'<link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">',
+			'<link rel="modulepreload" href="https://cdn.ampproject.org/v0.mjs" as="script" crossorigin="anonymous">',
 			'<link rel="preconnect" href="https://cdn.ampproject.org">',
 			'<link rel="dns-prefetch" href="//cdn.ampproject.org">',
 			'<link rel="preload" as="script" href="https://cdn.ampproject.org/v0/amp-dynamic-css-classes-0.1.js">',

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2063,7 +2063,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Verify that error log was properly populated.
 		$this->assertRegExp(
-			'/^\[[^\]]*\] A PHP error occurred while trying to prepare the AMP response\..*- Undefined class constant \'DOES_NOT_EXIST\' \(0\) \[Error\].*/',
+			'/^\[[^\]]*\] A PHP error occurred while trying to prepare the AMP response\..*- (Undefined class constant \'DOES_NOT_EXIST\'|Undefined constant AMP_Theme_Support::DOES_NOT_EXIST) \(0\) \[Error\].*/',
 			stream_get_contents( $capture )
 		);
 


### PR DESCRIPTION
## Summary

* Update amp-toolbox-php to dev-main which is 0.6.0 minus https://github.com/ampproject/amp-toolbox-php/issues/55.
* ~Fix fatal error now raised in `AMP_Object_Sanitizer` since `Tag::OBJECT` no longer exists in amp-toolbox-php.~
* Catch fatal errors during post-processing in PHP 7+ in the same way exceptions are caught.
* Add a link to the support forum on the error page.

### Fatal Error Handling

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/123190005-a88b2f00-d453-11eb-8b17-0fdc77a3da90.png) | ![image](https://user-images.githubusercontent.com/134745/123189938-8a253380-d453-11eb-91b6-987e6eaf9a23.png)

### Forum Link

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/123189842-6530c080-d453-11eb-90ef-d479167314ad.png) | ![image](https://user-images.githubusercontent.com/134745/123189878-724daf80-d453-11eb-8b58-0d52efb73b2b.png)


## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
