### PR TITLE
Update amphtml spec to dc6cd22a52

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -551,7 +551,6 @@ def ParseRules(repo_directory, out_dir):
 			# Now convert requires_versions back into a list of extensions rather than an extension/versions mapping.
 			tag['tag_spec']['requires_extension'] = sorted( tag['tag_spec']['requires_extension'].keys() )
 
-
 	return allowed_tags, attr_lists, descendant_lists, reference_points, versions
 
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -516,8 +516,7 @@ def ParseRules(repo_directory, out_dir):
 
 	# Now that Bento information is in hand, re-decorate specs with require_extension to indicate which
 	for tag_name, tags in allowed_tags.items():
-		has_bento = False
-
+		tags_bento_status = []
 		for tag in tags:
 			if 'requires_extension' not in tag['tag_spec']:
 				continue
@@ -532,15 +531,21 @@ def ParseRules(repo_directory, out_dir):
 
 			# Mark that this tag is for Bento since all its required extensions have Bento available.
 			if len( tag_extensions_with_bento ) > 0 and False not in tag_extensions_with_bento.values():
-				has_bento = True
+				tags_bento_status.append( True )
 				tag['tag_spec']['bento'] = True
+			else:
+				tags_bento_status.append( False )
 
-		# Now that the ones with Bento have been identified, indicate the others as not having Bento.
+		# Now that the ones with Bento have been identified, add flags to tag specs when there are different versions specifically for Bento:
 		for tag in tags:
 			if 'requires_extension' not in tag['tag_spec']:
 				continue
 
-			if has_bento and 'bento' not in tag['tag_spec']:
+			if False not in tags_bento_status:
+				# Clear the Bento flag if _all_ of the components are for Bento.
+				tag['tag_spec'].pop( 'bento', None )
+			elif True in tags_bento_status and 'bento' not in tag['tag_spec']:
+				# Otherwise, if _some_ of the components were exclusively for Bento, flag the others as being _not_ for Bento specifically.
 				tag['tag_spec']['bento'] = False
 
 			# Now convert requires_versions back into a list of extensions rather than an extension/versions mapping.

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1629,6 +1629,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-base-carousel',
 					),
@@ -1718,6 +1719,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'reference_points' => array(
 						'AMP-BASE-CAROUSEL lightbox [child]' => array(
 							'mandatory' => false,
@@ -1729,8 +1731,8 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'requires_extension' => array(
-						'amp-lightbox-gallery',
 						'amp-base-carousel',
+						'amp-lightbox-gallery',
 					),
 					'spec_name' => 'AMP-BASE-CAROUSEL [lightbox]',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel/',
@@ -2402,6 +2404,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'mandatory_oneof' => array(
 						'end-date',
 						'timeleft-ms',
@@ -2454,6 +2457,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'mandatory_oneof' => array(
 						'datetime',
 						'timestamp-ms',
@@ -3134,6 +3138,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => false,
 					'requires_extension' => array(
 						'amp-facebook-comments',
 					),
@@ -3162,6 +3167,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-facebook',
 					),
@@ -3200,6 +3206,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => false,
 					'requires_extension' => array(
 						'amp-facebook-like',
 					),
@@ -3235,6 +3242,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-facebook',
 					),
@@ -3273,6 +3281,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => false,
 					'requires_extension' => array(
 						'amp-facebook-page',
 					),
@@ -3308,6 +3317,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-facebook',
 					),
@@ -3918,6 +3928,7 @@ class AMP_Allowed_Tags_Generated {
 							5,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-inline-gallery',
 					),
@@ -3947,6 +3958,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -3973,6 +3985,7 @@ class AMP_Allowed_Tags_Generated {
 							1,
 						),
 					),
+					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -4023,6 +4036,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -5475,6 +5489,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'mandatory_anyof' => array(
 						'data-amp-bind-src',
 						'src',
@@ -7061,6 +7076,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-stream-gallery',
 					),
@@ -7164,6 +7180,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'bento' => true,
 					'requires_extension' => array(
 						'amp-timeago',
 					),
@@ -11689,8 +11706,8 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-autocomplete',
 					'requires_extension' => array(
-						'amp-form',
 						'amp-autocomplete',
+						'amp-form',
 					),
 					'spec_name' => 'amp-autocomplete > input',
 				),
@@ -15313,7 +15330,6 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
-					'spec_name' => 'amp-ad extension script',
 				),
 			),
 			array(
@@ -16303,7 +16319,6 @@ class AMP_Allowed_Tags_Generated {
 							'1.0',
 						),
 					),
-					'spec_name' => 'amp-facebook 1.0',
 				),
 			),
 			array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -260,6 +260,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-list',
 			'amp-live-list',
 			'amp-pixel',
+			'amp-render',
 			'amp-state',
 			'amp-story-360',
 			'amp-story-auto-analytics',
@@ -441,6 +442,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-powr-player',
 			'amp-reach-player',
 			'amp-reddit',
+			'amp-render',
 			'amp-riddle-quiz',
 			'amp-soundcloud',
 			'amp-springboard-player',
@@ -550,6 +552,7 @@ class AMP_Allowed_Tags_Generated {
 			'table',
 			'tbody',
 			'td',
+			'template',
 			'text',
 			'textpath',
 			'tfoot',
@@ -1584,7 +1587,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false)',
 					),
 					'loop' => array(
-						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false)',
+						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false|^$)',
 					),
 					'media' => array(),
 					'mixed-length' => array(
@@ -1673,7 +1676,7 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'loop' => array(
-						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false)',
+						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false|^$)',
 					),
 					'media' => array(),
 					'mixed-length' => array(
@@ -3136,6 +3139,35 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 			),
+			array(
+				'attr_spec_list' => array(
+					'data-href' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-facebook',
+					),
+					'spec_name' => 'amp-facebook-comments 1.0',
+				),
+			),
 		),
 		'amp-facebook-like' => array(
 			array(
@@ -3173,6 +3205,42 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 			),
+			array(
+				'attr_spec_list' => array(
+					'data-href' => array(
+						'mandatory' => true,
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'http',
+								'https',
+							),
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-facebook',
+					),
+					'spec_name' => 'amp-facebook-like 1.0',
+				),
+			),
 		),
 		'amp-facebook-page' => array(
 			array(
@@ -3208,6 +3276,42 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-facebook-page',
 					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'data-href' => array(
+						'mandatory' => true,
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'http',
+								'https',
+							),
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-facebook',
+					),
+					'spec_name' => 'amp-facebook-page 1.0',
 				),
 			),
 		),
@@ -3897,6 +4001,7 @@ class AMP_Allowed_Tags_Generated {
 						'value' => array(
 							'true',
 							'false',
+							'',
 						),
 					),
 					'media' => array(),
@@ -6911,7 +7016,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'loop' => array(
-						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false)',
+						'value_regex' => '([^,]+\\s+(true|false),\\s*)*(true|false|^$)',
 					),
 					'max-item-width' => array(
 						'value_regex' => '([^,]+\\s+(\\d+),\\s*)*(\\d+)',
@@ -11082,14 +11187,7 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'html' => array(
 			array(
-				'attr_spec_list' => array(
-					'data-amp-autocomplete-opt-in' => array(
-						'disallowed_value_regex' => 'false',
-						'value' => array(
-							'false',
-						),
-					),
-				),
+				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => '!doctype',
@@ -15710,11 +15808,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-brightcove',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
 				),
@@ -16188,13 +16291,19 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-facebook',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
+					'spec_name' => 'amp-facebook 1.0',
 				),
 			),
 			array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1629,7 +1629,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'requires_extension' => array(
 						'amp-base-carousel',
 					),
@@ -1719,7 +1718,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'reference_points' => array(
 						'AMP-BASE-CAROUSEL lightbox [child]' => array(
 							'mandatory' => false,
@@ -2404,7 +2402,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'mandatory_oneof' => array(
 						'end-date',
 						'timeleft-ms',
@@ -2457,7 +2454,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'mandatory_oneof' => array(
 						'datetime',
 						'timestamp-ms',
@@ -3928,7 +3924,6 @@ class AMP_Allowed_Tags_Generated {
 							5,
 						),
 					),
-					'bento' => true,
 					'requires_extension' => array(
 						'amp-inline-gallery',
 					),
@@ -3958,7 +3953,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -3985,7 +3979,6 @@ class AMP_Allowed_Tags_Generated {
 							1,
 						),
 					),
-					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -4036,7 +4029,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'mandatory_ancestor' => 'amp-inline-gallery',
 					'requires_extension' => array(
 						'amp-inline-gallery',
@@ -5489,7 +5481,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'mandatory_anyof' => array(
 						'data-amp-bind-src',
 						'src',
@@ -7076,7 +7067,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'requires_extension' => array(
 						'amp-stream-gallery',
 					),
@@ -7180,7 +7170,6 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'bento' => true,
 					'requires_extension' => array(
 						'amp-timeago',
 					),

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -180,6 +180,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			'amp_allowed_tags'                => AMP_Allowed_Tags_Generated::get_allowed_tags(),
 			'amp_globally_allowed_attributes' => AMP_Allowed_Tags_Generated::get_allowed_attributes(),
 			'amp_layout_allowed_attributes'   => AMP_Allowed_Tags_Generated::get_layout_attributes(),
+			'prefer_bento'                    => false,
 		];
 
 		parent::__construct( $dom, $args );
@@ -431,6 +432,17 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		$validation_errors          = [];
 		$rule_spec_list             = $this->allowed_tags[ $node->nodeName ];
 		foreach ( $rule_spec_list as $id => $rule_spec ) {
+			// When there are multiple versions of a rule spec, with one specifically for Bento and another for
+			// non-Bento make sure that only the preferred version is considered. Otherwise, the wrong requires_extension
+			// constraint may be applied.
+			if (
+				isset( $rule_spec['tag_spec']['bento'] )
+				&&
+				$this->args['prefer_bento'] !== $rule_spec['tag_spec']['bento']
+			) {
+				continue;
+			}
+
 			$validity = $this->validate_tag_spec_for_node( $node, $rule_spec[ AMP_Rule_Spec::TAG_SPEC ] );
 			if ( true === $validity ) {
 				$rule_spec_list_to_validate[ $id ] = $this->get_rule_spec_list_to_validate( $node, $rule_spec );

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -186,7 +186,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 				[ 'amp-ad' ],
 			],
 
-			'amp-facebook-comments'                        => [
+			'amp-facebook-comments_pass'                   => [
 				'<amp-facebook-comments width="486" height="657" data-href="http://example.com/baz" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				null, // No change.
 				[ 'amp-facebook-comments' ],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -803,7 +803,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 
 			'base_carousel'                                => [
 				'
-					<amp-base-carousel width="4" height="3" auto-advance="true" controls="auto" layout="responsive" heights="(min-width: 600px) calc(100% * 4 * 3 / 2), calc(100% * 3 * 3 / 2)" visible-count="(min-width: 600px) 4, 3" advance-count="(min-width: 600px) 4, 3">
+					<amp-base-carousel width="4" height="3" auto-advance="true" controls="auto" layout="responsive" heights="(min-width: 600px) calc(100% * 4 * 3 / 2), calc(100% * 3 * 3 / 2)" visible-count="(min-width: 600px) 4, 3" advance-count="(min-width: 600px) 4, 3" loop>
 						<div lightbox-thumbnail-id="food">first slide</div>
 						<div lightbox-exclude>second slide</div>
 					</amp-base-carousel>

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -192,6 +192,14 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 				[ 'amp-facebook-comments' ],
 			],
 
+			'amp-facebook-comments_bento'                  => [
+				'<amp-facebook-comments width="486" height="657" data-href="http://example.com/baz" layout="responsive" data-numposts="5"></amp-facebook-comments>',
+				null, // No change.
+				[ 'amp-facebook' ],
+				[],
+				[ 'prefer_bento' => true ],
+			],
+
 			'amp-facebook-comments_missing_required_attribute' => [
 				'<amp-facebook-comments width="486" height="657" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				'',
@@ -208,6 +216,28 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 				'<amp-facebook-like width="90" height="20" data-href="http://example.com/baz" layout="fixed" data-layout="button_count"></amp-facebook-like>',
 				null, // No change.
 				[ 'amp-facebook-like' ],
+			],
+
+			'amp-facebook-like_bento'                      => [
+				'<amp-facebook-like width="90" height="20" data-href="http://example.com/baz" layout="fixed" data-layout="button_count"></amp-facebook-like>',
+				null, // No change.
+				[ 'amp-facebook' ],
+				[],
+				[ 'prefer_bento' => true ],
+			],
+
+			'amp-facebook-page'                            => [
+				'<amp-facebook-page width="340" height="130" layout="responsive" data-href="https://www.facebook.com/imdb/"></amp-facebook-page>',
+				null, // No change.
+				[ 'amp-facebook-page' ],
+			],
+
+			'amp-facebook-page_bento'                      => [
+				'<amp-facebook-page width="340" height="130" layout="responsive" data-href="https://www.facebook.com/imdb/"></amp-facebook-page>',
+				null, // No change.
+				[ 'amp-facebook' ],
+				[],
+				[ 'prefer_bento' => true ],
 			],
 
 			'amp-facebook-like_missing_required_attribute' => [
@@ -3696,20 +3726,24 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 	 * @param string     $expected         The markup to expect.
 	 * @param array      $expected_scripts The AMP component script names that are obtained through sanitization.
 	 * @param array|null $expected_errors  Expected validation errors, either codes or validation error subsets.
+	 * @param array      $sanitizer_args   Sanitizer args.
 	 */
-	public function test_sanitize( $source, $expected = null, $expected_scripts = [], $expected_errors = [] ) {
+	public function test_sanitize( $source, $expected = null, $expected_scripts = [], $expected_errors = [], $sanitizer_args = [] ) {
 		$expected      = isset( $expected ) ? $expected : $source;
 		$dom           = Document::fromHtml( $source, Options::DEFAULTS );
 		$actual_errors = [];
 		$sanitizer     = new AMP_Tag_And_Attribute_Sanitizer(
 			$dom,
-			[
-				'use_document_element'      => true,
-				'validation_error_callback' => static function( $error ) use ( &$actual_errors ) {
-					$actual_errors[] = $error;
-					return true;
-				},
-			]
+			array_merge(
+				[
+					'use_document_element'      => true,
+					'validation_error_callback' => static function( $error ) use ( &$actual_errors ) {
+						$actual_errors[] = $error;
+						return true;
+					},
+				],
+				$sanitizer_args
+			)
 		);
 		$sanitizer->sanitize();
 		$content = $dom->saveHTML( $dom->documentElement );

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -186,7 +186,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 				[ 'amp-ad' ],
 			],
 
-			'amp-facebook-comments_pass'                   => [
+			'amp-facebook-comments'                        => [
 				'<amp-facebook-comments width="486" height="657" data-href="http://example.com/baz" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				null, // No change.
 				[ 'amp-facebook-comments' ],


### PR DESCRIPTION
Previously #6436.

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [x] Update spec generator as needed based on spec format changes.
- [x] Modify validating sanitizer based on changes to spec, if needed.
- [x] Add tests for key changes.

## Changelog

* Allow `loop` as boolean attribute on `amp-base-carousel`, `amp-inline-gallery-thumbnails`, and `amp-stream-gallery`. See https://github.com/swissspidy/gutenberg-bento/issues/1 and https://github.com/ampproject/amphtml/issues/35555.
* Add `amp-brightcove` (v1.0) as Bento component.
* Add `amp-facebook` (v1.0) as Bento component (including `amp-facebook-comments`, `amp-facebook-like`, and `amp-facebook-page`). This required some hoops to go through since there are Bento-specific tag specs which are identical to the non-Bento tag specs except that the Bento version requires `amp-facebook` (1.0) and the non-Bento versions require their own respective non-Bento scripts. I'm not super happy with the changes to `amphtml-update.py` but they'll hold us over for now, given that we'll be replacing the plugin's entire spec generation with the spec from `amp-toolbox-php` (see https://github.com/ampproject/amp-toolbox-php/pull/297). See also https://github.com/ampproject/amphtml/pull/35395#issuecomment-897104502.
* Allow `amp-render` in `amp-story`.
* Remove `data-amp-autocomplete-opt-in` validator hack.

## Details

```bash
(
    PREV_VERSION=ed0504b;
    THIS_VERSION=dc6cd22a52;
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

```diff
diff --git a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
index 6c80f07f78..0e6529ac48 100644
--- a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
+++ b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
@@ -70,7 +70,7 @@ attr_lists: {
   attrs: {
     name: "loop"
     # Media query / boolean pairs
-    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false|^$)"
   }
   attrs: {
     name: "mixed-length"
diff --git a/extensions/amp-brightcove/validator-amp-brightcove.protoascii b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
index e38295a94a..225f4f9813 100644
--- a/extensions/amp-brightcove/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
@@ -14,11 +14,26 @@
 # limitations under the license.
 #
 
-tags: {  # amp-brightcove
+tags: {  # amp-brightcove 1.0
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-brightcove 1.0"
+  excludes: "amp-brightcove 0.1"
   extension_spec: {
     name: "amp-brightcove"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-brightcove 0.1 and latest
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-brightcove 0.1"
+  excludes: "amp-brightcove 1.0"
+  extension_spec: {
+    name: "amp-brightcove"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
     requires_usage: EXEMPTED
diff --git a/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii b/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii
index d38cee1698..2e98c02721 100644
--- a/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii
+++ b/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii
@@ -17,6 +17,8 @@
 tags: {  # amp-facebook-comments
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-facebook-comments 0.1"
+  excludes: "amp-facebook 1.0"
   extension_spec: {
     name: "amp-facebook-comments"
     version: "0.1"
@@ -28,11 +30,9 @@ tags: {  # <amp-facebook-comments>
   html_format: AMP
   tag_name: "AMP-FACEBOOK-COMMENTS"
   requires_extension: "amp-facebook-comments"
-  # data-* is generally allowed, but it's not generally mandatory.
-  attrs: {
-    name: "data-href"
-    mandatory: true
-  }
+  requires: "amp-facebook-comments 0.1"
+  # The amp-facebook attr_list is defined in the amp-facebook protoascii
+  attr_lists: "amp-facebook"
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
diff --git a/extensions/amp-facebook-like/validator-amp-facebook-like.protoascii b/extensions/amp-facebook-like/validator-amp-facebook-like.protoascii
index eee4f29d7b..214109856b 100644
--- a/extensions/amp-facebook-like/validator-amp-facebook-like.protoascii
+++ b/extensions/amp-facebook-like/validator-amp-facebook-like.protoascii
@@ -17,6 +17,8 @@
 tags: {  # amp-facebook-like
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-facebook-like 0.1"
+  excludes: "amp-facebook 1.0"
   extension_spec: {
     name: "amp-facebook-like"
     version: "0.1"
@@ -28,16 +30,9 @@ tags: {  # <amp-facebook-like>
   html_format: AMP
   tag_name: "AMP-FACEBOOK-LIKE"
   requires_extension: "amp-facebook-like"
-  # data-* is generally allowed, but it's not generally mandatory.
-  attrs: {
-    name: "data-href"
-    mandatory: true
-    value_url: {
-      protocol: "http"
-      protocol: "https"
-      allow_relative: false
-    }
-  }
+  requires: "amp-facebook-like 0.1"
+  # The amp-facebook-strict attr_list is defined in the amp-facebook protoascii
+  attr_lists: "amp-facebook-strict"
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
diff --git a/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii b/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii
index 046b4e4659..70719c57ba 100644
--- a/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii
+++ b/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii
@@ -17,6 +17,8 @@
 tags: {  # amp-facebook-page
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-facebook-page 0.1"
+  excludes: "amp-facebook 1.0"
   extension_spec: {
     name: "amp-facebook-page"
     version: "0.1"
@@ -28,16 +30,9 @@ tags: {  # <amp-facebook-page>
   html_format: AMP
   tag_name: "AMP-FACEBOOK-PAGE"
   requires_extension: "amp-facebook-page"
-  # data-* is generally allowed, but it's not generally mandatory.
-  attrs: {
-    name: "data-href"
-    mandatory: true
-    value_url: {
-      protocol: "http"
-      protocol: "https"
-      allow_relative: false
-    }
-  }
+  requires: "amp-facebook-page 0.1"
+  # The amp-facebook-strict attr_list is defined in the amp-facebook protoascii
+  attr_lists: "amp-facebook-strict"
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
diff --git a/extensions/amp-facebook/validator-amp-facebook.protoascii b/extensions/amp-facebook/validator-amp-facebook.protoascii
index 100c4e8ada..526fcdaa5a 100644
--- a/extensions/amp-facebook/validator-amp-facebook.protoascii
+++ b/extensions/amp-facebook/validator-amp-facebook.protoascii
@@ -14,11 +14,33 @@
 # limitations under the license.
 #
 
-tags: {  # amp-facebook
+
+tags: {  # amp-facebook 1.0
+  html_format: AMP
+  tag_name: "SCRIPT"
+  # The 1.0 amp-facebook script registers all amp-facebook-* components.
+  # See https://github.com/ampproject/amphtml/pull/35395 for context.
+  spec_name: "amp-facebook 1.0"
+  satisfies: "amp-facebook 1.0"
+  excludes: "amp-facebook 0.1"
+  excludes: "amp-facebook-comments 0.1"
+  excludes: "amp-facebook-like 0.1"
+  excludes: "amp-facebook-page 0.1"
+  extension_spec: {
+    name: "amp-facebook"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-facebook 0.1 and latest
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-facebook 0.1"
+  excludes: "amp-facebook 1.0"
   extension_spec: {
     name: "amp-facebook"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
     requires_usage: EXEMPTED
@@ -30,11 +52,24 @@ tags: {  # <amp-facebook>
   html_format: AMP
   tag_name: "AMP-FACEBOOK"
   requires_extension: "amp-facebook"
-  # data-* is generally allowed, but it's not generally mandatory.
-  attrs: {
-    name: "data-href"
-    mandatory: true
+  attr_lists: "amp-facebook"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
   }
+}
+tags: {  # <amp-facebook-comments> via amp-facebook script
+  html_format: AMP
+  spec_name: "amp-facebook-comments 1.0"
+  tag_name: "AMP-FACEBOOK-COMMENTS"
+  requires_extension: "amp-facebook"
+  requires: "amp-facebook 1.0"
+  attr_lists: "amp-facebook"
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
@@ -45,3 +80,58 @@ tags: {  # <amp-facebook>
     supported_layouts: RESPONSIVE
   }
 }
+tags: {  # <amp-facebook-like> via amp-facebook script
+  html_format: AMP
+  spec_name: "amp-facebook-like 1.0"
+  tag_name: "AMP-FACEBOOK-LIKE"
+  requires_extension: "amp-facebook"
+  requires: "amp-facebook 1.0"
+  attr_lists: "amp-facebook-strict"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-facebook-page> via amp-facebook script
+  html_format: AMP
+  spec_name: "amp-facebook-page 1.0"
+  tag_name: "AMP-FACEBOOK-PAGE"
+  requires_extension: "amp-facebook"
+  requires: "amp-facebook 1.0"
+  attr_lists: "amp-facebook-strict"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+attr_lists: {
+  name: "amp-facebook"
+  # data-* is generally allowed, but it's not generally mandatory.
+  attrs: {
+    name: "data-href"
+    mandatory: true
+  }
+}
+attr_lists: {
+  name: "amp-facebook-strict"
+  # data-* is generally allowed, but it's not generally mandatory.
+  attrs: {
+    name: "data-href"
+    mandatory: true
+    value_url: {
+      protocol: "http"
+      protocol: "https"
+      allow_relative: false
+    }
+  }
+}
diff --git a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
index 088a3f8fe9..ac921ea96b 100644
--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -101,6 +101,7 @@ tags: {  # <amp-inline-gallery-thumbnails>
     name: "loop"
     value: "true"
     value: "false"
+    value: ""
   }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index c71289deb3..ccfd025ecb 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -716,6 +716,7 @@ descendant_tag_list: {
   tag: "AMP-LIST"
   tag: "AMP-LIVE-LIST"
   tag: "AMP-PIXEL"
+  tag: "AMP-RENDER"
   tag: "AMP-STATE"
   tag: "AMP-STORY-360"
   tag: "AMP-STORY-AUTO-ANALYTICS"
@@ -1090,6 +1091,7 @@ descendant_tag_list {
   tag: "AMP-POWR-PLAYER"
   tag: "AMP-REACH-PLAYER"
   tag: "AMP-REDDIT"
+  tag: "AMP-RENDER"
   tag: "AMP-RIDDLE-QUIZ"
   tag: "AMP-SOUNDCLOUD"
   tag: "AMP-SPRINGBOARD-PLAYER"
@@ -1201,6 +1203,7 @@ descendant_tag_list {
   tag: "TABLE"
   tag: "TBODY"
   tag: "TD"
+  tag: "TEMPLATE"
   tag: "TEXT"
   tag: "TEXTPATH"
   tag: "TFOOT"
diff --git a/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii b/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
index 543f541a62..1284bff7fa 100644
--- a/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
+++ b/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
@@ -60,7 +60,7 @@ attr_lists: {
   attrs: {
     name: "loop"
     # Media query / boolean pairs
-    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false|^$)"
   }
   attrs: {
     name: "min-visible-count"
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index 485c435ce6..2fa66f8224 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -100,14 +100,6 @@ tags: {  # HTML tag for non-transformed AMP.
   tag_name: "HTML"
   mandatory: true
   mandatory_parent: "!DOCTYPE"
-  attrs: {
-    # This attribute should always be invalid. See https://github.com/ampproject/amphtml/pull/27174
-    # To align with HTML spec, custom attributes should be prefixed with `data-`.
-    # Because `data-*` attributes are always valid AMP, the following rules explicitly disallow usage.
-    name: "data-amp-autocomplete-opt-in"
-    value: "false"
-    disallowed_value_regex: "false"
-  }
   unique: true
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup"
 }
```