### PR TITLE
Add overflow buttons to Twitter, Facebook, and Instagram embeds

### DIFF
--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -7,6 +7,9 @@
  * @package  AMP
  */
 
+use AmpProject\Attribute;
+use AmpProject\Dom\Document;
+use AmpProject\Dom\Element;
 use AmpProject\Tag;
 
 /**
@@ -199,5 +202,36 @@ abstract class AMP_Base_Embed_Handler {
 				$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 			}
 		}
+	}
+
+	/**
+	 * Create overflow button element.
+	 *
+	 * @param Document $dom  Document.
+	 * @param string   $text Button text (optional).
+	 * @return Element Button element.
+	 */
+	protected function create_overflow_button_element( Document $dom, $text = null ) {
+		if ( ! $text ) {
+			$text = __( 'See more', 'amp' );
+		}
+		$overflow = $dom->createElement( Tag::BUTTON );
+		$overflow->setAttributeNode( $dom->createAttribute( 'overflow' ) );
+		$overflow->setAttribute( Attribute::TYPE, 'button' );
+		$overflow->textContent = $text;
+		return $overflow;
+	}
+
+	/**
+	 * Create overflow button markup.
+	 *
+	 * @param string $text Button text (optional).
+	 * @return string Button markup.
+	 */
+	protected function create_overflow_button_markup( $text = null ) {
+		if ( ! $text ) {
+			$text = __( 'See more', 'amp' );
+		}
+		return sprintf( '<button overflow type="button">%s</button>', esc_html( $text ) );
 	}
 }

--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -216,7 +216,7 @@ abstract class AMP_Base_Embed_Handler {
 			$text = __( 'See more', 'amp' );
 		}
 		$overflow = $dom->createElement( Tag::BUTTON );
-		$overflow->setAttributeNode( $dom->createAttribute( 'overflow' ) );
+		$overflow->setAttributeNode( $dom->createAttribute( Attribute::OVERFLOW ) );
 		$overflow->setAttribute( Attribute::TYPE, 'button' );
 		$overflow->textContent = $text;
 		return $overflow;

--- a/includes/embeds/class-amp-facebook-embed-handler.php
+++ b/includes/embeds/class-amp-facebook-embed-handler.php
@@ -102,7 +102,8 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 				'layout'    => 'responsive',
 				'width'     => $this->args['width'],
 				'height'    => $this->args['height'],
-			]
+			],
+			$this->create_overflow_button_markup()
 		);
 	}
 
@@ -248,6 +249,8 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			$amp_tag,
 			$attributes
 		);
+
+		$amp_facebook_node->appendChild( $this->create_overflow_button_element( $dom ) );
 
 		$fallback = null;
 		foreach ( $node->childNodes as $child_node ) {

--- a/includes/embeds/class-amp-instagram-embed-handler.php
+++ b/includes/embeds/class-amp-instagram-embed-handler.php
@@ -115,7 +115,8 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 				'layout'         => 'responsive',
 				'width'          => $this->args['width'],
 				'height'         => $this->args['height'],
-			]
+			],
+			$this->create_overflow_button_markup()
 		);
 	}
 
@@ -188,6 +189,7 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 			}
 
 			$new_node = AMP_DOM_Utils::create_node( $dom, $this->amp_tag, $node_args );
+			$new_node->appendChild( $this->create_overflow_button_element( $dom ) );
 		} else {
 			$new_node = AMP_DOM_Utils::create_node(
 				$dom,

--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -6,6 +6,8 @@
  */
 
 use AmpProject\Dom\Document;
+use AmpProject\Tag;
+use AmpProject\Attribute;
 
 /**
  * Class AMP_Twitter_Embed_Handler
@@ -103,7 +105,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$this->did_convert_elements = true;
 
-		return AMP_HTML_Utils::build_tag( $this->amp_tag, $attributes );
+		return AMP_HTML_Utils::build_tag( $this->amp_tag, $attributes, $this->create_overflow_button_markup() );
 	}
 
 	/**
@@ -178,6 +180,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			$this->amp_tag,
 			$attributes
 		);
+
+		$new_node->appendChild( $this->create_overflow_button_element( $dom ) );
 
 		/**
 		 * Placeholder element to append to the new node.

--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -6,8 +6,6 @@
  */
 
 use AmpProject\Dom\Document;
-use AmpProject\Tag;
-use AmpProject\Attribute;
 
 /**
  * Class AMP_Twitter_Embed_Handler

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -71,6 +71,8 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_raw_embed_dataset() {
+		$overflow_button = '<button overflow type="button">See more</button>';
+
 		return [
 			'no_embed_blockquote'           => [
 				'<p>Hello world.</p>',
@@ -84,27 +86,27 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 
 			'simple_url_https'              => [
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				'<amp-facebook data-href="https://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook>' . PHP_EOL,
+				'<amp-facebook data-href="https://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400">' . $overflow_button . '</amp-facebook>' . PHP_EOL,
 			],
 
 			'notes_url'                     => [
 				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
-				'<amp-facebook data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" layout="responsive" width="600" height="400"></amp-facebook>' . PHP_EOL,
+				'<amp-facebook data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" layout="responsive" width="600" height="400">' . $overflow_button . '</amp-facebook>' . PHP_EOL,
 			],
 
 			'photo_url'                     => [
 				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
-				'<amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400"></amp-facebook>' . PHP_EOL,
+				'<amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400">' . $overflow_button . '</amp-facebook>' . PHP_EOL,
 			],
 
 			'video_url'                     => [
 				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
-				'<amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400"></amp-facebook>' . PHP_EOL,
+				'<amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400">' . $overflow_button . '</amp-facebook>' . PHP_EOL,
 			],
 
 			'post_embed'                    => [
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
-				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive"></amp-facebook>',
+				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive">' . $overflow_button . '</amp-facebook>',
 			],
 
 			'post_with_fallbacks'           => [
@@ -115,6 +117,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 				',
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/"  data-show-text="true" data-embed-as="post" layout="responsive">
+						' . $overflow_button . '
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore" fallback=""><!--blockquote_contents--></blockquote>
 					</amp-facebook>
 				',
@@ -122,7 +125,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 
 			'video_embed'                   => [
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
-				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video" layout="responsive"></amp-facebook>',
+				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video" layout="responsive">' . $overflow_button . '</amp-facebook>',
 			],
 
 			'page_embed'                    => [
@@ -135,6 +138,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 				',
 				'
 					<amp-facebook-page width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false" layout="responsive">
+						' . $overflow_button . '
 						<div class="fb-xfbml-parse-ignore" fallback="">
 							<blockquote cite="https://www.facebook.com/xwp.co/"><!--blockquote_contents--></blockquote>
 						</div>
@@ -146,9 +150,7 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 				'
 					<div class="fb-like" data-href="https://developers.facebook.com/docs/plugins/" data-width="400" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
 				',
-				'
-					<amp-facebook-like width="400" height="400" data-href="https://developers.facebook.com/docs/plugins/" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true" layout="responsive">
-					</amp-facebook-like>
+				'<amp-facebook-like width="400" height="400" data-href="https://developers.facebook.com/docs/plugins/" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true" layout="responsive">' . $overflow_button . '</amp-facebook-like>
 				',
 			],
 
@@ -156,28 +158,28 @@ class AMP_Facebook_Embed_Handler_Test extends WP_UnitTestCase {
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></div>
 				',
-				'<amp-facebook-comments width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="responsive"></amp-facebook-comments>',
+				'<amp-facebook-comments width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="responsive">' . $overflow_button . '</amp-facebook-comments>',
 			],
 
 			'comments_full_width'           => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
 				',
-				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
+				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height">' . $overflow_button . '</amp-facebook-comments>',
 			],
 
 			'comments_full_width_2'         => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-height="123" data-width="100%" data-numposts="5"></div>
 				',
-				'<amp-facebook-comments width="auto" height="123" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
+				'<amp-facebook-comments width="auto" height="123" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height">' . $overflow_button . '</amp-facebook-comments>',
 			],
 
 			'comment_embed'                 => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
 				',
-				'<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment" layout="responsive"></amp-facebook>',
+				'<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment" layout="responsive">' . $overflow_button . '</amp-facebook>',
 			],
 
 			'remove_fb_root'                => [

--- a/tests/php/test-amp-instagram-embed-handler.php
+++ b/tests/php/test-amp-instagram-embed-handler.php
@@ -7,6 +7,8 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 	use WithoutBlockPreRendering;
 
 	public function get_conversion_data() {
+		$overflow_button = '<button overflow type="button">See more</button>';
+
 		return [
 			'no_embed'        => [
 				'<p>Hello world.</p>',
@@ -14,23 +16,23 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 			],
 			'simple_url'      => [
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
-				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram></p>' . PHP_EOL,
 			],
 			'simple_tv_url'   => [
 				'https://instagram.com/tv/7-l0z_p4A4/' . PHP_EOL,
-				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram></p>' . PHP_EOL,
 			],
 			'simple_reel_url' => [
 				'https://instagram.com/reel/COWmlFLB_7P/' . PHP_EOL,
-				'<p><amp-instagram data-shortcode="COWmlFLB_7P" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="COWmlFLB_7P" data-captioned layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram></p>' . PHP_EOL,
 			],
 			'short_url'       => [
 				'https://instagr.am/p/7-l0z_p4A4' . PHP_EOL,
-				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram></p>' . PHP_EOL,
 			],
 			'short_tv_url'    => [
 				'https://instagr.am/tv/7-l0z_p4A4' . PHP_EOL,
-				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
+				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram></p>' . PHP_EOL,
 			],
 		];
 	}
@@ -97,6 +99,8 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_raw_embed_dataset() {
+		$overflow_button = '<button overflow type="button">See more</button>';
+
 		return [
 			'no_embed'                               => [
 				'<p>Hello world.</p>',
@@ -109,32 +113,32 @@ class AMP_Instagram_Embed_Handler_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                       => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram>' . "\n\n",
 			],
 
 			'blockquote_tv_embed'                    => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/tv/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram>' . "\n\n",
 			],
 
 			'blockquote_reel_embed'                  => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/reel/COWmlFLB_7P/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="COWmlFLB_7P" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
+				'<amp-instagram data-shortcode="COWmlFLB_7P" layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram>' . "\n\n",
 			],
 
 			'blockquote_embed_notautop'              => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram> ',
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600">' . $overflow_button . '</amp-instagram> ',
 			],
 
 			'blockquote_embed_with_caption'          => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/" data-instgrm-captioned><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned=""></amp-instagram>' . "\n\n",
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned="">' . $overflow_button . '</amp-instagram>' . "\n\n",
 			],
 
 			'blockquote_embed_with_caption_notautop' => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/" data-instgrm-captioned><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned=""></amp-instagram> ',
+				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned="">' . $overflow_button . '</amp-instagram> ',
 			],
 
 			'blockquote_unsupported_permalink'       => [

--- a/tests/php/test-amp-twitter-embed-handler.php
+++ b/tests/php/test-amp-twitter-embed-handler.php
@@ -94,6 +94,8 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
+		$overflow_button = '<button overflow type="button">See more</button>';
+
 		return [
 			'no_embed'                  => [
 				'<p>Hello world.</p>',
@@ -101,27 +103,27 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 			],
 			'url_simple'                => [
 				'https://twitter.com/wordpress/status/987437752164737025' . PHP_EOL,
-				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"987437752164737025\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\"><blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">Celebrate the WordPress 15th Anniversary on May 27 <a href=\"https://t.co/jv62WkI9lr\">https://t.co/jv62WkI9lr</a> <a href=\"https://t.co/4ZECodSK78\">pic.twitter.com/4ZECodSK78</a></p>\n<p>— WordPress (@WordPress) <a href=\"https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw\">April 20, 2018</a></p></blockquote></amp-twitter>\n\n",
+				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"987437752164737025\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\">$overflow_button<blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">Celebrate the WordPress 15th Anniversary on May 27 <a href=\"https://t.co/jv62WkI9lr\">https://t.co/jv62WkI9lr</a> <a href=\"https://t.co/4ZECodSK78\">pic.twitter.com/4ZECodSK78</a></p>\n<p>— WordPress (@WordPress) <a href=\"https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw\">April 20, 2018</a></p></blockquote></amp-twitter>\n\n",
 			],
 			'url_with_big_tweet_id'     => [
 				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
-				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"705219971425574912\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\"><blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">On our way to the <a href=\"https://twitter.com/hashtag/GoogleDance?src=hash&amp;ref_src=twsrc%5Etfw\">#GoogleDance</a>! <a href=\"https://twitter.com/hashtag/SMX?src=hash&amp;ref_src=twsrc%5Etfw\">#SMX</a> 💃🏻 <a href=\"https://t.co/N8kZ9M3eN4\">pic.twitter.com/N8kZ9M3eN4</a></p>\n<p>— Search Engine Land (@sengineland) <a href=\"https://twitter.com/sengineland/status/705219971425574912?ref_src=twsrc%5Etfw\">March 3, 2016</a></p></blockquote></amp-twitter>\n\n",
+				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"705219971425574912\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\">$overflow_button<blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">On our way to the <a href=\"https://twitter.com/hashtag/GoogleDance?src=hash&amp;ref_src=twsrc%5Etfw\">#GoogleDance</a>! <a href=\"https://twitter.com/hashtag/SMX?src=hash&amp;ref_src=twsrc%5Etfw\">#SMX</a> 💃🏻 <a href=\"https://t.co/N8kZ9M3eN4\">pic.twitter.com/N8kZ9M3eN4</a></p>\n<p>— Search Engine Land (@sengineland) <a href=\"https://twitter.com/sengineland/status/705219971425574912?ref_src=twsrc%5Etfw\">March 3, 2016</a></p></blockquote></amp-twitter>\n\n",
 			],
 			'timeline_url_with_profile' => [
 				'https://twitter.com/wordpress' . PHP_EOL,
-				"<p><amp-twitter data-timeline-source-type=\"profile\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"profile\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\">$overflow_button</amp-twitter></p>\n",
 			],
 			'timeline_url_with_likes'   => [
 				'https://twitter.com/wordpress/likes' . PHP_EOL,
-				"<p><amp-twitter data-timeline-source-type=\"likes\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"likes\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\">$overflow_button</amp-twitter></p>\n",
 			],
 			'timeline_url_with_list'    => [
 				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
-				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"random_list\" data-timeline-owner-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"random_list\" data-timeline-owner-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\">$overflow_button</amp-twitter></p>\n",
 			],
 			'timeline_url_with_list2'   => [
 				'https://twitter.com/robertnyman/lists/web-gdes' . PHP_EOL,
-				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"web-gdes\" data-timeline-owner-screen-name=\"robertnyman\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"web-gdes\" data-timeline-owner-screen-name=\"robertnyman\" layout=\"responsive\" width=\"600\" height=\"480\">$overflow_button</amp-twitter></p>\n",
 			],
 		];
 	}
@@ -192,6 +194,8 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_raw_embed_dataset() {
+		$overflow_button = '<button overflow type="button">See more</button>';
+
 		return [
 			'no_embed'                                => [
 				'<p>Hello world.</p>',
@@ -204,22 +208,22 @@ class AMP_Twitter_Embed_Handler_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                        => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"><blockquote class="twitter-tweet" data-lang="en" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en">' . $overflow_button . '<blockquote class="twitter-tweet" data-lang="en" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_conversation' => [
 				wpautop( '<blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-conversation="none"><blockquote class="twitter-tweet" data-conversation="none" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>— WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-conversation="none">' . $overflow_button . '<blockquote class="twitter-tweet" data-conversation="none" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>— WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_theme'        => [
 				wpautop( '<blockquote class="twitter-tweet" data-theme="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-theme="en"><blockquote class="twitter-tweet" data-theme="en" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>— WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-theme="en">' . $overflow_button . '<blockquote class="twitter-tweet" data-theme="en" placeholder="">' . "\n" . '<p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>' . "\n" . '<p>— WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></p></blockquote></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_not_autop'              => [
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"><blockquote class="twitter-tweet" data-lang="en" placeholder=""><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote></amp-twitter> ',
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en">' . $overflow_button . '<blockquote class="twitter-tweet" data-lang="en" placeholder=""><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>-- WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote></amp-twitter> ',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

As of https://github.com/ampproject/amphtml/pull/35027, Bento versions of `amp-twitter`, `amp-facebook-*`, and `amp-instagram` will require an `overflow` button to resize if they are in the initial viewport. This is to prevent these components from negatively impacting CLS, as they do currently. To prevent the need for users to click the overflow button, we'll eventually need to provide the components the required dimensions up-front as much as possible. See #4729.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
