### PR TITLE
Only unserialize cached response if it is a string

### DIFF
--- a/src/RemoteRequest/CachedRemoteGetRequest.php
+++ b/src/RemoteRequest/CachedRemoteGetRequest.php
@@ -111,7 +111,7 @@ final class CachedRemoteGetRequest implements RemoteGetRequest {
 		$cached_response = get_transient( $cache_key );
 		$headers         = [];
 
-		if ( false !== $cached_response ) {
+		if ( is_string( $cached_response ) ) {
 			if ( PHP_MAJOR_VERSION >= 7 ) {
 				$cached_response = unserialize( $cached_response, [ CachedResponse::class, DateTimeImmutable::class ] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize,PHPCompatibility.FunctionUse.NewFunctionParameters.unserialize_optionsFound
 			} else {

--- a/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
+++ b/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
@@ -24,8 +24,8 @@ class CachedRemoteGetRequestTest extends WP_UnitTestCase {
 	/** @covers ::get() */
 	public function test_get_with_serialized_cached_response() {
 		$url         = 'https://example.com/foo.css';
-		$body        = '';
-		$headers     = [];
+		$body        = 'body {color:red}';
+		$headers     = [ 'content-type' => 'text/css' ];
 		$status_code = 418;
 		$expiry      = new DateTimeImmutable( '+ ' . DAY_IN_SECONDS . ' seconds' );
 
@@ -51,8 +51,8 @@ class CachedRemoteGetRequestTest extends WP_UnitTestCase {
 	/** @covers ::get() */
 	public function test_get_with_unserialized_cached_response() {
 		$url         = 'https://example.com/foo.css';
-		$body        = '';
-		$headers     = [];
+		$body        = 'body {color:red}';
+		$headers     = [ 'content-type' => 'text/css' ];
 		$status_code = 418;
 		$expiry      = new DateTimeImmutable( '+ ' . DAY_IN_SECONDS . ' seconds' );
 
@@ -78,8 +78,8 @@ class CachedRemoteGetRequestTest extends WP_UnitTestCase {
 	/** @covers ::get() */
 	public function test_get_without_cached_response() {
 		$url         = 'https://example.com/foo.css';
-		$body        = '';
-		$headers     = [];
+		$body        = 'body {color:red}';
+		$headers     = [ 'content-type' => 'text/css' ];
 		$status_code = 200;
 
 		$remote_request         = new StubbedRemoteGetRequest( [ $url => $body ] );

--- a/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
+++ b/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests\RemoteRequest;
+
+use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
+use AmpProject\AmpWP\RemoteRequest\CachedResponse;
+use AmpProject\RemoteRequest\RemoteGetRequestResponse;
+use AmpProject\RemoteRequest\StubbedRemoteGetRequest;
+use DateTimeImmutable;
+use WP_UnitTestCase;
+
+/** @coversDefaultClass \AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest */
+class CachedRemoteGetRequestTest extends WP_UnitTestCase {
+
+	/** @var CachedRemoteGetRequest */
+	private $instance;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new CachedRemoteGetRequest( new StubbedRemoteGetRequest( [] ) );
+	}
+
+	/** @covers ::get() */
+	public function test_get_with_serialized_cached_response() {
+		$url         = 'https://example.com/foo.css';
+		$body        = '';
+		$headers     = [];
+		$status_code = 418;
+		$expiry      = new DateTimeImmutable( '+ ' . DAY_IN_SECONDS . ' seconds' );
+
+		$cache_key = CachedRemoteGetRequest::TRANSIENT_PREFIX . md5( CachedRemoteGetRequest::class . $url );
+
+		$cached_response = new CachedResponse( $body, $headers, $status_code, $expiry );
+		add_filter(
+			"pre_transient_${cache_key}",
+			static function () use ( $cached_response ) {
+				return serialize( $cached_response ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+			}
+		);
+
+		$cached_remote_request  = new CachedRemoteGetRequest( new StubbedRemoteGetRequest( [] ) );
+		$cached_remote_response = $cached_remote_request->get( $url );
+
+		$this->assertInstanceOf( RemoteGetRequestResponse::class, $cached_remote_response );
+		$this->assertSame( $body, $cached_remote_response->getBody() );
+		$this->assertSame( $headers, $cached_remote_response->getHeaders() );
+		$this->assertSame( $status_code, $cached_remote_response->getStatusCode() );
+	}
+
+	/** @covers ::get() */
+	public function test_get_with_unserialized_cached_response() {
+		$url         = 'https://example.com/foo.css';
+		$body        = '';
+		$headers     = [];
+		$status_code = 418;
+		$expiry      = new DateTimeImmutable( '+ ' . DAY_IN_SECONDS . ' seconds' );
+
+		$cache_key = CachedRemoteGetRequest::TRANSIENT_PREFIX . md5( CachedRemoteGetRequest::class . $url );
+
+		$cached_response = new CachedResponse( $body, $headers, $status_code, $expiry );
+		add_filter(
+			"pre_transient_${cache_key}",
+			static function () use ( $cached_response ) {
+				return $cached_response;
+			}
+		);
+
+		$cached_remote_request  = new CachedRemoteGetRequest( new StubbedRemoteGetRequest( [] ) );
+		$cached_remote_response = $cached_remote_request->get( $url );
+
+		$this->assertInstanceOf( RemoteGetRequestResponse::class, $cached_remote_response );
+		$this->assertSame( $body, $cached_remote_response->getBody() );
+		$this->assertSame( $headers, $cached_remote_response->getHeaders() );
+		$this->assertSame( $status_code, $cached_remote_response->getStatusCode() );
+	}
+
+	/** @covers ::get() */
+	public function test_get_without_cached_response() {
+		$url         = 'https://example.com/foo.css';
+		$body        = '';
+		$headers     = [];
+		$status_code = 200;
+
+		$remote_request         = new StubbedRemoteGetRequest( [ $url => $body ] );
+		$cached_remote_request  = new CachedRemoteGetRequest( $remote_request );
+		$cached_remote_response = $cached_remote_request->get( $url );
+
+		$this->assertInstanceOf( RemoteGetRequestResponse::class, $cached_remote_response );
+		$this->assertSame( $body, $cached_remote_response->getBody() );
+		$this->assertSame( $headers, $cached_remote_response->getHeaders() );
+		$this->assertSame( $status_code, $cached_remote_response->getStatusCode() );
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6505

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
