### PR TITLE
[2.1]  Add Composer plugin to correctly autoload PHP CSS Parser dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function( grunt ) {
 		'assets',
 		'back-compat',
 		'includes',
+		'php-css-parser-install-composer-plugin',
 		'src',
 		'templates',
 		'vendor',
@@ -20,10 +21,11 @@ module.exports = function( grunt ) {
 		/.*\/src\/.*/,
 	];
 
-	// These will be removed from the vendor directory after installing but prior to creating a ZIP.
+	// These will be removed from the build directory after installing but prior to creating a ZIP.
 	// ⚠️ Warning: These paths are passed straight to rm command in the shell, without any escaping.
-	const productionVendorExcludedFilePatterns = [
+	const productionInstallExcludedFilePatterns = [
 		'composer.*',
+		'php-css-parser-install-composer-plugin/*',
 		'vendor/*/*/.editorconfig',
 		'vendor/*/*/.git',
 		'vendor/*/*/.github',
@@ -84,7 +86,7 @@ module.exports = function( grunt ) {
 					'cd build',
 					'composer install --no-dev -o',
 					'composer remove cweagans/composer-patches --update-no-dev -o',
-					'rm -rf ' + productionVendorExcludedFilePatterns.join( ' ' ),
+					'rm -rf ' + productionInstallExcludedFilePatterns.join( ' ' ),
 				].join( ' && ' ),
 			},
 			create_build_zip: {

--- a/bin/ci/after-wp-install.sh
+++ b/bin/ci/after-wp-install.sh
@@ -49,7 +49,7 @@ if [[ $(php -r "echo PHP_VERSION;") == 8.0* ]]; then
 	DIFF=$(
 		cat <<-EOF
 diff --git a/composer.json b/composer.json
-index 5a150f830..f670267f8 100644
+index 5934aedec..2977df4a9 100644
 --- a/composer.json
 +++ b/composer.json
 @@ -86,7 +86,17 @@
@@ -70,7 +70,7 @@ index 5a150f830..f670267f8 100644
 +      "vendor/phpunit/phpunit/src/Framework/MockObject/MockMethod.php"
      ]
    },
-   "minimum-stability": "dev",
+   "repositories": [
 		EOF
 	)
 

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -108,7 +108,7 @@ wp plugin activate amp --quiet
 
 # Install & activate Gutenberg plugin.
 echo -e $(status_message "Installing and activating Gutenberg plugin...")
-wp plugin install gutenberg --activate --force --quiet
+wp plugin install gutenberg --activate --force --quiet --version=11.0.0
 
 # Set pretty permalinks.
 echo -e $(status_message "Setting permalink structure...")

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "sabberworm/php-css-parser": "dev-master#bfdd976"
   },
   "require-dev": {
+    "ampproject/php-css-parser-install-plugin": "*",
     "automattic/vipwpcs": "^2.2",
     "civicrm/composer-downloads-plugin": "^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
@@ -88,6 +89,12 @@
       "docs/includes/register-wp-cli-commands.php"
     ]
   },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "./php-css-parser-install-composer-plugin"
+    }
+  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29876189c35c5b781bab9481780c30d0",
+    "content-hash": "24e4763c881c13579ccdaa26ac3b584c",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
@@ -201,7 +201,7 @@
             },
             "require-dev": {
                 "codacy/coverage": "^1.4",
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.36"
             },
             "default-branch": true,
             "type": "library",
@@ -230,7 +230,7 @@
                 "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
                 "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/master"
             },
-            "time": "2021-07-05T09:19:13+00:00"
+            "time": "2021-07-19T05:52:43+00:00"
         },
         {
             "name": "willwashburn/stream",
@@ -285,6 +285,36 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "ampproject/php-css-parser-install-plugin",
+            "version": "2.1.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "./php-css-parser-install-composer-plugin",
+                "reference": "ed89dbc5de10f6ed5339ed00a03fad952515bb64"
+            },
+            "require": {
+                "composer-plugin-api": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "AmpProject\\AmpWP\\PhpCssParserInstall\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "AmpProject\\AmpWP\\PhpCssParserInstall\\": "./src"
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
         {
             "name": "automattic/vipwpcs",
             "version": "2.3.2",
@@ -1821,16 +1851,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.7.2",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42"
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/794e6eedfd5f2a334d581214c007fc398be588fe",
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe",
                 "shasum": ""
             },
             "replace": {
@@ -1859,9 +1889,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.8.0"
             },
-            "time": "2021-05-13T07:54:04+00:00"
+            "time": "2021-07-21T02:34:37+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2999,12 +3029,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1a08d0c7ab47e57fad0d254951a615f07445e91f"
+                "reference": "062365f16d85b8585d665a913f3d3874db1860b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1a08d0c7ab47e57fad0d254951a615f07445e91f",
-                "reference": "1a08d0c7ab47e57fad0d254951a615f07445e91f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/062365f16d85b8585d665a913f3d3874db1860b4",
+                "reference": "062365f16d85b8585d665a913f3d3874db1860b4",
                 "shasum": ""
             },
             "conflict": {
@@ -3062,6 +3092,7 @@
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
                 "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
@@ -3092,6 +3123,7 @@
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "froala/wysiwyg-editor": "<3.2.7",
                 "fuel/core": "<1.8.1",
                 "getgrav/grav": "<=1.7.10",
                 "getkirby/cms": "<=3.5.6",
@@ -3176,7 +3208,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<6.8.8",
+                "pimcore/pimcore": "<10.0.7",
                 "pocketmine/pocketmine-mp": "<3.15.4",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -3277,9 +3309,9 @@
                 "tribalsystems/zenario": "<8.8.53370",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "twig/twig": "<1.38|>=2,<2.7",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.25|>=10,<10.4.14|>=11,<11.1.1",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.28|>=10,<10.4.18|>=11,<11.3.1",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
-                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.25|>=10,<10.4.14|>=11,<11.1.1",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.28|>=10,<10.4.18|>=11,<11.3.1",
                 "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
@@ -3367,7 +3399,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-02T20:02:51+00:00"
+            "time": "2021-07-20T12:03:36+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5637,16 +5669,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.12",
+            "version": "v0.11.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e"
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a2866855ac1abc53005c102e901553ad5772dc04",
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04",
                 "shasum": ""
             },
             "require": {
@@ -5685,9 +5717,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.12"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.13"
             },
-            "time": "2021-03-03T12:43:49+00:00"
+            "time": "2021-07-01T15:08:16+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
@@ -5762,16 +5794,16 @@
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v3.0.14",
+            "version": "v3.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "03fdabdae9e9a081ef57b0ce7e6d66dc45212c09"
+                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/03fdabdae9e9a081ef57b0ce7e6d66dc45212c09",
-                "reference": "03fdabdae9e9a081ef57b0ce7e6d66dc45212c09",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/17ff779d7678e4dc3fbd85017fb921e44b8639d4",
+                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4",
                 "shasum": ""
             },
             "require": {
@@ -5786,7 +5818,7 @@
                 "wp-cli/eval-command": "^1 || ^2",
                 "wp-cli/wp-cli": "^2",
                 "wp-coding-standards/wpcs": "^2.3",
-                "yoast/phpunit-polyfills": "^0.2"
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-master"
@@ -5836,7 +5868,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli-tests/issues",
                 "source": "https://github.com/wp-cli/wp-cli-tests"
             },
-            "time": "2021-05-12T07:43:00+00:00"
+            "time": "2021-07-20T07:00:50+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -5936,25 +5968,25 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5d257d5a6977137016f3df440ce640ce72ffd61a",
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": ">=5.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -5995,7 +6027,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2020-11-25T02:59:57+00:00"
+            "time": "2021-06-21T03:13:22+00:00"
         }
     ],
     "aliases": [],

--- a/php-css-parser-install-composer-plugin/composer.json
+++ b/php-css-parser-install-composer-plugin/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "ampproject/php-css-parser-install-plugin",
+  "type": "composer-plugin",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "composer-plugin-api": "^2.0"
+  },
+  "require-dev": {
+    "composer/composer": "^2.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "AmpProject\\AmpWP\\PhpCssParserInstall\\": "./src"
+    }
+  },
+  "extra": {
+    "class": "AmpProject\\AmpWP\\PhpCssParserInstall\\Plugin"
+  }
+}

--- a/php-css-parser-install-composer-plugin/src/Plugin.php
+++ b/php-css-parser-install-composer-plugin/src/Plugin.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Plugin class.
+ *
+ * @package AmpProject\AmpWP\PhpCssParserInstall
+ */
+
+namespace AmpProject\AmpWP\PhpCssParserInstall;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Package\AliasPackage;
+use Composer\Package\CompleteAliasPackage;
+use Composer\Package\CompletePackageInterface;
+use Composer\Package\Link;
+use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\Locker;
+use Composer\Plugin\PluginInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\LockArrayRepository;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use Composer\Semver\Constraint\Constraint;
+
+/**
+ * This Composer plugin patches the `sabberworm/php-css-parser` package so that it autoloads the correct namespace.
+ */
+class Plugin implements PluginInterface, EventSubscriberInterface {
+
+	/** @var string */
+	const CSS_PARSER_PACKAGE_NAME = 'sabberworm/php-css-parser';
+
+	/**
+	 * Apply plugin modifications to Composer
+	 *
+	 * @param Composer    $composer Composer instance.
+	 * @param IOInterface $io       IO instance.
+	 */
+	public function activate( Composer $composer, IOInterface $io ) {
+	}
+
+	/**
+	 * Remove any hooks from Composer
+	 *
+	 * This will be called when a plugin is deactivated before being
+	 * uninstalled, but also before it gets upgraded to a new version
+	 * so the old one can be deactivated and the new one activated.
+	 *
+	 * @param Composer    $composer Composer instance.
+	 * @param IOInterface $io       IO instance.
+	 */
+	public function deactivate( Composer $composer, IOInterface $io ) {
+	}
+
+	/**
+	 * Prepare the plugin to be uninstalled
+	 *
+	 * This will be called after deactivate.
+	 *
+	 * @param Composer    $composer Composer instance.
+	 * @param IOInterface $io       IO instance.
+	 */
+	public function uninstall( Composer $composer, IOInterface $io ) {
+	}
+
+	/**
+	 * Returns an array of event names this subscriber wants to listen to.
+	 *
+	 * The array keys are event names and the value can be:
+	 *
+	 * * The method name to call (priority defaults to 0)
+	 * * An array composed of the method name to call and the priority
+	 * * An array of arrays composed of the method names to call and respective
+	 *   priorities, or 0 if unset
+	 *
+	 * For instance:
+	 *
+	 * * array('eventName' => 'methodName')
+	 * * array('eventName' => array('methodName', $priority))
+	 * * array('eventName' => array(array('methodName1', $priority), array('methodName2'))
+	 *
+	 * @return array The event names to listen to
+	 */
+	public static function getSubscribedEvents() {
+		return [
+			ScriptEvents::PRE_AUTOLOAD_DUMP => 'onPreAutoloadDump',
+		];
+	}
+
+	/**
+	 * Patch the package before the autoload file is generated.
+	 *
+	 * @param Event $event Composer event.
+	 */
+	public static function onPreAutoloadDump( Event $event ) {
+		$package_locker   = $event->getComposer()->getLocker();
+		$local_repository = $event->getComposer()->getRepositoryManager()->getLocalRepository();
+
+		self::patchComposerLockFile( $package_locker );
+		self::patchPackage( $local_repository );
+	}
+
+	/**
+	 * Patch the `composer.lock` file to use the correct dependency requirements and `psr-4` namespace.
+	 *
+	 * @param Locker $package_locker Package locker instance.
+	 */
+	private static function patchComposerLockFile( Locker $package_locker ) {
+		$lock_data = $package_locker->getLockData();
+
+		if ( ! isset( $lock_data['packages'] ) ) {
+			return;
+		}
+
+		$package_key = array_search( self::CSS_PARSER_PACKAGE_NAME, array_column( $lock_data['packages'], 'name' ), true );
+
+		if ( ! $package_key ) {
+			return;
+		}
+
+		unset( $lock_data['packages'][ $package_key ]['suggest'] );
+		$lock_data['packages'][ $package_key ]['require'] = [
+			'php' => '>=5.3.2',
+		];
+
+		$lock_data['packages'][ $package_key ]['autoload']['psr-4']['Sabberworm\\CSS\\'] = 'lib/Sabberworm/CSS/';
+
+		$package_locker->setLockData(
+			self::getLockedRepository( $lock_data['packages'], $lock_data['aliases'] )->getPackages(),
+			self::getLockedRepository( $lock_data['packages-dev'], $lock_data['aliases'] )->getPackages(),
+			$lock_data['platform'],
+			$lock_data['platform-dev'],
+			$lock_data['aliases'],
+			$lock_data['minimum-stability'],
+			$lock_data['stability-flags'],
+			$lock_data['prefer-stable'],
+			$lock_data['prefer-lowest'],
+			$lock_data['platform-overrides']
+		);
+	}
+
+	/**
+	 * Patch package to point to the correct `psr-4` namespace so that it can be autoloaded.
+	 *
+	 * @param InstalledRepositoryInterface $local_repository Local repository instance.
+	 */
+	private static function patchPackage( InstalledRepositoryInterface $local_repository ) {
+		$package = $local_repository->findPackage( self::CSS_PARSER_PACKAGE_NAME, '*' );
+
+		if ( ! $package ) {
+			return;
+		}
+
+		$root_package = $package instanceof CompleteAliasPackage ? $package->getAliasOf() : $package;
+
+		$root_package->setRequires(
+			[
+				'php' => new Link(
+					self::CSS_PARSER_PACKAGE_NAME,
+					'php',
+					new Constraint( '>=', '5.3.2' ),
+					Link::TYPE_REQUIRE,
+					'>=5.3.2'
+				),
+			]
+		);
+
+		$root_package->setAutoload(
+			[
+				'psr-4' => [
+					'Sabberworm\\CSS\\' => 'lib/Sabberworm/CSS/',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Converts string array representation of locked packages into a \Composer\Repository\LockArrayRepository object.
+	 *
+	 * Adapted from \Composer\Package\Locker::getLockedRepository().
+	 *
+	 * @param array      $locked_packages Array of locked packages.
+	 * @param array|null $locked_aliases  Array of locked package aliases.
+	 *
+	 * @return array|LockArrayRepository
+	 */
+	private static function getLockedRepository( array $locked_packages, $locked_aliases ) {
+		$loader   = new ArrayLoader( null, true );
+		$packages = new LockArrayRepository();
+
+		if ( empty( $locked_packages ) ) {
+			return $packages;
+		}
+
+		if ( isset( $locked_packages[0]['name'] ) ) {
+			$package_by_name = [];
+			foreach ( $locked_packages as $info ) {
+				$package = $loader->load( $info );
+				$packages->addPackage( $package );
+				$package_by_name[ $package->getName() ] = $package;
+
+				if ( $package instanceof AliasPackage ) {
+					$package_by_name[ $package->getAliasOf()->getName() ] = $package->getAliasOf();
+				}
+			}
+
+			if ( $locked_aliases ) {
+				foreach ( $locked_aliases as $alias ) {
+					if ( isset( $package_by_name[ $alias['package'] ] ) ) {
+						if ( $package_by_name[ $alias['package'] ] instanceof CompletePackageInterface ) {
+							$alias_pkg = new CompleteAliasPackage( $package_by_name[ $alias['package'] ], $alias['alias_normalized'], $alias['alias'] );
+						} else {
+							$alias_pkg = new AliasPackage( $package_by_name[ $alias['package'] ], $alias['alias_normalized'], $alias['alias'] );
+						}
+						$alias_pkg->setRootPackageAlias( true );
+						$packages->addPackage( $alias_pkg );
+					}
+				}
+			}
+
+			return $packages;
+		}
+
+		return [];
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Backport of #6464.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
