### PR TITLE
Use customizable `width`/`height` args on `AMP_Twitter_Embed_Handler` rather than literals/defaults

### DIFF
--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -113,7 +113,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			}
 		}
 
-		$attributes['width']  = $this->args['width'];
+		if ( ! empty( $this->args['width'] ) ) {
+			$attributes['width'] = $this->args['width'];
+		}
 		$attributes['height'] = $this->args['height'];
 		if ( empty( $attributes['width'] ) || 'auto' === $attributes['width'] ) {
 			$attributes['layout'] = 'fixed-height';
@@ -180,12 +182,17 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			return;
 		}
 
-		$attributes = [
-			'width'        => 'auto',
-			'height'       => $this->DEFAULT_HEIGHT,
-			'layout'       => 'fixed-height',
-			'data-tweetid' => $tweet_id,
-		];
+		$attributes = [];
+		if ( ! empty( $this->args['width'] ) ) {
+			$attributes['width'] = $this->args['width'];
+		}
+		$attributes['height'] = $this->args['height'];
+		if ( empty( $attributes['width'] ) || 'auto' === $attributes['width'] ) {
+			$attributes['layout'] = 'fixed-height';
+		} else {
+			$attributes['layout'] = 'responsive';
+		}
+		$attributes['data-tweetid'] = $tweet_id;
 
 		if ( $node->hasAttributes() ) {
 			foreach ( $node->attributes as $attr ) {


### PR DESCRIPTION
This is a follow-up on https://github.com/ampproject/amp-wp/pull/6504, fixing a flaw identified by @pierlon in https://github.com/ampproject/amp-wp/pull/6504/files#r681340739.

Instead of using `auto` as the `width`, it should have been using `$this->args['width]` which by default is `auto` but can be customized.

Similarly, instead of using `DEFAULT_HEIGHT` as the `height`, it should be using `$this->args['height']` which is customizable.