### PR TITLE
Replace `calc()` in media queries with their pixel values

### DIFF
--- a/templates/style.php
+++ b/templates/style.php
@@ -63,7 +63,7 @@ $alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 	width: 100%;
 }
 
-@media (min-width: calc(840px - 48px)) {
+@media (min-width: 792px) {
 	.alignwide {
 		width: calc(100vw - 48px);
 		max-width: calc(100vw - 48px);
@@ -72,7 +72,7 @@ $alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 	}
 }
 
-@media (min-width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?>)) {
+@media (min-width: <?php echo sprintf( '%dpx', $alignwide_max ); ?>) {
 	.alignwide {
 		width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?> - 48px);
 		max-width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?> - 48px);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6557

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
