### PR TITLE
Update automerge workflow to use PAT

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,11 @@
-name: Auto-merge
+name: Automerge
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  # ⚠️ WARNING: Secrets can be accessed by forks when triggered via this event!
+  # In this case no code is checked out and no cache is being saved, so this workflow should be fine.
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 jobs:
   automerge-dependencies:
@@ -16,4 +19,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes the issue of Dependabot PRs not being able to automerge.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
