### PR TITLE
Update amp-toolbox-php to 0.7.0-alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-main",
+    "ampproject/amp-toolbox": "dev-main#a155c37",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.6.0",
+    "ampproject/amp-toolbox": "dev-main",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "327cd9eef7a3bcafb8fc01c0337f0db6",
+    "content-hash": "656645a4cbfcb362497c45a6f9b26ae0",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e464f0ddcb357d098a60c1b98208c11e",
+    "content-hash": "327cd9eef7a3bcafb8fc01c0337f0db6",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "v0.6.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "500012f27cc27f4d72525cf0f010602fb95e2f6f"
+                "reference": "a155c3780eb35a66269c22f29cd91f7d2edfbb2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/500012f27cc27f4d72525cf0f010602fb95e2f6f",
-                "reference": "500012f27cc27f4d72525cf0f010602fb95e2f6f",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/a155c3780eb35a66269c22f29cd91f7d2edfbb2b",
+                "reference": "a155c3780eb35a66269c22f29cd91f7d2edfbb2b",
                 "shasum": ""
             },
             "require": {
@@ -36,7 +36,7 @@
                 "phpcompatibility/php-compatibility": "^9",
                 "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
                 "roave/security-advisories": "dev-master",
-                "sirbrillig/phpcs-variable-analysis": "2.11.1",
+                "sirbrillig/phpcs-variable-analysis": "2.11.2",
                 "squizlabs/php_codesniffer": "^3",
                 "wp-coding-standards/wpcs": "^2.3",
                 "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0"
@@ -46,6 +46,7 @@
                 "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
+            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -71,9 +72,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/v0.6.0"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2021-06-30T15:16:48+00:00"
+            "time": "2021-07-29T01:53:07+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -287,7 +288,7 @@
     "packages-dev": [
         {
             "name": "ampproject/php-css-parser-install-plugin",
-            "version": "dev-fix/php-css-parser-install",
+            "version": "dev-update/amp-toolbox-0.7.0-alpha",
             "dist": {
                 "type": "path",
                 "url": "./php-css-parser-install-composer-plugin",
@@ -1851,16 +1852,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.7.2",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42"
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
-                "reference": "beda02c58f1c4689d42c8dde6a84f7f0c9c93f42",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/794e6eedfd5f2a334d581214c007fc398be588fe",
+                "reference": "794e6eedfd5f2a334d581214c007fc398be588fe",
                 "shasum": ""
             },
             "replace": {
@@ -1889,9 +1890,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.8.0"
             },
-            "time": "2021-05-13T07:54:04+00:00"
+            "time": "2021-07-21T02:34:37+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -3029,12 +3030,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "062365f16d85b8585d665a913f3d3874db1860b4"
+                "reference": "52a126190a36bc9236846f5d42e10bff9ff60d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/062365f16d85b8585d665a913f3d3874db1860b4",
-                "reference": "062365f16d85b8585d665a913f3d3874db1860b4",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/52a126190a36bc9236846f5d42e10bff9ff60d72",
+                "reference": "52a126190a36bc9236846f5d42e10bff9ff60d72",
                 "shasum": ""
             },
             "conflict": {
@@ -3157,6 +3158,7 @@
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "librenms/librenms": "<21.1",
                 "livewire/livewire": ">2.2.4,<2.2.6",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
                 "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
                 "magento/magento1ce": "<1.9.4.3",
                 "magento/magento1ee": ">=1,<1.14.4.3",
@@ -3174,6 +3176,7 @@
                 "neos/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
                 "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "nilsteampassnet/teampass": "<=2.1.27.36",
                 "nukeviet/nukeviet": "<4.3.4",
                 "nystudio107/craft-seomatic": "<3.3",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
@@ -3311,7 +3314,7 @@
                 "twig/twig": "<1.38|>=2,<2.7",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.28|>=10,<10.4.18|>=11,<11.3.1",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
-                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.28|>=10,<10.4.18|>=11,<11.3.1",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<7.6.52|>=8,<8.7.41|>=9,<9.5.28|>=10,<10.4.18|>=11,<11.3.1",
                 "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
@@ -3399,7 +3402,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-20T12:03:36+00:00"
+            "time": "2021-07-26T22:02:34+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3911,6 +3914,7 @@
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
                 "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
             },
+            "abandoned": true,
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -5460,16 +5464,16 @@
         },
         {
             "name": "wp-cli/export-command",
-            "version": "v2.0.8",
+            "version": "v2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/export-command.git",
-                "reference": "e94f5f9e84768919aa6cd2193eb0c8b994e7f4c9"
+                "reference": "b32d4324e110901cedd8a663bea5563b7e332c44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/export-command/zipball/e94f5f9e84768919aa6cd2193eb0c8b994e7f4c9",
-                "reference": "e94f5f9e84768919aa6cd2193eb0c8b994e7f4c9",
+                "url": "https://api.github.com/repos/wp-cli/export-command/zipball/b32d4324e110901cedd8a663bea5563b7e332c44",
+                "reference": "b32d4324e110901cedd8a663bea5563b7e332c44",
                 "shasum": ""
             },
             "require": {
@@ -5481,6 +5485,7 @@
                 "wp-cli/entity-command": "^1.3 || ^2",
                 "wp-cli/extension-command": "^1.2 || ^2",
                 "wp-cli/import-command": "^1 || ^2",
+                "wp-cli/media-command": "^1 || ^2",
                 "wp-cli/wp-cli-tests": "^3.0.11"
             },
             "type": "wp-cli-package",
@@ -5516,32 +5521,32 @@
             "homepage": "https://github.com/wp-cli/export-command",
             "support": {
                 "issues": "https://github.com/wp-cli/export-command/issues",
-                "source": "https://github.com/wp-cli/export-command/tree/v2.0.8"
+                "source": "https://github.com/wp-cli/export-command/tree/v2.0.9"
             },
-            "time": "2021-05-12T06:03:45+00:00"
+            "time": "2021-07-25T17:00:42+00:00"
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "7ad4f9c0c93a1ee737521f825f161d4b79a46945"
+                "reference": "87c9e33154cf02da35a690d2b56b083125d71493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/7ad4f9c0c93a1ee737521f825f161d4b79a46945",
-                "reference": "7ad4f9c0c93a1ee737521f825f161d4b79a46945",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/87c9e33154cf02da35a690d2b56b083125d71493",
+                "reference": "87c9e33154cf02da35a690d2b56b083125d71493",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^1.4 || ^2 || ^3",
-                "wp-cli/wp-cli": "^2.5"
+                "wp-cli/wp-cli": "^2.5.1"
             },
             "require-dev": {
                 "wp-cli/entity-command": "^1.3 || ^2",
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^3.0.11"
+                "wp-cli/wp-cli-tests": "^3.0.16"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -5612,9 +5617,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.0"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.1"
             },
-            "time": "2021-05-12T06:06:34+00:00"
+            "time": "2021-07-26T08:17:56+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -5723,16 +5728,16 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.5.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "0bcf0c54f4d35685211d435e25219cc7acbe6d48"
+                "reference": "f40c35936e7a8faa59f12ba1fc7cbeb6082d03ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/0bcf0c54f4d35685211d435e25219cc7acbe6d48",
-                "reference": "0bcf0c54f4d35685211d435e25219cc7acbe6d48",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/f40c35936e7a8faa59f12ba1fc7cbeb6082d03ca",
+                "reference": "f40c35936e7a8faa59f12ba1fc7cbeb6082d03ca",
                 "shasum": ""
             },
             "require": {
@@ -5756,6 +5761,7 @@
                 "ext-readline": "Include for a better --prompt implementation",
                 "ext-zip": "Needed to support extraction of ZIP archives when doing downloads or updates"
             },
+            "default-branch": true,
             "bin": [
                 "bin/wp",
                 "bin/wp.bat"
@@ -5790,20 +5796,20 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2021-05-14T13:44:51+00:00"
+            "time": "2021-07-28T06:19:49+00:00"
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v3.0.15",
+            "version": "v3.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4"
+                "reference": "c10e6d7d46b1fba58e560953a8a1aa97d9a871eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/17ff779d7678e4dc3fbd85017fb921e44b8639d4",
-                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/c10e6d7d46b1fba58e560953a8a1aa97d9a871eb",
+                "reference": "c10e6d7d46b1fba58e560953a8a1aa97d9a871eb",
                 "shasum": ""
             },
             "require": {
@@ -5868,7 +5874,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli-tests/issues",
                 "source": "https://github.com/wp-cli/wp-cli-tests"
             },
-            "time": "2021-07-20T07:00:50+00:00"
+            "time": "2021-07-26T17:06:07+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -6033,6 +6039,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "ampproject/amp-toolbox": 20,
         "sabberworm/php-css-parser": 20,
         "roave/security-advisories": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "a155c3780eb35a66269c22f29cd91f7d2edfbb2b"
+                "reference": "98b020d6961c20689b855675030fabcd14d63a34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/a155c3780eb35a66269c22f29cd91f7d2edfbb2b",
-                "reference": "a155c3780eb35a66269c22f29cd91f7d2edfbb2b",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/98b020d6961c20689b855675030fabcd14d63a34",
+                "reference": "98b020d6961c20689b855675030fabcd14d63a34",
                 "shasum": ""
             },
             "require": {
@@ -74,7 +74,7 @@
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
                 "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2021-07-29T01:53:07+00:00"
+            "time": "2021-07-30T01:30:20+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -6,7 +6,6 @@
  */
 
 use AmpProject\Amp;
-use AmpProject\Dom\Document;
 
 /**
  * Class AMP_Comments_Sanitizer

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\Amp;
 use AmpProject\Dom\Document;
 
 /**
@@ -109,7 +110,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		$amp_bind_attr_format = Document::AMP_BIND_DATA_ATTR_PREFIX . '%s';
+		$amp_bind_attr_format = Amp::BIND_DATA_ATTR_PREFIX . '%s';
 		foreach ( $form_fields as $name => $form_field ) {
 			foreach ( $form_field as $element ) {
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -6,6 +6,7 @@
  * @since 1.0
  */
 
+use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
 use AmpProject\Role;
@@ -1499,12 +1500,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$amp_carousel_desktop_id = 'twentyFourteenSliderDesktop';
 		$amp_carousel_mobile_id  = 'twentyFourteenSliderMobile';
 		$amp_carousel_attributes = [
-			'layout'                                      => 'responsive',
-			'on'                                          => "slideChange:AMP.setState( { $selected_slide_state_id: event.index } )",
-			'width'                                       => '100',
-			'type'                                        => 'slides',
-			'loop'                                        => '',
-			Document::AMP_BIND_DATA_ATTR_PREFIX . 'slide' => $selected_slide_state_id,
+			'layout'                             => 'responsive',
+			'on'                                 => "slideChange:AMP.setState( { $selected_slide_state_id: event.index } )",
+			'width'                              => '100',
+			'type'                               => 'slides',
+			'loop'                               => '',
+			Amp::BIND_DATA_ATTR_PREFIX . 'slide' => $selected_slide_state_id,
 		];
 		$amp_carousel_desktop    = AMP_DOM_Utils::create_node(
 			$this->dom,
@@ -1552,7 +1553,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$li->setAttribute( 'selected', '' );
 				$a->setAttribute( 'class', 'slider-active' );
 			}
-			$a->setAttribute( Document::AMP_BIND_DATA_ATTR_PREFIX . 'class', "$selected_slide_state_id == $i ? 'slider-active' : ''" );
+			$a->setAttribute( Amp::BIND_DATA_ATTR_PREFIX . 'class', "$selected_slide_state_id == $i ? 'slider-active' : ''" );
 			$a->setAttribute( Attribute::ROLE, Role::BUTTON );
 			$a->setAttribute( Attribute::ON, "tap:AMP.setState( { $selected_slide_state_id: $i } )" );
 			$li->setAttribute( 'option', (string) $i );
@@ -1607,9 +1608,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Set visibility and aria-expanded based of the link based on whether the search bar is expanded.
 		$search_toggle_link->setAttribute( 'aria-expanded', wp_json_encode( $hidden ) );
-		$search_toggle_link->setAttribute( Document::AMP_BIND_DATA_ATTR_PREFIX . 'aria-expanded', "$hidden_state_id ? 'false' : 'true'" );
-		$search_toggle_div->setAttribute( Document::AMP_BIND_DATA_ATTR_PREFIX . 'class', "$hidden_state_id ? 'search-toggle' : 'search-toggle active'" );
-		$search_container->setAttribute( Document::AMP_BIND_DATA_ATTR_PREFIX . 'class', "$hidden_state_id ? 'search-box-wrapper hide' : 'search-box-wrapper'" );
+		$search_toggle_link->setAttribute( Amp::BIND_DATA_ATTR_PREFIX . 'aria-expanded', "$hidden_state_id ? 'false' : 'true'" );
+		$search_toggle_div->setAttribute( Amp::BIND_DATA_ATTR_PREFIX . 'class', "$hidden_state_id ? 'search-toggle' : 'search-toggle active'" );
+		$search_container->setAttribute( Amp::BIND_DATA_ATTR_PREFIX . 'class', "$hidden_state_id ? 'search-box-wrapper hide' : 'search-box-wrapper'" );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -8,7 +8,6 @@
 
 use AmpProject\Amp;
 use AmpProject\Attribute;
-use AmpProject\Dom\Document;
 use AmpProject\Role;
 
 /**

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -8,6 +8,7 @@
 
 use AmpProject\DevMode;
 use AmpProject\Dom\Document;
+use AmpProject\Dom\Document\Filter\MustacheScriptTemplates;
 
 /**
  * Class AMP_Form_Sanitizer
@@ -204,7 +205,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 			'submitting'     => null,
 		];
 
-		$templates = $this->dom->xpath->query( Document::XPATH_MUSTACHE_TEMPLATE_ELEMENTS_QUERY, $form );
+		$templates = $this->dom->xpath->query( MustacheScriptTemplates::XPATH_MUSTACHE_TEMPLATE_ELEMENTS_QUERY, $form );
 		foreach ( $templates as $template ) {
 			$parent = $template->parentNode;
 			if ( $parent instanceof DOMElement ) {

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -7,7 +7,6 @@
  */
 
 use AmpProject\DevMode;
-use AmpProject\Dom\Document;
 use AmpProject\Dom\Document\Filter\MustacheScriptTemplates;
 
 /**

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\Amp;
 use AmpProject\Dom\Document;
 
 /**
@@ -78,7 +79,7 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 
 		if ( ! empty( $this->args['nav_container_toggle_class'] ) ) {
 			$nav_el->setAttribute(
-				Document::AMP_BIND_DATA_ATTR_PREFIX . 'class',
+				Amp::BIND_DATA_ATTR_PREFIX . 'class',
 				sprintf(
 					"%s + ( $state_id ? %s : '' )",
 					wp_json_encode( $nav_el->getAttribute( 'class' ) ),
@@ -104,10 +105,10 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 		$button_on = sprintf( "tap:AMP.setState({ $state_id: ! $state_id })" );
 		$button_el->setAttribute( 'on', $button_on );
 		$button_el->setAttribute( 'aria-expanded', 'false' );
-		$button_el->setAttribute( Document::AMP_BIND_DATA_ATTR_PREFIX . 'aria-expanded', "$state_id ? 'true' : 'false'" );
+		$button_el->setAttribute( Amp::BIND_DATA_ATTR_PREFIX . 'aria-expanded', "$state_id ? 'true' : 'false'" );
 		if ( ! empty( $this->args['menu_button_toggle_class'] ) ) {
 			$button_el->setAttribute(
-				Document::AMP_BIND_DATA_ATTR_PREFIX . 'class',
+				Amp::BIND_DATA_ATTR_PREFIX . 'class',
 				sprintf( "%s + ( $state_id ? %s : '' )", wp_json_encode( $button_el->getAttribute( 'class' ) ), wp_json_encode( ' ' . $this->args['menu_button_toggle_class'] ) )
 			);
 		}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\Amp;
 use AmpProject\AmpWP\Icon;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
@@ -527,7 +528,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Find all [class] attributes and capture the contents of any single- or double-quoted strings.
-		foreach ( $this->dom->xpath->query( '//*/@' . Document::AMP_BIND_DATA_ATTR_PREFIX . 'class' ) as $bound_class_attribute ) {
+		foreach ( $this->dom->xpath->query( '//*/@' . Amp::BIND_DATA_ATTR_PREFIX . 'class' ) as $bound_class_attribute ) {
 			if ( preg_match_all( '/([\'"])([^\1]*?)\1/', $bound_class_attribute->nodeValue, $matches ) ) {
 				$classes = array_merge(
 					$classes,

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -7,6 +7,7 @@
  * @package AMP
  */
 
+use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\CssLength;
 use AmpProject\Dom\Document;
@@ -814,7 +815,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		// Check if element needs amp-bind component.
 		if ( $node instanceof DOMElement && ! in_array( 'amp-bind', $this->script_components, true ) ) {
 			foreach ( $node->attributes as $name => $value ) {
-				if ( Document::AMP_BIND_DATA_ATTR_PREFIX === substr( $name, 0, 14 ) ) {
+				if ( Amp::BIND_DATA_ATTR_PREFIX === substr( $name, 0, 14 ) ) {
 					$script_components[] = 'amp-bind';
 					break;
 				}
@@ -2245,7 +2246,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if (
 			isset( $attr_spec_list[ $attr_name ] )
 			||
-			( 'data-' === substr( $attr_name, 0, 5 ) && Document::AMP_BIND_DATA_ATTR_PREFIX !== substr( $attr_name, 0, 14 ) )
+			( 'data-' === substr( $attr_name, 0, 5 ) && Amp::BIND_DATA_ATTR_PREFIX !== substr( $attr_name, 0, 14 ) )
 			||
 			// Allow the 'amp' or '⚡' attribute in <html>, like <html ⚡>.
 			( 'html' === $attr_node->parentNode->nodeName && in_array( $attr_node->nodeName, [ 'amp', '⚡' ], true ) )

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -20,16 +20,6 @@ use AmpProject\Tag;
 class AMP_DOM_Utils {
 
 	/**
-	 * Attribute prefix for AMP-bind data attributes.
-	 *
-	 * @since 1.2.1
-	 * @deprecated Use AmpProject\Dom\Document::AMP_BIND_DATA_ATTR_PREFIX instead.
-	 * @internal
-	 * @var string
-	 */
-	const AMP_BIND_DATA_ATTR_PREFIX = Document::AMP_BIND_DATA_ATTR_PREFIX;
-
-	/**
 	 * Regular expression pattern to match events and actions within an 'on' attribute.
 	 *
 	 * @since 1.4.0
@@ -91,69 +81,6 @@ class AMP_DOM_Utils {
 	public static function is_valid_head_node( DOMNode $node ) {
 		_deprecated_function( __METHOD__, '1.5.0', 'AmpProject\Dom\Document->isValidHeadNode()' );
 		return Document::fromNode( $node )->isValidHeadNode( $node );
-	}
-
-	/**
-	 * Get attribute prefix for converted amp-bind attributes.
-	 *
-	 * This contains a random string to prevent HTML content containing this data- attribute
-	 * originally from being mutated to contain an amp-bind attribute when attributes are restored.
-	 *
-	 * @since 0.7
-	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
-	 * @see \AMP_DOM_Utils::restore_amp_bind_attributes()
-	 * @codeCoverageIgnore
-	 * @deprecated Use AmpProject\Dom\Document::AMP_BIND_DATA_ATTR_PREFIX instead.
-	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
-	 *
-	 * @return string HTML5 data-* attribute name prefix for AMP binding attributes.
-	 */
-	public static function get_amp_bind_placeholder_prefix() {
-		_deprecated_function( __METHOD__, '1.2.1' );
-		return Document::AMP_BIND_DATA_ATTR_PREFIX;
-	}
-
-	/**
-	 * Replace AMP binding attributes with something that libxml can parse (as HTML5 data-* attributes).
-	 *
-	 * This is necessary because attributes in square brackets are not understood in PHP and
-	 * get dropped with an error raised:
-	 * > Warning: DOMDocument::loadHTML(): error parsing attribute name
-	 * This is a reciprocal function of AMP_DOM_Utils::restore_amp_bind_attributes().
-	 *
-	 * @since 0.7
-	 * @codeCoverageIgnore
-	 * @deprecated This is handled automatically via AmpProject\Dom\Document.
-	 * @internal
-	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
-	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
-	 *
-	 * @param string $html HTML containing amp-bind attributes.
-	 * @return string HTML with AMP binding attributes replaced with HTML5 data-* attributes.
-	 */
-	public static function convert_amp_bind_attributes( $html ) {
-		_deprecated_function( __METHOD__, '1.5.0' );
-		return $html;
-	}
-
-	/**
-	 * Convert AMP bind-attributes back to their original syntax.
-	 *
-	 * This is a reciprocal function of AMP_DOM_Utils::convert_amp_bind_attributes().
-	 *
-	 * @since 0.7
-	 * @see \AMP_DOM_Utils::convert_amp_bind_attributes()
-	 * @codeCoverageIgnore
-	 * @deprecated This is handled automatically via AmpProject\Dom\Document.
-	 * @internal
-	 * @link https://www.ampproject.org/docs/reference/components/amp-bind
-	 *
-	 * @param string $html HTML with amp-bind attributes converted.
-	 * @return string HTML with amp-bind attributes restored.
-	 */
-	public static function restore_amp_bind_attributes( $html ) {
-		_deprecated_function( __METHOD__, '1.2.1' );
-		return $html;
 	}
 
 	/**

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -7,7 +7,7 @@
 
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use AmpProject\Dom\Document;
+use AmpProject\Dom\Document\Filter\MustacheScriptTemplates;
 
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 
@@ -219,7 +219,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 		$validating_sanitizer->sanitize();
 
 		// Normalize the contents of the templates.
-		foreach ( $dom->xpath->query( Document::XPATH_MUSTACHE_TEMPLATE_ELEMENTS_QUERY, $dom->body ) as $template ) {
+		foreach ( $dom->xpath->query( MustacheScriptTemplates::XPATH_MUSTACHE_TEMPLATE_ELEMENTS_QUERY, $dom->body ) as $template ) {
 			while ( $template->firstChild ) {
 				$template->removeChild( $template->firstChild );
 			}


### PR DESCRIPTION
There are some back-compat breakages currently in `main` of amp-toolbox-php which are caused by https://github.com/ampproject/amp-toolbox-php/pull/271. I searched through wpdirectoy.net for usages of these constants and I couldn't find any other than plugins that embed the entire library (e.g. AMP and Web Stories). So the back-compat issue shouldn't be a problem.

Question: Should `MinifyHtml` be included among `DEFAULT_TRANSFORMERS`? I just noticed `minifyJson` and there is one case where reformatted JSON could break certain services (sadly). The one example I know of is Alexa. See [support forum topic](https://wordpress.org/support/topic/alexa-atrk_acct-id-slash-encoding-adding-backslash/). In any case, this can be added in a subsequent PR.