### PR TITLE
Ensure first entry content in DetermineHeroImages matches amp-wp-article-content in legacy Reader templates

### DIFF
--- a/src/Optimizer/Transformer/DetermineHeroImages.php
+++ b/src/Optimizer/Transformer/DetermineHeroImages.php
@@ -38,11 +38,21 @@ final class DetermineHeroImages implements Transformer {
 	 * XPath query to find the first entry-content.
 	 *
 	 * Note that the 'entry-content' class name is the classic form for what the h-entry spec now has as 'e-content'.
+	 * The 'amp-wp-article-content' class name is used in legacy Reader templates. Note that 'entry-content' isn't
+	 * simply just added to templates/single.php and templates/page.php because these templates are frequently forked.
 	 *
 	 * @link https://microformats.org/wiki/h-entry
 	 * @var string
 	 */
-	const FIRST_ENTRY_CONTENT_XPATH_QUERY = ".//*[ @class ][ contains( concat( ' ', normalize-space( @class ), ' ' ), ' entry-content ' ) or contains( concat( ' ', normalize-space( @class ), ' ' ), ' e-content ' ) ]";
+	const FIRST_ENTRY_CONTENT_XPATH_QUERY = "
+		.//*[ @class ][
+			contains( concat( ' ', normalize-space( @class ), ' ' ), ' entry-content ' )
+			or
+			contains( concat( ' ', normalize-space( @class ), ' ' ), ' e-content ' )
+			or
+			contains( concat( ' ', normalize-space( @class ), ' ' ), ' amp-wp-article-content ' )
+		]
+	";
 
 	/**
 	 * XPath query to find an image at the beginning of entry content (including nested inside of another block).

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -79,6 +79,19 @@ final class DetermineHeroImagesTest extends WP_UnitTestCase {
 				),
 			],
 
+			'detects custom header as in document with amp-wp-article-content' => [
+				$input(
+					'<div class="my-header">'
+					. '<amp-img width="789" height="539" src="https://example.com/custom-header.jpg"></amp-img>'
+					. '</div><div class="h-feed"><div class="h-entry"><div class="amp-wp-article-content"></div></div></div>'
+				),
+				$output(
+					'<div class="my-header">'
+					. '<amp-img width="789" height="539" src="https://example.com/custom-header.jpg" data-hero-candidate></amp-img>'
+					. '</div><div class="h-feed"><div class="h-entry"><div class="amp-wp-article-content"></div></div></div>'
+				),
+			],
+
 			'ignores header image which was originally lazy-loaded' => [
 				$input(
 					'<header>'


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/ampproject/amp-wp/pull/6062 which looks for the first image descendant of the first `.entry-content` or `.e-content` to identify as a hero image. What this didn't account for was the legacy Reader templates which use neither of these standard class names; they instead use `amp-wp-article-content`. So this class needs to be checked for as well. Note that we cannot simply add the `entry-content` class to the existing `.amp-wp-article-content` element legacy Reader templates because these `single.php` and `page.php` templates are frequently forked.

See below with `[data-hero] { outline: solid 6px lime; }`:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/124042319-716dce00-d9bd-11eb-93da-360a4a0316f1.png) | ![image](https://user-images.githubusercontent.com/134745/124042374-8d716f80-d9bd-11eb-8924-9b381cfda7db.png)

Also relates to https://github.com/ampproject/amp-wp/pull/6435.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
