### PR TITLE
Use class constants instead of classes as string literals

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -16,11 +16,11 @@ use AmpProject\AmpWP\QueryVar;
 function amp_init_customizer() {
 
 	// Fire up the AMP Customizer.
-	add_action( 'customize_register', [ 'AMP_Template_Customizer', 'init' ], 500 );
+	add_action( 'customize_register', [ AMP_Template_Customizer::class, 'init' ], 500 );
 
 	if ( amp_is_legacy() ) {
 		// Add some basic design settings + controls to the Customizer.
-		add_action( 'amp_init', [ 'AMP_Customizer_Design_Settings', 'init' ] );
+		add_action( 'amp_init', [ AMP_Customizer_Design_Settings::class, 'init' ] );
 	}
 
 	// Add a link to the AMP Customizer in Reader mode.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -115,7 +115,7 @@ function amp_init() {
 	 */
 	do_action( 'amp_init' );
 
-	add_filter( 'allowed_redirect_hosts', [ 'AMP_HTTP', 'filter_allowed_redirect_hosts' ] );
+	add_filter( 'allowed_redirect_hosts', [ AMP_HTTP::class, 'filter_allowed_redirect_hosts' ] );
 	AMP_HTTP::purge_amp_query_vars();
 	AMP_HTTP::send_cors_headers();
 	AMP_HTTP::handle_xhr_request();
@@ -1322,27 +1322,27 @@ function amp_get_content_embed_handlers( $post = null ) {
 	return apply_filters(
 		'amp_content_embed_handlers',
 		[
-			'AMP_Core_Block_Handler'         => [],
-			'AMP_Twitter_Embed_Handler'      => [],
-			'AMP_YouTube_Embed_Handler'      => [],
-			'AMP_Crowdsignal_Embed_Handler'  => [],
-			'AMP_DailyMotion_Embed_Handler'  => [],
-			'AMP_Vimeo_Embed_Handler'        => [],
-			'AMP_SoundCloud_Embed_Handler'   => [],
-			'AMP_Instagram_Embed_Handler'    => [],
-			'AMP_Issuu_Embed_Handler'        => [],
-			'AMP_Meetup_Embed_Handler'       => [],
-			'AMP_Facebook_Embed_Handler'     => [],
-			'AMP_Pinterest_Embed_Handler'    => [],
-			'AMP_Playlist_Embed_Handler'     => [],
-			'AMP_Reddit_Embed_Handler'       => [],
-			'AMP_TikTok_Embed_Handler'       => [],
-			'AMP_Tumblr_Embed_Handler'       => [],
-			'AMP_Gallery_Embed_Handler'      => [],
-			'AMP_Gfycat_Embed_Handler'       => [],
-			'AMP_Imgur_Embed_Handler'        => [],
-			'AMP_Scribd_Embed_Handler'       => [],
-			'AMP_WordPress_TV_Embed_Handler' => [],
+			AMP_Core_Block_Handler::class         => [],
+			AMP_Twitter_Embed_Handler::class      => [],
+			AMP_YouTube_Embed_Handler::class      => [],
+			AMP_Crowdsignal_Embed_Handler::class  => [],
+			AMP_DailyMotion_Embed_Handler::class  => [],
+			AMP_Vimeo_Embed_Handler::class        => [],
+			AMP_SoundCloud_Embed_Handler::class   => [],
+			AMP_Instagram_Embed_Handler::class    => [],
+			AMP_Issuu_Embed_Handler::class        => [],
+			AMP_Meetup_Embed_Handler::class       => [],
+			AMP_Facebook_Embed_Handler::class     => [],
+			AMP_Pinterest_Embed_Handler::class    => [],
+			AMP_Playlist_Embed_Handler::class     => [],
+			AMP_Reddit_Embed_Handler::class       => [],
+			AMP_TikTok_Embed_Handler::class       => [],
+			AMP_Tumblr_Embed_Handler::class       => [],
+			AMP_Gallery_Embed_Handler::class      => [],
+			AMP_Gfycat_Embed_Handler::class       => [],
+			AMP_Imgur_Embed_Handler::class        => [],
+			AMP_Scribd_Embed_Handler::class       => [],
+			AMP_WordPress_TV_Embed_Handler::class => [],
 		],
 		$post
 	);
@@ -1478,10 +1478,10 @@ function amp_get_content_sanitizers( $post = null ) {
 	$native_post_forms_allowed = amp_is_native_post_form_allowed();
 
 	$sanitizers = [
-		'AMP_Embed_Sanitizer'             => [
+		AMP_Embed_Sanitizer::class             => [
 			'amp_to_amp_linking_enabled' => $amp_to_amp_linking_enabled,
 		],
-		'AMP_Core_Theme_Sanitizer'        => [
+		AMP_Core_Theme_Sanitizer::class        => [
 			'template'        => get_template(),
 			'stylesheet'      => get_stylesheet(),
 			'theme_features'  => [
@@ -1489,49 +1489,49 @@ function amp_get_content_sanitizers( $post = null ) {
 			],
 			'native_img_used' => $native_img_used,
 		],
-		'AMP_Srcset_Sanitizer'            => [],
-		'AMP_Img_Sanitizer'               => [
+		AMP_Srcset_Sanitizer::class            => [],
+		AMP_Img_Sanitizer::class               => [
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
 			'native_img_used'    => $native_img_used,
 		],
-		'AMP_Form_Sanitizer'              => [
+		AMP_Form_Sanitizer::class              => [
 			'native_post_forms_allowed' => $native_post_forms_allowed,
 		],
-		'AMP_Comments_Sanitizer'          => [
+		AMP_Comments_Sanitizer::class          => [
 			'comments_live_list' => ! empty( $theme_support_args['comments_live_list'] ),
 		],
-		'AMP_Video_Sanitizer'             => [],
-		'AMP_O2_Player_Sanitizer'         => [],
-		'AMP_Audio_Sanitizer'             => [],
-		'AMP_Playbuzz_Sanitizer'          => [],
-		'AMP_Object_Sanitizer'            => [],
-		'AMP_Iframe_Sanitizer'            => [
+		AMP_Video_Sanitizer::class             => [],
+		AMP_O2_Player_Sanitizer::class         => [],
+		AMP_Audio_Sanitizer::class             => [],
+		AMP_Playbuzz_Sanitizer::class          => [],
+		AMP_Object_Sanitizer::class            => [],
+		AMP_Iframe_Sanitizer::class            => [
 			'add_placeholder'    => true,
 			'current_origin'     => $current_origin,
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
 		],
-		'AMP_Gallery_Block_Sanitizer'     => [ // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
+		AMP_Gallery_Block_Sanitizer::class     => [ // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
 			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
 			'native_img_used'   => $native_img_used,
 		],
-		'AMP_Block_Sanitizer'             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
-		'AMP_Script_Sanitizer'            => [],
-		'AMP_Style_Sanitizer'             => [],
-		'AMP_Meta_Sanitizer'              => [],
-		'AMP_Layout_Sanitizer'            => [],
-		'AMP_Accessibility_Sanitizer'     => [],
+		AMP_Block_Sanitizer::class             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
+		AMP_Script_Sanitizer::class            => [],
+		AMP_Style_Sanitizer::class             => [],
+		AMP_Meta_Sanitizer::class              => [],
+		AMP_Layout_Sanitizer::class            => [],
+		AMP_Accessibility_Sanitizer::class     => [],
 		// Note: This validating sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
-		'AMP_Tag_And_Attribute_Sanitizer' => [
+		AMP_Tag_And_Attribute_Sanitizer::class => [
 			'prefer_bento' => amp_is_bento_enabled(),
 		],
 	];
 
 	if ( ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
-		$sanitizers['AMP_Nav_Menu_Toggle_Sanitizer'] = $theme_support_args['nav_menu_toggle'];
+		$sanitizers[ AMP_Nav_Menu_Toggle_Sanitizer::class ] = $theme_support_args['nav_menu_toggle'];
 	}
 
 	if ( ! empty( $theme_support_args['nav_menu_dropdown'] ) ) {
-		$sanitizers['AMP_Nav_Menu_Dropdown_Sanitizer'] = $theme_support_args['nav_menu_dropdown'];
+		$sanitizers[ AMP_Nav_Menu_Dropdown_Sanitizer::class ] = $theme_support_args['nav_menu_dropdown'];
 	}
 
 	if ( $amp_to_amp_linking_enabled && AMP_Theme_Support::STANDARD_MODE_SLUG !== AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) {
@@ -1550,7 +1550,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		 */
 		$excluded_urls = apply_filters( 'amp_to_amp_excluded_urls', [] );
 
-		$sanitizers['AMP_Link_Sanitizer'] = array_merge(
+		$sanitizers[ AMP_Link_Sanitizer::class ] = array_merge(
 			[ 'paired' => ! amp_is_canonical() ],
 			compact( 'excluded_urls' )
 		);
@@ -1601,7 +1601,7 @@ function amp_get_content_sanitizers( $post = null ) {
 
 		$sanitizers = array_merge(
 			[
-				'AMP_Dev_Mode_Sanitizer' => [
+				AMP_Dev_Mode_Sanitizer::class => [
 					'element_xpaths' => $dev_mode_xpaths,
 				],
 			],
@@ -1618,10 +1618,10 @@ function amp_get_content_sanitizers( $post = null ) {
 	 * @since 1.5.0
 	 * @param bool $transient_caching_allowed Transient caching allowed.
 	 */
-	$sanitizers['AMP_Style_Sanitizer']['allow_transient_caching'] = apply_filters( 'amp_parsed_css_transient_caching_allowed', true );
+	$sanitizers[ AMP_Style_Sanitizer::class ]['allow_transient_caching'] = apply_filters( 'amp_parsed_css_transient_caching_allowed', true );
 
 	// Force layout, style, meta, and validating sanitizers to be at the end.
-	foreach ( [ 'AMP_Layout_Sanitizer', 'AMP_Style_Sanitizer', 'AMP_Meta_Sanitizer', 'AMP_Tag_And_Attribute_Sanitizer' ] as $class_name ) {
+	foreach ( [ AMP_Layout_Sanitizer::class, AMP_Style_Sanitizer::class, AMP_Meta_Sanitizer::class, AMP_Tag_And_Attribute_Sanitizer::class ] as $class_name ) {
 		if ( isset( $sanitizers[ $class_name ] ) ) {
 			$sanitizer = $sanitizers[ $class_name ];
 			unset( $sanitizers[ $class_name ] );

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -26,7 +26,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
 
-	add_action( 'admin_bar_init', [ 'AMP_Theme_Support', 'init_admin_bar' ] );
+	add_action( 'admin_bar_init', [ AMP_Theme_Support::class, 'init_admin_bar' ] );
 	add_action( 'amp_post_template_footer', 'wp_admin_bar_render' );
 
 	// Printing scripts here is done primarily for the benefit of the admin bar. Note that wp_enqueue_scripts() is not called.

--- a/includes/class-amp-comment-walker.php
+++ b/includes/class-amp-comment-walker.php
@@ -8,7 +8,7 @@
  */
 
 /* translators: 1: AMP_Comment_Walker. 2: AMP_Comments_Sanitizer. */
-_deprecated_file( __FILE__, '1.1', null, sprintf( esc_html__( '%1$s functionality has been moved to %2$s.', 'amp' ), 'AMP_Comment_Walker', 'AMP_Comments_Sanitizer' ) );
+_deprecated_file( __FILE__, '1.1', null, esc_html( sprintf( __( '%1$s functionality has been moved to %2$s.', 'amp' ), AMP_Comment_Walker::class, AMP_Comments_Sanitizer::class ) ) );
 
 /**
  * Class AMP_Comment_Walker

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -351,7 +351,7 @@ class AMP_Theme_Support {
 		self::$sanitizer_classes = amp_get_content_sanitizers();
 		self::$sanitizer_classes = AMP_Validation_Manager::filter_sanitizer_args( self::$sanitizer_classes );
 		self::$embed_handlers    = self::register_content_embed_handlers();
-		self::$sanitizer_classes['AMP_Embed_Sanitizer']['embed_handlers'] = self::$embed_handlers;
+		self::$sanitizer_classes[ AMP_Embed_Sanitizer::class ]['embed_handlers'] = self::$embed_handlers;
 
 		foreach ( self::$sanitizer_classes as $sanitizer_class => $args ) {
 			if ( method_exists( $sanitizer_class, 'add_buffering_hooks' ) ) {
@@ -994,10 +994,10 @@ class AMP_Theme_Support {
 					__METHOD__,
 					esc_html(
 						sprintf(
-							/* translators: 1: embed handler. 2: AMP_Embed_Handler */
+							/* translators: 1: embed handler. 2: AMP_Base_Embed_Handler */
 							__( 'Embed Handler (%1$s) must extend `%2$s`', 'amp' ),
 							esc_html( $embed_handler_class ),
-							'AMP_Embed_Handler'
+							AMP_Base_Embed_Handler::class
 						)
 					),
 					'0.1'

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -99,7 +99,7 @@ class AMP_Content_Sanitizer {
 							/* translators: 1: sanitizer class. 2: AMP_Base_Sanitizer */
 							__( 'Sanitizer (%1$s) must extend `%2$s`', 'amp' ),
 							esc_html( $sanitizer_class ),
-							'AMP_Base_Sanitizer'
+							AMP_Base_Sanitizer::class
 						)
 					),
 					'0.1'

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -78,7 +78,7 @@ class AMP_Content {
 		$this->embed_handlers    = $this->register_embed_handlers( $embed_handler_classes );
 		$this->sanitizer_classes = $sanitizer_classes;
 
-		$this->sanitizer_classes['AMP_Embed_Sanitizer']['embed_handlers'] = $this->embed_handlers;
+		$this->sanitizer_classes[ AMP_Embed_Sanitizer::class ]['embed_handlers'] = $this->embed_handlers;
 
 		$this->transform();
 	}
@@ -175,10 +175,10 @@ class AMP_Content {
 					__METHOD__,
 					esc_html(
 						sprintf(
-							/* translators: 1: embed handler. 2: AMP_Embed_Handler */
+							/* translators: 1: embed handler. 2: AMP_Base_Embed_Handler */
 							__( 'Embed Handler (%1$s) must extend `%2$s`', 'amp' ),
 							esc_html( $embed_handler_class ),
-							'AMP_Embed_Handler'
+							AMP_Base_Embed_Handler::class
 						)
 					),
 					'0.1'

--- a/includes/validation/class-amp-validation-callback-wrapper.php
+++ b/includes/validation/class-amp-validation-callback-wrapper.php
@@ -88,7 +88,7 @@ class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 		// Wrap the markup output of (action) hooks in source comments.
 		AMP_Validation_Manager::$hook_source_stack[] = $this->callback['source'];
 		if ( ! $is_filter && AMP_Validation_Manager::can_output_buffer() ) {
-			$has_buffer_started = ob_start( [ 'AMP_Validation_Manager', 'wrap_buffer_with_source_comments' ] );
+			$has_buffer_started = ob_start( [ AMP_Validation_Manager::class, 'wrap_buffer_with_source_comments' ] );
 		} else {
 			$has_buffer_started = false;
 		}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1699,8 +1699,8 @@ class AMP_Validation_Manager {
 			$args['validation_error_callback'] = __CLASS__ . '::add_validation_error';
 		}
 
-		if ( isset( $sanitizers['AMP_Style_Sanitizer'] ) ) {
-			$sanitizers['AMP_Style_Sanitizer']['should_locate_sources'] = self::$is_validate_request;
+		if ( isset( $sanitizers[ AMP_Style_Sanitizer::class ] ) ) {
+			$sanitizers[ AMP_Style_Sanitizer::class ]['should_locate_sources'] = self::$is_validate_request;
 
 			$css_validation_errors = [];
 			foreach ( self::$validation_error_status_overrides as $slug => $status ) {
@@ -1722,7 +1722,7 @@ class AMP_Validation_Manager {
 				}
 			}
 			if ( ! empty( $css_validation_errors ) ) {
-				$sanitizers['AMP_Style_Sanitizer']['parsed_cache_variant'] = md5( wp_json_encode( $css_validation_errors ) );
+				$sanitizers[ AMP_Style_Sanitizer::class ]['parsed_cache_variant'] = md5( wp_json_encode( $css_validation_errors ) );
 			}
 		}
 

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -202,7 +202,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		do_action( 'after_setup_theme' );
 		do_action( 'init' );
 		$this->assertEquals( 1, did_action( 'amp_init' ) );
-		$this->assertEquals( 10, has_filter( 'allowed_redirect_hosts', [ 'AMP_HTTP', 'filter_allowed_redirect_hosts' ] ) );
+		$this->assertEquals( 10, has_filter( 'allowed_redirect_hosts', [ AMP_HTTP::class, 'filter_allowed_redirect_hosts' ] ) );
 		$this->assertEquals( 0, did_action( 'amp_plugin_update' ) );
 		$this->assertEqualSets(
 			[ 'post', 'page' ],
@@ -1636,7 +1636,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->last_filter_call = null;
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$handlers = amp_get_content_embed_handlers();
-		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
+		$this->assertArrayHasKey( AMP_SoundCloud_Embed_Handler::class, $handlers );
 		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
 		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
 		$this->assertNull( $this->last_filter_call['args'][1] );
@@ -1644,7 +1644,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->last_filter_call = null;
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		$handlers = amp_get_content_embed_handlers( $post );
-		$this->assertArrayHasKey( 'AMP_SoundCloud_Embed_Handler', $handlers );
+		$this->assertArrayHasKey( AMP_SoundCloud_Embed_Handler::class, $handlers );
 		$this->assertEquals( 'amp_content_embed_handlers', $this->last_filter_call['current_filter'] );
 		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
 		$this->assertEquals( $post, $this->last_filter_call['args'][1] );
@@ -1733,19 +1733,19 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->last_filter_call = null;
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$handlers = amp_get_content_sanitizers();
-		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
-		unset( $handlers['AMP_Style_Sanitizer']['allow_transient_caching'] ); // Remove item added after filter applied.
+		$this->assertArrayHasKey( AMP_Style_Sanitizer::class, $handlers );
+		unset( $handlers[ AMP_Style_Sanitizer::class ]['allow_transient_caching'] ); // Remove item added after filter applied.
 		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
 		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
 		$handler_classes = array_keys( $handlers );
 		$this->assertNull( $this->last_filter_call['args'][1] );
-		$this->assertEquals( 'AMP_Tag_And_Attribute_Sanitizer', end( $handler_classes ) );
+		$this->assertEquals( AMP_Tag_And_Attribute_Sanitizer::class, end( $handler_classes ) );
 
 		$this->last_filter_call = null;
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		$handlers = amp_get_content_sanitizers( $post );
-		unset( $handlers['AMP_Style_Sanitizer']['allow_transient_caching'] ); // Remove item added after filter applied.
-		$this->assertArrayHasKey( 'AMP_Style_Sanitizer', $handlers );
+		unset( $handlers[ AMP_Style_Sanitizer::class ]['allow_transient_caching'] ); // Remove item added after filter applied.
+		$this->assertArrayHasKey( AMP_Style_Sanitizer::class, $handlers );
 		$this->assertEquals( 'amp_content_sanitizers', $this->last_filter_call['current_filter'] );
 		$this->assertEquals( $handlers, $this->last_filter_call['args'][0] );
 		$this->assertEquals( $post, $this->last_filter_call['args'][1] );
@@ -1760,10 +1760,10 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		);
 		$ordered_sanitizers = array_keys( amp_get_content_sanitizers() );
 		$this->assertEquals( 'Even_After_Validating_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 5 ] );
-		$this->assertEquals( 'AMP_Layout_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 4 ] );
-		$this->assertEquals( 'AMP_Style_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
-		$this->assertEquals( 'AMP_Meta_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 2 ] );
-		$this->assertEquals( 'AMP_Tag_And_Attribute_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 1 ] );
+		$this->assertEquals( AMP_Layout_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 4 ] );
+		$this->assertEquals( AMP_Style_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
+		$this->assertEquals( AMP_Meta_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 2 ] );
+		$this->assertEquals( AMP_Tag_And_Attribute_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 1 ] );
 	}
 
 	/**
@@ -1783,18 +1783,18 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		// Check that AMP_Dev_Mode_Sanitizer is not registered if not in dev mode.
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertFalse( amp_is_dev_mode() );
-		$this->assertArrayNotHasKey( 'AMP_Dev_Mode_Sanitizer', $sanitizers );
+		$this->assertArrayNotHasKey( AMP_Dev_Mode_Sanitizer::class, $sanitizers );
 
 		// Check that AMP_Dev_Mode_Sanitizer is registered once in dev mode, but not with admin bar showing yet.
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertFalse( is_admin_bar_showing() );
 		$this->assertTrue( amp_is_dev_mode() );
-		$this->assertArrayHasKey( 'AMP_Dev_Mode_Sanitizer', $sanitizers );
-		$this->assertEquals( 'AMP_Dev_Mode_Sanitizer', current( array_keys( $sanitizers ) ) );
+		$this->assertArrayHasKey( AMP_Dev_Mode_Sanitizer::class, $sanitizers );
+		$this->assertEquals( AMP_Dev_Mode_Sanitizer::class, current( array_keys( $sanitizers ) ) );
 		$this->assertEquals(
 			compact( 'element_xpaths' ),
-			$sanitizers['AMP_Dev_Mode_Sanitizer']
+			$sanitizers[ AMP_Dev_Mode_Sanitizer::class ]
 		);
 		remove_filter( 'amp_dev_mode_enabled', '__return_true' );
 
@@ -1804,7 +1804,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertTrue( is_admin_bar_showing() );
 		$this->assertTrue( amp_is_dev_mode() );
-		$this->assertArrayHasKey( 'AMP_Dev_Mode_Sanitizer', $sanitizers );
+		$this->assertArrayHasKey( AMP_Dev_Mode_Sanitizer::class, $sanitizers );
 		$this->assertEqualSets(
 			array_merge(
 				$element_xpaths,
@@ -1814,7 +1814,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 					'//style[ @id = "admin-bar-inline-css" ]',
 				]
 			),
-			$sanitizers['AMP_Dev_Mode_Sanitizer']['element_xpaths']
+			$sanitizers[ AMP_Dev_Mode_Sanitizer::class ]['element_xpaths']
 		);
 	}
 
@@ -1836,7 +1836,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 	 * @covers ::amp_get_content_sanitizers()
 	 */
 	public function test_amp_get_content_sanitizers_amp_to_amp() {
-		$link_sanitizer_class_name = 'AMP_Link_Sanitizer';
+		$link_sanitizer_class_name = AMP_Link_Sanitizer::class;
 
 		// If AMP-to-AMP linking isn't enabled, this sanitizer shouldn't be present.
 		add_filter( 'amp_to_amp_linking_enabled', '__return_false' );

--- a/tests/php/test-amp-post-template-functions.php
+++ b/tests/php/test-amp-post-template-functions.php
@@ -34,7 +34,7 @@ class Test_AMP_Post_Template_Functions extends TestCase {
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'amp_post_template_add_default_styles' ) );
 		$this->assertSame( 99, has_action( 'amp_post_template_css', 'amp_post_template_add_styles' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' ) );
-		$this->assertSame( 10, has_action( 'admin_bar_init', [ 'AMP_Theme_Support', 'init_admin_bar' ] ) );
+		$this->assertSame( 10, has_action( 'admin_bar_init', [ AMP_Theme_Support::class, 'init_admin_bar' ] ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_footer', 'wp_admin_bar_render' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_head', 'wp_print_head_scripts' ) );
 		$this->assertSame( 10, has_action( 'amp_post_template_footer', 'wp_print_footer_scripts' ) );

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -342,7 +342,7 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 	 */
 	public function get_modals() {
 		$dom         = new Document();
-		$modal_roles = $this->get_private_property( 'AMP_Core_Theme_Sanitizer', 'modal_roles' );
+		$modal_roles = $this->get_private_property( AMP_Core_Theme_Sanitizer::class, 'modal_roles' );
 
 		$a = array_map(
 			static function ( $rule ) use ( $dom ) {

--- a/tests/php/test-class-amp-http.php
+++ b/tests/php/test-class-amp-http.php
@@ -381,10 +381,10 @@ class Test_AMP_HTTP extends TestCase {
 		$_SERVER['REQUEST_METHOD']                        = 'POST';
 		AMP_HTTP::purge_amp_query_vars();
 		AMP_HTTP::handle_xhr_request();
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', [ 'AMP_HTTP', 'intercept_post_request_redirect' ] ) );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_post_redirect', [ 'AMP_HTTP', 'filter_comment_post_redirect' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', [ AMP_HTTP::class, 'intercept_post_request_redirect' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_post_redirect', [ AMP_HTTP::class, 'filter_comment_post_redirect' ] ) );
 		$this->assertEquals(
-			[ 'AMP_HTTP', 'handle_wp_die' ],
+			[ AMP_HTTP::class, 'handle_wp_die' ],
 			apply_filters( 'wp_die_handler', '__return_true' )
 		);
 	}

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -315,9 +315,9 @@ class AMP_Link_Sanitizer_Test extends DependencyInjectedTestCase {
 		add_filter( 'amp_to_amp_linking_enabled', $filter );
 		$sanitizers = amp_get_content_sanitizers();
 		if ( $expected ) {
-			$this->assertArrayHasKey( 'AMP_Link_Sanitizer', $sanitizers );
+			$this->assertArrayHasKey( AMP_Link_Sanitizer::class, $sanitizers );
 		} else {
-			$this->assertArrayNotHasKey( 'AMP_Link_Sanitizer', $sanitizers );
+			$this->assertArrayNotHasKey( AMP_Link_Sanitizer::class, $sanitizers );
 		}
 	}
 }

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -35,7 +35,7 @@ class Test_AMP_Theme_Support extends TestCase {
 	 *
 	 * @var string
 	 */
-	const TESTED_CLASS = 'AMP_Theme_Support';
+	const TESTED_CLASS = AMP_Theme_Support::class;
 
 	/**
 	 * Set up before class.
@@ -240,7 +240,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( amp_is_request() );
 		AMP_Theme_Support::finish_init();
-		$this->assertEquals( 10, has_filter( 'index_template_hierarchy', [ 'AMP_Theme_Support', 'filter_amp_template_hierarchy' ] ), 'Expected add_amp_template_filters to have been called since template_dir is not empty' );
+		$this->assertEquals( 10, has_filter( 'index_template_hierarchy', [ AMP_Theme_Support::class, 'filter_amp_template_hierarchy' ] ), 'Expected add_amp_template_filters to have been called since template_dir is not empty' );
 		$this->assertEquals( 20, has_action( 'wp_head', 'amp_add_generator_metadata' ), 'Expected add_hooks to have been called' );
 		$this->assertTrue( current_theme_supports( 'amp' ) );
 
@@ -362,7 +362,7 @@ class Test_AMP_Theme_Support extends TestCase {
 	 * @covers AMP_Theme_Support::add_amp_template_filters()
 	 */
 	public function test_add_amp_template_filters() {
-		$template_types = $this->get_private_property( 'AMP_Theme_Support', 'template_types' );
+		$template_types = $this->get_private_property( AMP_Theme_Support::class, 'template_types' );
 
 		AMP_Theme_Support::add_amp_template_filters();
 
@@ -762,7 +762,7 @@ class Test_AMP_Theme_Support extends TestCase {
 
 		$this->assertFalse( has_action( 'wp_head', 'print_emoji_detection_script' ) );
 		$this->assertFalse( has_action( 'wp_print_styles', 'print_emoji_styles' ) );
-		$this->assertEquals( 10, has_action( 'wp_print_styles', [ 'AMP_Theme_Support', 'print_emoji_styles' ] ) );
+		$this->assertEquals( 10, has_action( 'wp_print_styles', [ AMP_Theme_Support::class, 'print_emoji_styles' ] ) );
 		$this->assertEquals( 10, has_filter( 'the_title', 'wp_staticize_emoji' ) );
 		$this->assertEquals( 10, has_filter( 'the_excerpt', 'wp_staticize_emoji' ) );
 		$this->assertEquals( 10, has_filter( 'the_content', 'wp_staticize_emoji' ) );
@@ -797,7 +797,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$content_width  = 1234;
 		$embed_handlers = AMP_Theme_Support::register_content_embed_handlers();
 		foreach ( $embed_handlers as $embed_handler ) {
-			$this->assertTrue( is_subclass_of( $embed_handler, 'AMP_Base_Embed_Handler' ) );
+			$this->assertTrue( is_subclass_of( $embed_handler, AMP_Base_Embed_Handler::class ) );
 			$property = $this->get_private_property( $embed_handler, 'args' );
 			$this->assertEquals( $content_width, $property['content_max_width'] );
 		}
@@ -1006,8 +1006,8 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->assertEquals( 10, has_action( 'wp_head', $callback ) );
 
 		AMP_Theme_Support::init_admin_bar();
-		$this->assertEquals( 10, has_filter( 'style_loader_tag', [ 'AMP_Theme_Support', 'filter_admin_bar_style_loader_tag' ] ) );
-		$this->assertEquals( 10, has_filter( 'script_loader_tag', [ 'AMP_Theme_Support', 'filter_admin_bar_script_loader_tag' ] ) );
+		$this->assertEquals( 10, has_filter( 'style_loader_tag', [ AMP_Theme_Support::class, 'filter_admin_bar_style_loader_tag' ] ) );
+		$this->assertEquals( 10, has_filter( 'script_loader_tag', [ AMP_Theme_Support::class, 'filter_admin_bar_script_loader_tag' ] ) );
 		$this->assertFalse( has_action( 'wp_head', $callback ) );
 		ob_start();
 		wp_print_styles();
@@ -1146,7 +1146,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$this->go_to( '/' );
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
-		add_filter( 'style_loader_tag', [ 'AMP_Theme_Support', 'filter_admin_bar_style_loader_tag' ], 10, 2 );
+		add_filter( 'style_loader_tag', [ AMP_Theme_Support::class, 'filter_admin_bar_style_loader_tag' ], 10, 2 );
 		$setup_callback();
 		ob_start();
 		echo '<html><head>';
@@ -1224,7 +1224,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 		$this->go_to( '/' );
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
-		add_filter( 'script_loader_tag', [ 'AMP_Theme_Support', 'filter_admin_bar_script_loader_tag' ], 10, 2 );
+		add_filter( 'script_loader_tag', [ AMP_Theme_Support::class, 'filter_admin_bar_script_loader_tag' ], 10, 2 );
 		$setup_callback();
 		ob_start();
 		echo '<html><head>';
@@ -2198,7 +2198,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		add_filter(
 			'amp_content_sanitizers',
 			static function( $sanitizers ) {
-				$sanitizers['AMP_Theme_Support_Sanitizer_Counter'] = [];
+				$sanitizers[ AMP_Theme_Support_Sanitizer_Counter::class ] = [];
 				return $sanitizers;
 			}
 		);

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -43,8 +43,8 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 		AMP_Options_Manager::update_option( Option::READER_THEME, ReaderThemes::DEFAULT_READER_THEME );
 		amp_init_customizer();
 		$this->assertTrue( amp_is_legacy() );
-		$this->assertEquals( 500, has_action( 'customize_register', [ 'AMP_Template_Customizer', 'init' ] ) );
-		$this->assertEquals( 10, has_action( 'amp_init', [ 'AMP_Customizer_Design_Settings', 'init' ] ) );
+		$this->assertEquals( 500, has_action( 'customize_register', [ AMP_Template_Customizer::class, 'init' ] ) );
+		$this->assertEquals( 10, has_action( 'amp_init', [ AMP_Customizer_Design_Settings::class, 'init' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', 'amp_add_customizer_link' ) );
 	}
 

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -26,7 +26,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 	use PrivateAccess;
 	use LoadsCoreThemes;
 
-	const TESTED_CLASS = 'AMP_Validated_URL_Post_Type';
+	const TESTED_CLASS = AMP_Validated_URL_Post_Type::class;
 
 	public function setUp() {
 		parent::setUp();
@@ -247,7 +247,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		$this->assertEquals( 'new rejected', $error['data']['code'] );
 		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, $error['term_status'] );
 
-		$summary = get_echo( [ 'AMP_Validated_URL_Post_Type', 'display_invalid_url_validation_error_counts_summary' ], [ $invalid_url_post_id ] );
+		$summary = get_echo( [ AMP_Validated_URL_Post_Type::class, 'display_invalid_url_validation_error_counts_summary' ], [ $invalid_url_post_id ] );
 		$this->assertStringContainsString( 'Invalid markup kept: 2', $summary );
 		$this->assertStringContainsString( 'Invalid markup removed: 2', $summary );
 	}
@@ -782,7 +782,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		AMP_Validation_Manager::init();
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors( $errors, home_url( '/' ) );
 
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'output_custom_column' ], [ $column_name, $invalid_url_post_id ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'output_custom_column' ], [ $column_name, $invalid_url_post_id ] );
 		$this->assertStringContainsString( $expected_value, $output );
 	}
 
@@ -807,12 +807,12 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		];
 
 		// If there is an embed and a theme source, this should only output the embed icon.
-		$sources_column = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>Embed</strong>', $sources_column );
 
 		// If there is no embed source, but there is a theme, this should output the theme icon.
 		unset( $error_summary['sources_with_invalid_output']['embed'] );
-		$sources_column      = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column      = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$expected_theme_icon = '<strong class="source"><span class="dashicons dashicons-admin-appearance"></span>' . $theme_name . '</strong>';
 		$this->assertEquals( $expected_theme_icon, $sources_column );
 
@@ -821,28 +821,28 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		$error_summary['sources_with_invalid_output']['plugin'] = [ $plugin_name ];
 		$expected_plugin_icon                                   = '<strong class="source"><span class="dashicons dashicons-admin-plugins"></span>' . $plugin_name . '</strong>';
 		unset( $error_summary['sources_with_invalid_output']['embed'] );
-		$sources_column = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( $expected_plugin_icon . $expected_theme_icon, $sources_column );
 
 		// If there is a 'core' source, it should appear in the column output.
 		$error_summary['sources_with_invalid_output']['core'] = [];
-		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                                       = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertStringContainsString( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>Other (0)</strong>', $sources_column );
 
 		// Even if there is a hook in the sources, it should not appear in the column if there is any other source.
 		$hook_name = 'wp_header';
 		$error_summary['sources_with_invalid_output']['hook'] = [ $hook_name ];
-		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                                       = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertStringNotContainsString( $hook_name, $sources_column );
 
 		// If a hook is the only source, it should appear in the column.
 		$error_summary['sources_with_invalid_output'] = [ 'hook' => $hook_name ];
-		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                               = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>Hook: ' . $hook_name . '</strong>', $sources_column );
 
 		// Content gets a translated name.
 		$error_summary['sources_with_invalid_output'] = [ 'hook' => 'the_content' ];
-		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                               = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-edit"></span>Content</strong>', $sources_column );
 
 		// Blocks are listed separately, overriding Content.
@@ -850,13 +850,13 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 			'hook'   => 'the_content',
 			'blocks' => [ 'core/html' ],
 		];
-		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                               = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-edit"></span>Custom HTML</strong>', $sources_column );
 
 		// If there's no source in 'sources_with_invalid_output', this should output the theme name.
 		update_post_meta( $post_id, '_amp_validated_environment', [ 'theme' => $theme_name ] );
 		$error_summary['sources_with_invalid_output'] = [];
-		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
+		$sources_column                               = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
 		$this->assertEquals( '<div class="source"><span class="dashicons dashicons-admin-appearance"></span>' . $theme_name . ' (?)</div>', $sources_column );
 	}
 
@@ -961,11 +961,11 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Validation_Manager::init();
 
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertEmpty( $output );
 
 		$_GET['post_type'] = 'post';
-		$output            = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output            = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
@@ -973,24 +973,24 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '1';
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ]      = '1';
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertStringContainsString( 'The rechecked URL still has remaining invalid markup kept.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '2';
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertStringContainsString( 'The rechecked URLs still have remaining invalid markup kept.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '0';
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertStringContainsString( 'The rechecked URLs are free of non-removed invalid markup.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '1';
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertStringContainsString( 'The rechecked URL is free of non-removed invalid markup.', $output );
 
 		$error_message              = 'Something <code>bad</code> happened!';
 		$_GET['amp_validate_error'] = AMP_Validation_Manager::serialize_validation_error_messages( [ $error_message ] );
-		$output                     = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
+		$output                     = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_admin_notice' ] );
 		$this->assertStringContainsString( $error_message, $output );
 
 		unset( $GLOBALS['current_screen'] );
@@ -1339,12 +1339,12 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $current_screen;
 		set_current_screen( 'index.php' );
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_link_to_error_index_screen' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
 		$current_screen->post_type = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
-		$output                    = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ] );
+		$output                    = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_link_to_error_index_screen' ] );
 		$this->assertStringContainsString( 'View Error Index', $output );
 	}
 
@@ -1461,7 +1461,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 
 		$post_storing_error = get_post( $invalid_url_post_id );
 
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_status_meta_box' ], [ get_post( $invalid_url_post_id ) ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_status_meta_box' ], [ get_post( $invalid_url_post_id ) ] );
 
 		$this->assertStringContainsString( date_i18n( 'M j, Y @ H:i', strtotime( $post_storing_error->post_date ) ), $output );
 		$this->assertStringContainsString( 'Last checked:', $output );
@@ -1485,11 +1485,11 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		$GLOBALS['current_screen']->taxonomy = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
 
 		// If the post type is wrong, so the conditional should be false, and this should not echo anything.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ], [ $post_wrong_post_type ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_single_url_list_table' ], [ $post_wrong_post_type ] );
 		$this->assertEmpty( $output );
 
 		// Now that the current user has permissions, this should output the correct markup.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ], [ $post_correct_post_type ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_single_url_list_table' ], [ $post_correct_post_type ] );
 		$this->assertStringContainsString( '<form class="search-form wp-clearfix" method="get">', $output );
 		$this->assertStringContainsString( '<div id="remove-keep-buttons" class="hidden">', $output );
 		$this->assertStringContainsString( '<button type="button" class="button action remove">', $output );
@@ -1505,7 +1505,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		$post_wrong_post_type = self::factory()->post->create_and_get();
 
 		// The $post has the wrong post type, so the method should exit without echoing anything.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_wrong_post_type ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_url_as_title' ], [ $post_wrong_post_type ] );
 		$this->assertEmpty( $output );
 
 		// The post type is correct, but it doesn't have a validation URL associated with it, so this shouldn't output anything.
@@ -1514,7 +1514,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 				'post-type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 			]
 		);
-		$output                 = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_correct_post_type ] );
+		$output                 = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_url_as_title' ], [ $post_correct_post_type ] );
 		$this->assertEmpty( $output );
 
 		// The post has the correct type and a validation URL in the title, so this should output markup.
@@ -1524,7 +1524,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 				'post_title' => home_url(),
 			]
 		);
-		$output                 = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_correct_post_type ] );
+		$output                 = get_echo( [ AMP_Validated_URL_Post_Type::class, 'print_url_as_title' ], [ $post_correct_post_type ] );
 		$this->assertStringContainsString( '<h2 class="amp-validated-url">', $output );
 		$this->assertStringContainsString( home_url(), $output );
 	}
@@ -1614,15 +1614,15 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 		$wrong_which_second_argument   = 'bottom';
 
 		// This has an incorrect post type as the first argument, so it should not output anything.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $wrong_post_type, $correct_which_second_argument ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_post_filters' ], [ $wrong_post_type, $correct_which_second_argument ] );
 		$this->assertEmpty( $output );
 
 		// This has an incorrect second argument, so again it should not output anything.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $correct_post_type, $wrong_which_second_argument ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_post_filters' ], [ $correct_post_type, $wrong_which_second_argument ] );
 		$this->assertEmpty( $output );
 
 		// This is now on the invalid URL post type edit.php screen, so it should output a <select> element.
-		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $correct_post_type, $correct_which_second_argument ] );
+		$output = get_echo( [ AMP_Validated_URL_Post_Type::class, 'render_post_filters' ], [ $correct_post_type, $correct_which_second_argument ] );
 		$this->assertStringContainsString(
 			sprintf( 'With unreviewed errors <span class="count">(%d)</span>', $number_of_new_errors ),
 			$output

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -25,7 +25,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 	 *
 	 * @var string
 	 */
-	const TESTED_CLASS = 'AMP_Validation_Error_Taxonomy';
+	const TESTED_CLASS = AMP_Validation_Error_Taxonomy::class;
 
 	/**
 	 * Resets the state after each test method.
@@ -755,11 +755,11 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		// When passing the wrong $taxonomy argument, this should not render anything.
-		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ], [ 'category' ] );
+		$output = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_link_to_invalid_urls_screen' ], [ 'category' ] );
 		$this->assertEmpty( $output );
 
 		// When passing the correct taxonomy, this should render the link.
-		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ], [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
+		$output = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_link_to_invalid_urls_screen' ], [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
 		$this->assertStringContainsString( 'View Validated URLs', $output );
 		$this->assertStringContainsString(
 			add_query_arg(
@@ -781,7 +781,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		set_current_screen( 'post.php' );
 
 		// When this is not on the correct screen, this should not render anything.
-		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ] );
+		$output = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_error_status_filter' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
@@ -805,7 +805,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		}
 
 		// When there are 10 accepted errors, the <option> element for it should end with (10).
-		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ] );
+		$output = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_error_status_filter' ] );
 		$this->assertStringContainsString(
 			sprintf(
 				'With unreviewed errors <span class="count">(%d)</span>',
@@ -846,7 +846,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		}
 
 		// The strings below should be present.
-		$markup = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_type_filter' ] );
+		$markup = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_error_type_filter' ] );
 
 		$expected_to_contain = [
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR,
@@ -877,7 +877,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 	 */
 	public function test_render_clear_empty_button() {
 
-		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_clear_empty_button' ] );
+		$output = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'render_clear_empty_button' ] );
 		$this->assertEmpty( $output );
 
 		ob_start();
@@ -919,7 +919,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		set_current_screen( 'edit.php' );
 
 		// Test that the method exits when the first conditional isn't true.
-		$message = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
+		$message = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'add_admin_notices' ] );
 		$this->assertEmpty( $message );
 
 		// Test the first conditional, where the error is accepted.
@@ -927,18 +927,18 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 		$count                      = 5;
 		$_GET['amp_actioned_count'] = $count;
 		$current_screen->taxonomy   = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
-		$message                    = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
+		$message                    = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'add_admin_notices' ] );
 		$this->assertEquals( '', $message );
 
 		// Test the second conditional, where the error is rejected.
 		$_GET['amp_actioned'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION;
-		$message              = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
+		$message              = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'add_admin_notices' ] );
 		$this->assertEquals( '', $message );
 
 		// Test the second conditional, where the error is rejected.
 		$_GET['amp_actioned']       = 'delete';
 		$_GET['amp_actioned_count'] = 1;
-		$message                    = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
+		$message                    = get_echo( [ AMP_Validation_Error_Taxonomy::class, 'add_admin_notices' ] );
 		$this->assertEquals(
 			'<div class="notice notice-success is-dismissible"><p>Deleted 1 instance of validation errors.</p></div>',
 			$message

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -36,7 +36,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 *
 	 * @var string
 	 */
-	const TESTED_CLASS = 'AMP_Validation_Manager';
+	const TESTED_CLASS = AMP_Validation_Manager::class;
 
 	/**
 	 * An instance of DOMElement to test.
@@ -176,7 +176,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	public function test_maybe_fail_validate_request() {
 		$post_id = self::factory()->post->create();
 
-		remove_filter( 'wp', [ 'AMP_Validation_Manager', 'maybe_fail_validate_request' ] );
+		remove_filter( 'wp', [ AMP_Validation_Manager::class, 'maybe_fail_validate_request' ] );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		add_filter(
 			'wp_die_ajax_handler',
@@ -1089,7 +1089,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Validation_Manager::add_validation_error_sourcing();
 		$callback();
-		$this->set_private_property( 'AMP_Theme_Support', 'is_output_buffering', true );
+		$this->set_private_property( AMP_Theme_Support::class, 'is_output_buffering', true );
 		$this->go_to( home_url() );
 
 		ob_start();
@@ -1271,8 +1271,8 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		$this->assertIsArray( $wp_registered_widgets[ $archives_widget_id ]['callback'] );
 
 		AMP_Validation_Manager::wrap_widget_callbacks();
-		$this->assertInstanceOf( 'AMP_Validation_Callback_Wrapper', $wp_registered_widgets[ $search_widget_id ]['callback'] );
-		$this->assertInstanceOf( 'AMP_Validation_Callback_Wrapper', $wp_registered_widgets[ $archives_widget_id ]['callback'] );
+		$this->assertInstanceOf( AMP_Validation_Callback_Wrapper::class, $wp_registered_widgets[ $search_widget_id ]['callback'] );
+		$this->assertInstanceOf( AMP_Validation_Callback_Wrapper::class, $wp_registered_widgets[ $archives_widget_id ]['callback'] );
 		$this->assertInstanceOf( 'WP_Widget', $wp_registered_widgets[ $search_widget_id ]['callback'][0] );
 		$this->assertInstanceOf( 'WP_Widget', $wp_registered_widgets[ $archives_widget_id ]['callback'][0] );
 		$this->assertSame( 'display_callback', $wp_registered_widgets[ $search_widget_id ]['callback'][1] );
@@ -1458,7 +1458,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 * @covers AMP_Validation_Manager::has_parameters_passed_by_reference()
 	 */
 	public function test_has_parameters_passed_by_reference() {
-		$tested_method = new ReflectionMethod( 'AMP_Validation_Manager', 'has_parameters_passed_by_reference' );
+		$tested_method = new ReflectionMethod( AMP_Validation_Manager::class, 'has_parameters_passed_by_reference' );
 		$tested_method->setAccessible( true );
 		$reflection_by_value          = new ReflectionFunction( 'get_bloginfo' );
 		$reflection_by_ref_first_arg  = new ReflectionFunction( 'wp_handle_upload' );
@@ -2114,9 +2114,9 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		global $post;
 		$post       = self::factory()->post->create_and_get();
 		$sanitizers = [
-			'AMP_Img_Sanitizer'      => [],
-			'AMP_Form_Sanitizer'     => [],
-			'AMP_Comments_Sanitizer' => [],
+			AMP_Img_Sanitizer::class      => [],
+			AMP_Form_Sanitizer::class     => [],
+			AMP_Comments_Sanitizer::class => [],
 		];
 
 		$expected_callback   = self::TESTED_CLASS . '::add_validation_error';
@@ -2347,7 +2347,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 */
 	public function test_print_plugin_notice() {
 		global $pagenow;
-		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
+		$output = get_echo( [ AMP_Validation_Manager::class, 'print_plugin_notice' ] );
 		$this->assertEmpty( $output );
 		$pagenow          = 'plugins.php';
 		$_GET['activate'] = 'true';
@@ -2378,7 +2378,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 				],
 			]
 		);
-		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
+		$output = get_echo( [ AMP_Validation_Manager::class, 'print_plugin_notice' ] );
 		$this->assertStringContainsString( 'Warning: The following plugin may be incompatible with AMP', $output );
 		$this->assertStringContainsString( 'Foo Bar', $output );
 		$this->assertStringContainsString( 'More details', $output );


### PR DESCRIPTION
## Summary

Since we now require PHP 5.6+, we can make use of the `::class` constant instead of using string literals. This will make it easier to catch bugs (as this ended up doing) and make it easier to do refactorings.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
