### PR TITLE
Ensure services that are delayed and have requirements are scheduled correctly

### DIFF
--- a/src/Infrastructure/ServiceBasedPlugin.php
+++ b/src/Infrastructure/ServiceBasedPlugin.php
@@ -254,7 +254,7 @@ abstract class ServiceBasedPlugin implements Plugin {
 							return;
 						}
 
-						$this->schedule_potential_service_registration($id, $class );
+						$this->schedule_potential_service_registration( $id, $class );
 					},
 					PHP_INT_MAX
 				);
@@ -381,18 +381,18 @@ abstract class ServiceBasedPlugin implements Plugin {
 		if ( is_a( $class, Delayed::class, true ) ) {
 			$registration_action = $class::get_registration_action();
 
-			if (\did_action($registration_action)) {
-				$this->maybe_register_service($id, $class);
+			if ( \did_action( $registration_action ) ) {
+				$this->maybe_register_service( $id, $class );
 			} else {
 				\add_action(
 					$registration_action,
-					function () use ($id, $class) {
-						$this->maybe_register_service($id, $class);
+					function () use ( $id, $class ) {
+						$this->maybe_register_service( $id, $class );
 					}
 				);
 			}
 		} else {
-			$this->maybe_register_service($id, $class);
+			$this->maybe_register_service( $id, $class );
 		}
 	}
 

--- a/tests/php/src/Admin/PolyfillsTest.php
+++ b/tests/php/src/Admin/PolyfillsTest.php
@@ -67,6 +67,11 @@ class PolyfillsTest extends TestCase {
 	 */
 	public function test_registration() {
 		global $wp_scripts, $wp_styles;
+
+		if ( function_exists( 'is_gutenberg_page' ) ) {
+			$this->assertFalse( is_gutenberg_page() );
+		}
+
 		$this->instance->register();
 
 		$wp_scripts = new WP_Scripts();

--- a/tests/php/src/Admin/PolyfillsTest.php
+++ b/tests/php/src/Admin/PolyfillsTest.php
@@ -71,6 +71,10 @@ class PolyfillsTest extends TestCase {
 		if ( function_exists( 'is_gutenberg_page' ) ) {
 			$this->assertFalse( is_gutenberg_page() );
 		}
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			$this->assertTrue( empty( $screen->is_block_editor ) );
+		}
 
 		$this->instance->register();
 

--- a/tests/php/src/Admin/PolyfillsTest.php
+++ b/tests/php/src/Admin/PolyfillsTest.php
@@ -90,9 +90,6 @@ class PolyfillsTest extends TestCase {
 
 		$this->instance->register();
 
-		/** This action is documented in includes/class-amp-theme-support.php */
-		do_action( 'amp_register_polyfills' );
-
 		// These should pass in WP < 5.6.
 		$this->assertTrue( wp_script_is( 'lodash', 'registered' ) );
 		$this->assertStringContainsString( '_.noConflict();', wp_scripts()->print_inline_script( 'lodash', 'after', false ) );

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -692,7 +692,7 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		$this->assertTrue( call_user_func( [ $service_class, 'is_needed' ] ) );
 
-		$this->call_private_method( $this->plugin, 'register_service', [ $service_id, $service_classes[ $service_id ] ] );
+		$this->call_private_method( $this->plugin, 'maybe_register_service', [ $service_id, $service_classes[ $service_id ] ] );
 		$this->assertTrue( $this->container->has( $service_id ) );
 	}
 


### PR DESCRIPTION
## Summary

The code that was dealing with service requirements was missing logic for the scenario where the service has requirements AND it is `Delayed` itself. In that case, and if the delay of the service being checked is later than the delay of the requirements, that delay would not have been respected.

This PR changes up the logic to make it clearer when registration is scheduled.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
