### PR TITLE
Update `svgo` Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,9 +17,13 @@ module.exports = function( api ) {
 					svgo: {
 						plugins: [
 							{
-								name: 'cleanupIDs',
+								name: 'preset-default',
 								params: {
-									minify: false, // Prevent duplicate SVG IDs from minification.
+									overrides: {
+										cleanupIDs: {
+											minify: false, // Prevent duplicate SVG IDs from minification.
+										},
+									},
 								},
 							},
 						],
@@ -39,9 +43,13 @@ module.exports = function( api ) {
 							svgo: {
 								plugins: [
 									{
-										name: 'cleanupIDs',
+										name: 'preset-default',
 										params: {
-											minify: false, // Prevent duplicate SVG IDs from minification.
+											overrides: {
+												cleanupIDs: {
+													minify: false, // Prevent duplicate SVG IDs from minification.
+												},
+											},
 										},
 									},
 								],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-const { extendDefaultPlugins } = require( 'svgo' );
-
-/**
  * WordPress dependencies
  */
 const defaultConfig = require( '@wordpress/babel-preset-default' );
@@ -20,14 +15,14 @@ module.exports = function( api ) {
 				'inline-react-svg',
 				{
 					svgo: {
-						plugins: extendDefaultPlugins( [
+						plugins: [
 							{
 								name: 'cleanupIDs',
 								params: {
 									minify: false, // Prevent duplicate SVG IDs from minification.
 								},
 							},
-						] ),
+						],
 					},
 				},
 			],
@@ -42,14 +37,14 @@ module.exports = function( api ) {
 						'inline-react-svg',
 						{
 							svgo: {
-								plugins: extendDefaultPlugins( [
+								plugins: [
 									{
 										name: 'cleanupIDs',
 										params: {
 											minify: false, // Prevent duplicate SVG IDs from minification.
 										},
 									},
-								] ),
+								],
 							},
 						},
 					],


### PR DESCRIPTION
## Summary

Since the last [version bump of `svgo`](https://github.com/ampproject/amp-wp/pull/6540) to 2.4.0, a console message is being output on each build:

```
"extendDefaultPlugins" utility is deprecated.
Use "preset-default" plugin with overrides instead.
For example:
{
  name: 'preset-default',
  params: {
    overrides: {
      // customize plugin options
      convertShapeToPath: {
        convertArcs: true
      },
      // disable plugins
      convertPathData: false
    }
  }
}
```

This PR fixes the Babel config so that the deprecation notice is no longer rendered.

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes n/a

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
