### PR TITLE
Fix broken "Re-enable transient caching" button for "Transient caching of parsed stylesheets is disabled" site health test 

### DIFF
--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -56,8 +56,7 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 	 * @param string $hook_suffix Hook suffix to identify from what admin page the call is coming from.
 	 */
 	public function register_ajax_script( $hook_suffix ) {
-		$supported_hook_suffix = defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php';
-		if ( $supported_hook_suffix !== $hook_suffix ) {
+		if ( 'tools_page_health-check' !== $hook_suffix && 'site-health.php' !== $hook_suffix ) {
 			return;
 		}
 

--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -61,49 +61,42 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 			return;
 		}
 
-		$script = <<< 'JS_SCRIPT'
-;( function () {
-	var selector = SELECTOR;
-	setTimeout( function () {
-		( document.querySelectorAll( selector ) || [] )
-			.forEach( ( element ) => {
-				element.addEventListener( 'click', function ( event ) {
-					event.preventDefault();
-					if ( element.classList.contains( 'disabled' ) ) {
-						return;
-					}
-					wp.ajax.post( ACTION, ARGUMENTS )
-						.done( function () {
-							element.classList.remove( 'ajax-failure' );
-							element.classList.add( 'ajax-success' )
-							element.classList.add( 'disabled' )
-						} )
-						.fail( function () {
-							element.classList.remove( 'ajax-success' );
-							element.classList.add( 'ajax-failure' )
-							element.classList.add( 'disabled' )
-						} );
+		$exports = [
+			'selector' => self::SELECTOR,
+			'action'   => self::AJAX_ACTION,
+			'postArgs' => [ 'nonce' => wp_create_nonce( self::AJAX_ACTION ) ],
+		];
+
+		ob_start();
+		?>
+		<script>
+			(( $, { selector, action, postArgs } ) => {
+				document.addEventListener( 'DOMContentLoaded', () => {
+					$( '.health-check-body' ).on( 'click', selector, ( event ) => {
+						event.preventDefault();
+						const element = event.target;
+						if ( element.classList.contains( 'disabled' ) ) {
+							return;
+						}
+						wp.ajax.post( action, postArgs )
+							.done( () => {
+								element.classList.remove( 'ajax-failure' );
+								element.classList.add( 'ajax-success' );
+								element.classList.add( 'disabled' );
+							} )
+							.fail( function () {
+								element.classList.remove( 'ajax-success' );
+								element.classList.add( 'ajax-failure' );
+								element.classList.add( 'disabled' );
+							} );
+					} );
 				} );
-			} );
-	}, 1000 );
-} )();
-JS_SCRIPT;
+			})( jQuery, <?php echo wp_json_encode( $exports ); ?> );
+		</script>
+		<?php
+		$script = str_replace( [ '<script>', '</script>' ], '', ob_get_clean() );
 
-		$replacements = array_map(
-			'wp_json_encode',
-			[
-				'SELECTOR'  => self::SELECTOR,
-				'ACTION'    => self::AJAX_ACTION,
-				'ARGUMENTS' => [ 'nonce' => wp_create_nonce( self::AJAX_ACTION ) ],
-			]
-		);
-
-		$script = str_replace(
-			array_keys( $replacements ),
-			array_values( $replacements ),
-			$script
-		);
-
+		wp_enqueue_script( 'jquery' );
 		wp_enqueue_script( 'wp-util' );
 		wp_add_inline_script( 'wp-util', $script );
 	}

--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -56,7 +56,8 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 	 * @param string $hook_suffix Hook suffix to identify from what admin page the call is coming from.
 	 */
 	public function register_ajax_script( $hook_suffix ) {
-		if ( 'site-health.php' !== $hook_suffix ) {
+		$supported_hook_suffix = defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php';
+		if ( $supported_hook_suffix !== $hook_suffix ) {
 			return;
 		}
 

--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -62,8 +62,8 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 
 		$script = <<< 'JS_SCRIPT'
 ;( function () {
-	window.addEventListener( 'DOMContentLoaded', ( event ) => {
-		var selector = SELECTOR;
+	var selector = SELECTOR;
+	setTimeout( function () {
 		( document.querySelectorAll( selector ) || [] )
 			.forEach( ( element ) => {
 				element.addEventListener( 'click', function ( event ) {
@@ -84,7 +84,7 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 						} );
 				} );
 			} );
-	} );
+	}, 1000 );
 } )();
 JS_SCRIPT;
 

--- a/src/Admin/ReenableCssTransientCachingAjaxAction.php
+++ b/src/Admin/ReenableCssTransientCachingAjaxAction.php
@@ -78,16 +78,16 @@ final class ReenableCssTransientCachingAjaxAction implements Service, Registerab
 						if ( element.classList.contains( 'disabled' ) ) {
 							return;
 						}
+						element.classList.add( 'disabled' );
 						wp.ajax.post( action, postArgs )
 							.done( () => {
 								element.classList.remove( 'ajax-failure' );
 								element.classList.add( 'ajax-success' );
-								element.classList.add( 'disabled' );
 							} )
-							.fail( function () {
+							.fail( () => {
 								element.classList.remove( 'ajax-success' );
 								element.classList.add( 'ajax-failure' );
-								element.classList.add( 'disabled' );
+								element.classList.remove( 'disabled' );
 							} );
 					} );
 				} );

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -80,7 +80,12 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 		add_filter( 'debug_information', [ $this, 'add_debug_information' ] );
 		add_filter( 'site_status_test_result', [ $this, 'modify_test_result' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
-		add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
+
+		if ( ! defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
+			add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
+		} else {
+			add_action( 'admin_print_styles-tools_page_health-check', [ $this, 'add_styles' ] );
+		}
 	}
 
 	/**

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -81,11 +81,8 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 		add_filter( 'site_status_test_result', [ $this, 'modify_test_result' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
 
-		if ( ! defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
-			add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
-		} else {
-			add_action( 'admin_print_styles-tools_page_health-check', [ $this, 'add_styles' ] );
-		}
+		$hook_suffix = defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php';
+		add_action( "admin_print_styles-{$hook_suffix}", [ $this, 'add_styles' ] );
 	}
 
 	/**

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -81,8 +81,8 @@ final class SiteHealth implements Service, Registerable, Delayed, Conditional {
 		add_filter( 'site_status_test_result', [ $this, 'modify_test_result' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
 
-		$hook_suffix = defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php';
-		add_action( "admin_print_styles-{$hook_suffix}", [ $this, 'add_styles' ] );
+		add_action( 'admin_print_styles-tools_page_health-check', [ $this, 'add_styles' ] );
+		add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
 	}
 
 	/**

--- a/tests/php/src/Admin/ReenableCssTransientCachingAjaxActionTest.php
+++ b/tests/php/src/Admin/ReenableCssTransientCachingAjaxActionTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for ReenableCssTransientCachingAjaxAction class.
+ *
+ * @package AmpProject\AmpWP\Tests
+ */
+
+namespace AmpProject\AmpWP\Tests\Admin;
+
+use AMP_Options_Manager;
+use AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction;
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Tests\TestCase;
+use AmpProject\AmpWP\Option;
+use Exception;
+use WPDieException;
+
+/**
+ * Tests for ReenableCssTransientCachingAjaxAction class.
+ *
+ * @coversDefaultClass \AmpProject\AmpWP\Admin\ReenableCssTransientCachingAjaxAction
+ */
+class ReenableCssTransientCachingAjaxActionTest extends TestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ReenableCssTransientCachingAjaxAction
+	 */
+	private $instance;
+
+	/**
+	 * Set up.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		$this->instance = new ReenableCssTransientCachingAjaxAction();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wp_scripts;
+		$wp_scripts = null;
+	}
+
+	public function test__construct() {
+		$this->assertInstanceOf( ReenableCssTransientCachingAjaxAction::class, $this->instance );
+		$this->assertInstanceOf( Service::class, $this->instance );
+		$this->assertInstanceOf( Registerable::class, $this->instance );
+	}
+
+	/**
+	 * Tests ReenableCssTransientCachingAjaxAction::register
+	 *
+	 * @covers ::register
+	 */
+	public function test_register() {
+		$this->instance->register();
+
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', [ $this->instance, 'register_ajax_script' ] ) );
+		$this->assertEquals( 10, has_action( 'wp_ajax_amp_reenable_css_transient_caching', [ $this->instance, 'reenable_css_transient_caching' ] ) );
+	}
+
+	/** @covers ::register_ajax_script */
+	public function test_register_ajax_script_not_hook() {
+		$this->instance->register_ajax_script( 'nope' );
+		$this->assertFalse( wp_script_is( 'wp-util', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
+		$this->assertEmpty( wp_scripts()->get_data( 'wp-util', 'after' ) );
+	}
+
+	/** @covers ::register_ajax_script */
+	public function test_register_ajax_script_yes_hook() {
+		$this->instance->register_ajax_script( defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php' );
+		$this->assertTrue( wp_script_is( 'jquery', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'wp-util', 'enqueued' ) );
+		$after = wp_scripts()->get_data( 'wp-util', 'after' );
+		$this->assertStringContainsString( '$( \'.health-check-body\' )', implode( "\n", $after ) );
+	}
+
+	/** @return array */
+	public function get_data_to_test_reenable_css_transient_caching() {
+		return [
+			'no_nonce'            => [
+				'initial_value'   => true,
+				'nonce_action'    => null,
+				'user'            => null,
+				'expected_output' => '-1',
+				'final_value'     => true,
+			],
+			'no_auth'             => [
+				'initial_value'   => true,
+				'nonce_action'    => ReenableCssTransientCachingAjaxAction::AJAX_ACTION,
+				'user'            => null,
+				'expected_output' => '{"success":false,"data":"Unauthorized."}',
+				'final_value'     => true,
+			],
+			'bad_auth'            => [
+				'initial_value'   => true,
+				'nonce_action'    => ReenableCssTransientCachingAjaxAction::AJAX_ACTION,
+				'user'            => 'author',
+				'expected_output' => '{"success":false,"data":"Unauthorized."}',
+				'final_value'     => true,
+			],
+			'good_auth_bad_nonce' => [
+				'initial_value'   => true,
+				'nonce_action'    => 'other_action',
+				'user'            => 'administrator',
+				'expected_output' => '-1',
+				'final_value'     => true,
+			],
+			'good_auth'           => [
+				'initial_value'   => true,
+				'nonce_action'    => ReenableCssTransientCachingAjaxAction::AJAX_ACTION,
+				'user'            => 'administrator',
+				'expected_output' => '{"success":true,"data":"CSS transient caching was re-enabled."}',
+				'final_value'     => false,
+			],
+			'good_auth_no_change' => [
+				'initial_value'   => false,
+				'nonce_action'    => ReenableCssTransientCachingAjaxAction::AJAX_ACTION,
+				'user'            => 'administrator',
+				'expected_output' => '{"success":false,"data":"CSS transient caching could not be re-enabled."}',
+				'final_value'     => false,
+			],
+		];
+	}
+
+	/**
+	 * @covers ::reenable_css_transient_caching
+	 * @dataProvider get_data_to_test_reenable_css_transient_caching
+	 *
+	 * @param bool        $initial_value
+	 * @param string|null $nonce_action
+	 * @param string|null $user
+	 * @param string      $expected_output
+	 * @param bool        $final_value
+	 */
+	public function test_reenable_css_transient_caching( $initial_value, $nonce_action, $user, $expected_output, $final_value ) {
+		AMP_Options_Manager::update_option( Option::DISABLE_CSS_TRANSIENT_CACHING, $initial_value );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter(
+			'wp_die_ajax_handler',
+			static function () {
+				return function ( $message ) {
+					throw new WPDieException( $message );
+				};
+			}
+		);
+
+		if ( $user ) {
+			wp_set_current_user( self::factory()->user->create( [ 'role' => $user ] ) );
+		}
+		if ( $nonce_action ) {
+			$_REQUEST['nonce'] = wp_create_nonce( $nonce_action );
+		}
+
+		ob_start();
+		$exception = null;
+		try {
+			$this->instance->reenable_css_transient_caching();
+		} catch ( Exception $ex ) {
+			$exception = $ex;
+		}
+		$output = ob_get_clean();
+		$this->assertInstanceOf( WPDieException::class, $exception );
+		$actual_output = $output . $exception->getMessage();
+
+		$this->assertEquals( $expected_output, $actual_output );
+		$this->assertEquals(
+			$final_value,
+			AMP_Options_Manager::get_option( Option::DISABLE_CSS_TRANSIENT_CACHING )
+		);
+	}
+}

--- a/tests/php/src/Admin/ReenableCssTransientCachingAjaxActionTest.php
+++ b/tests/php/src/Admin/ReenableCssTransientCachingAjaxActionTest.php
@@ -82,9 +82,25 @@ class ReenableCssTransientCachingAjaxActionTest extends TestCase {
 		$this->assertEmpty( wp_scripts()->get_data( 'wp-util', 'after' ) );
 	}
 
-	/** @covers ::register_ajax_script */
-	public function test_register_ajax_script_yes_hook() {
-		$this->instance->register_ajax_script( defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ? 'tools_page_health-check' : 'site-health.php' );
+	/** @return array */
+	public function get_data_to_test_register_ajax_script_yes_hook() {
+		return [
+			'without_site_health_plugin' => [
+				'hook_suffix' => 'site-health.php',
+			],
+			'with_site_health_plugin'    => [
+				'hook_suffix' => 'tools_page_health-check',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_data_to_test_register_ajax_script_yes_hook
+	 * @covers ::register_ajax_script
+	 * @param string $hook_suffix
+	 */
+	public function test_register_ajax_script_yes_hook( $hook_suffix ) {
+		$this->instance->register_ajax_script( $hook_suffix );
 		$this->assertTrue( wp_script_is( 'jquery', 'enqueued' ) );
 		$this->assertTrue( wp_script_is( 'wp-util', 'enqueued' ) );
 		$after = wp_scripts()->get_data( 'wp-util', 'after' );

--- a/tests/php/src/Admin/SiteHealthTest.php
+++ b/tests/php/src/Admin/SiteHealthTest.php
@@ -7,6 +7,7 @@
 
 namespace AmpProject\AmpWP\Tests\Admin;
 
+use AMP_Options_Manager;
 use AmpProject\AmpWP\Admin\SiteHealth;
 use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
 use AmpProject\AmpWP\AmpWpPluginFactory;
@@ -522,7 +523,7 @@ class SiteHealthTest extends TestCase {
 			$this->instance->add_extensions( [] )
 		);
 
-		// Test that the the `intl` extension is added only when site URL is an IDN.
+		// Test that the `intl` extension is added only when site URL is an IDN.
 		add_filter( 'site_url', [ self::class, 'get_idn' ], 10, 4 );
 
 		$extensions = $this->instance->add_extensions( [] );

--- a/tests/php/src/Admin/SiteHealthTest.php
+++ b/tests/php/src/Admin/SiteHealthTest.php
@@ -75,11 +75,8 @@ class SiteHealthTest extends TestCase {
 		$this->assertEquals( 10, has_filter( 'site_status_test_result', [ $this->instance, 'modify_test_result' ] ) );
 		$this->assertEquals( 10, has_filter( 'site_status_test_php_modules', [ $this->instance, 'add_extensions' ] ) );
 
-		if ( ! defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
-			$this->assertEquals( 10, has_action( 'admin_print_styles-site-health.php', [ $this->instance, 'add_styles' ] ) );
-		} else {
-			$this->assertEquals( 10, has_action( 'admin_print_styles-tools_page_health-check', [ $this->instance, 'add_styles' ] ) );
-		}
+		$this->assertEquals( 10, has_action( 'admin_print_styles-site-health.php', [ $this->instance, 'add_styles' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_print_styles-tools_page_health-check', [ $this->instance, 'add_styles' ] ) );
 	}
 
 	/**

--- a/tests/php/src/Admin/test-class-site-health.php
+++ b/tests/php/src/Admin/test-class-site-health.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Test Site_Health.
+ * Test SiteHealthTest.
  *
- * @package AmpProject\AmpWP
+ * @package AmpProject\AmpWP\Tests
  */
+
+namespace AmpProject\AmpWP\Tests\Admin;
 
 use AmpProject\AmpWP\Admin\SiteHealth;
 use AmpProject\AmpWP\AmpSlugCustomizationWatcher;
@@ -14,9 +16,11 @@ use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\TestCase;
 
 /**
- * Test Site_Health.
+ * Test SiteHealthTest.
+ *
+ * @coversDefaultClass \AmpProject\AmpWP\Admin\SiteHealth
  */
-class Test_Site_Health extends TestCase {
+class SiteHealthTest extends TestCase {
 
 	use PrivateAccess;
 
@@ -61,7 +65,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test init.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::register()
+	 * @covers ::register()
 	 */
 	public function test_register() {
 		$this->instance->register();
@@ -69,13 +73,18 @@ class Test_Site_Health extends TestCase {
 		$this->assertEquals( 10, has_filter( 'debug_information', [ $this->instance, 'add_debug_information' ] ) );
 		$this->assertEquals( 10, has_filter( 'site_status_test_result', [ $this->instance, 'modify_test_result' ] ) );
 		$this->assertEquals( 10, has_filter( 'site_status_test_php_modules', [ $this->instance, 'add_extensions' ] ) );
-		$this->assertEquals( 10, has_action( 'admin_print_styles-site-health.php', [ $this->instance, 'add_styles' ] ) );
+
+		if ( ! defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
+			$this->assertEquals( 10, has_action( 'admin_print_styles-site-health.php', [ $this->instance, 'add_styles' ] ) );
+		} else {
+			$this->assertEquals( 10, has_action( 'admin_print_styles-tools_page_health-check', [ $this->instance, 'add_styles' ] ) );
+		}
 	}
 
 	/**
 	 * Test add_tests.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::add_tests()
+	 * @covers ::add_tests()
 	 */
 	public function test_add_tests() {
 		$tests = $this->instance->add_tests( [] );
@@ -102,7 +111,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test persistent_object_cache.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::persistent_object_cache()
+	 * @covers ::persistent_object_cache()
 	 */
 	public function test_persistent_object_cache() {
 		$data = [
@@ -144,7 +153,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test slug_definition_timing.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::slug_definition_timing()
+	 * @covers ::slug_definition_timing()
 	 */
 	public function test_slug_definition_timing() {
 		$data = [
@@ -197,7 +206,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test curl_multi_functions.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::curl_multi_functions()
+	 * @covers ::curl_multi_functions()
 	 */
 	public function test_curl_multi_functions() {
 		$this->assertArraySubset(
@@ -211,7 +220,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test icu_version.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::icu_version()
+	 * @covers ::icu_version()
 	 */
 	public function test_icu_version() {
 		$this->assertArraySubset(
@@ -225,7 +234,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test css_transient_caching.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::css_transient_caching()
+	 * @covers ::css_transient_caching()
 	 */
 	public function test_css_transient_caching() {
 		$data = [
@@ -268,7 +277,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test xdebug_extension.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::xdebug_extension()
+	 * @covers ::xdebug_extension()
 	 */
 	public function test_xdebug_extension() {
 		$actual = $this->instance->xdebug_extension();
@@ -283,7 +292,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test add_debug_information.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::add_debug_information()
+	 * @covers ::add_debug_information()
 	 */
 	public function test_add_debug_information() {
 		$debug_info = $this->instance->add_debug_information( [] );
@@ -343,7 +352,7 @@ class Test_Site_Health extends TestCase {
 	 *
 	 * @dataProvider get_test_result
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::modify_test_result()
+	 * @covers ::modify_test_result()
 	 *
 	 * @param array $test_data Data from Site Health test.
 	 * @param array $expected  Expected modified test result.
@@ -414,7 +423,7 @@ class Test_Site_Health extends TestCase {
 	 * Test add_debug_information.
 	 *
 	 * @dataProvider get_supported_templates_data
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::get_supported_templates()
+	 * @covers ::get_supported_templates()
 	 *
 	 * @param array  $supported_content_types The supported content types, like 'post'.
 	 * @param array  $supported_templates     The supported templates, like 'is_author'.
@@ -475,7 +484,7 @@ class Test_Site_Health extends TestCase {
 	 * Test get_serve_all_templates.
 	 *
 	 * @dataProvider get_serve_all_templates_data
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::get_serve_all_templates()
+	 * @covers ::get_serve_all_templates()
 	 *
 	 * @param string $theme_support          The template mode, like 'standard'.
 	 * @param bool   $do_serve_all_templates Whether the option to serve all templates is true.
@@ -491,7 +500,7 @@ class Test_Site_Health extends TestCase {
 	/**
 	 * Test add_extensions.
 	 *
-	 * @covers \AmpProject\AmpWP\Admin\SiteHealth::add_extensions()
+	 * @covers ::add_extensions()
 	 */
 	public function test_add_extensions() {
 		$this->assertEquals(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

Revert to using a timeout to set the button functionality as originally done by @schlessera (see https://github.com/ampproject/amp-wp/commit/5cbe86b36547ab71cf8b43d2c66c60cfa1c40289). This gives the Site Health screen some time to add all the direct tests so that we can then add the necessary callback to the button.

This PR also ensures the button works when using the Site Health plugin.

Fixes #6549

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
