### PR TITLE
Decouple tests from external `TestCase` dependency

### DIFF
--- a/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
+++ b/tests/php/src/Admin/AnalyticsOptionsSubmenuTest.php
@@ -14,7 +14,7 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Admin\RESTPreloader;
 use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\LoadingError;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AnalyticsOptionsSubmenu.

--- a/tests/php/src/Admin/GoogleFontsTest.php
+++ b/tests/php/src/Admin/GoogleFontsTest.php
@@ -10,7 +10,7 @@ namespace AmpProject\AmpWP\Tests\Admin;
 use AmpProject\AmpWP\Admin\GoogleFonts;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for GoogleFonts class.

--- a/tests/php/src/Admin/OnboardingWizardSubmenuTest.php
+++ b/tests/php/src/Admin/OnboardingWizardSubmenuTest.php
@@ -11,7 +11,7 @@ use AmpProject\AmpWP\Admin\OnboardingWizardSubmenu;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for OnboardingWizardSubmenu  class.

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -16,7 +16,7 @@ use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\LoadingError;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for OptionsMenu.

--- a/tests/php/src/Admin/PluginActivationNoticeTest.php
+++ b/tests/php/src/Admin/PluginActivationNoticeTest.php
@@ -9,8 +9,8 @@ namespace AmpProject\AmpWP\Tests\Admin;
 
 use AmpProject\AmpWP\Admin\PluginActivationNotice;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\Tests\TestCase;
 use AMP_Options_Manager;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for PluginActivationNotice class.

--- a/tests/php/src/Admin/PluginRowMetaTest.php
+++ b/tests/php/src/Admin/PluginRowMetaTest.php
@@ -11,7 +11,7 @@ use AmpProject\AmpWP\Admin\PluginRowMeta;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for PluginRowMeta class.

--- a/tests/php/src/Admin/PolyfillsTest.php
+++ b/tests/php/src/Admin/PolyfillsTest.php
@@ -13,9 +13,9 @@ use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\HasRequirements;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Tests\TestCase;
 use WP_Scripts;
 use WP_Styles;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for Polyfills class.

--- a/tests/php/src/Admin/RESTPreloaderTest.php
+++ b/tests/php/src/Admin/RESTPreloaderTest.php
@@ -8,7 +8,7 @@
 namespace AmpProject\AmpWP\Tests\Admin;
 
 use AmpProject\AmpWP\Admin\RESTPreloader;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for RESTPreloader class.

--- a/tests/php/src/Admin/ReaderThemesTest.php
+++ b/tests/php/src/Admin/ReaderThemesTest.php
@@ -15,7 +15,7 @@ use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 use Closure;
 use WP_Error;
 

--- a/tests/php/src/Admin/ValidationCountsTest.php
+++ b/tests/php/src/Admin/ValidationCountsTest.php
@@ -19,7 +19,7 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Services;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for ValidationCounts class.

--- a/tests/php/src/AmpSlugCustomizationWatcherTest.php
+++ b/tests/php/src/AmpSlugCustomizationWatcherTest.php
@@ -5,7 +5,6 @@ namespace AmpProject\AmpWP\Tests;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\AmpSlugCustomizationWatcher */
 final class AmpSlugCustomizationWatcherTest extends TestCase {

--- a/tests/php/src/AmpWpPluginTest.php
+++ b/tests/php/src/AmpWpPluginTest.php
@@ -6,7 +6,6 @@ use AmpProject\AmpWP\AmpWpPlugin;
 use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\Tests\Fixture\DummyService;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 final class AmpWpPluginTest extends TestCase {
 

--- a/tests/php/src/BackgroundTask/BackgroundTaskDeactivatorTest.php
+++ b/tests/php/src/BackgroundTask/BackgroundTaskDeactivatorTest.php
@@ -10,7 +10,7 @@ use AmpProject\AmpWP\Infrastructure\Deactivateable;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * @coversDefaultClass \AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator

--- a/tests/php/src/BackgroundTask/MonitorCssTransientCachingTest.php
+++ b/tests/php/src/BackgroundTask/MonitorCssTransientCachingTest.php
@@ -9,8 +9,8 @@ use AMP_Options_Manager;
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\Tests\TestCase;
 use DateTime;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\BackgroundTask\MonitorCssTransientCaching */
 class MonitorCssTransientCachingTest extends TestCase {

--- a/tests/php/src/DependencyInjectedTestCase.php
+++ b/tests/php/src/DependencyInjectedTestCase.php
@@ -7,7 +7,6 @@ use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\ServiceContainer;
 use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 abstract class DependencyInjectedTestCase extends TestCase {
 

--- a/tests/php/src/DependencySupportTest.php
+++ b/tests/php/src/DependencySupportTest.php
@@ -4,7 +4,6 @@ namespace AmpProject\AmpWP\Tests;
 
 use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Infrastructure\Service;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\DependencySupport */
 class DependencySupportTest extends TestCase {

--- a/tests/php/src/DevTools/BlockSourcesTest.php
+++ b/tests/php/src/DevTools/BlockSourcesTest.php
@@ -16,7 +16,7 @@ use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\Tests\Helpers\MockPluginEnvironment;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for the BlockSources class.

--- a/tests/php/src/DevTools/UserAccessTest.php
+++ b/tests/php/src/DevTools/UserAccessTest.php
@@ -11,8 +11,8 @@ use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Option;
+use AmpProject\AmpWP\Tests\TestCase;
 use WP_Error;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for UserAccess class.

--- a/tests/php/src/Editor/EditorSupportTest.php
+++ b/tests/php/src/Editor/EditorSupportTest.php
@@ -6,7 +6,7 @@ use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Editor\EditorSupport;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Editor\EditorSupport */
 final class EditorSupportTest extends TestCase {

--- a/tests/php/src/ExtraThemeAndPluginHeadersTest.php
+++ b/tests/php/src/ExtraThemeAndPluginHeadersTest.php
@@ -5,7 +5,6 @@ namespace AmpProject\AmpWP\Tests;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\ExtraThemeAndPluginHeaders;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\ExtraThemeAndPluginHeaders */
 final class ExtraThemeAndPluginHeadersTest extends TestCase {

--- a/tests/php/src/IconTest.php
+++ b/tests/php/src/IconTest.php
@@ -3,7 +3,6 @@
 namespace AmpProject\AmpWP\Tests;
 
 use AmpProject\AmpWP\Icon;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Icon */
 final class IconTest extends TestCase {

--- a/tests/php/src/Infrastructure/ServiceBasedPluginTest.php
+++ b/tests/php/src/Infrastructure/ServiceBasedPluginTest.php
@@ -10,7 +10,7 @@ use AmpProject\AmpWP\Tests\Fixture\DummyService;
 use AmpProject\AmpWP\Tests\Fixture\DummyServiceBasedPlugin;
 use AmpProject\AmpWP\Tests\Fixture\DummyServiceWithDelay;
 use AmpProject\AmpWP\Tests\Fixture\DummyServiceWithRequirements;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 final class ServiceBasedPluginTest extends TestCase {
 

--- a/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
+++ b/tests/php/src/ObsoleteBlockAttributeRemoverTest.php
@@ -6,7 +6,6 @@ use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\ObsoleteBlockAttributeRemover;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 use WP_REST_Response;
 
 /** @coversDefaultClass \AmpProject\AmpWP\ObsoleteBlockAttributeRemover */

--- a/tests/php/src/Optimizer/AmpWPConfigurationTest.php
+++ b/tests/php/src/Optimizer/AmpWPConfigurationTest.php
@@ -7,7 +7,7 @@ use AmpProject\Optimizer\Configuration\OptimizeHeroImagesConfiguration;
 use AmpProject\Optimizer\Transformer\OptimizeHeroImages;
 use AmpProject\Optimizer\Transformer\ServerSideRendering;
 use AmpProject\Optimizer\TransformerConfiguration;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Optimizer\AmpWPConfiguration */
 final class AmpWPConfigurationTest extends TestCase {

--- a/tests/php/src/Optimizer/OptimizerServiceTest.php
+++ b/tests/php/src/Optimizer/OptimizerServiceTest.php
@@ -11,7 +11,7 @@ use AmpProject\Optimizer\TransformationEngine;
 use \AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\RemoteGetRequest;
 use AmpProject\RemoteRequest\FallbackRemoteGetRequest;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Optimizer\OptimizerService */
 final class OptimizerServiceTest extends TestCase {

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\Optimizer\Transformer\DetermineHeroImages;
 use AmpProject\Dom\Document;
 use AmpProject\Optimizer\Error;
 use AmpProject\Optimizer\ErrorCollection;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Optimizer\Transformer\DetermineHeroImages */
 final class DetermineHeroImagesTest extends TestCase {

--- a/tests/php/src/PluginRegistryTest.php
+++ b/tests/php/src/PluginRegistryTest.php
@@ -6,7 +6,6 @@ use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\PluginRegistry;
 use AmpProject\AmpWP\Tests\Helpers\MockPluginEnvironment;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\PluginRegistry */
 final class PluginRegistryTest extends TestCase {

--- a/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
+++ b/tests/php/src/RemoteRequest/CachedRemoteGetRequestTest.php
@@ -7,8 +7,8 @@ use AmpProject\AmpWP\RemoteRequest\CachedResponse;
 use AmpProject\AmpWP\RemoteRequest\WpHttpRemoteGetRequest;
 use AmpProject\RemoteRequest\RemoteGetRequestResponse;
 use AmpProject\RemoteRequest\StubbedRemoteGetRequest;
+use AmpProject\AmpWP\Tests\TestCase;
 use DateTimeImmutable;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest */
 class CachedRemoteGetRequestTest extends TestCase {

--- a/tests/php/src/TestCase.php
+++ b/tests/php/src/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as PolyfilledTestCase;
+
+/**
+ * Class TestCase.
+ *
+ * @package AmpProject\AmpWP\Tests
+ */
+abstract class TestCase extends PolyfilledTestCase {
+
+}

--- a/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
+++ b/tests/php/src/ValidatedUrlStylesheetDataGarbageCollectionTest.php
@@ -10,7 +10,6 @@ namespace AmpProject\AmpWP\Tests;
 use AMP_Validated_URL_Post_Type;
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
 use AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\BackgroundTask\ValidatedUrlStylesheetDataGarbageCollection */
 class ValidatedUrlStylesheetDataGarbageCollectionTest extends TestCase {

--- a/tests/php/src/Validation/SavePostValidationEventTest.php
+++ b/tests/php/src/Validation/SavePostValidationEventTest.php
@@ -13,9 +13,9 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\SavePostValidationEvent;
 use AmpProject\AmpWP\Validation\URLValidationProvider;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * @coversDefaultClass \AmpProject\AmpWP\Validation\SavePostValidationEvent

--- a/tests/php/src/Validation/ScannableURLProviderTest.php
+++ b/tests/php/src/Validation/ScannableURLProviderTest.php
@@ -8,10 +8,10 @@ use AMP_Post_Meta_Box;
 use AMP_Theme_Support;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\ScannableURLProvider;
 use AmpProject\AmpWP\Validation\URLScanningContext;
 use WP_Query;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Validation\ScannableURLProvider */
 final class ScannableURLProviderTest extends TestCase {

--- a/tests/php/src/Validation/URLScanningContextTest.php
+++ b/tests/php/src/Validation/URLScanningContextTest.php
@@ -3,8 +3,8 @@
 namespace AmpProject\AmpWP\Tests\Validation;
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\URLScanningContext;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Validation\URLScanningContext */
 final class URLScanningContextTest extends TestCase {

--- a/tests/php/src/Validation/URLValidationCronTest.php
+++ b/tests/php/src/Validation/URLValidationCronTest.php
@@ -9,11 +9,11 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\ScannableURLProvider;
 use AmpProject\AmpWP\Validation\URLScanningContext;
 use AmpProject\AmpWP\Validation\URLValidationCron;
 use AmpProject\AmpWP\Validation\URLValidationProvider;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Validation\URLValidationCron */
 final class URLValidationCronTest extends TestCase {

--- a/tests/php/src/Validation/URLValidationProviderTest.php
+++ b/tests/php/src/Validation/URLValidationProviderTest.php
@@ -3,8 +3,8 @@
 namespace AmpProject\AmpWP\Tests\Validation;
 
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\URLValidationProvider;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /** @coversDefaultClass \AmpProject\AmpWP\Validation\URLValidationProvider */
 final class URLValidationProviderTest extends TestCase {

--- a/tests/php/src/Validation/URLValidationRESTControllerTest.php
+++ b/tests/php/src/Validation/URLValidationRESTControllerTest.php
@@ -9,11 +9,11 @@ namespace AmpProject\AmpWP\Tests\Validation;
 
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
+use AmpProject\AmpWP\Tests\TestCase;
 use AmpProject\AmpWP\Validation\URLValidationProvider;
 use AmpProject\AmpWP\Validation\URLValidationRESTController;
 use WP_REST_Controller;
 use WP_REST_Request;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for URLValidationRESTController.

--- a/tests/php/test-amp-analytics-options.php
+++ b/tests/php/test-amp-analytics-options.php
@@ -2,7 +2,7 @@
 
 use AmpProject\AmpWP\Option;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Analytics_Options_Test extends TestCase {
 

--- a/tests/php/test-amp-audio-converter.php
+++ b/tests/php/test-amp-audio-converter.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 

--- a/tests/php/test-amp-carousel.php
+++ b/tests/php/test-amp-carousel.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\Component\Carousel;
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Dom\ElementList;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for Carousel class.

--- a/tests/php/test-amp-crowdsignal-embed-handler.php
+++ b/tests/php/test-amp-crowdsignal-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Crowdsignal_Embed_Handler_Test

--- a/tests/php/test-amp-dailymotion-embed-handler.php
+++ b/tests/php/test-amp-dailymotion-embed-handler.php
@@ -1,7 +1,7 @@
 <?php
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_DailyMotion_Embed_Handler_Test extends TestCase {
 

--- a/tests/php/test-amp-dev-mode-sanitizer.php
+++ b/tests/php/test-amp-dev-mode-sanitizer.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Dev_Mode_Sanitizer.

--- a/tests/php/test-amp-facebook-embed-handler.php
+++ b/tests/php/test-amp-facebook-embed-handler.php
@@ -7,7 +7,7 @@
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Facebook_Embed_Handler_Test

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\DevMode;
 use AmpProject\Dom\Document\Filter\MustacheScriptTemplates;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Gallery_Embed_Handler_Test

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 

--- a/tests/php/test-amp-image-dimension-extract-download.php
+++ b/tests/php/test-amp-image-dimension-extract-download.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Image_Dimension_Extractor.

--- a/tests/php/test-amp-image-dimension-extractor.php
+++ b/tests/php/test-amp-image-dimension-extractor.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Image_Dimension_Extractor.

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Img_Sanitizer_Test

--- a/tests/php/test-amp-instagram-embed-handler.php
+++ b/tests/php/test-amp-instagram-embed-handler.php
@@ -1,7 +1,7 @@
 <?php
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Instagram_Embed_Handler_Test extends TestCase {
 

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Layout_Sanitizer_Test

--- a/tests/php/test-amp-o2-player-sanitizer.php
+++ b/tests/php/test-amp-o2-player-sanitizer.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_O2_Player_Sanitizer

--- a/tests/php/test-amp-pinterest-embed-handler.php
+++ b/tests/php/test-amp-pinterest-embed-handler.php
@@ -1,7 +1,7 @@
 <?php
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Pinterest_Embed_Handler_Test extends TestCase {
 

--- a/tests/php/test-amp-playbuzz-sanitizer.php
+++ b/tests/php/test-amp-playbuzz-sanitizer.php
@@ -1,6 +1,6 @@
 <?php
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Playbuzz_Sanitizer_Test extends TestCase {
 

--- a/tests/php/test-amp-post-template-functions.php
+++ b/tests/php/test-amp-post-template-functions.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class Test_AMP_Post_Template_Functions

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -1,7 +1,7 @@
 <?php
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Render_Post_Test extends TestCase {
 

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Scribd_Embed_Handler_Test

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -7,7 +7,7 @@
 
 use AmpProject\AmpWP\Dom\Options;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Script_Sanitizer.

--- a/tests/php/test-amp-soundcloud-embed-handler.php
+++ b/tests/php/test-amp-soundcloud-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_SoundCloud_Embed_Handler_Test

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -16,7 +16,7 @@ use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\Exception\FailedToGetFromRemoteUrl;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Style_Sanitizer.

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -4,7 +4,7 @@
 // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends TestCase {
 

--- a/tests/php/test-amp-tumblr-embed-handler.php
+++ b/tests/php/test-amp-tumblr-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for Tumblr embeds.

--- a/tests/php/test-amp-twitter-embed-handler.php
+++ b/tests/php/test-amp-twitter-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Twitter_Embed_Handler_Test

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 

--- a/tests/php/test-amp-vimeo-embed-handler.php
+++ b/tests/php/test-amp-vimeo-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Vimeo_Embed_Handler_Test

--- a/tests/php/test-amp.php
+++ b/tests/php/test-amp.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for amp.php.

--- a/tests/php/test-class-amp-accessibility-sanitizer.php
+++ b/tests/php/test-class-amp-accessibility-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests the accessibility sanitizer class.

--- a/tests/php/test-class-amp-admin-pointer.php
+++ b/tests/php/test-class-amp-admin-pointer.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Admin_Pointers class.

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -7,7 +7,7 @@
 
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Tests\Helpers\StubSanitizer;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test AMP_Base_Sanitizer_Test

--- a/tests/php/test-class-amp-block-sanitizer.php
+++ b/tests/php/test-class-amp-block-sanitizer.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Block_Sanitizer_Test

--- a/tests/php/test-class-amp-cli-validation-command.php
+++ b/tests/php/test-class-amp-cli-validation-command.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\Cli\ValidationCommand;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\ValidationRequestMocking;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for Test_AMP_CLI_Validation_Command class.

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -7,7 +7,7 @@
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Comments_Sanitizer class.

--- a/tests/php/test-class-amp-content-sanitizer.php
+++ b/tests/php/test-class-amp-content-sanitizer.php
@@ -1,7 +1,7 @@
 <?php
 
 use AmpProject\AmpWP\Tests\Helpers\StubSanitizer;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Content_Sanitizer class.

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -8,7 +8,7 @@
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Core_Block_Handler.

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -8,7 +8,7 @@
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Core_Theme_Sanitizer_Test

--- a/tests/php/test-class-amp-customizer-design-settings.php
+++ b/tests/php/test-class-amp-customizer-design-settings.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class Test_AMP_Customizer_Design_Settings

--- a/tests/php/test-class-amp-dom-utils.php
+++ b/tests/php/test-class-amp-dom-utils.php
@@ -2,7 +2,7 @@
 
 use AmpProject\AmpWP\Dom\Options;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_DOM_Utils_Test

--- a/tests/php/test-class-amp-editor-blocks.php
+++ b/tests/php/test-class-amp-editor-blocks.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Editor_Blocks class.

--- a/tests/php/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/php/test-class-amp-gallery-block-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Gallery_Block_Sanitizer_Test

--- a/tests/php/test-class-amp-gfycat-embed-handler.php
+++ b/tests/php/test-class-amp-gfycat-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Gfycat_Embed_Handler_Test

--- a/tests/php/test-class-amp-http.php
+++ b/tests/php/test-class-amp-http.php
@@ -7,7 +7,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_HTTP.

--- a/tests/php/test-class-amp-imgur-embed-handler.php
+++ b/tests/php/test-class-amp-imgur-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Imgur_Embed_Handler_Test

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\AssertRestApiField;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Post_Meta_Box.

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -8,7 +8,7 @@
 use AmpProject\AmpWP\Dom\Options;
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Meta_Sanitizer.

--- a/tests/php/test-class-amp-nav-menu-dropdown-sanitizer.php
+++ b/tests/php/test-class-amp-nav-menu-dropdown-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class Test_AMP_Nav_Menu_Dropdown_Sanitizer

--- a/tests/php/test-class-amp-nav-menu-toggle-sanitizer.php
+++ b/tests/php/test-class-amp-nav-menu-toggle-sanitizer.php
@@ -7,7 +7,7 @@
 
 use AmpProject\AmpWP\Dom\Options;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Nav_Menu_Toggle_Sanitizer.

--- a/tests/php/test-class-amp-object-sanitizer.php
+++ b/tests/php/test-class-amp-object-sanitizer.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Object_Sanitizer_Test

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -8,7 +8,7 @@
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Admin\ReaderThemes;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Options_Manager.

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -7,7 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Playlist_Embed_Handler.

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -7,7 +7,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for Post Type Support.

--- a/tests/php/test-class-amp-reader-themes-rest-controller.php
+++ b/tests/php/test-class-amp-reader-themes-rest-controller.php
@@ -8,7 +8,7 @@
 
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Tests\Helpers\ThemesApiRequestMocking;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Reader_Theme_REST_Controller.

--- a/tests/php/test-class-amp-schema-org-metadata.php
+++ b/tests/php/test-class-amp-schema-org-metadata.php
@@ -10,7 +10,7 @@ use AmpProject\AmpWP\Optimizer\Transformer\AmpSchemaOrgMetadata;
 use AmpProject\AmpWP\Optimizer\Transformer\AmpSchemaOrgMetadataConfiguration;
 use AmpProject\Dom\Document;
 use AmpProject\Optimizer\ErrorCollection;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test Site_Health.

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -7,7 +7,7 @@
  */
 
 use AmpProject\AmpWP\Option;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Service_Worker.

--- a/tests/php/test-class-amp-srcset-sanitizer.php
+++ b/tests/php/test-class-amp-srcset-sanitizer.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class AMP_Srcset_Sanitizer_Test

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -18,7 +18,7 @@ use AmpProject\DevMode;
 use AmpProject\Dom\Document;
 use AmpProject\Dom\Element;
 use org\bovigo\vfs;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for Theme Support.

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class Test_AMP_TikTok_Embed_Handler

--- a/tests/php/test-class-amp-wordpress-tv-embed-handler.php
+++ b/tests/php/test-class-amp-wordpress-tv-embed-handler.php
@@ -7,7 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_WordPress_TV_Embed_Handler.

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -8,7 +8,7 @@
 
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_YouTube_Embed_Handler.

--- a/tests/php/test-class-site-health.php
+++ b/tests/php/test-class-site-health.php
@@ -11,7 +11,7 @@ use AmpProject\AmpWP\AmpWpPluginFactory;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\QueryVar;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Test Site_Health.

--- a/tests/php/test-dom-element-list.php
+++ b/tests/php/test-dom-element-list.php
@@ -8,7 +8,7 @@
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Dom\ElementList;
 use AmpProject\AmpWP\Component\CaptionedSlide;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP carousel and slide classes.

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -8,7 +8,7 @@
 use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Class Test_AMP_Admin_Includes_Functions

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -8,7 +8,7 @@
 use AmpProject\AmpWP\Dom\Options;
 use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\Dom\Document;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.WP.EnqueuedResources
 

--- a/tests/php/test-uninstall.php
+++ b/tests/php/test-uninstall.php
@@ -5,7 +5,7 @@
  * @package AMP
  */
 
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * @runInSeparateProcess

--- a/tests/php/test-wp-http-remote-get-request.php
+++ b/tests/php/test-wp-http-remote-get-request.php
@@ -6,7 +6,7 @@
  */
 
 use AmpProject\AmpWP\RemoteRequest\WpHttpRemoteGetRequest;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for the WpHttpRemoteGetRequest class.

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -11,7 +11,7 @@ use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 // phpcs:disable WordPress.Variables.GlobalVariables.OverrideProhibited
 

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -9,7 +9,7 @@ use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Services;
 use AmpProject\AmpWP\Tests\Helpers\HandleValidation;
-use Yoast\WPTestUtils\WPIntegration\TestCase;
+use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * Tests for AMP_Validation_Error_Taxonomy class.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Adds a local `TestCase` class that each test file will now extend from to decouple them from the external `Yoast\WPTestUtils\WPIntegration\TestCase` class.

Props to @schlessera for recommending it (https://github.com/ampproject/amp-wp/pull/6525#issuecomment-897435010).

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
