### PR TITLE
Fix stepper icons occasionally not being displayed correctly in Onboarding Wizard

### DIFF
--- a/assets/src/components/svg/check.js
+++ b/assets/src/components/svg/check.js
@@ -1,13 +1,20 @@
 /**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+
+/**
  * Check mark SVG.
  */
 export function Check() {
+	const id = useInstanceId( Check );
+
 	return (
 		<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="5" width="16" height="12">
+			<mask id={ `mask-${ id }` } mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="5" width="16" height="12">
 				<path d="M7.32923 14.137L3.85423 10.662L2.6709 11.837L7.32923 16.4953L17.3292 6.49531L16.1542 5.32031L7.32923 14.137Z" fill="white" />
 			</mask>
-			<g mask="url(#mask0)">
+			<g mask={ `url(#mask-${ id })` }>
 				<rect y="0.90625" width="20" height="20" fill="white" />
 			</g>
 		</svg>

--- a/assets/src/onboarding-wizard/components/stepper/test/__snapshots__/index.js.snap
+++ b/assets/src/onboarding-wizard/components/stepper/test/__snapshots__/index.js.snap
@@ -13,7 +13,7 @@ exports[`StepperBullet matches snaphnot when neither index nor active index are 
   >
     <mask
       height="12"
-      id="mask0"
+      id="mask-1"
       mask-type="alpha"
       maskUnits="userSpaceOnUse"
       width="16"
@@ -26,7 +26,7 @@ exports[`StepperBullet matches snaphnot when neither index nor active index are 
       />
     </mask>
     <g
-      mask="url(#mask0)"
+      mask="url(#mask-1)"
     >
       <rect
         fill="white"
@@ -60,7 +60,7 @@ exports[`StepperBullet matches snapshot when index is 0 and active index is some
   >
     <mask
       height="12"
-      id="mask0"
+      id="mask-0"
       mask-type="alpha"
       maskUnits="userSpaceOnUse"
       width="16"
@@ -73,7 +73,7 @@ exports[`StepperBullet matches snapshot when index is 0 and active index is some
       />
     </mask>
     <g
-      mask="url(#mask0)"
+      mask="url(#mask-0)"
     >
       <rect
         fill="white"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

This PR fixes an issue with the "check" SVG icon not rendering correctly on the Onboarding Wizard page. This seems to only affect Safari and stems from the SVG icon being repeated multiple times on the page, causing the IDs within the SVG to be repeated as well. The fix for this then would be to use a unique IDs for each instance of the SVG icon on the page.

This [CSS-Tricks](https://css-tricks.com/heres-how-i-solved-a-weird-bug-using-tried-and-true-debugging-strategies/) blog post helped me to debug the issue at hand and I noticed that the Web Stories team also ran into a similar issue in https://github.com/google/web-stories-wp/issues/8401.

## Demo

### Before

https://user-images.githubusercontent.com/16200219/127575360-77acfa9d-8eb7-4c50-9b2c-36c0c9d00849.mp4

### After

https://user-images.githubusercontent.com/16200219/127575397-cd654c50-aedd-4ca8-b7a1-a82642f504a8.mp4

Fixes #6490

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
