### PR TITLE
Allow the `amp-carousel` script to be used on page when there is just `amp-lightbox-gallery`

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1503,6 +1503,16 @@ class AMP_Theme_Support {
 			array_keys( $amp_scripts ),
 			array_merge( $script_handles, [ Amp::RUNTIME ] )
 		);
+
+		// Allow the amp-carousel script as a special case to be on the page when there is no <amp-carousel> since the
+		// amp-lightbox-gallery component will lazy-load the amp-carousel script when a lightbox is opened, and since
+		// amp-carousel v0.1 is still the 'latest' version, this can mean that fixes needed with the 0.2 version won't
+		// be present on the page. Adding the amp-carousel v0.2 script is a stated workaround suggested in an AMP core
+		// issue: <https://github.com/ampproject/amphtml/issues/35402#issuecomment-887837815>.
+		if ( in_array( 'amp-lightbox-gallery', $script_handles, true ) ) {
+			$superfluous_script_handles = array_diff( $superfluous_script_handles, [ 'amp-carousel' ] );
+		}
+
 		foreach ( $superfluous_script_handles as $superfluous_script_handle ) {
 			if ( ! empty( $extension_specs[ $superfluous_script_handle ]['requires_usage'] ) ) {
 				unset( $amp_scripts[ $superfluous_script_handle ] );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1354,7 +1354,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::finish_init();
 
 		// These should all get removed, unless used.
-		$required_usage_grandfathered = [
+		$required_usage_exempted = [
 			'amp-anim',
 			'amp-ad',
 			'amp-mustache',
@@ -1362,6 +1362,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'amp-youtube',
 			'amp-form',
 			'amp-live-list',
+		];
+
+		$conditionally_allowed_usage = [
+			'amp-carousel',
 		];
 
 		// These also should get removed, unless used.
@@ -1384,7 +1388,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		<html>
 			<head></head>
 			<body>
-				<?php wp_print_scripts( array_merge( $required_usage_grandfathered, $required_usage_error, $required_usage_none ) ); ?>
+				<amp-img src="https://example.com/cat.jpg" width="100" height="100" lightbox></amp-img>
+				<amp-img src="https://example.com/dog.jpg" width="100" height="100" lightbox></amp-img>
+				<amp-img src="https://example.com/bird.jpg" width="100" height="100" lightbox></amp-img>
+
+				<?php wp_print_scripts( array_merge( $required_usage_exempted, $conditionally_allowed_usage, $required_usage_error, $required_usage_none ) ); ?>
 				<?php wp_footer(); ?>
 			</body>
 		</html>
@@ -1403,7 +1411,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$expected_script_srcs = [
 			wp_scripts()->registered['amp-runtime']->src,
 		];
-		foreach ( $required_usage_none as $handle ) {
+		foreach ( array_merge( $required_usage_none, $conditionally_allowed_usage ) as $handle ) {
 			$expected_script_srcs[] = wp_scripts()->registered[ $handle ]->src;
 		}
 


### PR DESCRIPTION
## Summary

Allow the amp-carousel script as a special case to be on the page when there is no <amp-carousel> since the
amp-lightbox-gallery component will lazy-load the amp-carousel script when a lightbox is opened, and since
amp-carousel v0.1 is still the 'latest' version, this can mean that fixes needed with the 0.2 version won't
be present on the page. Adding the amp-carousel v0.2 script is a stated workaround suggested in an AMP core
issue: https://github.com/ampproject/amphtml/issues/35402#issuecomment-887837815.

See also https://github.com/ampproject/amp-wp/pull/3115#issuecomment-890130430.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
