### PR TITLE
Add support for custom non-AMP scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-add/enforced-css-max-byte-count-transformed-identifier-config#bfdd976",
+    "ampproject/amp-toolbox": "dev-add/enforced-css-max-byte-count-transformed-identifier-config#718d9dad",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-main#a155c37",
+    "ampproject/amp-toolbox": "dev-add/enforced-css-max-byte-count-transformed-identifier-config#bfdd976",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21fc63ecbbc5d31716e574af01f7f472",
+    "content-hash": "903c0c0cf89cce5699c649ccc3c82119",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "903c0c0cf89cce5699c649ccc3c82119",
+    "content-hash": "78b6a18b78105960db02188eba07a6de",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "dev-main",
+            "version": "dev-add/enforced-css-max-byte-count-transformed-identifier-config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "a155c37"
+                "reference": "718d9dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/a155c37",
-                "reference": "a155c37",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/718d9dad",
+                "reference": "718d9dad",
                 "shasum": ""
             },
             "require": {
@@ -46,7 +46,6 @@
                 "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
-            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -72,9 +71,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/add/enforced-css-max-byte-count-transformed-identifier-config"
             },
-            "time": "2021-08-11T01:48:15+00:00"
+            "time": "2021-08-17T06:06:31+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -288,7 +287,7 @@
     "packages-dev": [
         {
             "name": "ampproject/php-css-parser-install-plugin",
-            "version": "dev-enhancement/phpunit-polyfills",
+            "version": "dev-add/custom-script-allowance",
             "dist": {
                 "type": "path",
                 "url": "./php-css-parser-install-composer-plugin",
@@ -318,16 +317,16 @@
         },
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.12",
+            "version": "2.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
+                "reference": "0158dbd62bd852b178307d17a5b43a9415ca391b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/0158dbd62bd852b178307d17a5b43a9415ca391b",
+                "reference": "0158dbd62bd852b178307d17a5b43a9415ca391b",
                 "shasum": ""
             },
             "require": {
@@ -360,9 +359,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.12"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.13"
             },
-            "time": "2019-12-22T17:52:09+00:00"
+            "time": "2021-08-15T16:32:48+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -2033,16 +2032,16 @@
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb"
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/772a954e5f119f6f5871d015b23eabed8cbdadfb",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/761f3806e30239b5fcd90a0a45d41dc2138de192",
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192",
                 "shasum": ""
             },
             "require": {
@@ -2056,7 +2055,7 @@
             "require-dev": {
                 "nette/tester": "^1.3 || ^2.0",
                 "php-parallel-lint/php-console-highlighter": "~0.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "suggest": {
                 "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
@@ -2084,9 +2083,9 @@
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
             "support": {
                 "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.0"
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.1"
             },
-            "time": "2021-04-07T14:42:48+00:00"
+            "time": "2021-08-13T05:35:13+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -5972,12 +5971,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "da03bb1e8e929fe42a8f9e3814ef284028ee33fc"
+                "reference": "c4aba2085554e8872c0fb78ba25e7cf8d337e24a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/da03bb1e8e929fe42a8f9e3814ef284028ee33fc",
-                "reference": "da03bb1e8e929fe42a8f9e3814ef284028ee33fc",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/c4aba2085554e8872c0fb78ba25e7cf8d337e24a",
+                "reference": "c4aba2085554e8872c0fb78ba25e7cf8d337e24a",
                 "shasum": ""
             },
             "require": {
@@ -6036,7 +6035,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2021-08-06T13:54:16+00:00"
+            "time": "2021-08-12T15:46:55+00:00"
         },
         {
             "name": "wp-cli/wp-cli-tests",

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1479,7 +1479,7 @@ function amp_get_content_sanitizers( $post = null ) {
 
 	$sanitizers = [
 		// The AMP_Script_Sanitizer runs first because based on whether it allows custom scripts
-		// to be kept, it may impact impact the behavior of other sanitizers. For example, if custom
+		// to be kept, it may impact the behavior of other sanitizers. For example, if custom
 		// scripts are kept then this is a signal that tree shaking in AMP_Style_Sanitizer cannot be
 		// performed.
 		AMP_Script_Sanitizer::class            => [],

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1516,7 +1516,9 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		AMP_Block_Sanitizer::class             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
 		AMP_Script_Sanitizer::class            => [],
-		AMP_Style_Sanitizer::class             => [],
+		AMP_Style_Sanitizer::class             => [
+			'skip_tree_shaking' => is_customize_preview(),
+		],
 		AMP_Meta_Sanitizer::class              => [],
 		AMP_Layout_Sanitizer::class            => [],
 		AMP_Accessibility_Sanitizer::class     => [],

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1478,6 +1478,11 @@ function amp_get_content_sanitizers( $post = null ) {
 	$native_post_forms_allowed = amp_is_native_post_form_allowed();
 
 	$sanitizers = [
+		// The AMP_Script_Sanitizer runs first because based on whether it allows custom scripts
+		// to be kept, it may impact impact the behavior of other sanitizers. For example, if custom
+		// scripts are kept then this is a signal that tree shaking in AMP_Style_Sanitizer cannot be
+		// performed.
+		AMP_Script_Sanitizer::class            => [],
 		AMP_Embed_Sanitizer::class             => [
 			'amp_to_amp_linking_enabled' => $amp_to_amp_linking_enabled,
 		],
@@ -1515,7 +1520,6 @@ function amp_get_content_sanitizers( $post = null ) {
 			'native_img_used'   => $native_img_used,
 		],
 		AMP_Block_Sanitizer::class             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
-		AMP_Script_Sanitizer::class            => [],
 		AMP_Style_Sanitizer::class             => [
 			'skip_tree_shaking' => is_customize_preview(),
 		],

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1533,7 +1533,11 @@ class AMP_Theme_Support {
 		}
 
 		// When opting-in to POST forms, omit the amp-form component entirely since it blocks submission.
-		if ( amp_is_native_post_form_allowed() && $dom->xpath->query( '//form[ @action and @method and translate( @method, "POST", "post" ) = "post" ]' )->length > 0 ) {
+		if (
+			in_array( Extension::FORM, $script_handles, true )
+			&&
+			$dom->xpath->query( '//form[ @action and @method and translate( @method, "POST", "post" ) = "post" ]' )->length > 0
+		) {
 			$superfluous_script_handles[] = Extension::FORM;
 		}
 

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -141,6 +141,17 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Update args.
+	 *
+	 * Merges the supplied args with the existing args.
+	 *
+	 * @param array $args Args.
+	 */
+	public function update_args( $args ) {
+		$this->args = array_merge( $this->args, $args );
+	}
+
+	/**
 	 * Run logic before any sanitizers are run.
 	 *
 	 * After the sanitizers are instantiated but before calling sanitize on each of them, this

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -210,6 +210,22 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		// @todo Also need to check for inline script attributes.
+		$event_handler_attributes = $this->dom->xpath->query( '//*[ not( @data-ampdevmode ) ]/@*[ substring(name(), 1, 2) = "on" ]' );
+		foreach ( $event_handler_attributes as $event_handler_attribute ) {
+			/** @var DOMAttr $event_handler_attribute */
+			/** @var Element $element */
+			$element = $event_handler_attribute->parentNode;
+
+			$removed = $this->remove_invalid_attribute(
+				$element,
+				$event_handler_attribute,
+				[ 'code' => self::CUSTOM_EVENT_HANDLER_ATTR ]
+			);
+			if ( ! $removed ) {
+				$element->setAttribute( DevMode::DEV_MODE_ATTRIBUTE, '' );
+				$this->dom->documentElement->setAttribute( DevMode::DEV_MODE_ATTRIBUTE, '' );
+				$this->kept_script_count++;
+			}
+		}
 	}
 }

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -138,10 +138,10 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		if ( ! empty( $this->args['sanitize_scripts'] ) ) {
-			$this->sanitize_script_elements();
+			$this->sanitize_js_script_elements();
 		}
 
-		// If custom scripts were kept (after sanitize_script_elements() ran) it's important that noscripts not be
+		// If custom scripts were kept (after sanitize_js_script_elements() ran) it's important that noscripts not be
 		// unwrapped or else this could result in the JS and no-JS fallback experiences both being present on the page.
 		// So unwrapping is only done when no custom scripts were retained (and the sanitizer arg opts-in to unwrap).
 		if ( 0 === $this->kept_script_count && ! empty( $this->args['unwrap_noscripts'] ) ) {
@@ -226,7 +226,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 2.2
 	 */
-	protected function sanitize_script_elements() {
+	protected function sanitize_js_script_elements() {
 		$scripts = $this->dom->xpath->query( '//script[ not( @type ) or not( contains( @type, "json" ) ) ]' );
 
 		/** @var Element $script */

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -8,8 +8,9 @@
 
 use AmpProject\Attribute;
 use AmpProject\DevMode;
-use AmpProject\Tag;
 use AmpProject\Dom\Element;
+use AmpProject\Extension;
+use AmpProject\Tag;
 
 /**
  * Class AMP_Script_Sanitizer
@@ -202,11 +203,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 				//@*[
 					substring(name(), 1, 2) = "on"
 					and
-					substring(name(), 1, 3) != "on-"
-					and
 					name() != "on"
-					and
-					name() != "once"
 				]
 			'
 		);
@@ -214,7 +211,21 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $event_handler_attributes as $event_handler_attribute ) {
 			/** @var Element $element */
 			$element = $event_handler_attribute->parentNode;
-			if ( DevMode::hasExemptionForNode( $element ) ) {
+			if (
+				DevMode::hasExemptionForNode( $element )
+				||
+				(
+					Extension::POSITION_OBSERVER === $element->tagName
+					&&
+					Attribute::ONCE === $event_handler_attribute->nodeName
+				)
+				||
+				(
+					Extension::FONT === $element->tagName
+					&&
+					substr( $event_handler_attribute->nodeName, 0, 3 ) === 'on-'
+				)
+			) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -121,7 +121,9 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 		// When there are kept custom scripts, skip tree shaking since it's likely JS will toggle classes that have
 		// associated style rules.
 		// @todo There should be an attribute on script tags that opt-in to keeping tree shaking and/or to indicate what class names need to be included.
+		// @todo Depending on the size of the underlying stylesheets, this may need to retain the use of external styles to prevent inlining excessive CSS. This may involve writing minified CSS to disk, or skipping style processing altogether if no selector conversions are needed.
 		if ( $this->kept_script_count > 0 && $this->style_sanitizer instanceof AMP_Base_Sanitizer ) {
+			// @todo In addition to skipping tree shaking in the style sanitizer, sometimes this should also disable certain conversions (e.g. native_img for AMP_Img_Sanitizer).
 			$this->style_sanitizer->update_args( [ 'skip_tree_shaking' => true ] );
 		}
 	}

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -60,16 +60,16 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [
-		'unwrap_noscripts'    => true,
-		'sanitize_js_scripts' => false,
+		'unwrap_noscripts' => true,
+		'sanitize_scripts' => false,
 	];
 
 	/**
 	 * Array of flags used to control sanitization.
 	 *
 	 * @var array {
-	 *      @type bool $sanitize_js_scripts Whether to sanitize JS scripts (and not defer for final sanitizer).
-	 *      @type bool $unwrap_noscripts    Whether to unwrap noscript elements.
+	 *      @type bool $sanitize_scripts Whether to sanitize scripts (and not defer for final sanitizer).
+	 *      @type bool $unwrap_noscripts Whether to unwrap noscript elements.
 	 * }
 	 */
 	protected $args;
@@ -86,17 +86,11 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Sanitize script and noscript elements.
 	 *
-	 * Eventually this should also handle script elements, if there is a known AMP equivalent.
-	 * If nothing is done with script elements, the validating sanitizer will deal with them ultimately.
-	 *
-	 * @todo Eventually this try to automatically convert script tags to AMP when they are recognized. See <https://github.com/ampproject/amp-wp/issues/1032>.
-	 * @todo When a script has an adjacent noscript, consider removing the script here to prevent validation error later. See <https://github.com/ampproject/amp-wp/issues/1213>.
-	 *
 	 * @since 1.0
 	 */
 	public function sanitize() {
-		if ( ! empty( $this->args['sanitize_js_scripts'] ) ) {
-			$this->sanitize_js_script_elements();
+		if ( ! empty( $this->args['sanitize_scripts'] ) ) {
+			$this->sanitize_script_elements();
 		}
 
 		// If custom scripts were kept (after sanitize_js_script_elements ran) it's important that noscripts not be
@@ -165,8 +159,10 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * This runs explicitly in the script sanitizer before the final validating sanitizer (tag-and-attribute) so that
 	 * the style sanitizer will be able to know whether there are custom scripts in the page, and thus whether tree
 	 * shaking can be performed.
+	 *
+	 * @since 2.2
 	 */
-	protected function sanitize_js_script_elements() {
+	protected function sanitize_script_elements() {
 		$scripts = $this->dom->xpath->query( '//script[ not( @type ) or @type != "application/ld+json" ]' );
 
 		/** @var Element $script */

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -120,6 +120,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 
 		// When there are kept custom scripts, skip tree shaking since it's likely JS will toggle classes that have
 		// associated style rules.
+		// @todo There should be an attribute on script tags that opt-in to keeping tree shaking and/or to indicate what class names need to be included.
 		if ( $this->kept_script_count > 0 && $this->style_sanitizer instanceof AMP_Base_Sanitizer ) {
 			$this->style_sanitizer->update_args( [ 'skip_tree_shaking' => true ] );
 		}

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -210,7 +210,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		$event_handler_attributes = $this->dom->xpath->query( '//*[ not( @data-ampdevmode ) ]/@*[ substring(name(), 1, 2) = "on" ]' );
+		$event_handler_attributes = $this->dom->xpath->query( '//*[ not( @data-ampdevmode ) ]/@*[ substring(name(), 1, 2) = "on" and name() != "on" ]' );
 		foreach ( $event_handler_attributes as $event_handler_attribute ) {
 			/** @var DOMAttr $event_handler_attribute */
 			/** @var Element $element */

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -227,7 +227,21 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 2.2
 	 */
 	protected function sanitize_js_script_elements() {
-		$scripts = $this->dom->xpath->query( '//script[ not( @type ) or not( contains( @type, "json" ) ) ]' );
+		// Note that this is looking for type attributes that contain "script" as a normalization of the variations
+		// of javascript, ecmascript, jscript, and livescript. This could also end up matching MIME types such as
+		// application/postscript or text/vbscript, but such scripts are either unlikely to be the source of a script
+		// tag or else they would be extremely rare (and would be invalid AMP anyway).
+		// See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript>.
+		$scripts = $this->dom->xpath->query(
+			'
+				//script[
+					not( @type )
+					or
+					@type = "module"
+					or
+					contains( @type, "script" )
+				]'
+		);
 
 		/** @var Element $script */
 		foreach ( $scripts as $script ) {

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -92,6 +92,13 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	protected $img_sanitizer;
 
 	/**
+	 * Form sanitizer.
+	 *
+	 * @var AMP_Form_Sanitizer
+	 */
+	protected $form_sanitizer;
+
+	/**
 	 * Init.
 	 *
 	 * @param AMP_Base_Sanitizer[] $sanitizers Sanitizers.
@@ -113,6 +120,14 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			$sanitizers[ AMP_Img_Sanitizer::class ] instanceof AMP_Img_Sanitizer
 		) {
 			$this->img_sanitizer = $sanitizers[ AMP_Img_Sanitizer::class ];
+		}
+
+		if (
+			array_key_exists( AMP_Form_Sanitizer::class, $sanitizers )
+			&&
+			$sanitizers[ AMP_Form_Sanitizer::class ] instanceof AMP_Form_Sanitizer
+		) {
+			$this->form_sanitizer = $sanitizers[ AMP_Form_Sanitizer::class ];
 		}
 	}
 
@@ -144,7 +159,9 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $this->img_sanitizer ) {
 				$this->img_sanitizer->update_args( [ 'native_img_used' => true ] );
 			}
-			// @todo In addition to skipping tree shaking and using native images, other conversions should perhaps be disabled to prevent breaking custom scripts.
+			if ( $this->form_sanitizer ) {
+				$this->form_sanitizer->update_args( [ 'native_post_forms_allowed' => true ] );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -27,13 +27,6 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	const CUSTOM_INLINE_SCRIPT = 'CUSTOM_INLINE_SCRIPT';
 
 	/**
-	 * Error code for custom inline JSON script tag.
-	 *
-	 * @var string
-	 */
-	const CUSTOM_JSON_SCRIPT = 'CUSTOM_JSON_SCRIPT';
-
-	/**
 	 * Error code for custom external JS script tag.
 	 *
 	 * @var string
@@ -68,7 +61,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * Array of flags used to control sanitization.
 	 *
 	 * @var array {
-	 *      @type bool $sanitize_scripts Whether to sanitize scripts (and not defer for final sanitizer).
+	 *      @type bool $sanitize_scripts Whether to sanitize JS scripts (and not defer for final sanitizer).
 	 *      @type bool $unwrap_noscripts Whether to unwrap noscript elements.
 	 * }
 	 */
@@ -163,7 +156,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 2.2
 	 */
 	protected function sanitize_script_elements() {
-		$scripts = $this->dom->xpath->query( '//script[ not( @type ) or @type != "application/ld+json" ]' );
+		$scripts = $this->dom->xpath->query( '//script[ not( @type ) or not( contains( @type, "json" ) ) ]' );
 
 		/** @var Element $script */
 		foreach ( $scripts as $script ) {
@@ -192,15 +185,9 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 					continue;
 				}
 
-				if ( $script->hasAttribute( Attribute::TYPE ) && false !== strpos( $script->getAttribute( Attribute::TYPE ), 'json' ) ) {
-					$code = self::CUSTOM_JSON_SCRIPT;
-				} else {
-					$code = self::CUSTOM_INLINE_SCRIPT;
-				}
-
 				$removed = $this->remove_invalid_child(
 					$script,
-					[ 'code' => $code ]
+					[ 'code' => self::CUSTOM_INLINE_SCRIPT ]
 				);
 				if ( ! $removed ) {
 					$script->setAttribute( DevMode::DEV_MODE_ATTRIBUTE, '' );

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -141,9 +141,9 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			$this->sanitize_script_elements();
 		}
 
-		// If custom scripts were kept (after sanitize_js_script_elements ran) it's important that noscripts not be
+		// If custom scripts were kept (after sanitize_script_elements() ran) it's important that noscripts not be
 		// unwrapped or else this could result in the JS and no-JS fallback experiences both being present on the page.
-		// So unwrapping is only done no custom scripts were retained (and the sanitizer arg opts-in to unwrap).
+		// So unwrapping is only done when no custom scripts were retained (and the sanitizer arg opts-in to unwrap).
 		if ( 0 === $this->kept_script_count && ! empty( $this->args['unwrap_noscripts'] ) ) {
 			$this->unwrap_noscript_elements();
 		}

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -197,11 +197,26 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		$event_handler_attributes = $this->dom->xpath->query( '//*[ not( @data-ampdevmode ) ]/@*[ substring(name(), 1, 2) = "on" and name() != "on" ]' );
+		$event_handler_attributes = $this->dom->xpath->query(
+			'
+				//@*[
+					substring(name(), 1, 2) = "on"
+					and
+					substring(name(), 1, 3) != "on-"
+					and
+					name() != "on"
+					and
+					name() != "once"
+				]
+			'
+		);
+		/** @var DOMAttr $event_handler_attribute */
 		foreach ( $event_handler_attributes as $event_handler_attribute ) {
-			/** @var DOMAttr $event_handler_attribute */
 			/** @var Element $element */
 			$element = $event_handler_attribute->parentNode;
+			if ( DevMode::hasExemptionForNode( $element ) ) {
+				continue;
+			}
 
 			$removed = $this->remove_invalid_attribute(
 				$element,

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -85,6 +85,13 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	protected $style_sanitizer;
 
 	/**
+	 * Image sanitizer.
+	 *
+	 * @var AMP_Img_Sanitizer
+	 */
+	protected $img_sanitizer;
+
+	/**
 	 * Init.
 	 *
 	 * @param AMP_Base_Sanitizer[] $sanitizers Sanitizers.
@@ -98,6 +105,14 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			$sanitizers[ AMP_Style_Sanitizer::class ] instanceof AMP_Style_Sanitizer
 		) {
 			$this->style_sanitizer = $sanitizers[ AMP_Style_Sanitizer::class ];
+		}
+
+		if (
+			array_key_exists( AMP_Img_Sanitizer::class, $sanitizers )
+			&&
+			$sanitizers[ AMP_Img_Sanitizer::class ] instanceof AMP_Img_Sanitizer
+		) {
+			$this->img_sanitizer = $sanitizers[ AMP_Img_Sanitizer::class ];
 		}
 	}
 
@@ -122,9 +137,14 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 		// associated style rules.
 		// @todo There should be an attribute on script tags that opt-in to keeping tree shaking and/or to indicate what class names need to be included.
 		// @todo Depending on the size of the underlying stylesheets, this may need to retain the use of external styles to prevent inlining excessive CSS. This may involve writing minified CSS to disk, or skipping style processing altogether if no selector conversions are needed.
-		if ( $this->kept_script_count > 0 && $this->style_sanitizer instanceof AMP_Base_Sanitizer ) {
-			// @todo In addition to skipping tree shaking in the style sanitizer, sometimes this should also disable certain conversions (e.g. native_img for AMP_Img_Sanitizer).
-			$this->style_sanitizer->update_args( [ 'skip_tree_shaking' => true ] );
+		if ( $this->kept_script_count > 0 ) {
+			if ( $this->style_sanitizer ) {
+				$this->style_sanitizer->update_args( [ 'skip_tree_shaking' => true ] );
+			}
+			if ( $this->img_sanitizer ) {
+				$this->img_sanitizer->update_args( [ 'native_img_used' => true ] );
+			}
+			// @todo In addition to skipping tree shaking and using native images, other conversions should perhaps be disabled to prevent breaking custom scripts.
 		}
 	}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -54,16 +54,16 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [
-		'unwrap_noscripts' => true,
-		'sanitize_scripts' => false,
+		'unwrap_noscripts'    => true,
+		'sanitize_js_scripts' => false,
 	];
 
 	/**
 	 * Array of flags used to control sanitization.
 	 *
 	 * @var array {
-	 *      @type bool $sanitize_scripts Whether to sanitize JS scripts (and not defer for final sanitizer).
-	 *      @type bool $unwrap_noscripts Whether to unwrap noscript elements.
+	 *      @type bool $sanitize_js_scripts Whether to sanitize JS scripts (and not defer for final sanitizer).
+	 *      @type bool $unwrap_noscripts    Whether to unwrap noscript elements.
 	 * }
 	 */
 	protected $args;
@@ -137,7 +137,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 */
 	public function sanitize() {
-		if ( ! empty( $this->args['sanitize_scripts'] ) ) {
+		if ( ! empty( $this->args['sanitize_js_scripts'] ) ) {
 			$this->sanitize_js_script_elements();
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -153,6 +153,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'focus_within_classes'      => [ 'focus' ],
 		'low_priority_plugins'      => [ 'query-monitor' ],
 		'allow_transient_caching'   => true,
+		'skip_tree_shaking'         => false,
 	];
 
 	/**
@@ -343,14 +344,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var RemoteGetRequest
 	 */
 	private $remote_request;
-
-	/**
-	 * Cached call to is_customize_preview()
-	 *
-	 * @see is_customize_preview()
-	 * @var bool
-	 */
-	private $is_customize_preview;
 
 	/**
 	 * Get error codes that can be raised during parsing of CSS.
@@ -882,8 +875,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.4
 	 */
 	public function sanitize() {
-		$this->is_customize_preview = is_customize_preview();
-
 		$elements = [];
 
 		$this->focus_class_name_selector_pattern = (
@@ -3320,7 +3311,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$used_selector_count = 0;
 				$selectors           = [];
 				foreach ( $selectors_parsed as $selector => $parsed_selector ) {
-					$should_include = $this->is_customize_preview || (
+					$should_include = $this->args['skip_tree_shaking'] || (
 						// If all class names are used in the doc.
 						(
 							empty( $parsed_selector[ self::SELECTOR_EXTRACTED_CLASSES ] )
@@ -3490,7 +3481,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Report validation error if size is now too big.
-			if ( ! $this->is_customize_preview && $current_concatenated_size + $this->pending_stylesheets[ $i ]['final_size'] > $max_bytes ) {
+			if ( ! $this->args['skip_tree_shaking'] && $current_concatenated_size + $this->pending_stylesheets[ $i ]['final_size'] > $max_bytes ) {
 				$validation_error = [
 					'code'      => self::STYLESHEET_TOO_LONG,
 					'type'      => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -346,6 +346,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $remote_request;
 
 	/**
+	 * All current sanitizers.
+	 *
+	 * @see AMP_Style_Sanitizer::init()
+	 * @var AMP_Base_Sanitizer[]
+	 */
+	private $sanitizers = [];
+
+	/**
 	 * Get error codes that can be raised during parsing of CSS.
 	 *
 	 * This is used to determine which validation errors should be taken into account
@@ -850,7 +858,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	public function init( $sanitizers ) {
 		parent::init( $sanitizers );
 
-		foreach ( $sanitizers as $sanitizer ) {
+		$this->sanitizers = $sanitizers;
+	}
+
+	/**
+	 * Sanitize CSS styles within the HTML contained in this instance's Dom\Document.
+	 *
+	 * @since 0.4
+	 */
+	public function sanitize() {
+		// Capture the selector conversion mappings from the other sanitizers.
+		foreach ( $this->sanitizers as $sanitizer ) {
 			foreach ( $sanitizer->get_selector_conversion_mapping() as $html_selectors => $amp_selectors ) {
 				if ( ! isset( $this->selector_mappings[ $html_selectors ] ) ) {
 					$this->selector_mappings[ $html_selectors ] = $amp_selectors;
@@ -867,14 +885,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				);
 			}
 		}
-	}
 
-	/**
-	 * Sanitize CSS styles within the HTML contained in this instance's Dom\Document.
-	 *
-	 * @since 0.4
-	 */
-	public function sanitize() {
 		$elements = [];
 
 		$this->focus_class_name_selector_pattern = (

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3350,14 +3350,18 @@ class AMP_Validation_Error_Taxonomy {
 				);
 
 			case AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT:
-				return esc_html__( 'Custom external script encountered', 'amp' );
+				return sprintf(
+					/* translators: %s is script basename */
+					esc_html__( 'Custom external script %s encountered', 'amp' ),
+					'<code>' . basename( strtok( $validation_error['node_attributes']['src'], '?#' ) ) . '</code>'
+				);
 
 			case AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT:
 				return esc_html__( 'Custom inline script encountered', 'amp' );
 
 			case AMP_Script_Sanitizer::CUSTOM_EVENT_HANDLER_ATTR:
 				return sprintf(
-					/* translators: %1$s is attribute name */
+					/* translators: %s is attribute name */
 					esc_html__( 'Event handler attribute %s encountered', 'amp' ),
 					'<code>' . $validation_error['node_name'] . '</code>'
 				);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3349,6 +3349,19 @@ class AMP_Validation_Error_Taxonomy {
 					'<code>action-xhr</code>'
 				);
 
+			case AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT:
+				return esc_html__( 'Custom external script encountered', 'amp' );
+
+			case AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT:
+				return esc_html__( 'Custom inline script encountered', 'amp' );
+
+			case AMP_Script_Sanitizer::CUSTOM_EVENT_HANDLER_ATTR:
+				return sprintf(
+					/* translators: %1$s is attribute name */
+					esc_html__( 'Event handler attribute %s encountered', 'amp' ),
+					'<code>' . $validation_error['node_name'] . '</code>'
+				);
+
 			default:
 				/* translators: %s error code */
 				return sprintf( esc_html__( 'Unknown error (%s)', 'amp' ), $validation_error['code'] );

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\Services;
 use AmpProject\Attribute;
 use AmpProject\Tag;
 use AmpProject\Dom\Document;
+use AmpProject\Exception\MaxCssByteCountExceeded;
 
 /**
  * Class AMP_Validation_Manager
@@ -1682,8 +1683,12 @@ class AMP_Validation_Manager {
 		$text .= ' ' . implode( ', ', $items );
 
 		$validate_link->appendChild( $dom->createTextNode( ' ' ) );
-		$small = $dom->createElement( 'small' );
-		$small->setAttribute( 'style', 'font-size: smaller' );
+		$small = $dom->createElement( Tag::SMALL );
+		try {
+			$small->setAttribute( Attribute::STYLE, 'font-size: smaller' );
+		} catch ( MaxCssByteCountExceeded $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Making the font size smaller is just a nice-to-have.
+		}
 		$small->appendChild( $dom->createTextNode( sprintf( '(%s)', $text ) ) );
 		$validate_link->appendChild( $small );
 	}

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -85,22 +85,42 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			'inline_scripts_removed'        => [
 				'
 					<html><head><meta charset="utf-8"></head><body>
-						<script>document.write("Hey.")</script>
+						<script>document.write("Hey")</script>
+						<script type="text/javascript">document.write("Hey")</script>
+						<script type="text/ecmascript">document.write("Hey")</script>
+						<script type="application/javascript">document.write("Hey")</script>
+						<script type="application/ecmascript">document.write("Hey")</script>
+						<script type="module">document.write("Hey")</script>
 						<script type="application/json">{"data":1}</script>
 						<script type="application/ld+json">{"data":2}</script>
 						<amp-state id="test"><script type="application/json">{"data":3}</script></amp-state>
+						<amp-script width="200" height="100" script="hello-world"><button>Hello amp-script!</button></amp-script>
+						<script id="hello-world" type="text/plain" target="amp-script">
+							/* This is perfectly fine! */
+						</script>
+						<script type="text/plain" template="amp-mustache">Hello {{world}}!</script>
 					</body></html>
 				',
 				'
 					<html><head><meta charset="utf-8"></head><body>
-					<script type="application/ld+json">{"data":2}</script>
-					<amp-state id="test"><script type="application/json">{"data":3}</script></amp-state>
+						<script type="application/ld+json">{"data":2}</script>
+						<amp-state id="test"><script type="application/json">{"data":3}</script></amp-state>
+						<amp-script width="200" height="100" script="hello-world"><button>Hello amp-script!</button></amp-script>
+						<script id="hello-world" type="text/plain" target="amp-script">
+							/* This is perfectly fine! */
+						</script>
+						<script type="text/plain" template="amp-mustache">Hello {{world}}!</script>
 					</body></html>
 				',
 				[
 					'sanitize_js_scripts' => true,
 				],
 				[
+					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
 					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
 					AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG,
 				],

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -129,6 +129,49 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
 				],
 			],
+			'external_scripts_kept'         => [
+				'
+					<html>
+					<head><meta charset="utf-8"></head>
+					<body>
+						<script src="https://example.com/1"></script>
+						<script type="text/javascript" src="https://example.com/2"></script>
+						<script type="module" src="https://example.com/3"></script>
+					</body></html>
+				',
+				'
+					<html data-ampdevmode>
+					<head><meta charset="utf-8"></head>
+					<body>
+						<script src="https://example.com/1" data-ampdevmode></script>
+						<script type="text/javascript" src="https://example.com/2" data-ampdevmode></script>
+						<script type="module" src="https://example.com/3" data-ampdevmode></script>
+					</body></html>
+				',
+				[
+					'sanitize_scripts'          => true,
+					'validation_error_callback' => '__return_false',
+				],
+				[
+					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
+					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
+				],
+			],
+			'external_devmode_script_kept'  => [
+				'
+					<html data-ampdevmode>
+					<head><meta charset="utf-8"></head>
+					<body>
+						<script data-ampdevmode src="https://example.com/1"></script>
+					</body></html>
+				',
+				null,
+				[
+					'sanitize_scripts' => true,
+				],
+				[],
+			],
 			'external_amp_script_kept'      => [
 				'
 					<html>

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -26,40 +26,40 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 	 */
 	public function get_sanitizer_data() {
 		return [
-			'document_write'               => [
+			'document_write'                => [
 				'<html><head><meta charset="utf-8"></head><body>Has script? <script>document.write("Yep!")</script><noscript>Nope!</noscript></body></html>',
 				'<html><head><meta charset="utf-8"></head><body>Has script? <!--noscript-->Nope!<!--/noscript--></body></html>',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
 			],
-			'nested_elements'              => [
+			'nested_elements'               => [
 				'<html><head><meta charset="utf-8"></head><body><noscript>before <em><strong>middle</strong> end</em></noscript></body></html>',
 				'<html><head><meta charset="utf-8"></head><body><!--noscript-->before <em><strong>middle</strong> end</em><!--/noscript--></body></html>',
 			],
-			'head_noscript_style'          => [
+			'head_noscript_style'           => [
 				'<html><head><meta charset="utf-8"><noscript><style>body{color:red}</style></noscript></head><body></body></html>',
 				'<html><head><meta charset="utf-8"><!--noscript--><style>body{color:red}</style><!--/noscript--></head><body></body></html>',
 			],
-			'head_noscript_span'           => [
+			'head_noscript_span'            => [
 				'<html><head><meta charset="utf-8"><noscript><span>No script</span></noscript></head><body></body></html>',
 				'<html><head><meta charset="utf-8"></head><body><!--noscript--><span>No script</span><!--/noscript--></body></html>',
 			],
-			'test_with_dev_mode'           => [
+			'test_with_dev_mode'            => [
 				'<html data-ampdevmode=""><head><meta charset="utf-8"></head><body><noscript data-ampdevmode="">hey</noscript></body></html>',
 				null,
 			],
-			'noscript_no_unwrap_attr'      => [
+			'noscript_no_unwrap_attr'       => [
 				'<html><head><meta charset="utf-8"></head><body><noscript data-amp-no-unwrap><span>No script</span></noscript></body></html>',
 				null,
 			],
-			'noscript_no_unwrap_arg'       => [
+			'noscript_no_unwrap_arg'        => [
 				'<html><head><meta charset="utf-8"></head><body><noscript><span>No script</span></noscript></body></html>',
 				null,
 				[
 					'unwrap_noscripts' => false,
 				],
 			],
-			'script_kept_no_unwrap'        => [
+			'script_kept_no_unwrap'         => [
 				'
 					<html><head><meta charset="utf-8"></head><body>
 						<script>document.write("Hey.")</script>
@@ -80,7 +80,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
 				],
 			],
-			'inline_scripts_removed'       => [
+			'inline_scripts_removed'        => [
 				'
 					<html><head><meta charset="utf-8"></head><body>
 						<script>document.write("Hey.")</script>
@@ -103,7 +103,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG,
 				],
 			],
-			'external_scripts_removed'     => [
+			'external_scripts_removed'      => [
 				'
 					<html>
 					<head><meta charset="utf-8"></head>
@@ -127,7 +127,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
 				],
 			],
-			'external_amp_script_kept'     => [
+			'external_amp_script_kept'      => [
 				'
 					<html>
 					<head>
@@ -142,7 +142,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				],
 				[],
 			],
-			'amp_onerror_script_kept'      => [
+			'amp_onerror_script_kept'       => [
 				'
 					<html>
 					<head>
@@ -157,7 +157,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				],
 				[],
 			],
-			'inline_event_handler_removed' => [
+			'inline_event_handler_removed'  => [
 				'
 					<html><head><meta charset="utf-8"></head>
 					<body onload="alert(\'Hey there.\')">
@@ -181,7 +181,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					AMP_Script_Sanitizer::CUSTOM_EVENT_HANDLER_ATTR,
 				],
 			],
-			'inline_event_handler_kept'    => [
+			'inline_event_handler_kept'     => [
 				'
 					<html><head><meta charset="utf-8"></head>
 					<body onload="alert(\'Hey there.\')">
@@ -205,6 +205,32 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				[
 					AMP_Script_Sanitizer::CUSTOM_EVENT_HANDLER_ATTR,
 				],
+			],
+			'event_handler_lookalikes_kept' => [
+				'
+					<html><head><meta charset="utf-8"></head>
+					<body>
+						<noscript>I should get unwrapped.</noscript>
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+						<amp-position-observer intersection-ratios="0.5" on="enter:clockAnim.start;exit:clockAnim.pause" layout="nodisplay" once></amp-position-observer>
+						<amp-font layout="nodisplay" font-family="My Font" timeout="3000" on-error-remove-class="my-font-loading" on-error-add-class="my-font-missing"></amp-font>
+					</body></html>
+				',
+				'
+					<html><head><meta charset="utf-8"></head>
+					<body>
+						<!--noscript-->I should get unwrapped.<!--/noscript-->
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+						<amp-position-observer intersection-ratios="0.5" on="enter:clockAnim.start;exit:clockAnim.pause" layout="nodisplay" once></amp-position-observer>
+						<amp-font layout="nodisplay" font-family="My Font" timeout="3000" on-error-remove-class="my-font-loading" on-error-add-class="my-font-missing"></amp-font>
+					</body></html>
+				',
+				[
+					'sanitize_scripts' => true,
+				],
+				[],
 			],
 		];
 	}

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -70,7 +70,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_js_scripts'       => true,
+					'sanitize_scripts'          => true,
 					'unwrap_noscripts'          => true, // This will be ignored because of the kept script.
 					'validation_error_callback' => '__return_false',
 				],
@@ -92,7 +92,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_js_scripts' => true,
+					'sanitize_scripts' => true,
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
@@ -115,7 +115,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					<body></body></html>
 				',
 				[
-					'sanitize_js_scripts' => true,
+					'sanitize_scripts' => true,
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -74,7 +74,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts'          => true,
+					'sanitize_js_scripts'       => true,
 					'unwrap_noscripts'          => true, // This will be ignored because of the kept script.
 					'validation_error_callback' => '__return_false',
 				],
@@ -98,7 +98,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
@@ -121,7 +121,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					<body></body></html>
 				',
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_EXTERNAL_SCRIPT,
@@ -149,7 +149,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts'          => true,
+					'sanitize_js_scripts'       => true,
 					'validation_error_callback' => '__return_false',
 				],
 				[
@@ -168,7 +168,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				',
 				null,
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[],
 			],
@@ -183,7 +183,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				',
 				null,
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[],
 			],
@@ -198,7 +198,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				',
 				null,
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[],
 			],
@@ -220,7 +220,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_EVENT_HANDLER_ATTR,
@@ -244,7 +244,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts'          => true,
+					'sanitize_js_scripts'       => true,
 					'validation_error_callback' => '__return_false',
 				],
 				[
@@ -273,7 +273,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 					</body></html>
 				',
 				[
-					'sanitize_scripts' => true,
+					'sanitize_js_scripts' => true,
 				],
 				[],
 			],
@@ -358,7 +358,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			AMP_Script_Sanitizer::class => new AMP_Script_Sanitizer(
 				$dom,
 				[
-					'sanitize_scripts'          => true,
+					'sanitize_js_scripts'       => true,
 					'validation_error_callback' => function () use ( $remove_custom_scripts ) {
 						return $remove_custom_scripts;
 					},

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -158,11 +158,19 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			'inline_event_handler_removed' => [
 				'
 					<html><head><meta charset="utf-8"></head>
-					<body onload="alert(\'Hey there.\')"><noscript>I should get unwrapped.</noscript></body></html>
+					<body onload="alert(\'Hey there.\')">
+						<noscript>I should get unwrapped.</noscript>
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+					</body></html>
 				',
 				'
 					<html><head><meta charset="utf-8"></head>
-					<body><!--noscript-->I should get unwrapped.<!--/noscript--></body></html>
+					<body>
+						<!--noscript-->I should get unwrapped.<!--/noscript-->
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+					</body></html>
 				',
 				[
 					'sanitize_scripts' => true,
@@ -174,11 +182,19 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			'inline_event_handler_kept'    => [
 				'
 					<html><head><meta charset="utf-8"></head>
-					<body onload="alert(\'Hey there.\')"><noscript>I should not get unwrapped.</noscript></body></html>
+					<body onload="alert(\'Hey there.\')">
+						<noscript>I should not get unwrapped.</noscript>
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+					</body></html>
 				',
 				'
 					<html data-ampdevmode><head><meta charset="utf-8"></head>
-					<body data-ampdevmode onload="alert(\'Hey there.\')"><noscript>I should not get unwrapped.</noscript></body></html>
+					<body data-ampdevmode onload="alert(\'Hey there.\')">
+						<noscript>I should not get unwrapped.</noscript>
+						<div id="warning-message">Warning...</div>
+						<button on="tap:warning-message.hide">Cool, thanks!</button>
+					</body></html>
 				',
 				[
 					'sanitize_scripts'          => true,

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -86,11 +86,13 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 						<script>document.write("Hey.")</script>
 						<script type="application/json">{"data":1}</script>
 						<script type="application/ld+json">{"data":2}</script>
+						<amp-state id="test"><script type="application/json">{"data":3}</script></amp-state>
 					</body></html>
 				',
 				'
 					<html><head><meta charset="utf-8"></head><body>
 					<script type="application/ld+json">{"data":2}</script>
+					<amp-state id="test"><script type="application/json">{"data":3}</script></amp-state>
 					</body></html>
 				',
 				[
@@ -98,7 +100,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 				],
 				[
 					AMP_Script_Sanitizer::CUSTOM_INLINE_SCRIPT,
-					AMP_Script_Sanitizer::CUSTOM_JSON_SCRIPT,
+					AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG,
 				],
 			],
 			'external_scripts_removed'     => [

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -924,24 +924,9 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 	}
 
 	/**
-	 * Test that tree shaking and CSS limits are disabled when in the Customizer Preview.
+	 * Test that tree shaking and CSS limits are disabled when requested.
 	 */
-	public function test_tree_shaking_disabled_in_customizer_preview() {
-		$active_theme = 'twentynineteen';
-		$reader_theme = 'twentytwenty';
-		if ( ! wp_get_theme( $active_theme )->exists() || ! wp_get_theme( $reader_theme )->exists() ) {
-			$this->markTestSkipped();
-		}
-		switch_theme( $active_theme );
-		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
-		AMP_Options_Manager::update_option( Option::READER_THEME, $reader_theme );
-
-		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
-		global $wp_customize;
-		$wp_customize = new WP_Customize_Manager();
-		$wp_customize->start_previewing_theme();
-		$this->assertTrue( is_customize_preview() );
-
+	public function test_tree_shaking_disabled() {
 		$dom = Document::fromHtml(
 			sprintf(
 				'
@@ -973,6 +958,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 
 		$args = [
 			'use_document_element' => true,
+			'skip_tree_shaking'    => true,
 		];
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, $args );

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -13,7 +13,7 @@ use AmpProject\AmpWP\Tests\TestCase;
 /**
  * Test AMP_Base_Sanitizer_Test
  *
- * @coversDefaultClass AMP_Base_Sanitizer
+ * @coversDefaultClass \AMP_Base_Sanitizer
  */
 class AMP_Base_Sanitizer_Test extends TestCase {
 	use PrivateAccess;

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -6,15 +6,17 @@
  */
 
 use AmpProject\Dom\Document;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\StubSanitizer;
 use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Base_Sanitizer_Test
  *
- * @covers AMP_Base_Sanitizer
+ * @coversDefaultClass AMP_Base_Sanitizer
  */
 class AMP_Base_Sanitizer_Test extends TestCase {
+	use PrivateAccess;
 
 	/**
 	 * Set up.
@@ -191,6 +193,44 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 		];
 	}
 
+	/** @covers ::get_selector_conversion_mapping() */
+	public function test_get_selector_conversion_mapping() {
+		$sanitizer = new StubSanitizer( new Document() );
+		$this->assertEquals( [], $sanitizer->get_selector_conversion_mapping() );
+	}
+
+	/** @covers ::update_args() */
+	public function test_update_args() {
+		$sanitizer = new StubSanitizer(
+			new Document(),
+			[
+				'foo' => 1,
+				'bar' => 2,
+			]
+		);
+		$this->assertEquals(
+			[
+				'foo' => 1,
+				'bar' => 2,
+			],
+			$this->get_private_property( $sanitizer, 'args' )
+		);
+		$sanitizer->update_args(
+			[
+				'foo' => 'one',
+				'baz' => 'three',
+			]
+		);
+		$this->assertEquals(
+			[
+				'foo' => 'one',
+				'bar' => 2,
+				'baz' => 'three',
+			],
+			$this->get_private_property( $sanitizer, 'args' )
+		);
+	}
+
 	/**
 	 * Test AMP_Base_Sanitizer::set_layout().
 	 *
@@ -198,7 +238,7 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	 * @param array $source_attributes   Source Attrs.
 	 * @param array $expected_attributes Expected Attrs.
 	 * @param array $args                Args.
-	 * @covers AMP_Base_Sanitizer::set_layout()
+	 * @covers ::set_layout()
 	 */
 	public function test_set_layout( $source_attributes, $expected_attributes, $args = [] ) {
 		$sanitizer           = new StubSanitizer( new Document(), $args );
@@ -274,7 +314,7 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	 * @param array $expected_value Expected Attrs.
 	 * @param array $args           Args.
 	 * @dataProvider get_sanitize_dimension_data
-	 * @covers AMP_Base_Sanitizer::sanitize_dimension()
+	 * @covers ::sanitize_dimension()
 	 */
 	public function test_sanitize_dimension( $source_params, $expected_value, $args = [] ) {
 		$sanitizer                 = new StubSanitizer( new Document(), $args );
@@ -288,9 +328,9 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests remove_invalid_child.
 	 *
-	 * @covers AMP_Base_Sanitizer::remove_invalid_child()
-	 * @covers AMP_Base_Sanitizer::should_sanitize_validation_error()
-	 * @covers AMP_Base_Sanitizer::prepare_validation_error()
+	 * @covers ::remove_invalid_child()
+	 * @covers ::should_sanitize_validation_error()
+	 * @covers ::prepare_validation_error()
 	 */
 	public function test_remove_invalid_child() {
 		$parent_tag_name = 'div';
@@ -361,9 +401,9 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests remove_invalid_child with script text normalization.
 	 *
-	 * @covers AMP_Base_Sanitizer::remove_invalid_child()
-	 * @covers AMP_Base_Sanitizer::should_sanitize_validation_error()
-	 * @covers AMP_Base_Sanitizer::prepare_validation_error()
+	 * @covers ::remove_invalid_child()
+	 * @covers ::should_sanitize_validation_error()
+	 * @covers ::prepare_validation_error()
 	 */
 	public function test_remove_invalid_child_with_script_text_normalization() {
 		$dom        = new Document( '1.0', 'utf-8' );
@@ -448,8 +488,8 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests remove_invalid_child.
 	 *
-	 * @covers AMP_Base_Sanitizer::remove_invalid_child()
-	 * @covers AMP_Base_Sanitizer::is_exempt_from_validation()
+	 * @covers ::remove_invalid_child()
+	 * @covers ::is_exempt_from_validation()
 	 */
 	public function test_remove_invalid_child_dev_mode() {
 		$id   = 'target';
@@ -484,9 +524,9 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests remove_invalid_child and should_sanitize_validation_error.
 	 *
-	 * @covers AMP_Base_Sanitizer::remove_invalid_attribute()
-	 * @covers AMP_Base_Sanitizer::should_sanitize_validation_error()
-	 * @covers AMP_Base_Sanitizer::prepare_validation_error()
+	 * @covers ::remove_invalid_attribute()
+	 * @covers ::should_sanitize_validation_error()
+	 * @covers ::prepare_validation_error()
 	 */
 	public function test_remove_invalid_attribute() {
 		$that = $this;
@@ -557,8 +597,8 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests remove_invalid_attribute in dev mode.
 	 *
-	 * @covers AMP_Base_Sanitizer::remove_invalid_attribute()
-	 * @covers AMP_Base_Sanitizer::is_exempt_from_validation()
+	 * @covers ::remove_invalid_attribute()
+	 * @covers ::is_exempt_from_validation()
 	 */
 	public function test_remove_invalid_attribute_dev_mode() {
 		$id   = 'target';
@@ -594,7 +634,7 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests get_data_amp_attributes.
 	 *
-	 * @covers AMP_Base_Sanitizer::get_data_amp_attributes()
+	 * @covers ::get_data_amp_attributes()
 	 */
 	public function test_get_data_amp_attributes() {
 		$tag          = 'figure';
@@ -619,7 +659,7 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests set_data_amp_attributes.
 	 *
-	 * @covers AMP_Base_Sanitizer::filter_data_amp_attributes()
+	 * @covers ::filter_data_amp_attributes()
 	 */
 	public function test_filter_data_amp_attributes() {
 		$amp_data   = [
@@ -642,7 +682,7 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 	/**
 	 * Tests set_attachment_layout_attributes.
 	 *
-	 * @covers AMP_Base_Sanitizer::filter_attachment_layout_attributes()
+	 * @covers ::filter_attachment_layout_attributes()
 	 */
 	public function test_filter_attachment_layout_attributes() {
 		$sanitizer    = new StubSanitizer( new Document(), [] );


### PR DESCRIPTION
See #6443.

This pull request adds an opt-in to the `AMP_Script_Sanitizer` to do the sanitization of scripts itself, rather than list limiting itself to unwrapping `noscript` elements. The new behavior is controlled by the `sanitize_scripts` sanitizer arg, which is `false` by default but which can be enabled as follows:

```php
add_filter(
	'amp_content_sanitizers',
	function ( $sanitizers ) {
		$sanitizers[ AMP_Script_Sanitizer::class ]['sanitize_scripts'] = true;
		return $sanitizers;
	}
);
```

When enabled, three new validation errors can be emitted by the script sanitizer:

* `CUSTOM_INLINE_SCRIPT`: A custom inline script is encountered.
* `CUSTOM_EXTERNAL_SCRIPT`: A custom external script is encountered (not loaded from the AMP CDN).
* `CUSTOM_EVENT_HANDLER_ATTR`: An event handler attribute is encountered (e.g. `onclick`).

When activating this [Test Custom Scripts](https://gist.github.com/westonruter/5c4b1cfe336c131507b1bffd1e5967d9) mini plugin and adding a `[custom_scripts]` shortcode to a post, the validation errors appear as follows:

![image](https://user-images.githubusercontent.com/134745/129809598-84e48f99-fafe-44e2-bc54-c12e7a583e55.png)

With this test plugin, when the scripts are removed the resulting output is as follows:

![image](https://user-images.githubusercontent.com/134745/129809704-f2a77943-d7bf-4780-a6e4-6eaad33c7365.png)

Notice how “Loading...” never changes since the script was removed and that the `noscript` was unwrapped. If if the invalid markup for the validation errors is marked as kept however:

> ![image](https://user-images.githubusercontent.com/134745/129809800-6ce02b70-487a-4d9b-8f40-adbd58e09732.png)

Then the result on the frontend is as follows:

> ![image](https://user-images.githubusercontent.com/134745/129809836-d51a7e85-88ec-48f1-9070-09220356d195.png)

The effect of keeping a custom script is as follows:

1. The script is not removed (obviously), and the `data-ampdevmode` attribute is added to prevent removal by the `AMP_Tag_And_Attribute_Sanitizer`.
2. The `noscript` unwrapping behavior is disabled since this could likely result in duplication of JS and non-JS functionality.
3. CSS tree shaking is disabled, allowing the green background color to be applied with style rule having a selector mentioning a JS-added class name. (The CSS max byte count enforcement is likewise lifted, via https://github.com/ampproject/amp-toolbox-php/pull/319.)
4. Native `img` elements are used instead of `amp-img`, since AMP validation is not going to happen anyway. See https://github.com/ampproject/amp-wp/pull/6518.
5. Likewise, native POST forms are also allowed without being converted to use `action-xhr`, as there may very well be scripts that are adding custom form validation logic on the page.  See https://github.com/ampproject/amp-wp/pull/6527.

Note: The `AMP_Script_Sanitizer` is moved to the beginning of the list of sanitizers because it's likely that keeping custom scripts will result in other behavior changes to other sanitizers beyond disabling tree-shaking in the style sanitizer and using native images. The ability of a sanitizer to change the behavior of subsequently-run sanitizers is enabled by the new `AMP_Base_Sanitizer::update_args()` method that allows the arguments to be updated.

### Unwrapping `noscript` elements

As noted above, when custom scripts are kept the `noscript` elements do not get unwrapped to avoid duplicated functionality (JS and non-JS fallback) from appearing on the page. 

There is also now a `unwrap_noscripts` sanitizer argument that allows unwrapping to be turned off entirely, although it is enabled by default.

Lastly, when an individual `noscript` element has a `data-amp-no-unwrap` attribute it will be selectively skipped from being unwrapped. Fixes #6030.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
