### PR TITLE
Fix test_get_mu_plugins_data for WP 5.8

### DIFF
--- a/tests/php/src/PluginRegistryTest.php
+++ b/tests/php/src/PluginRegistryTest.php
@@ -73,25 +73,30 @@ final class PluginRegistryTest extends TestCase {
 	public function test_get_mu_plugins_data() {
 		$plugin_registry = new PluginRegistry();
 
+		$expected_keys = [
+			'Name',
+			'PluginURI',
+			'Version',
+			'Description',
+			'Author',
+			'AuthorURI',
+			'TextDomain',
+			'DomainPath',
+			'Network',
+			'RequiresWP',
+			'RequiresPHP',
+			'Title',
+			'AuthorName',
+		];
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.8', '>=' ) ) {
+			$expected_keys[] = 'UpdateURI';
+		}
+
 		$plugins = $this->call_private_method( $plugin_registry, 'get_mu_plugins_data' );
 		$this->assertInternalType( 'array', $plugins );
 		foreach ( $plugins as $plugin_data ) {
 			$this->assertEqualSets(
-				[
-					'Name',
-					'PluginURI',
-					'Version',
-					'Description',
-					'Author',
-					'AuthorURI',
-					'TextDomain',
-					'DomainPath',
-					'Network',
-					'RequiresWP',
-					'RequiresPHP',
-					'Title',
-					'AuthorName',
-				],
+				$expected_keys,
 				array_keys( $plugin_data )
 			);
 		}


### PR DESCRIPTION
## Summary

I was getting test failures locally on WP 5.8-beta:

```
$ phpunit --filter test_get_mu_plugins_data
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 2.67 seconds, Memory: 68.50MB

There was 1 failure:

1) AmpProject\AmpWP\Tests\PluginRegistryTest::test_get_mu_plugins_data
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     11 => 'Title'
-    12 => 'Version'
+    12 => 'UpdateURI'
+    13 => 'Version'
 )

/app/public/content/plugins/amp/tests/php/src/PluginRegistryTest.php:135
/app/public/content/plugins/amp/tests/php/src/PluginRegistryTest.php:95

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

This updates the test to account for the new `UpdateURI` in WP 5.8.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
