### PR TITLE
Only load block editor related assets when it is used for a post

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -146,8 +146,8 @@ class AMP_Post_Meta_Box {
 		$validate = (
 			isset( $screen->base ) &&
 			'post' === $screen->base &&
-			( ! isset( $screen->is_block_editor ) || ! $screen->is_block_editor ) &&
-			in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true )
+			empty( $screen->is_block_editor ) &&
+			in_array( $post->post_type, AMP_Post_Type_Support::get_supported_post_types(), true )
 		);
 
 		if ( ! $validate ) {
@@ -344,7 +344,7 @@ class AMP_Post_Meta_Box {
 		$verify = (
 			isset( $post->ID )
 			&&
-			in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true )
+			in_array( $post->post_type, AMP_Post_Type_Support::get_supported_post_types(), true )
 			&&
 			current_user_can( 'edit_post', $post->ID )
 		);

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -216,12 +216,9 @@ class AMP_Post_Meta_Box {
 	 */
 	public function enqueue_block_assets() {
 		$post = get_post();
-		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, AMP_Post_Type_Support::get_eligible_post_types(), true ) ) {
-			return;
-		}
 
 		$editor_support = Services::get( 'editor.editor_support' );
-		if ( ! $editor_support->editor_supports_amp_block_editor_features() ) {
+		if ( ! $editor_support->supports_current_screen() ) {
 			return;
 		}
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -225,7 +225,7 @@ class AMP_Post_Meta_Box {
 
 		// Only enqueue scripts on the block editor for AMP-enabled posts.
 		$editor_support = Services::get( 'editor.editor_support' );
-		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		if ( ! $editor_support->is_current_screen_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -218,7 +218,7 @@ class AMP_Post_Meta_Box {
 		$post = get_post();
 
 		$editor_support = Services::get( 'editor.editor_support' );
-		if ( ! $editor_support->supports_current_screen() ) {
+		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -217,6 +217,13 @@ class AMP_Post_Meta_Box {
 	public function enqueue_block_assets() {
 		$post = get_post();
 
+		// Block validation script uses features only available beginning with WP 5.6.
+		$dependency_support = Services::get( 'dependency_support' );
+		if ( ! $dependency_support->has_support() ) {
+			return; // @codeCoverageIgnore
+		}
+
+		// Only enqueue scripts on the block editor for AMP-enabled posts.
 		$editor_support = Services::get( 'editor.editor_support' );
 		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			return;

--- a/includes/templates/amp-enabled-classic-editor-toggle.php
+++ b/includes/templates/amp-enabled-classic-editor-toggle.php
@@ -29,7 +29,7 @@ if ( ! ( $this instanceof AMP_Post_Meta_Box ) ) {
 	<?php if ( ! Services::get( 'dependency_support' )->has_support_from_core() ) : ?>
 		<div class="notice notice-info notice-alt inline">
 			<p>
-				<?php esc_html_e( 'Your version of WordPress is too old manage whether AMP is enabled. Please upgrade.', 'amp' ); ?>
+				<?php esc_html_e( 'Your version of WordPress is too old to manage whether AMP is enabled. Please upgrade.', 'amp' ); ?>
 			</p>
 		</div>
 	<?php else : ?>

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2178,7 +2178,7 @@ class AMP_Validation_Manager {
 		$editor_support = Services::get( 'editor.editor_support' );
 
 		// Block validation script uses features only available beginning with WP 5.6.
-		if ( ! $editor_support->supports_current_screen() ) {
+		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			return; // @codeCoverageIgnore
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2183,7 +2183,7 @@ class AMP_Validation_Manager {
 
 		// Only enqueue scripts on the block editor for AMP-enabled posts.
 		$editor_support = Services::get( 'editor.editor_support' );
-		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		if ( ! $editor_support->is_current_screen_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2178,7 +2178,7 @@ class AMP_Validation_Manager {
 		$editor_support = Services::get( 'editor.editor_support' );
 
 		// Block validation script uses features only available beginning with WP 5.6.
-		if ( ! $editor_support->editor_supports_amp_block_editor_features() ) {
+		if ( ! $editor_support->supports_current_screen() ) {
 			return; // @codeCoverageIgnore
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2175,11 +2175,16 @@ class AMP_Validation_Manager {
 			return;
 		}
 
-		$editor_support = Services::get( 'editor.editor_support' );
-
 		// Block validation script uses features only available beginning with WP 5.6.
-		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		$dependency_support = Services::get( 'dependency_support' );
+		if ( ! $dependency_support->has_support() ) {
 			return; // @codeCoverageIgnore
+		}
+
+		// Only enqueue scripts on the block editor for AMP-enabled posts.
+		$editor_support = Services::get( 'editor.editor_support' );
+		if ( ! $editor_support->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+			return;
 		}
 
 		$slug = 'amp-block-validation';

--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -44,7 +44,11 @@ final class EditorSupport implements Registerable, Service {
 	 * Shows a notice in the editor if the Gutenberg or WP version prevents plugin features from working.
 	 */
 	public function maybe_show_notice() {
-		if ( $this->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		if ( $this->dependency_support->has_support() ) {
+			return;
+		}
+
+		if ( ! $this->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 
@@ -66,19 +70,18 @@ final class EditorSupport implements Registerable, Service {
 	}
 
 	/**
-	 * Returns whether the current environment is supported by the plugin
-	 * and the current screen is using the block editor.
+	 * Returns whether the current screen is using the block editor and the post being edited supports AMP.
 	 *
 	 * @return bool
 	 */
 	public function is_current_screen_supported_block_editor_for_amp_enabled_post_type() {
 		$screen = get_current_screen();
-		return $this->dependency_support->has_support()
-			&&
+		return (
 			$screen
 			&&
 			! empty( $screen->is_block_editor )
 			&&
-			in_array( get_post_type(), AMP_Post_Type_Support::get_supported_post_types(), true );
+			in_array( get_post_type(), AMP_Post_Type_Support::get_supported_post_types(), true )
+		);
 	}
 }

--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -44,27 +44,7 @@ final class EditorSupport implements Registerable, Service {
 	 * Shows a notice in the editor if the Gutenberg or WP version prevents plugin features from working.
 	 */
 	public function maybe_show_notice() {
-		$screen = get_current_screen();
-
-		if ( ! $screen ) {
-			return;
-		}
-
-		$is_block_editor = (
-			! empty( $screen->is_block_editor )
-			||
-			// Applicable to Gutenberg v5.5.0 and older.
-			( function_exists( 'is_gutenberg_page' ) && is_gutenberg_page() )
-		);
-		if ( ! $is_block_editor ) {
-			return;
-		}
-
-		if ( ! in_array( get_post_type(), AMP_Post_Type_Support::get_eligible_post_types(), true ) ) {
-			return;
-		}
-
-		if ( $this->editor_supports_amp_block_editor_features() ) {
+		if ( $this->supports_current_screen() ) {
 			return;
 		}
 
@@ -86,11 +66,19 @@ final class EditorSupport implements Registerable, Service {
 	}
 
 	/**
-	 * Returns whether the editor in the current environment supports plugin features.
+	 * Returns whether the current environment is supported by the plugin
+	 * and the current screen is using the block editor.
 	 *
 	 * @return bool
 	 */
-	public function editor_supports_amp_block_editor_features() {
-		return $this->dependency_support->has_support() && use_block_editor_for_post( get_post() );
+	public function supports_current_screen() {
+		$screen = get_current_screen();
+		return $this->dependency_support->has_support()
+			&&
+			$screen
+			&&
+			! empty( $screen->is_block_editor )
+			&&
+			in_array( get_post_type(), AMP_Post_Type_Support::get_supported_post_types(), true );
 	}
 }

--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -44,7 +44,7 @@ final class EditorSupport implements Registerable, Service {
 	 * Shows a notice in the editor if the Gutenberg or WP version prevents plugin features from working.
 	 */
 	public function maybe_show_notice() {
-		if ( $this->supports_current_screen() ) {
+		if ( $this->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 
@@ -71,7 +71,7 @@ final class EditorSupport implements Registerable, Service {
 	 *
 	 * @return bool
 	 */
-	public function supports_current_screen() {
+	public function is_current_screen_supported_block_editor_for_amp_enabled_post_type() {
 		$screen = get_current_screen();
 		return $this->dependency_support->has_support()
 			&&

--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -91,6 +91,6 @@ final class EditorSupport implements Registerable, Service {
 	 * @return bool
 	 */
 	public function editor_supports_amp_block_editor_features() {
-		return $this->dependency_support->has_support();
+		return $this->dependency_support->has_support() && use_block_editor_for_post( get_post() );
 	}
 }

--- a/src/Editor/EditorSupport.php
+++ b/src/Editor/EditorSupport.php
@@ -48,7 +48,7 @@ final class EditorSupport implements Registerable, Service {
 			return;
 		}
 
-		if ( ! $this->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		if ( ! $this->is_current_screen_block_editor_for_amp_enabled_post_type() ) {
 			return;
 		}
 
@@ -74,7 +74,7 @@ final class EditorSupport implements Registerable, Service {
 	 *
 	 * @return bool
 	 */
-	public function is_current_screen_supported_block_editor_for_amp_enabled_post_type() {
+	public function is_current_screen_block_editor_for_amp_enabled_post_type() {
 		$screen = get_current_screen();
 		return (
 			$screen

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -33,16 +33,43 @@ final class EditorSupportTest extends TestCase {
 		$this->assertEquals( 99, has_action( 'admin_enqueue_scripts', [ $this->instance, 'maybe_show_notice' ] ) );
 	}
 
-	public function test_editor_supports_amp_block_editor_features() {
+	/**
+	 * Test data for test_editor_supports_amp_block_editor_features().
+	 *
+	 * @return array
+	 */
+	public function get_data_for_test_editor_supports_amp_block_editor_features() {
+		return [
+			'uses_block_editor'    => [ true ],
+			'not_use_block_editor' => [ false ],
+		];
+	}
+
+	/**
+	 * @covers ::editor_supports_amp_block_editor_features()
+	 * @dataProvider get_data_for_test_editor_supports_amp_block_editor_features()
+	 *
+	 * @param bool $post_uses_block_editor Whether post can be edited in the block editor.
+	 */
+	public function test_editor_supports_amp_block_editor_features( $post_uses_block_editor ) {
+		$GLOBALS['post'] = self::factory()->post->create();
+
+		add_filter(
+			'use_block_editor_for_post',
+			static function () use ( $post_uses_block_editor ) {
+				return $post_uses_block_editor;
+			} 
+		);
+
 		if (
 			defined( 'GUTENBERG_VERSION' )
 			&&
 			version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
 		) {
-			$this->assertTrue( $this->instance->editor_supports_amp_block_editor_features() );
+			$this->assertSame( $post_uses_block_editor, $this->instance->editor_supports_amp_block_editor_features() );
 		} else {
 			if ( version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
-				$this->assertTrue( $this->instance->editor_supports_amp_block_editor_features() );
+				$this->assertSame( $post_uses_block_editor, $this->instance->editor_supports_amp_block_editor_features() );
 			} else {
 				$this->assertFalse( $this->instance->editor_supports_amp_block_editor_features() );
 			}

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -20,6 +20,8 @@ final class EditorSupportTest extends TestCase {
 		parent::setUp();
 
 		$this->instance = new EditorSupport( new DependencySupport() );
+
+		unset( $GLOBALS['current_screen'], $GLOBALS['wp_scripts'] );
 	}
 
 	public function test_it_can_be_initialized() {

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -64,18 +64,18 @@ final class EditorSupportTest extends TestCase {
 		$this->setup_environment( $post_type_uses_block_editor, $post_type_supports_amp );
 
 		if (
-			defined( 'GUTENBERG_VERSION' )
-			&&
-			version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
+			(
+				defined( 'GUTENBERG_VERSION' )
+				&&
+				version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
+			)
+			||
+			version_compare( get_bloginfo( 'version' ), '5.0', '>=' )
 		) {
 			$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 		} else {
-			if ( version_compare( get_bloginfo( 'version' ), '5.0', '>=' ) ) {
-				$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
-			} else {
-				// WP < 5.0 doesn't include the block editor, so it should not be supported.
-				$this->assertFalse( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
-			}
+			// WP < 5.0 doesn't include the block editor, but Gutenberg would be installed, so it should be supported.
+			$this->assertTrue( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 		}
 	}
 
@@ -129,7 +129,8 @@ final class EditorSupportTest extends TestCase {
 		}
 
 		$this->setup_environment( true, true );
-		$this->assertFalse( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
+		// WP < 5.0 doesn't include the block editor, but Gutenberg would be installed, so it should be supported.
+		$this->assertTrue( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 
 		gutenberg_register_packages_scripts();
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -2,16 +2,17 @@
 
 namespace AmpProject\AmpWP\Tests\Editor;
 
-use AMP_Options_Manager;
 use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Editor\EditorSupport;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\Tests\Helpers\WithBlockEditorSupport;
 use AmpProject\AmpWP\Tests\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Editor\EditorSupport */
 final class EditorSupportTest extends TestCase {
+
+	use WithBlockEditorSupport;
 
 	/** @var EditorSupport */
 	private $instance;
@@ -134,31 +135,5 @@ final class EditorSupportTest extends TestCase {
 		$this->instance->maybe_show_notice();
 		$inline_script = wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false );
 		$this->assertStringContainsString( 'AMP functionality is not available', $inline_script );
-	}
-
-	/**
-	 * Setup test environment to ensure the correct result for ::supports_current_screen().
-	 *
-	 * @param bool   $post_type_uses_block_editor Whether the post type uses the block editor.
-	 * @param bool   $post_type_supports_amp      Whether the post type supports AMP.
-	 * @param string $post_type                   Post type ID.
-	 */
-	private function setup_environment( $post_type_uses_block_editor, $post_type_supports_amp, $post_type = 'foo' ) {
-		if ( $post_type_uses_block_editor ) {
-			set_current_screen( 'post.php' );
-			get_current_screen()->is_block_editor = $post_type_uses_block_editor;
-		}
-
-		if ( $post_type_supports_amp ) {
-			register_post_type( $post_type, [ 'public' => true ] );
-			$GLOBALS['post'] = self::factory()->post->create( [ 'post_type' => $post_type ] );
-			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-
-			$supported_post_types = array_merge(
-				AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES ),
-				[ $post_type ]
-			);
-			AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
-		}
 	}
 }

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -63,20 +63,9 @@ final class EditorSupportTest extends TestCase {
 	public function test_supports_current_screen( $post_type_uses_block_editor, $post_type_supports_amp, $expected_result ) {
 		$this->setup_environment( $post_type_uses_block_editor, $post_type_supports_amp );
 
-		if (
-			(
-				defined( 'GUTENBERG_VERSION' )
-				&&
-				version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
-			)
-			||
-			version_compare( get_bloginfo( 'version' ), '5.0', '>=' )
-		) {
-			$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
-		} else {
-			// WP < 5.0 doesn't include the block editor, but Gutenberg would be installed, so it should be supported.
-			$this->assertTrue( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
-		}
+		// Note: Without Gutenberg being installed on WP 4.9, the expected result would be `false`
+		// when `$post_type_uses_block_editor` and `$post_type_supports_amp` are `true`.
+		$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 	}
 
 	/** @covers ::maybe_show_notice() */

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -131,6 +131,7 @@ final class EditorSupportTest extends TestCase {
 		$this->assertFalse( $this->instance->supports_current_screen() );
 
 		gutenberg_register_packages_scripts();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$this->instance->maybe_show_notice();
 		$inline_script = wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false );

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -70,9 +70,10 @@ final class EditorSupportTest extends TestCase {
 		) {
 			$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 		} else {
-			if ( version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
+			if ( version_compare( get_bloginfo( 'version' ), '5.0', '>=' ) ) {
 				$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 			} else {
+				// WP < 5.0 doesn't include the block editor, so it should not be supported.
 				$this->assertFalse( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 			}
 		}

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -2,10 +2,12 @@
 
 namespace AmpProject\AmpWP\Tests\Editor;
 
+use AMP_Options_Manager;
 use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Editor\EditorSupport;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Option;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Editor\EditorSupport */
@@ -34,44 +36,41 @@ final class EditorSupportTest extends TestCase {
 	}
 
 	/**
-	 * Test data for test_editor_supports_amp_block_editor_features().
+	 * Test data for test_supports_current_screen().
 	 *
 	 * @return array
 	 */
-	public function get_data_for_test_editor_supports_amp_block_editor_features() {
+	public function get_data_for_test_supports_current_screen() {
 		return [
-			'uses_block_editor'    => [ true ],
-			'not_use_block_editor' => [ false ],
+			'supports post type and amp'         => [ true, true, true ],
+			'supports only post type'            => [ true, false, false ],
+			'supports only amp'                  => [ false, true, false ],
+			'does not support post type nor amp' => [ false, false, false ],
 		];
 	}
 
 	/**
-	 * @covers ::editor_supports_amp_block_editor_features()
-	 * @dataProvider get_data_for_test_editor_supports_amp_block_editor_features()
+	 * @covers ::supports_current_screen()
+	 * @dataProvider get_data_for_test_supports_current_screen()
 	 *
-	 * @param bool $post_uses_block_editor Whether post can be edited in the block editor.
+	 * @param bool $post_type_uses_block_editor Whether post type can be edited in the block editor.
+	 * @param bool $post_type_supports_amp      Whether post type supports AMP.
+	 * @param bool $expected_result             Expected result for test assertions.
 	 */
-	public function test_editor_supports_amp_block_editor_features( $post_uses_block_editor ) {
-		$GLOBALS['post'] = self::factory()->post->create();
-
-		add_filter(
-			'use_block_editor_for_post',
-			static function () use ( $post_uses_block_editor ) {
-				return $post_uses_block_editor;
-			} 
-		);
+	public function test_supports_current_screen( $post_type_uses_block_editor, $post_type_supports_amp, $expected_result ) {
+		$this->setup_environment( $post_type_uses_block_editor, $post_type_supports_amp );
 
 		if (
 			defined( 'GUTENBERG_VERSION' )
 			&&
 			version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
 		) {
-			$this->assertSame( $post_uses_block_editor, $this->instance->editor_supports_amp_block_editor_features() );
+			$this->assertSame( $expected_result, $this->instance->supports_current_screen() );
 		} else {
 			if ( version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
-				$this->assertSame( $post_uses_block_editor, $this->instance->editor_supports_amp_block_editor_features() );
+				$this->assertSame( $expected_result, $this->instance->supports_current_screen() );
 			} else {
-				$this->assertFalse( $this->instance->editor_supports_amp_block_editor_features() );
+				$this->assertFalse( $this->instance->supports_current_screen() );
 			}
 		}
 	}
@@ -84,37 +83,22 @@ final class EditorSupportTest extends TestCase {
 
 	/** @covers ::maybe_show_notice() */
 	public function test_dont_show_notice_for_unsupported_post_type() {
-		global $post;
-
-		set_current_screen( 'post.php' );
-		register_post_type( 'my-post-type' );
-		$post = $this->factory()->post->create( [ 'post_type' => 'my-post-type' ] );
-		setup_postdata( get_post( $post ) );
-
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->setup_environment( true, false );
 
 		$this->instance->maybe_show_notice();
 		$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['wp_scripts'] );
 	}
 
 	/** @covers ::maybe_show_notice() */
 	public function test_show_notice_for_supported_post_type() {
-		global $post;
-
 		if ( version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '<' ) ) {
 			$this->markTestSkipped();
 		}
 
-		set_current_screen( 'post.php' );
-		$post = $this->factory()->post->create();
-		setup_postdata( get_post( $post ) );
-
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->setup_environment( true, true );
 
 		$this->instance->maybe_show_notice();
-		if ( $this->instance->editor_supports_amp_block_editor_features() ) {
+		if ( $this->instance->supports_current_screen() ) {
 			$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
 		} else {
 			$this->assertStringContainsString(
@@ -122,72 +106,57 @@ final class EditorSupportTest extends TestCase {
 				wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false )
 			);
 		}
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['wp_scripts'] );
 	}
 
 	/** @covers ::maybe_show_notice() */
 	public function test_maybe_show_notice_for_unsupported_user() {
-		global $post;
-
-		set_current_screen( 'post.php' );
-		$post = $this->factory()->post->create();
-		setup_postdata( get_post( $post ) );
+		$this->setup_environment( true, true );
+		wp_set_current_user( self::factory()->user->create() );
 
 		$this->instance->maybe_show_notice();
 
 		$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['wp_scripts'] );
-	}
-
-	/** @covers ::maybe_show_notice() */
-	public function test_maybe_show_notice_with_cpt_supporting_gutenberg_but_not_amp() {
-		global $post;
-
-		if ( ! $this->instance->editor_supports_amp_block_editor_features() ) {
-			$this->markTestSkipped();
-		}
-
-		register_post_type(
-			'my-gb-post-type',
-			[
-				'public'       => true,
-				'show_in_rest' => true,
-				'supports'     => [ 'editor' ],
-			]
-		);
-
-		set_current_screen( 'post.php' );
-		$post = $this->factory()->post->create( [ 'post_type' => 'my-gb-post-type' ] );
-		setup_postdata( get_post( $post ) );
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-
-		$this->instance->maybe_show_notice();
-		$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['wp_scripts'] );
 	}
 
 	/** @covers ::maybe_show_notice() */
 	public function test_maybe_show_notice_for_gutenberg_4_9() {
-		global $post;
 		if ( ! defined( 'GUTENBERG_VERSION' ) || version_compare( GUTENBERG_VERSION, '4.9.0', '>' ) ) {
 			$this->markTestSkipped( 'Test only applicable to Gutenberg v4.9.0 and older.' );
 		}
 
-		$this->assertFalse( $this->instance->editor_supports_amp_block_editor_features() );
+		$this->setup_environment( true, true );
+		$this->assertFalse( $this->instance->supports_current_screen() );
 
 		gutenberg_register_packages_scripts();
-		set_current_screen( 'post.php' );
-		$post = $this->factory()->post->create();
-		setup_postdata( get_post( $post ) );
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$this->instance->maybe_show_notice();
 		$inline_script = wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false );
 		$this->assertStringContainsString( 'AMP functionality is not available', $inline_script );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['wp_scripts'] );
+	}
+
+	/**
+	 * Setup test environment to ensure the correct result for ::supports_current_screen().
+	 *
+	 * @param bool   $post_type_uses_block_editor Whether the post type uses the block editor.
+	 * @param bool   $post_type_supports_amp      Whether the post type supports AMP.
+	 * @param string $post_type                   Post type ID.
+	 */
+	private function setup_environment( $post_type_uses_block_editor, $post_type_supports_amp, $post_type = 'foo' ) {
+		if ( $post_type_uses_block_editor ) {
+			set_current_screen( 'post.php' );
+			get_current_screen()->is_block_editor = $post_type_uses_block_editor;
+		}
+
+		if ( $post_type_supports_amp ) {
+			register_post_type( $post_type, [ 'public' => true ] );
+			$GLOBALS['post'] = self::factory()->post->create( [ 'post_type' => $post_type ] );
+			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+			$supported_post_types = array_merge(
+				AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES ),
+				[ $post_type ]
+			);
+			AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
+		}
 	}
 }

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -53,7 +53,7 @@ final class EditorSupportTest extends TestCase {
 	}
 
 	/**
-	 * @covers ::supports_current_screen()
+	 * @covers ::is_current_screen_supported_block_editor_for_amp_enabled_post_type()
 	 * @dataProvider get_data_for_test_supports_current_screen()
 	 *
 	 * @param bool $post_type_uses_block_editor Whether post type can be edited in the block editor.
@@ -68,12 +68,12 @@ final class EditorSupportTest extends TestCase {
 			&&
 			version_compare( GUTENBERG_VERSION, DependencySupport::GB_MIN_VERSION, '>=' )
 		) {
-			$this->assertSame( $expected_result, $this->instance->supports_current_screen() );
+			$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 		} else {
 			if ( version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
-				$this->assertSame( $expected_result, $this->instance->supports_current_screen() );
+				$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 			} else {
-				$this->assertFalse( $this->instance->supports_current_screen() );
+				$this->assertFalse( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 			}
 		}
 	}
@@ -101,7 +101,7 @@ final class EditorSupportTest extends TestCase {
 		$this->setup_environment( true, true );
 
 		$this->instance->maybe_show_notice();
-		if ( $this->instance->supports_current_screen() ) {
+		if ( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
 			$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
 		} else {
 			$this->assertStringContainsString(
@@ -128,7 +128,7 @@ final class EditorSupportTest extends TestCase {
 		}
 
 		$this->setup_environment( true, true );
-		$this->assertFalse( $this->instance->supports_current_screen() );
+		$this->assertFalse( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
 
 		gutenberg_register_packages_scripts();
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -53,7 +53,7 @@ final class EditorSupportTest extends TestCase {
 	}
 
 	/**
-	 * @covers ::is_current_screen_supported_block_editor_for_amp_enabled_post_type()
+	 * @covers ::is_current_screen_block_editor_for_amp_enabled_post_type()
 	 * @dataProvider get_data_for_test_supports_current_screen()
 	 *
 	 * @param bool $post_type_uses_block_editor Whether post type can be edited in the block editor.
@@ -65,7 +65,7 @@ final class EditorSupportTest extends TestCase {
 
 		// Note: Without Gutenberg being installed on WP 4.9, the expected result would be `false`
 		// when `$post_type_uses_block_editor` and `$post_type_supports_amp` are `true`.
-		$this->assertSame( $expected_result, $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
+		$this->assertSame( $expected_result, $this->instance->is_current_screen_block_editor_for_amp_enabled_post_type() );
 	}
 
 	/** @covers ::maybe_show_notice() */
@@ -91,7 +91,7 @@ final class EditorSupportTest extends TestCase {
 		$this->setup_environment( true, true );
 
 		$this->instance->maybe_show_notice();
-		if ( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() ) {
+		if ( $this->instance->is_current_screen_block_editor_for_amp_enabled_post_type() ) {
 			$this->assertFalse( wp_scripts()->print_inline_script( 'wp-edit-post', 'after', false ) );
 		} else {
 			$this->assertStringContainsString(
@@ -119,7 +119,7 @@ final class EditorSupportTest extends TestCase {
 
 		$this->setup_environment( true, true );
 		// WP < 5.0 doesn't include the block editor, but Gutenberg would be installed, so it should be supported.
-		$this->assertTrue( $this->instance->is_current_screen_supported_block_editor_for_amp_enabled_post_type() );
+		$this->assertTrue( $this->instance->is_current_screen_block_editor_for_amp_enabled_post_type() );
 
 		gutenberg_register_packages_scripts();
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );

--- a/tests/php/src/Helpers/WithBlockEditorSupport.php
+++ b/tests/php/src/Helpers/WithBlockEditorSupport.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Trait WithoutBlockPreRendering.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\Tests\Helpers;
+
+use AMP_Options_Manager;
+use AmpProject\AmpWP\Option;
+
+/**
+ * Helper trait to help with setting up the test environment for block editor support.
+ */
+trait WithBlockEditorSupport {
+
+	/**
+	 * Setup test environment to ensure the correct result for ::supports_current_screen().
+	 *
+	 * @param bool   $post_type_uses_block_editor Whether the post type uses the block editor.
+	 * @param bool   $post_type_supports_amp      Whether the post type supports AMP.
+	 * @param string $post_type                   Post type ID.
+	 */
+	public function setup_environment( $post_type_uses_block_editor, $post_type_supports_amp, $post_type = 'foo' ) {
+		if ( $post_type_uses_block_editor ) {
+			set_current_screen( 'post.php' );
+			get_current_screen()->is_block_editor = $post_type_uses_block_editor;
+		}
+
+		if ( $post_type_supports_amp ) {
+			register_post_type( $post_type, [ 'public' => true ] );
+			$GLOBALS['post'] = self::factory()->post->create( [ 'post_type' => $post_type ] );
+			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+			$supported_post_types = array_merge(
+				AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES ),
+				[ $post_type ]
+			);
+			AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
+		}
+	}
+}

--- a/tests/php/src/Helpers/WithBlockEditorSupport.php
+++ b/tests/php/src/Helpers/WithBlockEditorSupport.php
@@ -9,6 +9,7 @@ namespace AmpProject\AmpWP\Tests\Helpers;
 
 use AMP_Options_Manager;
 use AmpProject\AmpWP\Option;
+use WP_User;
 
 /**
  * Helper trait to help with setting up the test environment for block editor support.
@@ -31,6 +32,8 @@ trait WithBlockEditorSupport {
 		if ( $post_type_supports_amp ) {
 			register_post_type( $post_type, [ 'public' => true ] );
 			$GLOBALS['post'] = self::factory()->post->create( [ 'post_type' => $post_type ] );
+
+			$previous_user = wp_get_current_user();
 			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 			$supported_post_types = array_merge(
@@ -38,6 +41,8 @@ trait WithBlockEditorSupport {
 				[ $post_type ]
 			);
 			AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
+
+			wp_set_current_user( $previous_user instanceof WP_User ? $previous_user->ID : $previous_user );
 		}
 	}
 }

--- a/tests/php/src/Helpers/WithBlockEditorSupport.php
+++ b/tests/php/src/Helpers/WithBlockEditorSupport.php
@@ -26,7 +26,8 @@ trait WithBlockEditorSupport {
 	public function setup_environment( $post_type_uses_block_editor, $post_type_supports_amp, $post_type = 'foo' ) {
 		if ( $post_type_uses_block_editor ) {
 			set_current_screen( 'post.php' );
-			get_current_screen()->is_block_editor = $post_type_uses_block_editor;
+			add_filter( 'replace_editor', '__return_false' );
+			add_filter( 'use_block_editor_for_post', '__return_true' );
 		}
 
 		if ( $post_type_supports_amp ) {

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -284,16 +284,11 @@ class Test_AMP_Post_Meta_Box extends TestCase {
 			$this->assertStringContainsString( $no_support_notice, $output );
 		}
 
-		// Post type no longer supports AMP, so no status input.
+		// Post type no longer supports AMP, so no status input (and no mention of AMP at all).
 		$supported_post_types = array_diff( AMP_Options_Manager::get_option( Option::SUPPORTED_POST_TYPES ), [ 'post' ] );
 		AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
 		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
-		if ( Services::get( 'dependency_support' )->has_support_from_core() ) {
-			$this->assertStringContainsString( 'This post type is not', $output );
-			$this->assertStringNotContainsString( $checkbox_enabled, $output );
-		} else {
-			$this->assertStringContainsString( $no_support_notice, $output );
-		}
+		$this->assertEmpty( $output );
 		$supported_post_types[] = 'post';
 		AMP_Options_Manager::update_option( Option::SUPPORTED_POST_TYPES, $supported_post_types );
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2403,7 +2403,6 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			$this->markTestSkipped( 'Block editor is too old.' );
 		}
 
-		$this->setup_environment( true, true );
 		AMP_Validation_Manager::enqueue_block_validation();
 
 		$slug = 'amp-block-validation';
@@ -2416,6 +2415,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		AMP_Validation_Manager::enqueue_block_validation();
 		$this->assertFalse( wp_script_is( $slug, 'enqueued' ) );
 
+		$this->setup_environment( true, true );
 		$service->set_user_enabled( wp_get_current_user()->ID, true );
 		AMP_Validation_Manager::enqueue_block_validation();
 		$this->assertTrue( wp_script_is( $slug, 'enqueued' ) );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -14,6 +14,7 @@ use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use AmpProject\AmpWP\Tests\Helpers\WithBlockEditorSupport;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
 use AmpProject\Dom\Document;
 
@@ -27,6 +28,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 	use HandleValidation;
 	use PrivateAccess;
+	use WithBlockEditorSupport;
 	use WithoutBlockPreRendering {
 		setUp as public prevent_block_pre_render;
 	}
@@ -2401,10 +2403,10 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			$this->markTestSkipped( 'Block editor is too old.' );
 		}
 
-		global $post;
-		$post = self::factory()->post->create_and_get();
-		$slug = 'amp-block-validation';
+		$this->setup_environment( true, true );
 		AMP_Validation_Manager::enqueue_block_validation();
+
+		$slug = 'amp-block-validation';
 		$this->assertFalse( wp_script_is( $slug, 'enqueued' ) );
 
 		// Ensure not displayed when dev tools is disabled.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6521

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
