### PR TITLE
Experiment: Add native `img` opt-in to prevent conversion to `amp-img`/`amp-anim`

### DIFF
--- a/assets/css/src/amp-default.css
+++ b/assets/css/src/amp-default.css
@@ -4,8 +4,7 @@
  * width such as in the post content so that the contents do not get stretched or cropped.
  * See <https://github.com/ampproject/amphtml/issues/21371#issuecomment-475443219>.
  */
-amp-img.amp-wp-enforced-sizes,
-amp-anim.amp-wp-enforced-sizes {
+.amp-wp-unknown-size {
 	object-fit: contain;
 }
 

--- a/assets/css/src/amp-default.css
+++ b/assets/css/src/amp-default.css
@@ -4,6 +4,8 @@
  * width such as in the post content so that the contents do not get stretched or cropped.
  * See <https://github.com/ampproject/amphtml/issues/21371#issuecomment-475443219>.
  */
+amp-img.amp-wp-enforced-sizes,
+amp-anim.amp-wp-enforced-sizes,
 .amp-wp-unknown-size {
 	object-fit: contain;
 }

--- a/assets/css/src/amp-default.css
+++ b/assets/css/src/amp-default.css
@@ -4,7 +4,8 @@
  * width such as in the post content so that the contents do not get stretched or cropped.
  * See <https://github.com/ampproject/amphtml/issues/21371#issuecomment-475443219>.
  */
-.amp-wp-enforced-sizes {
+amp-img.amp-wp-enforced-sizes,
+amp-anim.amp-wp-enforced-sizes {
 	object-fit: contain;
 }
 

--- a/assets/css/src/amp-playlist-shortcode.css
+++ b/assets/css/src/amp-playlist-shortcode.css
@@ -2,10 +2,6 @@
 * For the custom AMP implementation of the 'playlist' shortcode.
 */
 .wp-playlist .wp-playlist-current-item img {
-	margin-right: 0;
-}
-
-.wp-playlist .wp-playlist-current-item amp-img {
 	float: left;
 	margin-right: 10px;
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1330,6 +1330,28 @@ function amp_is_dev_mode() {
 }
 
 /**
+ * Determine whether native `img` should be used instead of converting to `amp-img`.
+ *
+ * @since 2.2
+ *
+ * @return bool Whether to use `img`.
+ */
+function amp_is_using_native_img() {
+	/**
+	 * Filters whether to use the native `img` element rather than convert to `amp-img`.
+	 *
+	 * This filter is a feature flag to opt-in to discontinue using `amp-img` (and `amp-anim`) which will be deprecated
+	 * in AMP in the near future. Once this lands in AMP, this filter will switch to defaulting to true instead of false.
+	 *
+	 * @since 2.2
+	 * @link https://github.com/ampproject/amphtml/issues/30442
+	 *
+	 * @param bool $use_native Whether to use `img`.
+	 */
+	return (bool) apply_filters( 'amp_using_native_img', false );
+}
+
+/**
  * Get content sanitizers.
  *
  * @since 0.7
@@ -1373,6 +1395,8 @@ function amp_get_content_sanitizers( $post = null ) {
 		AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT )
 	);
 
+	$using_native_img = amp_is_using_native_img();
+
 	$sanitizers = [
 		'AMP_Embed_Sanitizer'             => [
 			'amp_to_amp_linking_enabled' => $amp_to_amp_linking_enabled,
@@ -1383,10 +1407,12 @@ function amp_get_content_sanitizers( $post = null ) {
 			'theme_features' => [
 				'force_svg_support' => [], // Always replace 'no-svg' class with 'svg' if it exists.
 			],
+			'use_native_img' => $using_native_img,
 		],
 		'AMP_Srcset_Sanitizer'            => [],
 		'AMP_Img_Sanitizer'               => [
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
+			'use_native_img'     => $using_native_img,
 		],
 		'AMP_Form_Sanitizer'              => [],
 		'AMP_Comments_Sanitizer'          => [

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1325,9 +1325,6 @@ function amp_is_dev_mode() {
 			( is_admin_bar_showing() && is_user_logged_in() )
 			||
 			is_customize_preview()
-			||
-			// Force dev mode when using native images since it prevents raising validation errors on img elements.
-			amp_is_using_native_img()
 		)
 	);
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1430,6 +1430,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		'AMP_Gallery_Block_Sanitizer'     => [ // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
 			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
+			'use_native_img'    => $using_native_img,
 		],
 		'AMP_Block_Sanitizer'             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
 		'AMP_Script_Sanitizer'            => [],

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1325,6 +1325,9 @@ function amp_is_dev_mode() {
 			( is_admin_bar_showing() && is_user_logged_in() )
 			||
 			is_customize_preview()
+			||
+			// Force dev mode when using native images since it's currently used as the mechanism to prevent removal.
+			amp_is_using_native_img()
 		)
 	);
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1326,7 +1326,7 @@ function amp_is_dev_mode() {
 			||
 			is_customize_preview()
 			||
-			// Force dev mode when using native images since it's currently used as the mechanism to prevent removal.
+			// Force dev mode when using native images since it prevents raising validation errors on img elements.
 			amp_is_using_native_img()
 		)
 	);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2092,7 +2092,7 @@ class AMP_Theme_Support {
 			return esc_html__( 'Redirecting since AMP version not available.', 'amp' );
 		}
 
-		// Prevent serving an AMP-marked page when it is not in dev mode and we know it is going to be invalid.
+		// Prevent serving an AMP-marked page when using native img since not yet AMP-valid to avoid search engines from flagging.
 		// @todo This should be removed when native <img> is allowed in AMP. See <https://github.com/ampproject/amphtml/issues/30442>.
 		if ( amp_is_using_native_img() && ! is_user_logged_in() ) {
 			$dom->documentElement->removeAttribute( Attribute::AMP );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2092,9 +2092,9 @@ class AMP_Theme_Support {
 			return esc_html__( 'Redirecting since AMP version not available.', 'amp' );
 		}
 
-		// Prevent serving an AMP-marked page when using native img since not yet AMP-valid to avoid search engines from flagging.
-		// @todo This should be removed when native <img> is allowed in AMP. See <https://github.com/ampproject/amphtml/issues/30442>.
-		if ( amp_is_using_native_img() && ! is_user_logged_in() ) {
+		// Prevent serving a page in Dev Mode as being marked as AMP when the user is not logged-in to avoid it from
+		// being flagged as invalid by Google Search Console.
+		if ( amp_is_dev_mode() && ! is_user_logged_in() ) {
 			$dom->documentElement->removeAttribute( Attribute::AMP );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI_ALT );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2094,7 +2094,7 @@ class AMP_Theme_Support {
 
 		// Prevent serving an AMP-marked page when it is not in dev mode and we know it is going to be invalid.
 		// @todo This should be removed when native <img> is allowed in AMP. See <https://github.com/ampproject/amphtml/issues/30442>.
-		if ( amp_is_using_native_img() && ! amp_is_dev_mode() ) {
+		if ( amp_is_using_native_img() && ! is_user_logged_in() ) {
 			$dom->documentElement->removeAttribute( Attribute::AMP );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI_ALT );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -14,6 +14,7 @@ use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\ConfigurationArgument;
 use AmpProject\AmpWP\Services;
 use AmpProject\Attribute;
+use AmpProject\DevMode;
 use AmpProject\Dom\Document;
 use AmpProject\Extension;
 use AmpProject\Optimizer;
@@ -2094,7 +2095,7 @@ class AMP_Theme_Support {
 
 		// Prevent serving a page in Dev Mode as being marked as AMP when the user is not logged-in to avoid it from
 		// being flagged as invalid by Google Search Console.
-		if ( amp_is_dev_mode() && ! is_user_logged_in() ) {
+		if ( $dom->documentElement->hasAttribute( DevMode::DEV_MODE_ATTRIBUTE ) && ! is_user_logged_in() ) {
 			$dom->documentElement->removeAttribute( Attribute::AMP );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI_ALT );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2092,6 +2092,14 @@ class AMP_Theme_Support {
 			return esc_html__( 'Redirecting since AMP version not available.', 'amp' );
 		}
 
+		// Prevent serving an AMP-marked page when it is not in dev mode and we know it is going to be invalid.
+		// @todo This should be removed when native <img> is allowed in AMP. See <https://github.com/ampproject/amphtml/issues/30442>.
+		if ( amp_is_using_native_img() && ! amp_is_dev_mode() ) {
+			$dom->documentElement->removeAttribute( Attribute::AMP );
+			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI );
+			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI_ALT );
+		}
+
 		$response = $dom->saveHTML();
 
 		/**

--- a/includes/embeds/class-amp-gallery-embed-handler.php
+++ b/includes/embeds/class-amp-gallery-embed-handler.php
@@ -24,7 +24,6 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function register_embed() {
 		add_filter( 'post_gallery', [ $this, 'generate_gallery_markup' ], 10, 2 );
-		add_action( 'wp_print_styles', [ $this, 'print_styles' ] );
 	}
 
 	/**
@@ -123,7 +122,6 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function unregister_embed() {
 		remove_filter( 'post_gallery', [ $this, 'generate_gallery_markup' ] );
-		remove_action( 'wp_print_styles', [ $this, 'print_styles' ] );
 	}
 
 	/**
@@ -199,24 +197,5 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		return $parent_element;
-	}
-
-	/**
-	 * Prints the Gallery block styling.
-	 *
-	 * It would be better to print this in AMP_Gallery_Block_Sanitizer,
-	 * but by the time that runs, it's too late.
-	 * This rule is copied exactly from block-library/style.css, but the selector here has amp-img >.
-	 * The image sanitizer normally converts the <img> from that original stylesheet <amp-img>,
-	 * but that doesn't have the same effect as applying it to the <img>.
-	 */
-	public function print_styles() {
-		?>
-		<style>
-			.wp-block-gallery.is-cropped .blocks-gallery-item amp-img > img {
-				object-fit: cover;
-			}
-		</style>
-		<?php
 	}
 }

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -176,7 +176,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 					<div>
 						<div class="wp-playlist-current-item">
 							<?php if ( $image_url ) : ?>
-								<amp-img src="<?php echo esc_url( $image_url ); ?>" height="<?php echo esc_attr( $dimensions['height'] ); ?>" width="<?php echo esc_attr( $dimensions['width'] ); ?>"></amp-img>
+								<img src="<?php echo esc_url( $image_url ); ?>" height="<?php echo esc_attr( $dimensions['height'] ); ?>" width="<?php echo esc_attr( $dimensions['width'] ); ?>">
 							<?php endif; ?>
 							<div class="wp-playlist-caption">
 								<span class="wp-playlist-item-meta wp-playlist-item-title"><?php echo esc_html( $title ); ?></span>

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -807,7 +807,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Add required styles for featured image header and image blocks in Twenty Twenty.
+	 * Add required styles for featured image header in Twenty Twenty.
 	 *
 	 * @param array $args Args.
 	 */
@@ -816,6 +816,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
+		// @todo This was introduced in <https://github.com/ampproject/amp-wp/commit/e1c7462> but it doesn't seem to have any effect.
 		add_action(
 			'wp_enqueue_scripts',
 			static function() {
@@ -824,10 +825,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				<style>
 				.featured-media amp-img {
 					position: static;
-				}
-
-				.wp-block-image img {
-					display: block;
 				}
 				</style>
 				<?php

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -29,6 +29,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type string $stylesheet     Stylesheet slug.
 	 *      @type string $template       Template slug.
 	 *      @type array  $theme_features List of theme features that need to be applied. Features are method names,
+	 *      @type bool   $use_native_img Whether to use native img.
 	 * }
 	 */
 	protected $args;
@@ -76,9 +77,10 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.5.0 Converted `theme_features` variable into `get_theme_config` function.
 	 *
 	 * @param string $theme_slug Theme slug.
+	 * @param array  $args       Sanitizer args.
 	 * @return array|null Array comprising of the theme config if its slug is found, null if it is not.
 	 */
-	protected static function get_theme_features_config( $theme_slug ) {
+	protected static function get_theme_features_config( $theme_slug, $args = [] ) {
 		switch ( $theme_slug ) {
 			case 'twentytwentyone':
 				$config = [
@@ -135,9 +137,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'add_twentytwenty_modals'          => [],
 					'add_twentytwenty_toggles'         => [],
 					'add_nav_menu_styles'              => [],
-					'add_twentytwenty_masthead_styles' => [],
-					'add_img_display_block_fix'        => [],
-					'add_twentytwenty_custom_logo_fix' => [],
+					'add_twentytwenty_masthead_styles' => $args,
+					'add_img_display_block_fix'        => $args,
+					'add_twentytwenty_custom_logo_fix' => $args,
 					'add_twentytwenty_current_page_awareness' => [],
 				];
 
@@ -188,7 +190,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					],
 					'force_fixed_background_support'      => [],
 					'add_twentyseventeen_masthead_styles' => [],
-					'add_twentyseventeen_image_styles'    => [],
+					'add_twentyseventeen_image_styles'    => $args,
 					'add_twentyseventeen_sticky_nav_menu' => [],
 					'add_has_header_video_body_class'     => [],
 					'add_nav_menu_styles'                 => [
@@ -199,7 +201,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						'//header[@id = "masthead"]//a[ contains( @class, "menu-scroll-down" ) ]',
 					],
 					'set_twentyseventeen_quotes_icon'     => [],
-					'add_twentyseventeen_attachment_image_attributes' => [],
+					'add_twentyseventeen_attachment_image_attributes' => $args,
 				];
 
 			// Twenty Sixteen.
@@ -489,7 +491,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$theme_candidates = wp_array_slice_assoc( $args, [ 'stylesheet', 'template' ] );
 		foreach ( $theme_candidates as $theme_candidate ) {
 			if ( in_array( $theme_candidate, self::$supported_themes, true ) ) {
-				$theme_features = self::get_theme_features_config( $theme_candidate );
+				$theme_features = self::get_theme_features_config( $theme_candidate, $args );
 				break;
 			}
 		}
@@ -563,8 +565,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 1.0
 	 * @link https://github.com/WordPress/wordpress-develop/blob/ddc8f803c6e99118998191fd2ea24124feb53659/src/wp-content/themes/twentyseventeen/functions.php#L545:L554
+	 *
+	 * @param array $args Args.
 	 */
-	public static function add_twentyseventeen_attachment_image_attributes() {
+	public static function add_twentyseventeen_attachment_image_attributes( $args = [] ) {
+		if ( ! empty( $args['use_native_img'] ) ) {
+			return;
+		}
+
 		/*
 		 * The max-height of the `.custom-logo-link img` is defined as being 80px, unless
 		 * there is header media in which case it is 200px. Issues related to vertically-squashed
@@ -800,8 +808,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
 	 * Add required styles for featured image header and image blocks in Twenty Twenty.
+	 *
+	 * @param array $args Args.
 	 */
-	public static function add_twentytwenty_masthead_styles() {
+	public static function add_twentytwenty_masthead_styles( $args = [] ) {
+		if ( ! empty( $args['use_native_img'] ) ) {
+			return;
+		}
+
 		add_action(
 			'wp_enqueue_scripts',
 			static function() {
@@ -833,8 +847,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.5
 	 * @link https://github.com/ampproject/amp-wp/issues/4418
 	 * @link https://codepen.io/westonruter/pen/rNVqadv
+	 *
+	 * @param array $args Args.
 	 */
-	public static function add_twentytwenty_custom_logo_fix() {
+	public static function add_twentytwenty_custom_logo_fix( $args = [] ) {
+		if ( ! empty( $args['use_native_img'] ) ) {
+			return;
+		}
+
 		$method = __METHOD__;
 		add_filter(
 			'get_custom_logo',
@@ -885,8 +905,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 1.5
 	 * @link https://github.com/ampproject/amp-wp/issues/4419
+	 *
+	 * @param array $args Args.
 	 */
-	public static function add_img_display_block_fix() {
+	public static function add_img_display_block_fix( $args = [] ) {
+		if ( ! empty( $args['use_native_img'] ) ) {
+			return;
+		}
+
 		$method = __METHOD__;
 		// Note that wp_add_inline_style() is not used because this stylesheet needs to be added _before_ style.css so
 		// that any subsequent style rules for images will continue to override.
@@ -964,8 +990,14 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 1.0
 	 * @link https://github.com/WordPress/wordpress-develop/blob/1af1f65a21a1a697fb5f33027497f9e5ae638453/src/wp-content/themes/twentyseventeen/style.css#L2100
+	 *
+	 * @param array $args Args.
 	 */
-	public static function add_twentyseventeen_image_styles() {
+	public static function add_twentyseventeen_image_styles( $args = [] ) {
+		if ( ! empty( $args['use_native_img'] ) ) {
+			return;
+		}
+
 		add_action(
 			'wp_enqueue_scripts',
 			static function() {
@@ -1344,7 +1376,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						padding-top: 0; /* Override responsive hack which is handled by AMP layout. */
 						overflow: visible;
 					}
-					.featured-content .post-thumbnail amp-img {
+					.featured-content .post-thumbnail .wp-post-image {
 						position: static;
 						left: auto;
 						top: auto;
@@ -1420,7 +1452,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 							font-size: 32px;
 							line-height: 46px;
 						}
-						.featured-content .post-thumbnail amp-img {
+						.featured-content .post-thumbnail .wp-post-image {
 							object-fit: cover;
 							object-position: top;
 						}
@@ -1430,7 +1462,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 								float: none;
 								margin: 0;
 							}
-							.featured-content .post-thumbnail amp-img {
+							.featured-content .post-thumbnail .wp-post-image {
 								height: 55.49132947vw;
 							}
 							.slider-control-paging li {

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -190,7 +190,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					],
 					'force_fixed_background_support'      => [],
 					'add_twentyseventeen_masthead_styles' => [],
-					'add_twentyseventeen_image_styles'    => $args,
 					'add_twentyseventeen_sticky_nav_menu' => [],
 					'add_has_header_video_body_class'     => [],
 					'add_nav_menu_styles'                 => [
@@ -971,44 +970,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						transform: translateY( -<?php echo (int) AMP_Core_Theme_Sanitizer::get_twentyseventeen_navigation_outer_height(); ?>px );
 						display: block;
 					}
-				}
-				</style>
-				<?php
-				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
-				wp_add_inline_style( get_template() . '-style', $styles );
-			},
-			11
-		);
-	}
-
-	/**
-	 * Override the featured image header styling in style.css.
-	 * Used only for Twenty Seventeen.
-	 *
-	 * @since 1.0
-	 * @link https://github.com/WordPress/wordpress-develop/blob/1af1f65a21a1a697fb5f33027497f9e5ae638453/src/wp-content/themes/twentyseventeen/style.css#L2100
-	 *
-	 * @param array $args Args.
-	 */
-	public static function add_twentyseventeen_image_styles( $args = [] ) {
-		if ( ! empty( $args['use_native_img'] ) ) {
-			return;
-		}
-
-		add_action(
-			'wp_enqueue_scripts',
-			static function() {
-				ob_start();
-				?>
-				<style>
-				/* Override the display: block in twentyseventeen/style.css, as <amp-img> is usually inline-block. */
-				.single-featured-image-header amp-img {
-					display: inline-block;
-				}
-
-				/* Because the <amp-img> is inline-block, its container needs this rule to center it. */
-				.single-featured-image-header {
-					text-align: center;
 				}
 				</style>
 				<?php

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -43,6 +43,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array {
 	 *      @type int  $content_max_width Max width of content.
 	 *      @type bool $carousel_required Whether carousels are required. This is used when amp theme support is not present, for back-compat.
+	 *      @type bool $use_native_img    Whether native img is being used.
 	 * }
 	 */
 	protected $args;
@@ -54,6 +55,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	protected $DEFAULT_ARGS = [
 		'carousel_required' => false,
+		'native_img'        => false,
 	];
 
 	/**
@@ -97,7 +99,10 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 				$gallery_node->setAttribute( 'data-amp-carousel', 'true' );
 			}
 
-			$img_elements = $this->dom->xpath->query( './/amp-img | .//img[ not( parent::noscript ) ]', $node );
+			$img_elements = $this->dom->xpath->query(
+				empty( $this->args['use_native_img'] ) ? './/amp-img | .//amp-anim' : './/img',
+				$node
+			);
 
 			$this->process_gallery_embed( $is_amp_carousel, $is_amp_lightbox, $node, $img_elements );
 		}

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -97,7 +97,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 				$gallery_node->setAttribute( 'data-amp-carousel', 'true' );
 			}
 
-			$img_elements = $node->getElementsByTagName( 'amp-img' );
+			$img_elements = $this->dom->xpath->query( './/amp-img | .//img[ not( parent::noscript ) ]', $node );
 
 			$this->process_gallery_embed( $is_amp_carousel, $is_amp_lightbox, $node, $img_elements );
 		}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -69,6 +69,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
+		if ( $this->args['use_native'] ) {
+			return [];
+		}
 		return [
 			Tag::IMG => [
 				'amp-img',

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -329,7 +329,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function adjust_and_replace_node( DOMElement $node ) {
 		if ( $this->args['use_native_img'] ) {
-			$attributes = $this->maybe_add_lightbox_attributes( [], $node );
+			$attributes = $this->maybe_add_lightbox_attributes( [], $node ); // @todo AMP doesn't support lightbox on <img> yet.
 
 			// Set decoding=async by default. See <https://core.trac.wordpress.org/ticket/53232>.
 			if ( ! $node->hasAttribute( Attribute::DECODING ) ) {
@@ -338,6 +338,13 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 			// @todo Remove once https://github.com/ampproject/amphtml/issues/30442 lands.
 			$attributes[ DevMode::DEV_MODE_ATTRIBUTE ] = '';
+
+			// @todo This class should really only be added if we actually have to provide dimensions.
+			$attributes[ Attribute::CLASS_ ] = (string) $node->getAttribute( Attribute::CLASS_ );
+			if ( ! empty( $attributes[ Attribute::CLASS_ ] ) ) {
+				$attributes[ Attribute::CLASS_ ] .= ' ';
+			}
+			$attributes[ Attribute::CLASS_ ] .= 'amp-wp-enforced-sizes';
 
 			foreach ( $attributes as $name => $value ) {
 				$node->setAttribute( $name, $value );

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -336,8 +336,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				$attributes[ Attribute::DECODING ] = 'async';
 			}
 
+			// Opt-in to dev mode to prevent raising validation errors for an intentionally invalid <img>.
+			// It doesn't make sense to raise a validation error to allow the user to decide whether to convert from
+			// <img> to <amp-img> since the use_native_img arg is the opt-in to not do any such conversion.
 			// @todo Remove once https://github.com/ampproject/amphtml/issues/30442 lands.
 			$attributes[ DevMode::DEV_MODE_ATTRIBUTE ] = '';
+			$this->dom->documentElement->setAttribute( DevMode::DEV_MODE_ATTRIBUTE, '' );
 
 			// @todo This class should really only be added if we actually have to provide dimensions.
 			$attributes[ Attribute::CLASS_ ] = (string) $node->getAttribute( Attribute::CLASS_ );

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1575,7 +1575,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				[ 'should_locate_sources', 'parsed_cache_variant', 'dynamic_element_selectors' ]
 			),
 			[
-				'language' => get_bloginfo( 'language' ), // Used to tree-shake html[lang] selectors.
+				'language'          => get_bloginfo( 'language' ), // Used to tree-shake html[lang] selectors.
+				'selector_mappings' => $this->selector_mappings,
 			]
 		);
 

--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -136,7 +136,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional, HasReq
 	 * Initialize frontend.
 	 */
 	public function init_frontend() {
-		if ( ! amp_is_available() || ! amp_is_dev_mode() ) {
+		if ( ! amp_is_available() || ! amp_is_dev_mode() || ! is_user_logged_in() ) {
 			return;
 		}
 

--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -12,6 +12,7 @@ use AMP_Theme_Support;
 use AMP_Validation_Manager;
 use AMP_Validated_URL_Post_Type;
 use AmpProject\AmpWP\Infrastructure\Conditional;
+use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\HasRequirements;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
@@ -30,7 +31,7 @@ use AmpProject\AmpWP\DevTools\UserAccess;
  * @since 2.1
  * @internal
  */
-final class PairedBrowsing implements Service, Registerable, Conditional, HasRequirements {
+final class PairedBrowsing implements Service, Registerable, Conditional, Delayed, HasRequirements {
 
 	/**
 	 * Query var for requests to open the app.
@@ -54,6 +55,18 @@ final class PairedBrowsing implements Service, Registerable, Conditional, HasReq
 	public $paired_routing;
 
 	/**
+	 * Get the action to use for registering the service.
+	 *
+	 * This action needs to run late enough in the frontend and the backend for the user to be logged-in and for
+	 * AMP dev mode to be opted-in to.
+	 *
+	 * @return string Registration action to use.
+	 */
+	public static function get_registration_action() {
+		return 'wp_loaded';
+	}
+
+	/**
 	 * Check whether the conditional object is currently needed.
 	 *
 	 * @return bool Whether the conditional object is needed.
@@ -71,6 +84,10 @@ final class PairedBrowsing implements Service, Registerable, Conditional, HasReq
 					get_stylesheet() === AMP_Options_Manager::get_option( Option::READER_THEME )
 				)
 			)
+			&&
+			amp_is_dev_mode()
+			&&
+			is_user_logged_in()
 		);
 	}
 
@@ -136,7 +153,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional, HasReq
 	 * Initialize frontend.
 	 */
 	public function init_frontend() {
-		if ( ! amp_is_available() || ! amp_is_dev_mode() || ! is_user_logged_in() ) {
+		if ( ! amp_is_available() ) {
 			return;
 		}
 
@@ -291,13 +308,6 @@ final class PairedBrowsing implements Service, Registerable, Conditional, HasReq
 	 * @return string Custom template if in paired browsing mode, else the supplied template.
 	 */
 	public function filter_template_include_for_app() {
-		if ( ! amp_is_dev_mode() ) {
-			wp_die(
-				esc_html__( 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).', 'amp' ),
-				esc_html__( 'AMP Paired Browsing Unavailable', 'amp' ),
-				[ 'response' => 403 ]
-			);
-		}
 
 		/** This action is documented in includes/class-amp-theme-support.php */
 		do_action( 'amp_register_polyfills' );

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -591,7 +591,7 @@ final class MobileRedirection implements Service, Registerable {
 			</a>
 		</div>
 
-		<?php if ( amp_is_dev_mode() && ( ! is_customize_preview() || AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) ) : ?>
+		<?php if ( amp_is_dev_mode() && is_user_logged_in() && ( ! is_customize_preview() || AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) ) : ?>
 			<?php
 			// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions.
 			$exports = [

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -268,7 +268,7 @@ final class MobileRedirection implements Service, Registerable {
 	 * @return bool True if mobile redirection should be done, false otherwise.
 	 */
 	public function is_using_client_side_redirection() {
-		if ( is_customize_preview() || amp_is_dev_mode() ) {
+		if ( is_customize_preview() || ( amp_is_dev_mode() && is_user_logged_in() ) ) {
 			return true;
 		}
 

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -268,7 +268,7 @@ final class MobileRedirection implements Service, Registerable {
 	 * @return bool True if mobile redirection should be done, false otherwise.
 	 */
 	public function is_using_client_side_redirection() {
-		if ( is_customize_preview() || ( amp_is_dev_mode() && is_user_logged_in() ) ) {
+		if ( is_customize_preview() || Services::has( 'admin.paired_browsing' ) ) {
 			return true;
 		}
 
@@ -591,19 +591,32 @@ final class MobileRedirection implements Service, Registerable {
 			</a>
 		</div>
 
-		<?php if ( amp_is_dev_mode() && is_user_logged_in() && ( ! is_customize_preview() || AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) ) : ?>
-			<?php
-			// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions.
+		<?php
+		// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions,
+		// and because there are controls which are AMP-specific which don't apply when switching between versions.
+		$is_amp_reader_customizer = (
+			is_customize_preview()
+			&&
+			AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT )
+		);
+
+		$is_possibly_paired_browsing = (
+			Services::has( 'admin.paired_browsing' )
+			&&
+			! is_customize_preview()
+		);
+
+		if ( $is_amp_reader_customizer || $is_possibly_paired_browsing ) :
 			$exports = [
-				'containerId'          => $container_id,
-				'isCustomizePreview'   => is_customize_preview(),
-				'notApplicableMessage' => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
+				'containerId'              => $container_id,
+				'isReaderCustomizePreview' => $is_amp_reader_customizer,
+				'notApplicableMessage'     => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
 			];
 			?>
 			<script data-ampdevmode>
-			(function( { containerId, isCustomizePreview, notApplicableMessage } ) {
+			(function( { containerId, isReaderCustomizePreview, notApplicableMessage } ) {
 				addEventListener( 'DOMContentLoaded', () => {
-					if ( isCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
+					if ( isReaderCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
 						const link = document.querySelector( `#${containerId} a[href]` );
 						link.style.cursor = 'not-allowed';
 						link.addEventListener( 'click', ( event ) => {

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -54,7 +54,7 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		add_filter( 'amp_dev_mode_enabled', '__return_false' );
 		$this->assertFalse( PairedBrowsing::is_needed() );
 		remove_filter( 'amp_dev_mode_enabled', '__return_false' );
-		$this->assertTrue( PairedBrowsing::is_needed() );
+		$this->assertSame( Services::get( 'dependency_support' )->has_support(), PairedBrowsing::is_needed() );
 
 		// Case where Reader theme is set to be the same as the active theme.
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -131,6 +131,7 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 	 * @covers ::init_app()
 	 */
 	public function test_init_frontend_app() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post = self::factory()->post->create_and_get();
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		$this->go_to( add_query_arg( PairedBrowsing::APP_QUERY_VAR, '1', get_permalink( $post ) ) );
@@ -153,6 +154,7 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 	 * @covers ::init_client()
 	 */
 	public function test_init_frontend_client() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post = self::factory()->post->create_and_get();
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -11,6 +11,7 @@ use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AmpProject\AmpWP\Admin\PairedBrowsing;
 use AmpProject\AmpWP\Infrastructure\Conditional;
+use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\HasRequirements;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
@@ -20,7 +21,6 @@ use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AmpProject\DevMode;
-use WPDieException;
 use WP_Admin_Bar;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Admin\PairedBrowsing */
@@ -44,12 +44,21 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		$this->assertFalse( PairedBrowsing::is_needed() );
 
+		$admin_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_user_id );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		$this->assertSame( Services::get( 'dependency_support' )->has_support(), PairedBrowsing::is_needed() );
+		wp_set_current_user( 0 );
+		$this->assertFalse( PairedBrowsing::is_needed() );
+		wp_set_current_user( $admin_user_id );
+		add_filter( 'amp_dev_mode_enabled', '__return_false' );
+		$this->assertFalse( PairedBrowsing::is_needed() );
+		remove_filter( 'amp_dev_mode_enabled', '__return_false' );
+		$this->assertTrue( PairedBrowsing::is_needed() );
 
+		// Case where Reader theme is set to be the same as the active theme.
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, get_stylesheet() );
-
 		$this->assertSame( Services::get( 'dependency_support' )->has_support(), PairedBrowsing::is_needed() );
 	}
 
@@ -58,12 +67,18 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		$this->assertSame( [ 'dependency_support' ], PairedBrowsing::get_requirements() );
 	}
 
+	/** @covers ::get_registration_action() */
+	public function test_get_registration_action() {
+		$this->assertSame( 'wp_loaded', PairedBrowsing::get_registration_action() );
+	}
+
 	/** @covers ::__construct() */
 	public function test__construct() {
 		$this->assertInstanceOf( PairedBrowsing::class, $this->instance );
 		$this->assertInstanceOf( Service::class, $this->instance );
 		$this->assertInstanceOf( Registerable::class, $this->instance );
 		$this->assertInstanceOf( Conditional::class, $this->instance );
+		$this->assertInstanceOf( Delayed::class, $this->instance );
 		$this->assertInstanceOf( HasRequirements::class, $this->instance );
 	}
 
@@ -104,26 +119,10 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 
 		// Check first short-circuit condition.
 		add_filter( 'amp_skip_post', '__return_true' );
-		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->assertFalse( amp_is_available() );
-		$this->assertTrue( amp_is_dev_mode() );
 		$this->instance->init_frontend();
 		$assert_short_circuited();
 		remove_all_filters( 'amp_skip_post' );
-		remove_all_filters( 'amp_dev_mode_enabled' );
-
-		// Check second short-circuit condition.
-		add_filter( 'amp_skip_post', '__return_false' );
-		add_filter( 'amp_dev_mode_enabled', '__return_false' );
-		$this->assertTrue( amp_is_available() );
-		$this->assertFalse( amp_is_dev_mode() );
-		$this->instance->init_frontend();
-		$assert_short_circuited();
-		remove_all_filters( 'amp_skip_post' );
-		remove_all_filters( 'amp_dev_mode_enabled' );
-
-		// Check condition for
-		$this->assertTrue( amp_is_available() );
 	}
 
 	/**
@@ -137,7 +136,6 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		$this->go_to( add_query_arg( PairedBrowsing::APP_QUERY_VAR, '1', get_permalink( $post ) ) );
 
 		add_filter( 'amp_skip_post', '__return_false' );
-		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->instance->init_frontend();
 
 		// Check that init_app() was called.
@@ -159,7 +157,6 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 
 		add_filter( 'amp_skip_post', '__return_false' );
-		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->go_to( $this->instance->paired_routing->add_endpoint( get_permalink( $post ) ) );
 		$this->assertTrue( amp_is_request() );
 		$this->instance->init_frontend();
@@ -234,15 +231,7 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 	}
 
 	/** @covers ::filter_template_include_for_app() */
-	public function test_filter_template_include_for_app_when_no_dev_mode() {
-		add_filter( 'amp_dev_mode_enabled', '__return_false' );
-		$this->setExpectedException( WPDieException::class, 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).' );
-		$this->instance->filter_template_include_for_app();
-	}
-
-	/** @covers ::filter_template_include_for_app() */
 	public function test_filter_template_include_for_app_when_allowed() {
-		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->assertEquals( 0, did_action( 'amp_register_polyfills' ) );
 
 		$include_path = $this->instance->filter_template_include_for_app();

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -9,6 +9,7 @@ use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\PairedRouting;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\MobileRedirection;
+use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\AssertContainsCompatibility;
 use AMP_Options_Manager;
 use AMP_Theme_Support;
@@ -627,6 +628,10 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 	 * @param bool   $is_paired_browsing Is paired browsing.
 	 */
 	public function test_add_mobile_version_switcher( $template_mode, $is_amp, $is_customizer, $is_paired_browsing ) {
+		if ( $is_paired_browsing && ! Services::get( 'dependency_support' )->has_support() ) {
+			$this->markTestSkipped( 'Paired browsing is not available in the current environment.' );
+		}
+
 		$post_id = self::factory()->post->create();
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, $template_mode );
 

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -436,6 +436,10 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 
 	/** @covers ::is_using_client_side_redirection() */
 	public function test_is_using_client_side_redirection_paired_browsing_active() {
+		if ( ! Services::get( 'dependency_support' )->has_support() ) {
+			$this->markTestSkipped( 'Paired browsing is not available in the current environment.' );
+		}
+
 		$this->assertTrue( $this->instance->is_using_client_side_redirection() );
 		add_filter( 'amp_mobile_client_side_redirection', '__return_false' );
 		$this->assertFalse( $this->instance->is_using_client_side_redirection() );

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -431,6 +431,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->assertTrue( $this->instance->is_using_client_side_redirection() );
 		remove_filter( 'amp_dev_mode_enabled', '__return_true' );
+		wp_set_current_user( 0 );
 
 		$this->assertFalse( $this->instance->is_using_client_side_redirection() );
 		global $wp_customize;

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -427,6 +427,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		add_filter( 'amp_mobile_client_side_redirection', '__return_false' );
 		$this->assertFalse( $this->instance->is_using_client_side_redirection() );
 
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->assertTrue( $this->instance->is_using_client_side_redirection() );
 		remove_filter( 'amp_dev_mode_enabled', '__return_true' );

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -618,6 +618,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 			}
 		);
 
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		ob_start();
 		$this->instance->add_mobile_version_switcher_link();

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1467,6 +1467,21 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * Test amp_is_using_native_img().
+	 *
+	 * @covers ::amp_is_using_native_img()
+	 */
+	public function test_amp_is_using_native_img() {
+		$this->assertFalse( amp_is_using_native_img(), 'Expected to be disabled by default for now.' );
+
+		add_filter( 'amp_using_native_img', '__return_true' );
+		$this->assertTrue( amp_is_using_native_img() );
+
+		add_filter( 'amp_using_native_img', '__return_false', 20 );
+		$this->assertFalse( amp_is_using_native_img() );
+	}
+
+	/**
 	 * Test deprecated $post param for amp_get_content_embed_handlers().
 	 *
 	 * @covers ::amp_get_content_embed_handlers()

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -57,6 +57,22 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'simple_native_image'                      => [
+				'<img src="https://placehold.it/300x300" width="300" height="300" class="align-center">',
+				'<img src="https://placehold.it/300x300" width="300" height="300" class="align-center amp-wp-enforced-sizes" decoding="async" data-ampdevmode="">',
+				[
+					'use_native_img' => true,
+				],
+			],
+
+			'native_image_with_no_dims_and_loading'    => [
+				'<img src="https://placehold.it/150x300" loading="lazy" decoding="sync">',
+				'<img src="https://placehold.it/150x300" loading="lazy" decoding="sync" width="150" height="300" class="amp-wp-enforced-sizes" data-ampdevmode="">',
+				[
+					'use_native_img' => true,
+				],
+			],
+
 			'image_with_new_platform_attributes'       => [
 				'<img src="https://placehold.it/150x300" width="150" height="300" importance="low" intrinsicsize="150x300" loading="lazy">',
 				'<amp-img src="https://placehold.it/150x300" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/150x300" width="150" height="300" importance="low" intrinsicsize="150x300" loading="lazy"></noscript></amp-img>',
@@ -439,8 +455,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer = new AMP_Img_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
-		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom, $args );
-		$sanitizer->sanitize();
+		// Skip validation if using native img since not yet valid and data-ampdevmode present.
+		if ( empty( $args['use_native_img'] ) ) {
+			$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom, $args );
+			$sanitizer->sanitize();
+		}
 
 		$this->assertEqualSets( $error_codes, $expected_error_codes );
 

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -77,24 +77,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider get_data_for_using_native_img
-	 * @covers::add_twentyseventeen_image_styles()
-	 * @param bool $use_native_img Use native img.
-	 */
-	public function test_add_twentyseventeen_image_styles( $use_native_img ) {
-		wp_enqueue_style( get_template() . '-style', get_stylesheet_uri(), [], '0.1' );
-		AMP_Core_Theme_Sanitizer::add_twentyseventeen_image_styles( compact( 'use_native_img' ) );
-		wp_enqueue_scripts();
-		$output = get_echo( 'wp_print_styles' );
-		$needle = '.single-featured-image-header amp-img';
-		if ( $use_native_img ) {
-			$this->assertStringNotContains( $needle, $output );
-		} else {
-			$this->assertStringContains( $needle, $output );
-		}
-	}
-
-	/**
 	 * Data for testing the conversion of a CSS selector to a XPath.
 	 *
 	 * @return array

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -37,6 +37,64 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider get_data_for_using_native_img
+	 * @covers::add_twentyseventeen_attachment_image_attributes()
+	 * @param bool $use_native_img Use native img.
+	 */
+	public function test_add_twentyseventeen_attachment_image_attributes( $use_native_img ) {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg', 0 );
+		set_theme_mod( 'custom_logo', $attachment_id );
+
+		AMP_Core_Theme_Sanitizer::add_twentyseventeen_attachment_image_attributes( compact( 'use_native_img' ) );
+		$logo = get_custom_logo();
+
+		$this->assertFalse( has_custom_header() );
+
+		$needle = 'height="80"';
+		if ( $use_native_img ) {
+			$this->assertStringNotContains( $needle, $logo );
+		} else {
+			$this->assertStringContains( $needle, $logo );
+		}
+	}
+
+	/**
+	 * @dataProvider get_data_for_using_native_img
+	 * @covers::add_twentytwenty_masthead_styles()
+	 * @param bool $use_native_img Use native img.
+	 */
+	public function test_add_twentytwenty_masthead_styles( $use_native_img ) {
+		wp_enqueue_style( get_template() . '-style', get_stylesheet_uri(), [], '0.1' );
+		AMP_Core_Theme_Sanitizer::add_twentytwenty_masthead_styles( compact( 'use_native_img' ) );
+		wp_enqueue_scripts();
+		$output = get_echo( 'wp_print_styles' );
+		$needle = '.featured-media amp-img';
+		if ( $use_native_img ) {
+			$this->assertStringNotContains( $needle, $output );
+		} else {
+			$this->assertStringContains( $needle, $output );
+		}
+	}
+
+	/**
+	 * @dataProvider get_data_for_using_native_img
+	 * @covers::add_twentyseventeen_image_styles()
+	 * @param bool $use_native_img Use native img.
+	 */
+	public function test_add_twentyseventeen_image_styles( $use_native_img ) {
+		wp_enqueue_style( get_template() . '-style', get_stylesheet_uri(), [], '0.1' );
+		AMP_Core_Theme_Sanitizer::add_twentyseventeen_image_styles( compact( 'use_native_img' ) );
+		wp_enqueue_scripts();
+		$output = get_echo( 'wp_print_styles' );
+		$needle = '.single-featured-image-header amp-img';
+		if ( $use_native_img ) {
+			$this->assertStringNotContains( $needle, $output );
+		} else {
+			$this->assertStringContains( $needle, $output );
+		}
+	}
+
+	/**
 	 * Data for testing the conversion of a CSS selector to a XPath.
 	 *
 	 * @return array
@@ -340,25 +398,41 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $actual );
 	}
 
+	/** @return array */
+	public function get_data_for_using_native_img() {
+		return [
+			'using_native_img'     => [ true ],
+			'not_using_native_img' => [ false ],
+		];
+	}
+
 	/**
 	 * Tests add_img_display_block_fix.
 	 *
+	 * @dataProvider get_data_for_using_native_img
 	 * @covers ::add_img_display_block_fix()
+	 * @param bool $use_native_img Use native img.
 	 */
-	public function test_add_img_display_block_fix() {
-		AMP_Core_Theme_Sanitizer::add_img_display_block_fix();
-		ob_start();
-		wp_print_styles();
-		$output = ob_get_clean();
-		$this->assertRegExp( '/amp-img.+display.+block/s', $output );
+	public function test_add_img_display_block_fix( $use_native_img ) {
+		remove_all_actions( 'wp_print_styles' );
+		AMP_Core_Theme_Sanitizer::add_img_display_block_fix( compact( 'use_native_img' ) );
+		$output = get_echo( 'wp_print_styles' );
+		$regex  = '/amp-img.+display.+block/s';
+		if ( $use_native_img ) {
+			$this->assertNotRegExp( $regex, $output );
+		} else {
+			$this->assertRegExp( $regex, $output );
+		}
 	}
 
 	/**
 	 * Tests add_twentytwenty_custom_logo_fix.
 	 *
+	 * @dataProvider get_data_for_using_native_img
 	 * @covers ::add_twentytwenty_custom_logo_fix()
+	 * @param bool $use_native_img Use native img.
 	 */
-	public function test_add_twentytwenty_custom_logo_fix() {
+	public function test_add_twentytwenty_custom_logo_fix( $use_native_img ) {
 		add_filter(
 			'get_custom_logo',
 			static function () {
@@ -366,12 +440,16 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 			}
 		);
 
-		AMP_Core_Theme_Sanitizer::add_twentytwenty_custom_logo_fix();
+		AMP_Core_Theme_Sanitizer::add_twentytwenty_custom_logo_fix( compact( 'use_native_img' ) );
 		$logo = get_custom_logo();
 
 		$needle = '.site-logo amp-img { width: 3.000000rem; } @media (min-width: 700px) { .site-logo amp-img { width: 4.500000rem; } }';
 
-		$this->assertStringContains( $needle, $logo );
+		if ( $use_native_img ) {
+			$this->assertStringNotContains( $needle, $logo );
+		} else {
+			$this->assertStringContains( $needle, $logo );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1754,6 +1754,30 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test prepare_response when dev mode is forced.
+	 *
+	 * @global WP_Widget_Factory $wp_widget_factory
+	 * @global WP_Scripts $wp_scripts
+	 * @covers AMP_Theme_Support::prepare_response()
+	 * @covers AMP_Theme_Support::ensure_required_markup()
+	 * @covers ::amp_render_scripts()
+	 */
+	public function test_prepare_response_in_forced_dev_mode() {
+		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
+
+		add_filter( 'amp_dev_mode_enabled', '__return_true' );
+		wp();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$html = AMP_Theme_Support::prepare_response( $this->get_original_html() );
+		$this->assertStringContains( '<html amp', $html );
+
+		wp_set_current_user( 0 );
+		$html = AMP_Theme_Support::prepare_response( $this->get_original_html() );
+		$this->assertStringNotContains( '<html amp', $html );
+	}
+
+	/**
 	 * Test prepare_response for standard mode when some validation errors aren't auto-sanitized.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()


### PR DESCRIPTION
See #6443.

When `amp_using_native_img` is filtered to be true, discontinue converting `img` to `amp-img`/`amp-anim` but continue to supply any missing dimensions.

Once https://github.com/ampproject/amphtml/issues/30442 is implemented and `amp-img` is deprecated, then this will become the default.

To prevent native `img` elements from being sanitized from the page, when native `img` is enabled, the page is forced into AMP Dev Mode and all `img` elements get `data-ampdevmode` attributes added to them. This is a temporary measure until `img` is valid. On such Dev Mode pages, when accessed by an unauthenticated user, the `amp` attribute will be removed from the page to prevent Google Search from flagging it as being invalid (since we already know this to be the case via the opt-in). This aspect fixes #5549.