### PR TITLE
Try adding a method to PairedBrowsing for whether available

### DIFF
--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -154,11 +154,20 @@ final class PairedBrowsing implements Service, Registerable {
 	 * Initialize frontend.
 	 */
 	public function init_frontend() {
+		$is_requesting_app = isset( $_GET[ self::APP_QUERY_VAR ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 		if ( ! amp_is_available() || ! $this->is_available() ) {
+			if ( $is_requesting_app ) {
+				wp_die(
+					esc_html__( 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).', 'amp' ),
+					esc_html__( 'AMP Paired Browsing Unavailable', 'amp' ),
+					[ 'response' => 403 ]
+				);
+			}
 			return;
 		}
 
-		if ( isset( $_GET[ self::APP_QUERY_VAR ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $is_requesting_app ) {
 			$this->init_app();
 		} else {
 			$this->init_client();
@@ -309,14 +318,6 @@ final class PairedBrowsing implements Service, Registerable {
 	 * @return string Custom template if in paired browsing mode, else the supplied template.
 	 */
 	public function filter_template_include_for_app() {
-		if ( ! amp_is_dev_mode() ) {
-			// @todo This appears to be dead code.
-			wp_die(
-				esc_html__( 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).', 'amp' ),
-				esc_html__( 'AMP Paired Browsing Unavailable', 'amp' ),
-				[ 'response' => 403 ]
-			);
-		}
 
 		/** This action is documented in includes/class-amp-theme-support.php */
 		do_action( 'amp_register_polyfills' );

--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -310,6 +310,7 @@ final class PairedBrowsing implements Service, Registerable {
 	 */
 	public function filter_template_include_for_app() {
 		if ( ! amp_is_dev_mode() ) {
+			// @todo This appears to be dead code.
 			wp_die(
 				esc_html__( 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).', 'amp' ),
 				esc_html__( 'AMP Paired Browsing Unavailable', 'amp' ),

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -191,6 +191,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 	 */
 	protected function get_shared_instances() {
 		return [
+			Admin\PairedBrowsing::class,
 			AmpSlugCustomizationWatcher::class,
 			PluginRegistry::class,
 			Instrumentation\StopWatch::class,

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -602,25 +602,31 @@ final class MobileRedirection implements Service, Registerable {
 		</div>
 
 		<?php
-		$is_reader_customizer = (
+		// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions,
+		// and because there are controls which are AMP-specific which don't apply when switching between versions.
+		$is_amp_reader_customizer = (
 			is_customize_preview()
 			&&
 			AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT )
 		);
-		?>
-		<?php if ( $this->paired_browsing->is_available() || $is_reader_customizer ) : ?>
-			<?php
-			// Note that the switcher link is disabled in Reader mode because there is a separate toggle to switch versions.
+
+		$is_possibly_paired_browsing = (
+			$this->paired_browsing->is_available()
+			&&
+			! is_customize_preview()
+		);
+
+		if ( $is_amp_reader_customizer || $is_possibly_paired_browsing ) :
 			$exports = [
-				'containerId'          => $container_id,
-				'isCustomizePreview'   => is_customize_preview(),
-				'notApplicableMessage' => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
+				'containerId'              => $container_id,
+				'isReaderCustomizePreview' => $is_amp_reader_customizer,
+				'notApplicableMessage'     => __( 'This link is not applicable in this context. It remains here for preview purposes only.', 'amp' ),
 			];
 			?>
 			<script data-ampdevmode>
-			(function( { containerId, isCustomizePreview, notApplicableMessage } ) {
+			(function( { containerId, isReaderCustomizePreview, notApplicableMessage } ) {
 				addEventListener( 'DOMContentLoaded', () => {
-					if ( isCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
+					if ( isReaderCustomizePreview || [ 'paired-browsing-non-amp', 'paired-browsing-amp' ].includes( window.name ) ) {
 						const link = document.querySelector( `#${containerId} a[href]` );
 						link.style.cursor = 'not-allowed';
 						link.addEventListener( 'click', ( event ) => {

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -122,6 +122,14 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		$this->assertTrue( amp_is_available() );
 	}
 
+	/** @covers ::init_frontend() */
+	public function test_frontend_when_requesting_app_and_not_available() {
+		add_filter( 'amp_dev_mode_enabled', '__return_false' );
+		$this->go_to( add_query_arg( PairedBrowsing::APP_QUERY_VAR, '1', home_url() ) );
+		$this->setExpectedException( WPDieException::class, 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).' );
+		$this->instance->init_frontend();
+	}
+
 	/**
 	 * @covers ::init_frontend()
 	 * @covers ::init_app()
@@ -219,6 +227,8 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 				return false;
 			}
 		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 
 		// Test that redirection is not needed.
 		$this->go_to( $this->instance->get_paired_browsing_url( home_url( '/' ) ) );
@@ -229,13 +239,6 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		$this->go_to( add_query_arg( QueryVar::NOAMP, $this->instance->get_paired_browsing_url( home_url( '/' ) ) ) );
 		$this->instance->ensure_app_location();
 		$this->assertTrue( $redirected );
-	}
-
-	/** @covers ::filter_template_include_for_app() */
-	public function test_filter_template_include_for_app_when_no_dev_mode() {
-		add_filter( 'amp_dev_mode_enabled', '__return_false' );
-		$this->setExpectedException( WPDieException::class, 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).' );
-		$this->instance->filter_template_include_for_app();
 	}
 
 	/** @covers ::filter_template_include_for_app() */

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -2,6 +2,7 @@
 
 namespace AmpProject\AmpWP\Tests;
 
+use AmpProject\AmpWP\Admin\PairedBrowsing;
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
@@ -26,10 +27,14 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 	/** @var PairedRouting */
 	private $paired_routing;
 
+	/** @var PairedBrowsing */
+	private $paired_browsing;
+
 	public function setUp() {
 		parent::setUp();
-		$this->paired_routing = $this->injector->make( PairedRouting::class );
-		$this->instance       = new MobileRedirection( $this->paired_routing );
+		$this->paired_routing  = $this->injector->make( PairedRouting::class );
+		$this->paired_browsing = $this->injector->make( PairedBrowsing::class );
+		$this->instance        = new MobileRedirection( $this->paired_routing, $this->paired_browsing );
 	}
 
 	public function tearDown() {
@@ -422,6 +427,8 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 
 	/** @covers ::is_using_client_side_redirection() */
 	public function test_is_using_client_side_redirection() {
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+		$this->paired_browsing->register();
 		$this->assertTrue( $this->instance->is_using_client_side_redirection() );
 
 		add_filter( 'amp_mobile_client_side_redirection', '__return_false' );
@@ -601,6 +608,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 	 */
 	public function test_add_mobile_version_switcher( $is_amp, $link_rel ) {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+		$this->paired_browsing->register();
 		$this->go_to( '/' );
 		if ( $is_amp ) {
 			set_query_var( QueryVar::AMP, '1' );


### PR DESCRIPTION
I'm splitting this out from #6518 because it gets a bit out of the scope of that PR.

What I wasn't happy about in that PR (9e634f32297fa40ae2dfbf83a0a25bae9aedea65 & 4d2504c0c087cdaad280900d3e6ebe69f274ae5b) was having the `amp_is_dev_mode() && is_user_logged_in()` condition for whether Paired Browsing was available, including across services. Ideally it would be defined once in a single method.

~This PR doesn't fully work yet.~