### PR TITLE
Use `amp-tiktok` for TikTok instead of `amp-embedly-card`

### DIFF
--- a/includes/embeds/class-amp-tiktok-embed-handler.php
+++ b/includes/embeds/class-amp-tiktok-embed-handler.php
@@ -94,8 +94,12 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		// Handle case where script is wrapped in paragraph by wpautop.
 		if ( $next_element_sibling instanceof Element && Tag::P === $next_element_sibling->nodeName ) {
-			$children = $next_element_sibling->getElementsByTagName( '*' );
-			if ( 1 === $children->length && Tag::SCRIPT === $children->item( 0 )->nodeName && false !== strpos( $children->item( 0 )->getAttribute( Attribute::SRC ), $script_src ) ) {
+			$script = $next_element_sibling->getElementsByTagName( Tag::SCRIPT )->item( 0 );
+			if (
+				$script instanceof Element
+				&&
+				false !== strpos( $script->getAttribute( Attribute::SRC ), $script_src )
+			) {
 				$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 				return;
 			}

--- a/includes/embeds/class-amp-tiktok-embed-handler.php
+++ b/includes/embeds/class-amp-tiktok-embed-handler.php
@@ -34,25 +34,11 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param Document $dom DOM.
 	 */
 	public function sanitize_raw_embeds( Document $dom ) {
-		$nodes = $dom->xpath->query( '//blockquote[ contains( @class, "tiktok-embed" ) ]' );
+		$nodes = $dom->xpath->query( '//blockquote[ contains( @class, "tiktok-embed" ) and not( parent::amp-tiktok ) ]' );
 
 		foreach ( $nodes as $node ) {
-			if ( ! $this->is_raw_embed( $node ) ) {
-				continue;
-			}
-
 			$this->make_embed_amp_compatible( $node );
 		}
-	}
-
-	/**
-	 * Determine if the node has already been sanitized.
-	 *
-	 * @param DOMElement $node The DOMNode.
-	 * @return bool Whether the node is a raw embed.
-	 */
-	protected function is_raw_embed( DOMElement $node ) {
-		return ! $node->firstChild || ( $node->firstChild && 'amp-embedly-card' !== $node->firstChild->nodeName );
 	}
 
 	/**

--- a/includes/embeds/class-amp-tiktok-embed-handler.php
+++ b/includes/embeds/class-amp-tiktok-embed-handler.php
@@ -39,7 +39,9 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param Document $dom DOM.
 	 */
 	public function sanitize_raw_embeds( Document $dom ) {
-		$nodes = $dom->xpath->query( '//blockquote[ @cite and @data-video-id and contains( @class, "tiktok-embed" ) and not( parent::amp-tiktok ) ]' );
+		$nodes = $dom->xpath->query(
+			sprintf( '//blockquote[ @cite and @data-video-id and contains( @class, "tiktok-embed" ) and not( parent::%s ) ]', Extension::TIKTOK )
+		);
 
 		foreach ( $nodes as $node ) {
 			$this->make_embed_amp_compatible( $node );

--- a/includes/embeds/class-amp-tiktok-embed-handler.php
+++ b/includes/embeds/class-amp-tiktok-embed-handler.php
@@ -5,7 +5,12 @@
  * @package AMP
  */
 
+use AmpProject\Attribute;
 use AmpProject\Dom\Document;
+use AmpProject\Dom\Element;
+use AmpProject\Extension;
+use AmpProject\Layout;
+use AmpProject\Tag;
 
 /**
  * Class AMP_TikTok_Embed_Handler
@@ -34,7 +39,7 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param Document $dom DOM.
 	 */
 	public function sanitize_raw_embeds( Document $dom ) {
-		$nodes = $dom->xpath->query( '//blockquote[ contains( @class, "tiktok-embed" ) and not( parent::amp-tiktok ) ]' );
+		$nodes = $dom->xpath->query( '//blockquote[ @cite and @data-video-id and contains( @class, "tiktok-embed" ) and not( parent::amp-tiktok ) ]' );
 
 		foreach ( $nodes as $node ) {
 			$this->make_embed_amp_compatible( $node );
@@ -44,71 +49,53 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Make TikTok embed AMP compatible.
 	 *
-	 * @param DOMElement $blockquote_node The <blockquote> node to make AMP compatible.
+	 * @param Element $blockquote The <blockquote> node to make AMP compatible.
 	 */
-	protected function make_embed_amp_compatible( DOMElement $blockquote_node ) {
-		$dom       = $blockquote_node->ownerDocument;
-		$video_url = $blockquote_node->getAttribute( 'cite' );
+	protected function make_embed_amp_compatible( Element $blockquote ) {
+		$dom       = $blockquote->ownerDocument;
+		$video_url = $blockquote->getAttribute( Attribute::CITE );
 
-		// If there is no video ID, stop here as its needed for the `data-url` parameter.
+		// If there is no video ID, stop here as its needed for the `data-src` parameter.
 		if ( empty( $video_url ) ) {
 			return;
 		}
 
-		$this->remove_embed_script( $blockquote_node );
+		$this->remove_embed_script( $blockquote );
 
-		$amp_node = AMP_DOM_Utils::create_node(
+		$amp_tiktok = AMP_DOM_Utils::create_node(
 			Document::fromNode( $dom ),
-			'amp-embedly-card',
+			Extension::TIKTOK,
 			[
-				'layout'             => 'responsive',
-				'height'             => 700,
-				'width'              => 340,
-				'data-card-controls' => 0,
-				'data-url'           => $video_url,
+				Attribute::LAYOUT   => Layout::RESPONSIVE,
+				Attribute::HEIGHT   => 575,
+				Attribute::WIDTH    => 325,
+				Attribute::DATA_SRC => $video_url,
 			]
 		);
 
-		// Find existing <section> node to use as the placeholder.
-		foreach ( iterator_to_array( $blockquote_node->childNodes ) as $child ) {
-			if ( ! ( $child instanceof DOMElement ) ) {
-				continue;
-			}
-
-			// Append the placeholder if it was found.
-			if ( 'section' === $child->nodeName ) {
-				/**
-				 * Placeholder to append to the AMP component.
-				 *
-				 * @var DOMElement $placeholder_node
-				 */
-				$placeholder_node = $blockquote_node->removeChild( $child );
-				$placeholder_node->setAttribute( 'placeholder', '' );
-				$amp_node->appendChild( $placeholder_node );
-				break;
-			}
-		}
-
-		$blockquote_node->parentNode->replaceChild( $amp_node, $blockquote_node );
+		$blockquote->parentNode->replaceChild( $amp_tiktok, $blockquote );
+		$amp_tiktok->appendChild( $blockquote );
+		$blockquote->setAttributeNode( $dom->createAttribute( Attribute::PLACEHOLDER ) );
+		$blockquote->removeAttribute( Attribute::STYLE );
 	}
 
 	/**
 	 * Remove the TikTok embed script if it exists.
 	 *
-	 * @param DOMElement $node The DOMNode to make AMP compatible.
+	 * @param Element $blockquote The blockquote element being made AMP-compatible.
 	 */
-	protected function remove_embed_script( DOMElement $node ) {
-		$next_element_sibling = $node->nextSibling;
-		while ( $next_element_sibling && ! ( $next_element_sibling instanceof DOMElement ) ) {
+	protected function remove_embed_script( Element $blockquote ) {
+		$next_element_sibling = $blockquote->nextSibling;
+		while ( $next_element_sibling && ! ( $next_element_sibling instanceof Element ) ) {
 			$next_element_sibling = $next_element_sibling->nextSibling;
 		}
 
 		$script_src = 'tiktok.com/embed.js';
 
 		// Handle case where script is wrapped in paragraph by wpautop.
-		if ( $next_element_sibling instanceof DOMElement && 'p' === $next_element_sibling->nodeName ) {
+		if ( $next_element_sibling instanceof Element && Tag::P === $next_element_sibling->nodeName ) {
 			$children = $next_element_sibling->getElementsByTagName( '*' );
-			if ( 1 === $children->length && 'script' === $children->item( 0 )->nodeName && false !== strpos( $children->item( 0 )->getAttribute( 'src' ), $script_src ) ) {
+			if ( 1 === $children->length && Tag::SCRIPT === $children->item( 0 )->nodeName && false !== strpos( $children->item( 0 )->getAttribute( Attribute::SRC ), $script_src ) ) {
 				$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 				return;
 			}
@@ -116,11 +103,11 @@ class AMP_TikTok_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		// Handle case where script is immediately following.
 		$is_embed_script = (
-			$next_element_sibling instanceof DOMElement
+			$next_element_sibling instanceof Element
 			&&
-			'script' === strtolower( $next_element_sibling->nodeName )
+			Tag::SCRIPT === strtolower( $next_element_sibling->nodeName )
 			&&
-			false !== strpos( $next_element_sibling->getAttribute( 'src' ), $script_src )
+			false !== strpos( $next_element_sibling->getAttribute( Attribute::SRC ), $script_src )
 		);
 		if ( $is_embed_script ) {
 			$next_element_sibling->parentNode->removeChild( $next_element_sibling );

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -82,18 +82,13 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 				'https://www.tiktok.com/@scout2015/video/6718335390845095173' . PHP_EOL,
 
 				'
-					<amp-embedly-card layout="responsive" height="700" width="340" data-card-controls="0" data-url="https://www.tiktok.com/@scout2015/video/6718335390845095173">
-						<section placeholder="">
-							<a target="_blank" title="@scout2015" href="https://www.tiktok.com/@scout2015">@scout2015</a>
-							<p>Scramble up ur name &amp; I’ll try to guess it😍❤️ <a title="foryoupage" target="_blank" href="https://www.tiktok.com/tag/foryoupage">#foryoupage</a>
-								<a title="PetsOfTikTok" target="_blank" href="https://www.tiktok.com/tag/PetsOfTikTok">#petsoftiktok</a>
-								<a title="aesthetic" target="_blank" href="https://www.tiktok.com/tag/aesthetic">#aesthetic</a>
-							</p>
-							<p>
-								<a target="_blank" title="♬ original sound - tiff" href="https://www.tiktok.com/music/original-sound-6689804660171082501">♬ original sound – tiff</a>
-							</p>
-						</section>
-					</amp-embedly-card>
+					<amp-tiktok layout="responsive" height="575" width="325" data-src="https://www.tiktok.com/@scout2015/video/6718335390845095173">
+						<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@scout2015/video/6718335390845095173" data-video-id="6718335390845095173" placeholder>
+							<section> <a target="_blank" title="@scout2015" href="https://www.tiktok.com/@scout2015">@scout2015</a>
+							<p>Scramble up ur name &amp; I’ll try to guess it😍❤️ <a title="foryoupage" target="_blank" href="https://www.tiktok.com/tag/foryoupage">#foryoupage</a> <a title="PetsOfTikTok" target="_blank" href="https://www.tiktok.com/tag/PetsOfTikTok">#petsoftiktok</a> <a title="aesthetic" target="_blank" href="https://www.tiktok.com/tag/aesthetic">#aesthetic</a></p>
+							<p> <a target="_blank" title="♬ original sound - tiff" href="https://www.tiktok.com/music/original-sound-6689804660171082501">♬ original sound – tiff</a> </p></section>
+						</blockquote>
+					</amp-tiktok>
 				',
 			],
 
@@ -102,13 +97,15 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 					<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a> <p>You can now embed TikTok\'s in AMP</p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound - countingprimes</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
 				',
 				'
-					<amp-embedly-card layout="responsive" height="700" width="340" data-card-controls="0" data-url="https://www.tiktok.com/@countingprimes/video/6988237085899574533">
-						<section placeholder="">
-							<a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a>
-							<p>You can now embed TikTok’s in AMP</p>
-							<p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound – countingprimes</a> </p>
-						</section>
-					</amp-embedly-card>
+					<amp-tiktok layout="responsive" height="575" width="325" data-src="https://www.tiktok.com/@countingprimes/video/6988237085899574533">
+						<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" placeholder>
+							<section>
+								<a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a>
+								<p>You can now embed TikTok’s in AMP</p>
+								<p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound – countingprimes</a> </p>
+							</section>
+						</blockquote>
+					</amp-tiktok>
 				',
 			],
 

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -138,7 +138,7 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 	 */
 	public function test_conversion( $source, $expected = null ) {
 		if ( version_compare( '5.4-alpha', get_bloginfo( 'version' ), '>' ) ) {
-			$this->markTestSkipped( 'The TikTok embed is only available in 5.4-alpha (until 5.4 is stable)' );
+			$this->markTestSkipped( 'The TikTok oEmbed provider is only available in 5.4-alpha and later' );
 		}
 		if ( ! $expected ) {
 			$expected = $source;

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -5,6 +5,7 @@
  * @package AMP.
  */
 
+use AmpProject\AmpWP\Tests\Helpers\MarkupComparison;
 use AmpProject\AmpWP\Tests\Helpers\WithoutBlockPreRendering;
 use AmpProject\AmpWP\Tests\TestCase;
 
@@ -12,6 +13,8 @@ use AmpProject\AmpWP\Tests\TestCase;
  * Class Test_AMP_TikTok_Embed_Handler
  */
 class Test_AMP_TikTok_Embed_Handler extends TestCase {
+
+	use MarkupComparison;
 
 	use WithoutBlockPreRendering {
 		setUp as public prevent_block_pre_render;
@@ -70,17 +73,61 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 	 */
 	public function get_conversion_data() {
 		return [
-			'no_embed'   => [
+			'no_embed'               => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
 
-			'url_simple' => [
+			'url_simple'             => [
 				'https://www.tiktok.com/@scout2015/video/6718335390845095173' . PHP_EOL,
 
-				'<amp-embedly-card layout="responsive" height="700" width="340" data-card-controls="0" data-url="https://www.tiktok.com/@scout2015/video/6718335390845095173"><section placeholder=""> <a target="_blank" title="@scout2015" href="https://www.tiktok.com/@scout2015">@scout2015</a> ' . PHP_EOL .
-				'<p>Scramble up ur name &amp; I’ll try to guess it😍❤️ <a title="foryoupage" target="_blank" href="https://www.tiktok.com/tag/foryoupage">#foryoupage</a> <a title="PetsOfTikTok" target="_blank" href="https://www.tiktok.com/tag/PetsOfTikTok">#petsoftiktok</a> <a title="aesthetic" target="_blank" href="https://www.tiktok.com/tag/aesthetic">#aesthetic</a></p>' . PHP_EOL .
-				'<p> <a target="_blank" title="♬ original sound - tiff" href="https://www.tiktok.com/music/original-sound-6689804660171082501">♬ original sound – tiff</a> </p></section></amp-embedly-card>' . PHP_EOL . PHP_EOL,
+				'
+					<amp-embedly-card layout="responsive" height="700" width="340" data-card-controls="0" data-url="https://www.tiktok.com/@scout2015/video/6718335390845095173">
+						<section placeholder="">
+							<a target="_blank" title="@scout2015" href="https://www.tiktok.com/@scout2015">@scout2015</a>
+							<p>Scramble up ur name &amp; I’ll try to guess it😍❤️ <a title="foryoupage" target="_blank" href="https://www.tiktok.com/tag/foryoupage">#foryoupage</a>
+								<a title="PetsOfTikTok" target="_blank" href="https://www.tiktok.com/tag/PetsOfTikTok">#petsoftiktok</a>
+								<a title="aesthetic" target="_blank" href="https://www.tiktok.com/tag/aesthetic">#aesthetic</a>
+							</p>
+							<p>
+								<a target="_blank" title="♬ original sound - tiff" href="https://www.tiktok.com/music/original-sound-6689804660171082501">♬ original sound – tiff</a>
+							</p>
+						</section>
+					</amp-embedly-card>
+				',
+			],
+
+			'amp-tiktok-embed-code'  => [
+				'
+					<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a> <p>You can now embed TikTok\'s in AMP</p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound - countingprimes</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
+				',
+				'
+					<amp-embedly-card layout="responsive" height="700" width="340" data-card-controls="0" data-url="https://www.tiktok.com/@countingprimes/video/6988237085899574533">
+						<section placeholder="">
+							<a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a>
+							<p>You can now embed TikTok’s in AMP</p>
+							<p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound – countingprimes</a> </p>
+						</section>
+					</amp-embedly-card>
+				',
+			],
+
+			'amp-tiktok-passthrough' => [
+				'
+				<!-- wp:html -->
+				<amp-tiktok width="300" height="800" layout="intrinsic">
+					<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" style="max-width: 605px;min-width: 325px;">
+						<section>
+							<a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a>
+							<p>You can now embed TikTok’s in AMP</p>
+							<a target="_blank" title="♬ original sound — countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound — countingprimes</a>
+						</section>
+					</blockquote>
+				</amp-tiktok>
+				<!-- /wp:html -->
+				',
+
+				null,
 			],
 		];
 	}
@@ -92,10 +139,15 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 	 * @param string $expected Expected.
 	 * @dataProvider get_conversion_data
 	 */
-	public function test_conversion( $source, $expected ) {
+	public function test_conversion( $source, $expected = null ) {
 		if ( version_compare( '5.4-alpha', get_bloginfo( 'version' ), '>' ) ) {
 			$this->markTestSkipped( 'The TikTok embed is only available in 5.4-alpha (until 5.4 is stable)' );
 		}
+		if ( ! $expected ) {
+			$expected = $source;
+		}
+
+		$expected = preg_replace( '/<!--.*?-->/s', '', $expected );
 
 		$embed = new AMP_TikTok_Embed_Handler();
 		$embed->register_embed();
@@ -104,8 +156,8 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
-		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$actual = AMP_DOM_Utils::get_content_from_dom( $dom );
 
-		$this->assertEquals( $expected, $content );
+		$this->assertSimilarMarkup( $expected, $actual );
 	}
 }

--- a/tests/php/test-class-amp-tiktok-embed-handler.php
+++ b/tests/php/test-class-amp-tiktok-embed-handler.php
@@ -73,12 +73,12 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 	 */
 	public function get_conversion_data() {
 		return [
-			'no_embed'               => [
+			'no_embed'                          => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
 
-			'url_simple'             => [
+			'url_simple'                        => [
 				'https://www.tiktok.com/@scout2015/video/6718335390845095173' . PHP_EOL,
 
 				'
@@ -92,7 +92,7 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 				',
 			],
 
-			'amp-tiktok-embed-code'  => [
+			'tiktok-embed-code-with-wpautop'    => [
 				'
 					<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a> <p>You can now embed TikTok\'s in AMP</p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound - countingprimes</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
 				',
@@ -109,7 +109,26 @@ class Test_AMP_TikTok_Embed_Handler extends TestCase {
 				',
 			],
 
-			'amp-tiktok-passthrough' => [
+			'tiktok-embed-code-without-wpautop' => [
+				'
+					<!-- wp:html -->
+					<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a> <p>You can now embed TikTok\'s in AMP</p> <a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound - countingprimes</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
+					<!-- /wp:html -->
+				',
+				'
+					<amp-tiktok layout="responsive" height="575" width="325" data-src="https://www.tiktok.com/@countingprimes/video/6988237085899574533">
+						<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@countingprimes/video/6988237085899574533" data-video-id="6988237085899574533" placeholder>
+							<section>
+								<a target="_blank" title="@countingprimes" href="https://www.tiktok.com/@countingprimes">@countingprimes</a>
+								<p>You can now embed TikTok’s in AMP</p>
+								<a target="_blank" title="♬ original sound - countingprimes" href="https://www.tiktok.com/music/original-sound-6988236987325057798">♬ original sound – countingprimes</a>
+							</section>
+						</blockquote>
+					</amp-tiktok>
+				',
+			],
+
+			'amp-tiktok-passthrough'            => [
 				'
 				<!-- wp:html -->
 				<amp-tiktok width="300" height="800" layout="intrinsic">


### PR DESCRIPTION
## Summary

See https://github.com/ampproject/amphtml/issues/32219.

Fixes #6060.

Before | After
-------|-----
<img width="1611" alt="Screen Shot 2021-08-24 at 13 23 29" src="https://user-images.githubusercontent.com/134745/130684832-1b1fc66d-a20b-4cab-8cb4-fb074a829786.png"> | <img width="1611" alt="Screen Shot 2021-08-24 at 13 22 23" src="https://user-images.githubusercontent.com/134745/130684840-d59fed22-2485-4d52-a972-11525459ac02.png">

Embeds can be added via the TikTok block:

![image](https://user-images.githubusercontent.com/134745/130685079-cfcbf6f3-bc6e-41f4-a4cf-e3a5bb548bab.png)

No validation errors result:

![image](https://user-images.githubusercontent.com/134745/130685201-9867c429-ba25-4604-9617-fdfe1905d2d7.png)

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
