### PR TITLE
Update hero image handling to remove max count

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-main",
+    "ampproject/amp-toolbox": "dev-add/55-optimize-hero-images-transformer",
     "cweagans/composer-patches": "1.7.1",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-add/55-optimize-hero-images-transformer",
+    "ampproject/amp-toolbox": "0.6.0",
     "cweagans/composer-patches": "1.7.1",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5377f8bfb7da87f0e559eb750908cb7",
+    "content-hash": "4d7d392e957acda0acceee8b3ae1ed69",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "dev-add/55-optimize-hero-images-transformer",
+            "version": "v0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "af51a4636e0f9b77f5556d26834d270e9b7fa444"
+                "reference": "500012f27cc27f4d72525cf0f010602fb95e2f6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/af51a4636e0f9b77f5556d26834d270e9b7fa444",
-                "reference": "af51a4636e0f9b77f5556d26834d270e9b7fa444",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/500012f27cc27f4d72525cf0f010602fb95e2f6f",
+                "reference": "500012f27cc27f4d72525cf0f010602fb95e2f6f",
                 "shasum": ""
             },
             "require": {
@@ -71,9 +71,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/add/55-optimize-hero-images-transformer"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/v0.6.0"
             },
-            "time": "2021-06-30T03:00:01+00:00"
+            "time": "2021-06-30T15:16:48+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -5969,7 +5969,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "ampproject/amp-toolbox": 20,
         "sabberworm/php-css-parser": 20,
         "roave/security-advisories": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fce79e8016e43fda3ee3335f06d46f88",
+    "content-hash": "e5377f8bfb7da87f0e559eb750908cb7",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "dev-main",
+            "version": "dev-add/55-optimize-hero-images-transformer",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "eea2e2416a2d858a17d947fe978ac02e62abcda0"
+                "reference": "fc4742c0b25d9d9ca191915fd17627dae318b76c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/eea2e2416a2d858a17d947fe978ac02e62abcda0",
-                "reference": "eea2e2416a2d858a17d947fe978ac02e62abcda0",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/fc4742c0b25d9d9ca191915fd17627dae318b76c",
+                "reference": "fc4742c0b25d9d9ca191915fd17627dae318b76c",
                 "shasum": ""
             },
             "require": {
@@ -38,6 +38,7 @@
                 "roave/security-advisories": "dev-master",
                 "sirbrillig/phpcs-variable-analysis": "2.11.1",
                 "squizlabs/php_codesniffer": "^3",
+                "wp-coding-standards/wpcs": "^2.3",
                 "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0"
             },
             "suggest": {
@@ -45,7 +46,6 @@
                 "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
-            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -71,9 +71,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/add/55-optimize-hero-images-transformer"
             },
-            "time": "2021-06-24T05:45:26+00:00"
+            "time": "2021-06-29T23:50:09+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "fc4742c0b25d9d9ca191915fd17627dae318b76c"
+                "reference": "af51a4636e0f9b77f5556d26834d270e9b7fa444"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/fc4742c0b25d9d9ca191915fd17627dae318b76c",
-                "reference": "fc4742c0b25d9d9ca191915fd17627dae318b76c",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/af51a4636e0f9b77f5556d26834d270e9b7fa444",
+                "reference": "af51a4636e0f9b77f5556d26834d270e9b7fa444",
                 "shasum": ""
             },
             "require": {
@@ -73,7 +73,7 @@
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
                 "source": "https://github.com/ampproject/amp-toolbox-php/tree/add/55-optimize-hero-images-transformer"
             },
-            "time": "2021-06-29T23:50:09+00:00"
+            "time": "2021-06-30T03:00:01+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/src/Cli/TransformerCommand.php
+++ b/src/Cli/TransformerCommand.php
@@ -14,7 +14,6 @@ use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\Optimizer\Configuration;
 use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
 use WP_CLI;
-use WP_CLI\Utils;
 
 /**
  * Commands that deal with the transformers registered with the AMP optimizer. (EXPERIMENTAL)
@@ -186,7 +185,7 @@ final class TransformerCommand implements Service, CliCommand {
 	 * +-------------------+----------------------------+
 	 *
 	 * # Fetch the attribute that is added to store a backup of inlined styles.
-	 * $ wp amp optimizer transformer config PreloadHeroImage --key=inlineStyleBackupAttribute --field=value
+	 * $ wp amp optimizer transformer config OptimizeHeroImages --key=inlineStyleBackupAttribute --field=value
 	 * data-amp-original-style
 	 *
 	 * # Render the configuration of the AmpRuntimeCss transformer as a JSON array.

--- a/src/Optimizer/AmpWPConfiguration.php
+++ b/src/Optimizer/AmpWPConfiguration.php
@@ -58,7 +58,7 @@ final class AmpWPConfiguration extends DefaultConfiguration {
 				[
 					Transformer\AmpRuntimeCss::class,
 					Transformer\OptimizeAmpBind::class,
-					Transformer\PreloadHeroImage::class,
+					Transformer\OptimizeHeroImages::class,
 					Transformer\RewriteAmpUrls::class,
 					Transformer\ServerSideRendering::class,
 					Transformer\TransformedIdentifier::class,
@@ -87,9 +87,10 @@ final class AmpWPConfiguration extends DefaultConfiguration {
 		$this->configuration = apply_filters(
 			'amp_optimizer_config',
 			[
-				self::KEY_TRANSFORMERS              => $transformers,
-				Transformer\PreloadHeroImage::class => [
-					Configuration\PreloadHeroImageConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE => 'data-amp-original-style',
+				self::KEY_TRANSFORMERS                => $transformers,
+				Transformer\OptimizeHeroImages::class => [
+					Configuration\OptimizeHeroImagesConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE => 'data-amp-original-style',
+					Configuration\OptimizeHeroImagesConfiguration::MAX_HERO_IMAGE_COUNT          => PHP_INT_MAX,
 				],
 			]
 		);

--- a/src/Optimizer/Transformer/DetermineHeroImages.php
+++ b/src/Optimizer/Transformer/DetermineHeroImages.php
@@ -13,7 +13,6 @@ use AmpProject\Dom\Element;
 use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Optimizer\ImageDimensions;
 use AmpProject\Optimizer\Transformer;
-use AmpProject\Optimizer\Transformer\PreloadHeroImage;
 
 /**
  * Determine the images to flag with data-hero-candidate so the Optimizer can prerender them.
@@ -65,30 +64,28 @@ final class DetermineHeroImages implements Transformer {
 		$hero_image_elements = [];
 
 		foreach ( [ 'header_images', 'initial_content_image' ] as $hero_image_source ) {
-			if ( count( $hero_image_elements ) < PreloadHeroImage::DATA_HERO_MAX ) {
-				$candidate = null;
+			$candidate = null;
 
-				switch ( $hero_image_source ) {
-					case 'header_images':
-						$candidate = $this->get_header_images( $document );
-						break;
-					case 'initial_content_image':
-						$candidate = $this->get_initial_content_image( $document );
-						break;
-				}
+			switch ( $hero_image_source ) {
+				case 'header_images':
+					$candidate = $this->get_header_images( $document );
+					break;
+				case 'initial_content_image':
+					$candidate = $this->get_initial_content_image( $document );
+					break;
+			}
 
-				if ( $candidate instanceof Element ) {
-					$hero_image_elements[ spl_object_hash( $candidate ) ] = $candidate;
-				} elseif ( is_array( $candidate ) ) {
-					foreach ( $candidate as $hero_image_element ) {
-						$hero_image_elements[ spl_object_hash( $hero_image_element ) ] = $hero_image_element;
-					}
+			if ( $candidate instanceof Element ) {
+				$hero_image_elements[ spl_object_hash( $candidate ) ] = $candidate;
+			} elseif ( is_array( $candidate ) ) {
+				foreach ( $candidate as $hero_image_element ) {
+					$hero_image_elements[ spl_object_hash( $hero_image_element ) ] = $hero_image_element;
 				}
 			}
 		}
 
 		$this->add_data_hero_candidate_attribute(
-			array_slice( array_values( $hero_image_elements ), 0, PreloadHeroImage::DATA_HERO_MAX )
+			array_values( $hero_image_elements )
 		);
 	}
 

--- a/tests/php/src/Optimizer/AmpWPConfigurationTest.php
+++ b/tests/php/src/Optimizer/AmpWPConfigurationTest.php
@@ -3,8 +3,8 @@
 namespace AmpProject\AmpWP\Tests\Optimizer;
 
 use AmpProject\AmpWP\Optimizer\AmpWPConfiguration;
-use AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration;
-use AmpProject\Optimizer\Transformer\PreloadHeroImage;
+use AmpProject\Optimizer\Configuration\OptimizeHeroImagesConfiguration;
+use AmpProject\Optimizer\Transformer\OptimizeHeroImages;
 use AmpProject\Optimizer\Transformer\ServerSideRendering;
 use AmpProject\Optimizer\TransformerConfiguration;
 use WP_UnitTestCase;
@@ -44,12 +44,12 @@ final class AmpWPConfigurationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_unfiltered_transformer_configuration_key() {
 		$configuration             = new AmpWPConfiguration();
-		$transformer_configuration = $configuration->getTransformerConfiguration( PreloadHeroImage::class );
+		$transformer_configuration = $configuration->getTransformerConfiguration( OptimizeHeroImages::class );
 
 		$this->assertInstanceOf( TransformerConfiguration::class, $transformer_configuration );
 		$this->assertEquals(
 			'data-amp-original-style',
-			$transformer_configuration->get( PreloadHeroImageConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE )
+			$transformer_configuration->get( OptimizeHeroImagesConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE )
 		);
 	}
 
@@ -59,19 +59,19 @@ final class AmpWPConfigurationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_filtered_transformer_configuration_key() {
 		$configuration_filter = static function ( $configuration ) {
-			$configuration[ PreloadHeroImage::class ]['inlineStyleBackupAttribute'] = 'data-backup-style';
+			$configuration[ OptimizeHeroImages::class ]['inlineStyleBackupAttribute'] = 'data-backup-style';
 			return $configuration;
 		};
 
 		add_filter( 'amp_optimizer_config', $configuration_filter );
 
 		$configuration             = new AmpWPConfiguration();
-		$transformer_configuration = $configuration->getTransformerConfiguration( PreloadHeroImage::class );
+		$transformer_configuration = $configuration->getTransformerConfiguration( OptimizeHeroImages::class );
 
 		$this->assertInstanceOf( TransformerConfiguration::class, $transformer_configuration );
 		$this->assertEquals(
 			'data-backup-style',
-			$transformer_configuration->get( PreloadHeroImageConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE )
+			$transformer_configuration->get( OptimizeHeroImagesConfiguration::INLINE_STYLE_BACKUP_ATTRIBUTE )
 		);
 
 		remove_filter( 'amp_optimizer_config', $configuration_filter );

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -213,14 +213,14 @@ final class DetermineHeroImagesTest extends WP_UnitTestCase {
 				),
 			],
 
-			'site icon and custom header are prioritized over content block' => [
+			'site icon and custom header and content block' => [
 				$input(
 					'<header><a href="https://amp.lndo.site/" class="custom-logo-link" rel="home">'
 					. '<amp-img width="789" height="539" src="https://example.com/site-icon.jpg" class="custom-logo" alt="Theme Unit Test" loading="lazy" srcset="https://example.com/site-icon_789.jpg 789w, https://example.com/site-icon_300.jpg 300w, https://example.com/site-icon_768.jpg 768w" sizes="(max-width: 789px) 100vw, 789px"></amp-img>'
 					. '</a>'
 					. '<div class="wp-custom-header"><amp-img width="640" height="480" src="https://example.com/custom-header.jpg"></amp-img></div></header>'
 					. '<div class="entry-content">'
-					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img loading="lazy" width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
 					. '</div>'
 				),
 				$output(
@@ -229,19 +229,19 @@ final class DetermineHeroImagesTest extends WP_UnitTestCase {
 					. '</a>'
 					. '<div class="wp-custom-header"><amp-img data-hero-candidate width="640" height="480" src="https://example.com/custom-header.jpg"></amp-img></div></header>'
 					. '<div class="entry-content">'
-					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img loading="lazy" width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" data-hero-candidate alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
 					. '</div>'
 				),
 			],
 
-			'featured image and custom header prioritized over cover blocks' => [
+			'featured image and custom header and cover blocks' => [
 				$input(
 					'<header><a href="https://amp.lndo.site/" class="custom-logo-link" rel="home">'
 					. '<amp-img width="789" height="539" src="https://example.com/site-icon.jpg" class="custom-logo" alt="Theme Unit Test" loading="lazy" srcset="https://example.com/site-icon_789.jpg 789w, https://example.com/site-icon_300.jpg 300w, https://example.com/site-icon_768.jpg 768w" sizes="(max-width: 789px) 100vw, 789px"></amp-img>'
 					. '</a>'
 					. '<div class="wp-custom-header"><amp-img width="640" height="480" src="https://example.com/custom-header.jpg"></amp-img></div></header>'
 					. '<div class="entry-content">'
-					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img loading="lazy" width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
 					. '</div>'
 				),
 				$output(
@@ -250,7 +250,7 @@ final class DetermineHeroImagesTest extends WP_UnitTestCase {
 					. '</a>'
 					. '<div class="wp-custom-header"><amp-img data-hero-candidate width="640" height="480" src="https://example.com/custom-header.jpg"></amp-img></div></header>'
 					. '<div class="entry-content">'
-					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img loading="lazy" width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-hero-candidate data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
 					. '</div>'
 				),
 			],


### PR DESCRIPTION
## Summary

See https://github.com/ampproject/amp-toolbox-php/issues/55#issuecomment-825913927:

> In the context of the AMP plugin's `DetermineHeroImages` transformer, we should remove any limit for hero images that are located in the header. Basically, we should do SSR for every image that has `data-hero` or `data-hero-candidate`. The limit should only apply to automatic detection.

Since WordPress doesn't add `data-hero` or `data-hero-candidate` itself and we only add it via automatic detection, we can just omit the max hero count entirely on pages we generate.

Depends on https://github.com/ampproject/amp-toolbox-php/pull/262.

With the changes here, you can see that in addition to the custom logo and header image being identified as hero images, the first content image is also now able to be identified as a hero since previously the hero identification was cut off at 2:

Before | After
-------|------
<img width="406" alt="Screen Shot 2021-06-29 at 20 17 29" src="https://user-images.githubusercontent.com/134745/123896866-3dd86880-d917-11eb-98de-97d975a59936.png"> | <img width="406" alt="Screen Shot 2021-06-29 at 20 18 26" src="https://user-images.githubusercontent.com/134745/123896876-42048600-d917-11eb-8f25-5b16b8a7208b.png">

(Hero images are marked in red.)

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
