### PR TITLE
Pass `amp_is_bento_enabled()` to `AMP_Tag_And_Attribute_Sanitizer` as `prefer_bento` arg

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1520,7 +1520,10 @@ function amp_get_content_sanitizers( $post = null ) {
 		'AMP_Meta_Sanitizer'              => [],
 		'AMP_Layout_Sanitizer'            => [],
 		'AMP_Accessibility_Sanitizer'     => [],
-		'AMP_Tag_And_Attribute_Sanitizer' => [], // Note: This validating sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
+		// Note: This validating sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
+		'AMP_Tag_And_Attribute_Sanitizer' => [
+			'prefer_bento' => amp_is_bento_enabled(),
+		],
 	];
 
 	if ( ! empty( $theme_support_args['nav_menu_toggle'] ) ) {


### PR DESCRIPTION
Given a post that has a Custom HTML block with this content:

```html
<script src="https://cdn.ampproject.org/v0/amp-facebook-page-0.1.mjs" async="" custom-element="amp-facebook-page" type="module" crossorigin="anonymous"></script>
```

Accessing an AMP page (without Bento enabled) will result in v0.1 of the AMP component added to the page (as expected):

```html
<script src="https://cdn.ampproject.org/v0/amp-facebook-page-0.1.mjs" async="" custom-element="amp-facebook" type="module"></script>
```

When adding this feature flag plugin to enable bento when `?bento` is added to the URL:

```php
if ( isset( $_GET['bento'] ) ) {
	add_filter( 'amp_bento_enabled', '__return_true' );
}
```

Accessing the same AMP page with Bento still results in the same script being added as opposed to `amp-facebook` v1.0:

```html
<script src="https://cdn.ampproject.org/v0/amp-facebook-page-0.1.js" async="" custom-element="amp-facebook-page"></script>
```

With this PR, this is fixed by passing the Bento enabled state to the `AMP_Tag_And_Attribute_Sanitizer` as the `prefer_bento` arg. So the resulting page then has:

```html
<script src="https://cdn.ampproject.org/v0/amp-facebook-1.0.js" async="" custom-element="amp-facebook"></script>
```

(Note that `amp-facebook-1.0.js` is served rather than `amp-facebook-1.0.mjs` because SSR for Bento is currently broken per https://github.com/ampproject/amphtml/issues/35485, and so SSR is currently disabled when Bento is enabled.)

Props @pierlon for recognizing this oversight in https://github.com/ampproject/amp-wp/pull/6353#issuecomment-897376540.