### PR TITLE
Reduce size of UI elements on Settings screen

### DIFF
--- a/assets/src/css/core-components.css
+++ b/assets/src/css/core-components.css
@@ -185,7 +185,7 @@
 	width: 100%;
 
 	@media screen and (min-width: 783px) {
-		padding: 30px 90px;
+		padding: 20px 90px;
 	}
 }
 

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -74,21 +74,12 @@ html {
 	}
 }
 
-.amp .settings-welcome__button.is-primary {
-	box-shadow: none;
-	margin-right: 1rem;
-}
-
 .settings-welcome__body h2 {
 	margin-bottom: 1rem;
 }
 
 .settings-welcome__body p {
 	margin: 0;
-}
-
-.settings-welcome__body .components-button {
-	margin-top: 1rem;
 }
 
 /* Supported templates section. */

--- a/assets/src/settings-page/welcome.js
+++ b/assets/src/settings-page/welcome.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useContext } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -76,19 +76,20 @@ export function Welcome() {
 					</h2>
 					<p>
 						{ __( 'The AMP configuration wizard helps you choose the best configuration settings for your site.', 'amp' ) }
+						{ ' ' }
+						<a href={ onboardingWizardLink } >
+							{ pluginConfigured ? __( 'Reopen Wizard', 'amp' ) : __( 'Open Wizard', 'amp' ) }
+						</a>
+						{ customizerLink && templateModeWasOverridden === false && (
+							<>
+								{ ` ${ _x( 'or', 'e.g. do this or that', 'amp' ) } ` }
+								<a href={ customizerLink } >
+									{ __( 'Customize Reader Theme', 'amp' ) }
+								</a>
+							</>
+						) }
+						{ '.' }
 					</p>
-
-					<a className="components-button is-primary settings-welcome__button" href={ onboardingWizardLink } >
-						{ pluginConfigured ? __( 'Reopen Wizard', 'amp' ) : __( 'Open Wizard', 'amp' ) }
-					</a>
-
-					{
-						customizerLink && templateModeWasOverridden === false && (
-							<a className="components-button is-secondary" href={ customizerLink } rel="noreferrer">
-								{ __( 'Customize Reader Theme', 'amp' ) }
-							</a>
-						)
-					}
 				</div>
 			</div>
 		</div>

--- a/assets/src/settings-page/welcome.js
+++ b/assets/src/settings-page/welcome.js
@@ -88,7 +88,7 @@ export function Welcome() {
 								</a>
 							</>
 						) }
-						{ '.' }
+						{ _x( '.', 'End of sentence.', 'amp' ) }
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5559

This PR updates the Settings screen UI as follows:

1. The Welcome message buttons are changed to links:

| Before | After |
| --- | --- |
| <img width="960" alt="Screenshot 2021-07-30 at 14 01 48" src="https://user-images.githubusercontent.com/478735/127646824-00a97c48-6cfb-488c-8f4b-6aeab94b6e95.png"> | <img width="959" alt="Screenshot 2021-07-30 at 14 15 03" src="https://user-images.githubusercontent.com/478735/127646832-ed632795-3369-4a4a-a982-840a61ad68d6.png"> |

@jwold Note that there can be 2 links in the welcome message. They are now both turned into links. Does it look good to you?

2. Reduce the vertical padding on the Save button bar to 20px:

<img width="367" alt="Screenshot 2021-07-30 at 14 32 51" src="https://user-images.githubusercontent.com/478735/127647178-abd2ca20-9540-4eea-9732-0f65f885d3a4.png">

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
