### PR TITLE
Add PostFeaturedImage to PrePublishPanel

### DIFF
--- a/assets/src/block-editor/plugins/pre-publish-panel.js
+++ b/assets/src/block-editor/plugins/pre-publish-panel.js
@@ -5,7 +5,7 @@ import { PrePublishPanel } from '../../common/components';
 
 export const name = 'amp-post-featured-image-pre-publish-panel';
 
-// On clicking 'Publish,' display a notice if no featured image exists or its width is too small.
+// Add the featured image selection component as a pre-publish check.
 export const render = () => {
 	return (
 		<PrePublishPanel />

--- a/assets/src/block-editor/plugins/pre-publish-panel.js
+++ b/assets/src/block-editor/plugins/pre-publish-panel.js
@@ -2,16 +2,12 @@
  * Internal dependencies
  */
 import { PrePublishPanel } from '../../common/components';
-import { getMinimumFeaturedImageDimensions } from '../../common/helpers';
 
 export const name = 'amp-post-featured-image-pre-publish-panel';
 
 // On clicking 'Publish,' display a notice if no featured image exists or its width is too small.
 export const render = () => {
 	return (
-		<PrePublishPanel
-			dimensions={ getMinimumFeaturedImageDimensions() }
-			required={ false }
-		/>
+		<PrePublishPanel />
 	);
 };

--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -13,7 +13,32 @@ import { Notice } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { validateFeaturedImage, getMinimumFeaturedImageDimensions } from '../../helpers';
+
+/**
+ * Create notice UI for featured image component.
+ *
+ * @param {string[]} messages Notices.
+ * @param {string}   status   Status type of notice.
+ * @return {JSX.Element} Notice component.
+ */
+const createNoticeUI = ( messages, status ) => {
+	return (
+		<Notice
+			status={ status }
+			isDismissible={ false }
+		>
+			{ messages.map( ( message, index ) => {
+				return (
+					<p key={ `message-${ index }` }>
+						{ message }
+					</p>
+				);
+			} ) }
+		</Notice>
+	);
+};
 
 /**
  * Higher-order component that is used for filtering the PostFeaturedImage component.
@@ -30,29 +55,19 @@ export default createHigherOrderComponent(
 
 		const withFeaturedImageNotice = ( props ) => {
 			const { media } = props;
+			const mediaIsRequired = false;
+			let noticeUI;
 
-			const errors = validateFeaturedImage( media, getMinimumFeaturedImageDimensions(), false );
-
-			if ( ! errors ) {
-				return <PostFeaturedImage { ...props } />;
+			if ( ! media && ! mediaIsRequired ) {
+				const message = __( 'Selecting a featured image is recommended for an optimal user experience.', 'amp' );
+				noticeUI = createNoticeUI( [ message ], 'notice' );
+			} else {
+				const errorMessages = validateFeaturedImage( media, getMinimumFeaturedImageDimensions() );
+				noticeUI = errorMessages ? createNoticeUI( errorMessages, 'warning' ) : null;
 			}
 
 			return (
-				<>
-					<Notice
-						status="warning"
-						isDismissible={ false }
-					>
-						{ errors.map( ( errorMessage, index ) => {
-							return (
-								<p key={ `error-${ index }` }>
-									{ errorMessage }
-								</p>
-							);
-						} ) }
-					</Notice>
-					<PostFeaturedImage { ...props } />
-				</>
+				<PostFeaturedImage { ...props } noticeUI={ noticeUI } />
 			);
 		};
 

--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -9,11 +9,11 @@ import { isFunction } from 'lodash';
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { validateFeaturedImage, getMinimumFeaturedImageDimensions } from '../../helpers';
 
 /**

--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -55,10 +55,9 @@ export default createHigherOrderComponent(
 
 		const withFeaturedImageNotice = ( props ) => {
 			const { media } = props;
-			const mediaIsRequired = false;
 			let noticeUI;
 
-			if ( ! media && ! mediaIsRequired ) {
+			if ( ! media ) {
 				const message = __( 'Selecting a featured image is recommended for an optimal user experience.', 'amp' );
 				noticeUI = createNoticeUI( [ message ], 'notice' );
 			} else {

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -1,73 +1,26 @@
 /**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-
-/**
  * WordPress dependencies
  */
-import { Notice } from '@wordpress/components';
 import { PostFeaturedImage } from '@wordpress/editor';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
-import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import { validateFeaturedImage } from '../helpers';
-
-/**
- * Conditionally adds a notice to the pre-publish panel for the featured image.
+ * Adds a notice to the pre-publish panel for the featured image.
  *
- * @param {Object}  props               Component props.
- * @param {Object}  props.featuredMedia Media object.
- * @param {Array}   props.dimensions    Required image dimensions.
- * @param {boolean} props.required      Whether selecting a featured image is required.
  * @return {Function} Either a plain pre-publish panel, or the panel with a featured image notice.
  */
-const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {
-	const errors = validateFeaturedImage( featuredMedia, dimensions, required );
-	const noticeUI = errors ? (
-		<Notice
-			status={ required ? 'warning' : 'notice' }
-			isDismissible={ false }
-		>
-			{ errors.map( ( errorMessage, index ) => {
-				return (
-					<p key={ `error-${ index }` }>
-						{ errorMessage }
-					</p>
-				);
-			} ) }
-		</Notice>
-	) : null;
-
+const PrePublishPanel = () => {
 	return (
 		<PluginPrePublishPanel
 			title={ __( 'Featured Image', 'amp' ) }
 			initialOpen="true"
 		>
-			<PostFeaturedImage noticeUI={ noticeUI } />
+			<PostFeaturedImage />
 		</PluginPrePublishPanel>
 	);
 };
 
-PrePublishPanel.propTypes = {
-	featuredMedia: PropTypes.object,
-	dimensions: PropTypes.shape( {
-		width: PropTypes.number.isRequired,
-		height: PropTypes.number.isRequired,
-	} ),
-	required: PropTypes.bool,
-};
+PrePublishPanel.propTypes = {};
 
-export default withSelect( ( select ) => {
-	const currentPost = select( 'core/editor' ).getCurrentPost();
-	const editedFeaturedMedia = select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
-	const featuredMedia = currentPost.featured_media || editedFeaturedMedia;
-
-	return {
-		featuredMedia: featuredMedia ? select( 'core' ).getMedia( featuredMedia ) : null,
-	};
-} )( PrePublishPanel );
+export default PrePublishPanel;

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -6,9 +6,12 @@ import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Adds a notice to the pre-publish panel for the featured image.
+ * Adds a pre-publish panel containing the featured image selection component.
  *
- * @return {Function} Either a plain pre-publish panel, or the panel with a featured image notice.
+ * Note: The `PostFeaturedImage` component would have already been filtered to include
+ * any notices for the featured image so there is no need to recreate them here.
+ *
+ * @return {Function} A pre-publish panel containing the featured image selection component.
  */
 const PrePublishPanel = () => {
 	return (

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -28,32 +28,27 @@ import { validateFeaturedImage } from '../helpers';
  */
 const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {
 	const errors = validateFeaturedImage( featuredMedia, dimensions, required );
-
-	if ( ! errors ) {
-		return null;
-	}
+	const noticeUI = errors ? (
+		<Notice
+			status={ required ? 'warning' : 'notice' }
+			isDismissible={ false }
+		>
+			{ errors.map( ( errorMessage, index ) => {
+				return (
+					<p key={ `error-${ index }` }>
+						{ errorMessage }
+					</p>
+				);
+			} ) }
+		</Notice>
+	) : null;
 
 	return (
 		<PluginPrePublishPanel
 			title={ __( 'Featured Image', 'amp' ) }
 			initialOpen="true"
 		>
-			<PostFeaturedImage
-				noticeUI={
-					<Notice
-						status={ required ? 'warning' : 'notice' }
-						isDismissible={ false }
-					>
-						{ errors.map( ( errorMessage, index ) => {
-							return (
-								<p key={ `error-${ index }` }>
-									{ errorMessage }
-								</p>
-							);
-						} ) }
-					</Notice>
-				}
-			/>
+			<PostFeaturedImage noticeUI={ noticeUI } />
 		</PluginPrePublishPanel>
 	);
 };

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -24,6 +24,4 @@ const PrePublishPanel = () => {
 	);
 };
 
-PrePublishPanel.propTypes = {};
-
 export default PrePublishPanel;

--- a/assets/src/common/components/pre-publish-panel.js
+++ b/assets/src/common/components/pre-publish-panel.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { Notice } from '@wordpress/components';
+import { PostFeaturedImage } from '@wordpress/editor';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -37,18 +38,22 @@ const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {
 			title={ __( 'Featured Image', 'amp' ) }
 			initialOpen="true"
 		>
-			<Notice
-				status={ required ? 'warning' : 'notice' }
-				isDismissible={ false }
-			>
-				{ errors.map( ( errorMessage, index ) => {
-					return (
-						<p key={ `error-${ index }` }>
-							{ errorMessage }
-						</p>
-					);
-				} ) }
-			</Notice>
+			<PostFeaturedImage
+				noticeUI={
+					<Notice
+						status={ required ? 'warning' : 'notice' }
+						isDismissible={ false }
+					>
+						{ errors.map( ( errorMessage, index ) => {
+							return (
+								<p key={ `error-${ index }` }>
+									{ errorMessage }
+								</p>
+							);
+						} ) }
+					</Notice>
+				}
+			/>
 		</PluginPrePublishPanel>
 	);
 };

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -65,24 +65,19 @@ export const getMinimumFeaturedImageDimensions = () => {
 /**
  * Validates the an image based on requirements.
  *
- * @param {Object}  media                      A media object.
- * @param {string}  media.mime_type            The media item's mime type.
- * @param {Object}  media.media_details        A media details object with width and height values.
- * @param {number}  media.media_details.width  Media width in pixels.
- * @param {number}  media.media_details.height Media height in pixels.
- * @param {Object}  dimensions                 An object with minimum required width and height values.
- * @param {number}  dimensions.width           Minimum required width value.
- * @param {number}  dimensions.height          Minimum required height value.
- * @param {boolean} required                   Whether the image is required or not.
+ * @param {Object|null} media                      A media object.
+ * @param {string}      media.mime_type            The media item's mime type.
+ * @param {Object}      media.media_details        A media details object with width and height values.
+ * @param {number}      media.media_details.width  Media width in pixels.
+ * @param {number}      media.media_details.height Media height in pixels.
+ * @param {Object}      dimensions                 An object with minimum required width and height values.
+ * @param {number}      dimensions.width           Minimum required width value.
+ * @param {number}      dimensions.height          Minimum required height value.
  * @return {string[]|null} Validation errors, or null if there were no errors.
  */
-export const validateFeaturedImage = ( media, dimensions, required ) => {
+export const validateFeaturedImage = ( media, dimensions ) => {
 	if ( ! media ) {
-		if ( required ) {
-			return [ __( 'Selecting a featured image is required.', 'amp' ) ];
-		}
-
-		return [ __( 'Selecting a featured image is recommended for an optimal user experience.', 'amp' ) ];
+		return [ __( 'Selecting a featured image is required.', 'amp' ) ];
 	}
 
 	const errors = [];

--- a/assets/src/common/helpers/test/validateFeaturedImage.js
+++ b/assets/src/common/helpers/test/validateFeaturedImage.js
@@ -4,13 +4,8 @@
 import { validateFeaturedImage } from '../';
 
 describe( 'validateFeaturedImage', () => {
-	it( 'returns an error if `media` is not an object', () => {
-		const isValid = validateFeaturedImage( null, {}, false );
-		expect( isValid ).toStrictEqual( [ 'Selecting a featured image is recommended for an optimal user experience.' ] );
-	} );
-
-	it( 'returns an error if the `media` object is not an object and is required', () => {
-		const isValid = validateFeaturedImage( null, null, true );
+	it( 'returns an error if the `media` is not an object', () => {
+		const isValid = validateFeaturedImage( null, { width: 10, height: 10 } );
 		expect( isValid ).toStrictEqual( [ 'Selecting a featured image is required.' ] );
 	} );
 
@@ -18,7 +13,6 @@ describe( 'validateFeaturedImage', () => {
 		const isValid = validateFeaturedImage(
 			{ mime_type: 'foo', media_details: { width: 11, height: 11 } },
 			{ width: 10, height: 10 },
-			false,
 		);
 		expect( isValid ).toStrictEqual( [ 'The featured image must be of either JPEG, PNG, GIF, WebP, or SVG format.' ] );
 	} );
@@ -27,7 +21,6 @@ describe( 'validateFeaturedImage', () => {
 		const isValid = validateFeaturedImage(
 			{ mime_type: 'image/png', media_details: { width: 10, height: 10 } },
 			{ width: 11, height: 11 },
-			false,
 		);
 		expect( isValid ).toStrictEqual( [ 'The featured image should have a size of at least 11 by 11 pixels.' ] );
 	} );
@@ -36,7 +29,6 @@ describe( 'validateFeaturedImage', () => {
 		const isValid = validateFeaturedImage(
 			{ mime_type: 'image/png', media_details: { width: 11, height: 11 } },
 			{ width: 10, height: 10 },
-			false,
 		);
 		expect( isValid ).toBeNull();
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "amp-wp",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/api-fetch": "5.2.1",
@@ -13,6 +12,7 @@
         "@wordpress/compose": "5.0.0",
         "@wordpress/date": "4.2.1",
         "@wordpress/dom-ready": "3.2.1",
+        "@wordpress/editor": "11.0.1",
         "@wordpress/element": "4.0.0",
         "@wordpress/escape-html": "2.2.1",
         "@wordpress/html-entities": "3.2.1",
@@ -91,6 +91,9 @@
       },
       "engines": {
         "node": ">=6.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.10.0 < 6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -108,7 +111,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
       "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -117,7 +119,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
       "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.0",
@@ -147,7 +148,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
       "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.15.0",
         "jsesc": "^2.5.1",
@@ -183,7 +183,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
       "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -212,6 +211,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
@@ -222,6 +224,9 @@
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "regexpu-core": "^4.7.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -238,6 +243,9 @@
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
         "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
       }
     },
     "node_modules/@babel/helper-explode-assignable-expression": {
@@ -253,7 +261,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
       "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-get-function-arity": "^7.14.5",
         "@babel/template": "^7.14.5",
@@ -267,7 +274,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
       "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -279,7 +285,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
       "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -291,7 +296,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
       "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.15.0"
       },
@@ -314,7 +318,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
       "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-replace-supers": "^7.15.0",
@@ -333,7 +336,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
       "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -364,7 +366,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
       "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.15.0",
         "@babel/helper-optimise-call-expression": "^7.14.5",
@@ -379,7 +380,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
       "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.8"
       },
@@ -400,7 +400,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
       "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -420,7 +419,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -441,7 +439,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
       "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.8",
@@ -468,7 +465,6 @@
       "version": "7.15.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
       "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -485,6 +481,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
         "@babel/plugin-proposal-optional-chaining": "^7.13.12"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
@@ -496,6 +495,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
@@ -509,6 +511,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
@@ -519,6 +524,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
@@ -529,6 +537,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
@@ -539,6 +550,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
@@ -549,6 +563,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -559,6 +576,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
@@ -569,6 +589,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
@@ -582,6 +605,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
@@ -592,6 +618,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
@@ -603,6 +632,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
@@ -613,6 +645,9 @@
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
@@ -626,6 +661,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -635,6 +673,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-bigint": {
@@ -644,6 +685,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -653,6 +697,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
@@ -662,6 +709,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
@@ -671,6 +721,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
@@ -680,6 +733,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
@@ -689,6 +745,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
@@ -697,6 +756,9 @@
       "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -706,6 +768,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -715,6 +780,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -724,6 +792,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
@@ -733,6 +804,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -742,6 +816,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -751,6 +828,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -760,6 +840,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
@@ -769,6 +852,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
@@ -778,6 +864,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
@@ -789,6 +878,9 @@
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
@@ -798,6 +890,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
@@ -807,6 +902,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -822,6 +920,9 @@
         "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "globals": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
@@ -831,6 +932,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
@@ -840,6 +944,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
@@ -850,6 +957,9 @@
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
@@ -859,6 +969,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
@@ -869,6 +982,9 @@
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
@@ -878,6 +994,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
@@ -888,6 +1007,9 @@
       "dependencies": {
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
@@ -897,6 +1019,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
@@ -906,6 +1031,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
@@ -917,6 +1045,9 @@
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
@@ -929,6 +1060,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-simple-access": "^7.12.13",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
@@ -942,6 +1076,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -952,6 +1089,9 @@
       "dependencies": {
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
@@ -961,6 +1101,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
@@ -970,6 +1113,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
@@ -980,6 +1126,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/helper-replace-supers": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
@@ -989,6 +1138,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
@@ -998,6 +1150,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-constant-elements": {
@@ -1007,6 +1162,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
@@ -1016,6 +1174,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
@@ -1029,6 +1190,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-jsx": "^7.12.13",
         "@babel/types": "^7.13.12"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
@@ -1038,6 +1202,9 @@
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.12.17"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
@@ -1048,6 +1215,9 @@
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
@@ -1057,6 +1227,9 @@
       "dev": true,
       "dependencies": {
         "regenerator-transform": "^0.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
@@ -1066,6 +1239,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
@@ -1080,6 +1256,9 @@
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -1089,6 +1268,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
@@ -1099,6 +1281,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
@@ -1108,6 +1293,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
@@ -1117,6 +1305,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
@@ -1126,6 +1317,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
@@ -1137,6 +1331,9 @@
         "@babel/helper-create-class-features-plugin": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-typescript": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
@@ -1146,6 +1343,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
@@ -1156,6 +1356,9 @@
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -1233,6 +1436,9 @@
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
         "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -1246,6 +1452,9 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-react": {
@@ -1260,6 +1469,9 @@
         "@babel/plugin-transform-react-jsx": "^7.13.12",
         "@babel/plugin-transform-react-jsx-development": "^7.12.17",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -1271,6 +1483,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
         "@babel/plugin-transform-typescript": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1295,7 +1510,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
       "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -1309,7 +1523,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
       "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.0",
@@ -1397,6 +1610,9 @@
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
         "stylis": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
@@ -1410,6 +1626,9 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@emotion/cache": {
@@ -1434,6 +1653,14 @@
         "@emotion/serialize": "^1.0.0",
         "@emotion/sheet": "^1.0.0",
         "@emotion/utils": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/hash": {
@@ -1445,7 +1672,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
@@ -1457,17 +1683,29 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.0.tgz",
-      "integrity": "sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz",
+      "integrity": "sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.4.0",
         "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.0.1",
+        "@emotion/sheet": "^1.0.2",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/serialize": {
@@ -1483,9 +1721,9 @@
       }
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
-      "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
+      "integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.3.0",
@@ -1497,6 +1735,19 @@
         "@emotion/is-prop-valid": "^1.1.0",
         "@emotion/serialize": "^1.0.2",
         "@emotion/utils": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
@@ -1575,6 +1826,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -1593,6 +1847,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
@@ -1602,30 +1859,37 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
       "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "deprecated": "Moved to 'npm install @sideway/address'",
       "dev": true
     },
     "node_modules/@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/joi": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
       "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "deprecated": "Switch to 'npm install joi'",
       "dev": true,
       "dependencies": {
         "@hapi/address": "2.x.x",
@@ -1638,6 +1902,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^8.3.0"
@@ -1770,6 +2035,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/chalk": {
@@ -1783,6 +2051,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/color-convert": {
@@ -1882,6 +2153,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/chalk": {
@@ -1895,6 +2169,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/color-convert": {
@@ -1934,6 +2211,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@jest/core/node_modules/strip-ansi": {
@@ -2054,6 +2334,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
@@ -2067,6 +2350,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
@@ -2207,6 +2493,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/chalk": {
@@ -2220,6 +2509,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
@@ -2296,6 +2588,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/chalk": {
@@ -2309,6 +2604,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/color-convert": {
@@ -2420,6 +2718,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@polka/url": {
@@ -2431,7 +2732,11 @@
     "node_modules/@popperjs/core": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz",
-      "integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ=="
+      "integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.2",
@@ -2458,6 +2763,10 @@
       "dev": true,
       "dependencies": {
         "@babel/core": ">=7.9.0"
+      },
+      "peerDependencies": {
+        "postcss": ">=7.0.0",
+        "postcss-syntax": ">=0.36.2"
       }
     },
     "node_modules/@stylelint/postcss-markdown": {
@@ -2468,6 +2777,10 @@
       "dependencies": {
         "remark": "^13.0.0",
         "unist-util-find-all-after": "^3.0.2"
+      },
+      "peerDependencies": {
+        "postcss": ">=7.0.0",
+        "postcss-syntax": ">=0.36.2"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -2477,6 +2790,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
@@ -2486,6 +2803,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
@@ -2495,6 +2816,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
@@ -2504,6 +2829,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
@@ -2513,6 +2842,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
@@ -2522,6 +2855,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
@@ -2531,6 +2868,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-plugin-transform-svg-component": {
@@ -2540,6 +2881,10 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/babel-preset": {
@@ -2559,6 +2904,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/core": {
@@ -2573,6 +2922,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/core/node_modules/camelcase": {
@@ -2582,6 +2935,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@svgr/core/node_modules/cosmiconfig": {
@@ -2610,6 +2966,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/plugin-jsx": {
@@ -2625,6 +2985,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/plugin-svgo": {
@@ -2639,6 +3003,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@svgr/plugin-svgo/node_modules/cosmiconfig": {
@@ -2701,6 +3069,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@tannin/compile": {
@@ -3065,6 +3437,19 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^4.0.0",
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
@@ -3097,6 +3482,13 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -3112,6 +3504,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3125,6 +3529,10 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -3134,6 +3542,10 @@
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
@@ -3152,6 +3564,15 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -3180,6 +3601,10 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3401,6 +3826,9 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.9"
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
@@ -3431,7 +3859,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
       "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/@wordpress/base-styles": {
       "version": "3.6.0",
@@ -3443,7 +3875,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.2.1.tgz",
       "integrity": "sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -3553,7 +3984,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.1.tgz",
       "integrity": "sha512-TKLGqFiysDKtLnc0pjPD1AOU5fg0LX12XfrK9Ke6QmCP2q7e57+9ZM9SRzXQ2U8GRgsIiwhjzi31R2HQGXqYng==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -3648,6 +4078,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
       }
     },
     "node_modules/@wordpress/compose": {
@@ -3675,16 +4108,16 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-4.0.0.tgz",
-      "integrity": "sha512-VLA2IzI4DnVVRlHLuqHEXGRM6GRSrZWILTPiA2p2ttmaD73N+MB3rLzvJVl6WpOpnDfdquOFVFMLTEZBIpLt9g==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-4.0.1.tgz",
+      "integrity": "sha512-+Qirkpm83WjKsFZ4JjP0tlNqN+Qz07xEtKCrJPxRxAJlZn+OU5AW6DqOWCxJ3kWDjy0RYVG7jd5nueDTdb1N4A==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/data-controls": "^2.2.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
+        "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/html-entities": "^3.2.1",
         "@wordpress/i18n": "^4.2.1",
@@ -3699,10 +4132,106 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+      "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/autop": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/shortcode": "^3.2.1",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
+      }
+    },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/primitives": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/data": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.0.tgz",
       "integrity": "sha512-fkub4wwdD2z7Ctn0syvNfDKodBeRlq/BCHObuklGAPu8hiyB7Fzel7VqHK11u77K+5fEO5UMYzqif1HDdICQOw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/compose": "^5.0.0",
@@ -3720,21 +4249,73 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
       }
     },
     "node_modules/@wordpress/data-controls": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.1.tgz",
-      "integrity": "sha512-w4LScjPn7i4IBUlnsucXkOFqIKOVQu+7MZaL82JbYPro0t5tMtnlq0ZUtWXuZcvUOtOyw8XH8jEnluzqJWVM8Q==",
-      "dev": true,
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.2.tgz",
+      "integrity": "sha512-kbHESAHt5nixx9ROaxSK0dP1R345qbutqLRclh+9ZwGfAoHWtn6ggagd9tzkoO8eG3Fzne5/psvGW0tCXo9Dtg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/deprecated": "^3.2.1"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/data-controls/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/data-controls/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
       }
     },
     "node_modules/@wordpress/date": {
@@ -3761,6 +4342,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "webpack": "^4.8.3 || ^5.0.0"
       }
     },
     "node_modules/@wordpress/deprecated": {
@@ -3776,9 +4360,9 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.1.tgz",
-      "integrity": "sha512-sl1MzQT8nvUfmRSrZgsLyfQo7wGFxZlLOzmAGMD4bUX/x40ZYAmsGc7E9zn7jnaqOmpbXKviUy0nBZiYGpfc2w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.2.tgz",
+      "integrity": "sha512-FRhnTsRO5/+fDBDU+Hs8WvMLd5+2eFgnu1jKCoumywqBx7WPJv6b3g5xFsiKliaj7aP1Jk0t55nYHPNMgfwBwA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -3812,6 +4396,10 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "jest": ">=26",
+        "puppeteer": ">=1.19.0"
       }
     },
     "node_modules/@wordpress/edit-post": {
@@ -3857,59 +4445,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/edit-post/node_modules/framer-motion": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.11.tgz",
-      "integrity": "sha512-7N67I8PUNH3OT0RTlNB672k5UiuWg5B17c+9Lc6BjICRo66gKeiq/Hy091lWCqNuSLEO59F9z39zxb3wMg6Tjg==",
-      "dev": true,
-      "dependencies": {
-        "framesync": "5.3.0",
-        "hey-listen": "^1.0.8",
-        "popmotion": "9.3.5",
-        "style-value-types": "4.1.4",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      }
-    },
-    "node_modules/@wordpress/edit-post/node_modules/framesync": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
-      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@wordpress/edit-post/node_modules/popmotion": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.5.tgz",
-      "integrity": "sha512-Lr2rq8OP0j8D7CO2/6eO17ALeFCxjx1hfTGbMg+TLqFj+KZSGOoj6gRBVTzDINGqo6LQrORQSSSDaCL5OrB3bw==",
-      "dev": true,
-      "dependencies": {
-        "framesync": "5.3.0",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "4.1.4",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@wordpress/edit-post/node_modules/style-value-types": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
-      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
-      "dev": true,
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@wordpress/edit-post/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
-    },
     "node_modules/@wordpress/edit-post/node_modules/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -3920,37 +4455,37 @@
       }
     },
     "node_modules/@wordpress/editor": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-11.0.0.tgz",
-      "integrity": "sha512-/LNtzn/OWfKV1xyFoWdOIC7cMPFyxIUYgH/AbuLrknwJhwPqPTDYxuuXuBRFrJEbYnQar+Phf8cG/xTRfKlcrA==",
-      "dev": true,
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-11.0.1.tgz",
+      "integrity": "sha512-MgLaIGKV8IssJm3LZO1/NU+Pgwu+xgEpibZjsoHL4Wk3PaNs24NydbrjruOWcwagRz5exJ0luXc8zx7pf/r4nw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
+        "@wordpress/a11y": "^3.2.1",
         "@wordpress/api-fetch": "^5.2.1",
         "@wordpress/autop": "^3.2.1",
         "@wordpress/blob": "^3.2.1",
-        "@wordpress/block-editor": "^7.0.0",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/core-data": "^4.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/data-controls": "^2.2.1",
+        "@wordpress/block-editor": "^7.0.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/core-data": "^4.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
         "@wordpress/date": "^4.2.1",
         "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/hooks": "^3.2.0",
         "@wordpress/html-entities": "^3.2.1",
         "@wordpress/i18n": "^4.2.1",
-        "@wordpress/icons": "^5.0.0",
+        "@wordpress/icons": "^5.0.1",
         "@wordpress/is-shallow-equal": "^4.2.0",
-        "@wordpress/keyboard-shortcuts": "^3.0.0",
+        "@wordpress/keyboard-shortcuts": "^3.0.1",
         "@wordpress/keycodes": "^3.2.1",
         "@wordpress/media-utils": "^3.0.0",
-        "@wordpress/notices": "^3.2.1",
-        "@wordpress/reusable-blocks": "^3.0.0",
-        "@wordpress/rich-text": "^5.0.0",
-        "@wordpress/server-side-render": "^3.0.0",
+        "@wordpress/notices": "^3.2.2",
+        "@wordpress/reusable-blocks": "^3.0.1",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/server-side-render": "^3.0.1",
         "@wordpress/url": "^3.2.1",
         "@wordpress/wordcount": "^3.2.1",
         "classnames": "^2.3.1",
@@ -3958,6 +4493,201 @@
         "memize": "^1.1.0",
         "react-autosize-textarea": "^7.1.0",
         "rememo": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/block-editor": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-7.0.1.tgz",
+      "integrity": "sha512-StOJtgFWkvDLy/EPBxIfv2KKA2oBMIkGNnNCif/VMSrCXgw9z8+/q7eJPVR1/rqCI/a/dlwZzD5VGED3Dgw/Ig==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/a11y": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keyboard-shortcuts": "^3.0.1",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/notices": "^3.2.2",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/shortcode": "^3.2.1",
+        "@wordpress/token-list": "^2.2.0",
+        "@wordpress/url": "^3.2.1",
+        "@wordpress/warning": "^2.2.1",
+        "@wordpress/wordcount": "^3.2.1",
+        "classnames": "^2.3.1",
+        "css-mediaquery": "^0.1.2",
+        "diff": "^4.0.2",
+        "dom-scroll-into-view": "^1.2.1",
+        "inherits": "^2.0.3",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-spring": "^8.0.19",
+        "redux-multi": "^0.1.12",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "traverse": "^0.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/blocks": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+      "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/autop": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/shortcode": "^3.2.1",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/components": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+      "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/date": "^4.2.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/primitives": "^3.0.0",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/warning": "^2.2.1",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "framer-motion": "^4.1.17",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/primitives": "^3.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -4017,6 +4747,15 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6.9"
+      },
+      "peerDependencies": {
+        "eslint": "^6 || ^7",
+        "typescript": "^4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/@es-joy/jsdoccomment": {
@@ -4067,6 +4806,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/globals": {
@@ -4079,19 +4821,9 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/prettier": {
-      "name": "wp-prettier",
-      "version": "2.2.1-beta-1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
       },
-      "engines": {
-        "node": ">=10.13.0"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
@@ -4210,6 +4942,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "jest": ">=26"
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
@@ -4226,6 +4961,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "jest": ">=26"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/@wojtekmaj/enzyme-adapter-react-17": {
@@ -4242,6 +4980,11 @@
         "prop-types": "^15.7.0",
         "react-is": "^17.0.2",
         "react-test-renderer": "^17.0.0"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.0.0",
+        "react": "^17.0.0-0",
+        "react-dom": "^17.0.0-0"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/@wojtekmaj/enzyme-adapter-utils": {
@@ -4255,6 +4998,9 @@
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
         "prop-types": "^15.7.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0-0"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/react-is": {
@@ -4273,6 +5019,9 @@
         "react-is": "^17.0.2",
         "react-shallow-renderer": "^16.13.1",
         "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/scheduler": {
@@ -4296,17 +5045,20 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "jest": ">=26",
+        "puppeteer": ">=1.19.0"
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.0.tgz",
-      "integrity": "sha512-C25tPSTYhbM5ImnQyS0FvGlOnS2R4yJov0bs7RSJeg7M7xqJtqBN3AEWq1iXkomeL+1z7jmV2N9gsHCoyxo1Wg==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.1.tgz",
+      "integrity": "sha512-uyHhK5w2FXIdwE3Z6PwmHhrX84UI8UAmfAaZZ3ZAiMEMOWiu0Ck+vpSNcKUG5Pibm8piH+/ZaXrFVLJvpTe3aw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/keycodes": "^3.2.1",
         "lodash": "^4.17.21",
@@ -4314,6 +5066,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
       }
     },
     "node_modules/@wordpress/keycodes": {
@@ -4333,7 +5135,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-3.0.0.tgz",
       "integrity": "sha512-oMs71qObEAFyYjBo8DDRrVf0+v8B4y1lNGWTb4FfXTx6e1tX12hi0tR0sKvRZJR/zmmpCMkJrAeWy3u3n7Cokw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
@@ -4347,18 +5148,67 @@
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.1.tgz",
-      "integrity": "sha512-BQHbaswaVEozE2qcIemauX9tnOdxhfDkQuP318zImAlwIHRF5ZGpAsx+ETBjlMrwDJufAm8+xHRmjk1lyesdUw==",
-      "dev": true,
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.2.tgz",
+      "integrity": "sha512-8RoaNpoVi6xTwwNKTHSmoSSomPDNEgI8t3fW7FxuVushXq/TbNb+YOING5M7ABJqNUEygRoQO7Zldm89PDwQYw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/a11y": "^3.2.1",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/data": "^6.0.1",
         "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
@@ -4368,6 +5218,9 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "npm-package-json-lint": ">=3.6.0"
       }
     },
     "node_modules/@wordpress/plugins": {
@@ -4419,6 +5272,13 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -4470,21 +5330,20 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-3.0.0.tgz",
-      "integrity": "sha512-UNhh9rfqWzX0OHtCzzOv9K49UwNVJ/MyUHxg42X7zEAGRo/CxSNRaxiV5IE0YDvFpqIY+PouPsOV89L2Ez32bQ==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-3.0.1.tgz",
+      "integrity": "sha512-KuW3j3Ao5EEDij9ehfUxU6qJcOa9a9nL5QMShBsVJbT40HbEw3qvq8Y5AcIrbFGf/kJJL6KkYyakvCJnQicfkg==",
       "dependencies": {
-        "@wordpress/block-editor": "^7.0.0",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/core-data": "^4.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/block-editor": "^7.0.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/core-data": "^4.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/i18n": "^4.2.1",
-        "@wordpress/icons": "^5.0.0",
-        "@wordpress/notices": "^3.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/notices": "^3.2.2",
         "@wordpress/url": "^3.2.1",
         "lodash": "^4.17.21"
       },
@@ -4492,15 +5351,210 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/rich-text": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.0.0.tgz",
-      "integrity": "sha512-v+QQ10aW3z9MFyW2YaC2LyomVFf6IJXMqZSsUyxuQBrM5HvXvr2Wl0u2vIbv0ZsJZUYtWU0BjNJzHI1vD8/D6w==",
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-editor": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-7.0.1.tgz",
+      "integrity": "sha512-StOJtgFWkvDLy/EPBxIfv2KKA2oBMIkGNnNCif/VMSrCXgw9z8+/q7eJPVR1/rqCI/a/dlwZzD5VGED3Dgw/Ig==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/dom": "^3.2.1",
+        "@wordpress/a11y": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keyboard-shortcuts": "^3.0.1",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/notices": "^3.2.2",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/shortcode": "^3.2.1",
+        "@wordpress/token-list": "^2.2.0",
+        "@wordpress/url": "^3.2.1",
+        "@wordpress/warning": "^2.2.1",
+        "@wordpress/wordcount": "^3.2.1",
+        "classnames": "^2.3.1",
+        "css-mediaquery": "^0.1.2",
+        "diff": "^4.0.2",
+        "dom-scroll-into-view": "^1.2.1",
+        "inherits": "^2.0.3",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-spring": "^8.0.19",
+        "redux-multi": "^0.1.12",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "traverse": "^0.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+      "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/autop": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/shortcode": "^3.2.1",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+      "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/date": "^4.2.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/primitives": "^3.0.0",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/warning": "^2.2.1",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "framer-motion": "^4.1.17",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/primitives": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/rich-text": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.0.1.tgz",
+      "integrity": "sha512-gQKKvpOw0BorVGHXkRQcrfDAlrj+sNVCr3cazvmxqCHRtcQlzi2Rgg8rRhqGcLl0xJkLGzVX1UM11S6h+cqUng==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/dom": "^3.2.2",
         "@wordpress/element": "^4.0.0",
         "@wordpress/escape-html": "^2.2.1",
         "@wordpress/is-shallow-equal": "^4.2.0",
@@ -4512,6 +5566,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -4591,6 +5695,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/chalk": {
@@ -4604,6 +5711,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/color-convert": {
@@ -4672,6 +5782,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/parse-json": {
@@ -4717,13 +5830,7 @@
       "version": "2.2.1-beta-1",
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
       "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
+      "dev": true
     },
     "node_modules/@wordpress/scripts/node_modules/read-pkg": {
       "version": "1.1.0",
@@ -4803,6 +5910,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
@@ -4817,6 +5931,10 @@
       },
       "engines": {
         "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/terser-webpack-plugin/node_modules/webpack-sources": {
@@ -4830,17 +5948,16 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-3.0.0.tgz",
-      "integrity": "sha512-SFe9Tej1QbCuS7AyXUhGO27HyFUzlaA+6kXvyaovi7+2l03UrwX1+RpWknC3eiCqiBZKpxjSTLLFoEu/7hvs9Q==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-3.0.1.tgz",
+      "integrity": "sha512-DXn0I9sVlIS/0VEhKHWffZuX1iovlr6vjocxshVrbN/iL+4E4r7StSEX+1BXv2/NCFfUNpTF6P95V9YXM8qHkQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/i18n": "^4.2.1",
@@ -4851,11 +5968,156 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+      "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/autop": "^3.2.1",
+        "@wordpress/blob": "^3.2.1",
+        "@wordpress/block-serialization-default-parser": "^4.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/html-entities": "^3.2.1",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/shortcode": "^3.2.1",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+      "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/css": "^11.1.3",
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "@emotion/utils": "1.0.0",
+        "@wordpress/a11y": "^3.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/date": "^4.2.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/hooks": "^3.2.0",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/primitives": "^3.0.0",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/warning": "^2.2.1",
+        "classnames": "^2.3.1",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "framer-motion": "^4.1.17",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.0",
+        "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.1.0",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.8",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "reakit-utils": "^0.15.1"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/compose": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+      "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@types/lodash": "4.14.149",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/dom": "^3.2.2",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/keycodes": "^3.2.1",
+        "@wordpress/priority-queue": "^2.2.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mousetrap": "^1.6.5",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/deprecated": "^3.2.1",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.2.0",
+        "@wordpress/priority-queue": "^2.2.1",
+        "@wordpress/redux-routine": "^4.2.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "redux": "^4.1.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+      "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/primitives": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/shortcode": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.1.tgz",
       "integrity": "sha512-nVELegRjoy/ShrKx2julCSCHiXlp8NTPfxYQCqNomUJzosdqVg7hj/LGt1STu7vZIqPayS8iVG3V7d0s2kGAkg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21",
@@ -4877,13 +6139,15 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "stylelint": "^13.7.0"
       }
     },
     "node_modules/@wordpress/token-list": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.2.0.tgz",
       "integrity": "sha512-0z6MhRv/pqxQcvTSeMAL69vcaxJ2J8U1Q5VeavHWnhtZ+nRglYNoE0yMLrEaeutoHeXOfWpY6baC91AgLDKE8A==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -4911,6 +6175,9 @@
       "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/@wordpress/viewport": {
@@ -4940,7 +6207,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.2.1.tgz",
       "integrity": "sha512-OBHR1QIuNC8RNrFJ1EnqWAJmaFCK71JDw8WvQWy2ZN7tAlzvKGofpmCWdOrP/JXGRhVpNzLGlyMoiGB0QmvYdw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -4999,7 +6265,10 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
@@ -5049,6 +6318,12 @@
         "prop-types": "^15.7.2",
         "prop-types-exact": "^1.2.0",
         "react-is": "^16.13.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
       }
     },
     "node_modules/ajv": {
@@ -5061,19 +6336,29 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      }
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
     },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
@@ -5100,6 +6385,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
@@ -5109,13 +6397,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5234,6 +6524,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-slice": {
@@ -5279,6 +6572,9 @@
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -5292,6 +6588,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flatmap": {
@@ -5307,6 +6606,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/arrify": {
@@ -5453,6 +6755,10 @@
       },
       "bin": {
         "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
       }
     },
     "node_modules/autoprefixer/node_modules/postcss": {
@@ -5467,6 +6773,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/autoprefixer/node_modules/source-map": {
@@ -5493,8 +6803,7 @@
     "node_modules/autosize": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
-      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==",
-      "dev": true
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -5530,6 +6839,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -5541,6 +6851,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
@@ -5569,6 +6882,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
@@ -5581,6 +6897,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/chalk": {
@@ -5594,6 +6913,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/color-convert": {
@@ -5648,6 +6970,10 @@
       },
       "engines": {
         "node": ">= 8.9"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "webpack": ">=2"
       }
     },
     "node_modules/babel-loader/node_modules/json5": {
@@ -5699,6 +7025,9 @@
       },
       "engines": {
         "node": ">=10.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -5751,6 +7080,9 @@
         "@babel/compat-data": "^7.13.0",
         "@babel/helper-define-polyfill-provider": "^0.1.5",
         "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
@@ -5761,6 +7093,9 @@
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.1.5",
         "core-js-compat": "^3.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
@@ -5770,6 +7105,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.1.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -5796,6 +7134,9 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -5809,6 +7150,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-runtime": {
@@ -5831,7 +7175,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -5910,7 +7258,21 @@
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -6111,7 +7473,6 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -6124,6 +7485,10 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -6139,6 +7504,20 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -6236,6 +7615,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cacache/node_modules/rimraf": {
@@ -6248,6 +7630,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cache-base": {
@@ -6277,6 +7662,9 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -6291,7 +7679,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6308,6 +7695,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-api": {
@@ -6326,7 +7716,10 @@
       "version": "1.0.30001248",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
       "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
-      "dev": true
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -6372,19 +7765,31 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chardet": {
       "version": "0.7.0",
@@ -6422,6 +7827,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/check-node-version/node_modules/chalk": {
@@ -6498,6 +7906,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
       "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+      "deprecated": "Use cheerio-select instead",
       "dev": true,
       "dependencies": {
         "css-select": "^3.1.2",
@@ -6505,6 +7914,9 @@
         "domelementtype": "^2.1.0",
         "domhandler": "^4.0.0",
         "domutils": "^2.4.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cheerio-select-tmp/node_modules/css-select": {
@@ -6518,6 +7930,9 @@
         "domhandler": "^4.0.0",
         "domutils": "^2.4.3",
         "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cheerio-select-tmp/node_modules/css-what": {
@@ -6527,6 +7942,9 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cheerio-select-tmp/node_modules/dom-serializer": {
@@ -6538,13 +7956,22 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/cheerio-select-tmp/node_modules/domelementtype": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/cheerio-select-tmp/node_modules/domutils": {
       "version": "2.5.0",
@@ -6555,6 +7982,9 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/cheerio-select-tmp/node_modules/nth-check": {
@@ -6564,6 +7994,9 @@
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/cheerio/node_modules/dom-serializer": {
@@ -6575,19 +8008,31 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/cheerio/node_modules/domelementtype": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/cheerio/node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.1",
@@ -6702,6 +8147,9 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "*"
       }
     },
     "node_modules/cli-cursor": {
@@ -6727,6 +8175,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate/node_modules/ansi-regex": {
@@ -6748,6 +8199,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cli-truncate/node_modules/color-convert": {
@@ -6843,7 +8297,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -6969,8 +8422,7 @@
     "node_modules/colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "node_modules/colors": {
       "version": "1.1.2",
@@ -7028,8 +8480,7 @@
     "node_modules/computed-style": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
-      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=",
-      "dev": true
+      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7173,6 +8624,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.37.0 || ^5.0.0"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/p-limit": {
@@ -7185,6 +8643,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
@@ -7199,6 +8660,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
@@ -7233,6 +8698,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -7244,6 +8710,10 @@
       "dependencies": {
         "browserslist": "^4.16.3",
         "semver": "7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -7260,7 +8730,11 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
       "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -7479,6 +8953,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/css-blank-pseudo/node_modules/source-map": {
@@ -7521,6 +8999,9 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
       }
     },
     "node_modules/css-has-pseudo": {
@@ -7563,6 +9044,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
@@ -7620,6 +9105,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.27.0 || ^5.0.0"
       }
     },
     "node_modules/css-loader/node_modules/camelcase": {
@@ -7629,6 +9121,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/css-loader/node_modules/schema-utils": {
@@ -7643,6 +9138,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/css-loader/node_modules/semver": {
@@ -7663,8 +9162,7 @@
     "node_modules/css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
-      "dev": true
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "node_modules/css-prefers-color-scheme": {
       "version": "3.1.1",
@@ -7693,6 +9191,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/css-prefers-color-scheme/node_modules/source-map": {
@@ -7763,6 +9265,9 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssdb": {
@@ -7795,6 +9300,13 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano-preset-default": {
@@ -7835,6 +9347,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano-utils": {
@@ -7844,6 +9359,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano/node_modules/cosmiconfig": {
@@ -7995,19 +9513,22 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8257,7 +9778,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8306,6 +9826,10 @@
       "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
       "bin": {
         "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/discontinuous-range": {
@@ -8332,6 +9856,9 @@
       "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
       "dependencies": {
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dom-scroll-into-view": {
@@ -8353,7 +9880,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -8393,13 +9926,22 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domhandler/node_modules/domelementtype": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -8441,6 +9983,9 @@
         "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
       }
     },
     "node_modules/downshift/node_modules/react-is": {
@@ -8515,8 +10060,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.3.736",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz",
-      "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig==",
-      "dev": true
+      "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -8546,13 +10090,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -8659,7 +10205,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/enzyme": {
       "version": "3.11.0",
@@ -8689,6 +10238,9 @@
         "raf": "^3.4.1",
         "rst-selector-parser": "^2.2.3",
         "string.prototype.trim": "^1.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/enzyme-shallow-equal": {
@@ -8699,6 +10251,9 @@
       "dependencies": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/enzyme-to-json": {
@@ -8713,6 +10268,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.4.0"
       }
     },
     "node_modules/equivalent-key-map": {
@@ -8773,6 +10331,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-to-primitive": {
@@ -8786,13 +10347,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8949,6 +10512,9 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -8958,6 +10524,9 @@
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -9012,6 +10581,12 @@
       },
       "engines": {
         "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -9126,6 +10701,15 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": ">= 4",
+        "eslint": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
@@ -9170,6 +10754,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/regextras": {
@@ -9216,6 +10805,9 @@
       },
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -9234,6 +10826,9 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.12.0 || >= 12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -9246,6 +10841,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.0.0",
+        "prettier": ">=1.13.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -9269,6 +10873,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -9278,6 +10885,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -9288,6 +10898,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -9313,6 +10926,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
@@ -9361,6 +10977,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/chalk": {
@@ -9374,6 +10993,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/color-convert": {
@@ -9427,6 +11049,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/globals": {
@@ -9439,6 +11064,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -9523,6 +11151,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/supports-color": {
@@ -9544,6 +11175,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/which": {
@@ -9854,6 +11488,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/color-convert": {
@@ -10042,6 +11679,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/extsprintf": {
@@ -10194,6 +11834,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/file-loader/node_modules/schema-utils": {
@@ -10208,6 +11855,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/file-sync-cmp": {
@@ -10244,6 +11895,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -10270,6 +11924,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-cache-dir/node_modules/find-up": {
@@ -10385,6 +12042,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/chalk": {
@@ -10398,6 +12058,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/color-convert": {
@@ -10457,7 +12120,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -10716,6 +12378,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/flatted": {
@@ -10728,6 +12393,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+      "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
       "dev": true
     },
     "node_modules/flush-write-stream": {
@@ -10827,6 +12493,10 @@
       "dev": true,
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
       }
     },
     "node_modules/fragment-cache": {
@@ -10840,6 +12510,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/framer-motion": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
+      "dependencies": {
+        "framesync": "5.3.0",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0",
+        "react-dom": ">=16.8 || ^17.0.0"
+      }
+    },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/framesync": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
+      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/from2": {
       "version": "2.3.0",
@@ -10973,6 +12680,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10998,6 +12706,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/functional-red-black-tree": {
@@ -11009,13 +12720,15 @@
     "node_modules/functions-have-names": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
-      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -11024,7 +12737,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -11037,6 +12749,9 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -11061,6 +12776,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -11126,6 +12844,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -11202,7 +12923,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11222,6 +12942,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globjoin": {
@@ -11352,6 +13075,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.5"
       }
     },
     "node_modules/grunt-contrib-copy": {
@@ -11469,6 +13195,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/grunt-legacy-log-utils/node_modules/chalk": {
@@ -11482,6 +13211,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/grunt-legacy-log-utils/node_modules/color-convert": {
@@ -11574,6 +13306,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "grunt": ">=1"
       }
     },
     "node_modules/grunt-wp-deploy": {
@@ -11586,6 +13321,9 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.1"
       }
     },
     "node_modules/grunt/node_modules/findup-sync": {
@@ -11659,6 +13397,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gzip-size": {
@@ -11671,6 +13412,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/har-schema": {
@@ -11686,6 +13430,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.3",
@@ -11739,7 +13484,10 @@
     "node_modules/has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -11755,6 +13503,9 @@
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-value": {
@@ -11853,8 +13604,7 @@
     "node_modules/hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "dev": true
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/highlight-words-core": {
       "version": "1.2.2",
@@ -11910,8 +13660,7 @@
     "node_modules/hpq": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
-      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
-      "dev": true
+      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
     },
     "node_modules/hsl-regex": {
       "version": "1.0.0",
@@ -11933,6 +13682,9 @@
       "dependencies": {
         "array-filter": "^1.0.0",
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -11967,6 +13719,13 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
       "integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
       "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -11983,13 +13742,22 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/htmlparser2/node_modules/domelementtype": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/htmlparser2/node_modules/domutils": {
       "version": "2.5.0",
@@ -12000,6 +13768,9 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/http-parser-js": {
@@ -12069,12 +13840,29 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/iferr": {
       "version": "0.1.5",
@@ -12107,6 +13895,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-lazy": {
@@ -12235,8 +14026,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -12393,7 +14183,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-alphanumerical": {
       "version": "1.0.4",
@@ -12403,6 +14197,10 @@
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arrayish": {
@@ -12413,7 +14211,10 @@
     "node_modules/is-bigint": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -12436,6 +14237,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-buffer": {
@@ -12450,6 +14254,9 @@
       "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -12528,13 +14335,20 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-descriptor": {
       "version": "0.1.6",
@@ -12570,6 +14384,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -12594,7 +14411,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12624,7 +14440,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
@@ -12632,6 +14452,9 @@
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -12649,6 +14472,9 @@
       "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -12735,6 +14561,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-regexp": {
@@ -12779,6 +14608,9 @@
       "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-subset": {
@@ -12796,6 +14628,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-touch-device": {
@@ -12828,6 +14663,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-utf8": {
@@ -13037,6 +14875,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -13049,6 +14890,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-changed-files/node_modules/is-stream": {
@@ -13159,6 +15003,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-circus/node_modules/chalk": {
@@ -13172,6 +15019,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-circus/node_modules/color-convert": {
@@ -13240,6 +15090,14 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-config/node_modules/ansi-styles": {
@@ -13252,6 +15110,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/chalk": {
@@ -13265,6 +15126,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/color-convert": {
@@ -13331,6 +15195,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-dev-server/node_modules/chalk": {
@@ -13410,6 +15277,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/chalk": {
@@ -13423,6 +15293,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/color-convert": {
@@ -13502,6 +15375,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/chalk": {
@@ -13515,6 +15391,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/color-convert": {
@@ -13666,6 +15545,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/chalk": {
@@ -13679,6 +15561,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/color-convert": {
@@ -13758,6 +15643,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
@@ -13771,6 +15659,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/color-convert": {
@@ -13842,6 +15733,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/chalk": {
@@ -13855,6 +15749,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
@@ -13916,6 +15813,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-regex-util": {
@@ -13970,6 +15875,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/chalk": {
@@ -13983,6 +15891,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
@@ -14085,6 +15996,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-resolve/node_modules/read-pkg/node_modules/type-fest": {
@@ -14149,6 +16063,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/chalk": {
@@ -14162,6 +16079,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/color-convert": {
@@ -14263,6 +16183,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/chalk": {
@@ -14276,6 +16199,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/cliui": {
@@ -14506,6 +16432,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-silent-reporter/node_modules/chalk": {
@@ -14519,6 +16448,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-silent-reporter/node_modules/color-convert": {
@@ -14597,6 +16529,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
@@ -14610,6 +16545,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
@@ -14693,6 +16631,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/chalk": {
@@ -14706,6 +16647,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/color-convert": {
@@ -14774,6 +16718,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
@@ -14783,6 +16730,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-validate/node_modules/chalk": {
@@ -14796,6 +16746,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/color-convert": {
@@ -14865,6 +16818,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/chalk": {
@@ -14878,6 +16834,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
@@ -14973,6 +16932,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/chalk": {
@@ -14986,6 +16948,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/cliui": {
@@ -15281,6 +17246,14 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
@@ -15308,7 +17281,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -15361,7 +17333,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -15607,7 +17578,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
       "integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
-      "dev": true,
       "dependencies": {
         "computed-style": "~0.1.3"
       },
@@ -15667,6 +17637,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
@@ -15680,6 +17653,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/color-convert": {
@@ -15757,6 +17733,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/get-stream": {
@@ -15766,6 +17745,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/has-flag": {
@@ -15793,6 +17775,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/npm-run-path": {
@@ -15880,6 +17865,9 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
       }
     },
     "node_modules/listr2/node_modules/ansi-regex": {
@@ -15901,6 +17889,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/color-convert": {
@@ -15946,6 +17937,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/listr2/node_modules/string-width": {
@@ -15986,6 +17980,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/livereload-js": {
@@ -16058,7 +18055,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -16155,6 +18151,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-symbols/node_modules/ansi-styles": {
@@ -16167,6 +18166,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
@@ -16180,6 +18182,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/color-convert": {
@@ -16234,6 +18239,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/ansi-regex": {
@@ -16255,6 +18263,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-update/node_modules/cli-cursor": {
@@ -16359,7 +18370,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
       "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -16394,6 +18409,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-iterator": {
@@ -16433,6 +18451,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/map-values": {
@@ -16479,7 +18500,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/markdownlint": {
       "version": "0.23.1",
@@ -16564,7 +18588,11 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -16588,6 +18616,10 @@
         "micromark": "~2.11.0",
         "parse-entities": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown/node_modules/parse-entities": {
@@ -16602,6 +18634,10 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
@@ -16611,6 +18647,10 @@
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-to-markdown": {
@@ -16625,6 +18665,10 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.0.0",
         "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-to-markdown/node_modules/parse-entities": {
@@ -16639,13 +18683,21 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdast-util-to-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
       "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/mdn-data": {
       "version": "2.0.4",
@@ -16739,6 +18791,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/find-up": {
@@ -16814,6 +18869,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
@@ -16841,6 +18899,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/yargs-parser": {
@@ -16902,6 +18963,16 @@
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
       "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "dependencies": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
@@ -16919,6 +18990,10 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/micromatch": {
@@ -17025,6 +19100,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0 || ^5.0.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
@@ -17039,6 +19121,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/source-map": {
@@ -17087,8 +19173,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -17292,8 +19377,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.7",
@@ -17364,6 +19448,10 @@
         "nearley-test": "bin/nearley-test.js",
         "nearley-unparse": "bin/nearley-unparse.js",
         "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
       }
     },
     "node_modules/neo-async": {
@@ -17536,8 +19624,7 @@
     "node_modules/node-releases": {
       "version": "1.1.71",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
-      "dev": true
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "node_modules/nopt": {
       "version": "3.0.6",
@@ -17651,6 +19738,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/chalk": {
@@ -17664,6 +19754,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/color-convert": {
@@ -17724,6 +19817,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/supports-color": {
@@ -17885,7 +19981,10 @@
     "node_modules/object-inspect": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-is": {
       "version": "1.1.5",
@@ -17897,6 +19996,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -17931,6 +20033,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.defaults": {
@@ -17986,6 +20091,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.getownpropertydescriptors": {
@@ -18000,6 +20108,9 @@
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.map": {
@@ -18050,6 +20161,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -18071,6 +20185,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/opener": {
@@ -18091,6 +20208,9 @@
         "cssnano": "^5.0.2",
         "last-call-webpack-plugin": "^3.0.0",
         "postcss": "^8.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/optionator": {
@@ -18151,6 +20271,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-finally": {
@@ -18166,19 +20289,20 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -18199,7 +20323,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18307,6 +20430,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-passwd": {
@@ -18359,7 +20485,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18457,6 +20582,9 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pidtree": {
@@ -18672,7 +20800,26 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/popmotion": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
+      "dependencies": {
+        "framesync": "5.3.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/popmotion/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
@@ -18718,6 +20865,10 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {
@@ -18742,6 +20893,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-attribute-case-insensitive/node_modules/source-map": {
@@ -18773,6 +20928,9 @@
       "dependencies": {
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.0.2"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-color-functional-notation": {
@@ -18800,6 +20958,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-color-functional-notation/node_modules/source-map": {
@@ -18849,6 +21011,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-color-gray/node_modules/source-map": {
@@ -18897,6 +21063,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-color-hex-alpha/node_modules/source-map": {
@@ -18946,6 +21116,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-color-mod-function/node_modules/source-map": {
@@ -18994,6 +21168,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-color-rebeccapurple/node_modules/source-map": {
@@ -19029,6 +21207,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-convert-values": {
@@ -19041,6 +21222,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-custom-media": {
@@ -19067,6 +21251,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-custom-media/node_modules/source-map": {
@@ -19115,6 +21303,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-custom-properties/node_modules/source-map": {
@@ -19175,6 +21367,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
@@ -19249,6 +21445,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
@@ -19293,6 +21493,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-discard-duplicates": {
@@ -19302,6 +21505,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-discard-empty": {
@@ -19311,6 +21517,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-discard-overridden": {
@@ -19320,6 +21529,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-double-position-gradients": {
@@ -19347,6 +21559,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-double-position-gradients/node_modules/source-map": {
@@ -19395,6 +21611,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-env-function/node_modules/source-map": {
@@ -19442,6 +21662,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-focus-visible/node_modules/source-map": {
@@ -19489,6 +21713,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-focus-within/node_modules/source-map": {
@@ -19533,6 +21761,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-font-variant/node_modules/source-map": {
@@ -19580,6 +21812,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-gap-properties/node_modules/source-map": {
@@ -19610,6 +21846,10 @@
       "dev": true,
       "dependencies": {
         "htmlparser2": "^3.10.0"
+      },
+      "peerDependencies": {
+        "postcss": ">=5.0.0",
+        "postcss-syntax": ">=0.36.0"
       }
     },
     "node_modules/postcss-html/node_modules/domhandler": {
@@ -19666,6 +21906,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-image-set-function/node_modules/source-map": {
@@ -19701,6 +21945,9 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-initial": {
@@ -19724,6 +21971,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-initial/node_modules/source-map": {
@@ -19773,6 +22024,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-lab-function/node_modules/source-map": {
@@ -19820,6 +22075,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-less/node_modules/source-map": {
@@ -19857,6 +22116,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/postcss-loader/node_modules/cosmiconfig": {
@@ -19887,6 +22154,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
@@ -19928,6 +22199,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-logical/node_modules/source-map": {
@@ -19975,6 +22250,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-media-minmax/node_modules/source-map": {
@@ -20016,6 +22295,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-merge-rules": {
@@ -20032,6 +22314,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-minify-font-values": {
@@ -20044,6 +22329,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-minify-gradients": {
@@ -20058,6 +22346,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-minify-params": {
@@ -20074,6 +22365,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-minify-selectors": {
@@ -20087,6 +22381,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
@@ -20110,6 +22407,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-local-by-default": {
@@ -20124,6 +22424,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-scope": {
@@ -20136,6 +22439,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -20148,6 +22454,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-nested": {
@@ -20160,6 +22469,13 @@
       },
       "engines": {
         "node": ">=10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-nesting": {
@@ -20186,6 +22502,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-nesting/node_modules/source-map": {
@@ -20216,6 +22536,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-display-values": {
@@ -20229,6 +22552,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-positions": {
@@ -20241,6 +22567,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
@@ -20254,6 +22583,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-string": {
@@ -20266,6 +22598,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
@@ -20279,6 +22614,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-unicode": {
@@ -20292,6 +22630,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-url": {
@@ -20306,6 +22647,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
@@ -20318,6 +22662,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-ordered-values": {
@@ -20331,6 +22678,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-overflow-shorthand": {
@@ -20357,6 +22707,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-overflow-shorthand/node_modules/source-map": {
@@ -20401,6 +22755,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-page-break/node_modules/source-map": {
@@ -20449,6 +22807,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-place/node_modules/source-map": {
@@ -20532,6 +22894,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-preset-env/node_modules/source-map": {
@@ -20592,6 +22958,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
@@ -20640,6 +23010,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-reduce-transforms": {
@@ -20653,6 +23026,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-replace-overflow-wrap": {
@@ -20676,6 +23052,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-replace-overflow-wrap/node_modules/source-map": {
@@ -20729,6 +23109,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-safe-parser/node_modules/source-map": {
@@ -20774,6 +23158,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-sass/node_modules/source-map": {
@@ -20821,6 +23209,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-scss/node_modules/source-map": {
@@ -20866,6 +23258,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-selector-matches/node_modules/source-map": {
@@ -20911,6 +23307,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-selector-not/node_modules/source-map": {
@@ -20958,13 +23358,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-syntax": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "postcss": ">=5.0.0"
+      }
     },
     "node_modules/postcss-unique-selectors": {
       "version": "5.0.0",
@@ -20978,6 +23384,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -21008,6 +23417,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/prettier": {
+      "name": "wp-prettier",
+      "version": "2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+      "dev": true
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
@@ -21055,6 +23471,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-format/node_modules/color-convert": {
@@ -21336,6 +23755,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
@@ -21345,6 +23767,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/q": {
@@ -21370,6 +23804,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -21388,7 +23823,21 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -21486,6 +23935,10 @@
       "integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
       "dependencies": {
         "fast-memoize": "^2.5.1"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0"
       }
     },
     "node_modules/react": {
@@ -21512,11 +23965,23 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
       "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-      "dev": true,
       "dependencies": {
         "autosize": "^4.0.2",
         "line-height": "^0.3.1",
         "prop-types": "^15.5.6"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.3.0.tgz",
+      "integrity": "sha512-zWE5E88zmjPXFhv6mGnRZqKin9s5vip1O3IIGynY9EhZxN8MATUxZkT3e/9OwTEm4DjQBXc6PFWP6AetY+Px+A==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dates": {
@@ -21537,6 +24002,11 @@
         "react-portal": "^4.1.5",
         "react-with-styles": "^3.2.0",
         "react-with-styles-interface-css": "^4.0.2"
+      },
+      "peerDependencies": {
+        "moment": "^2.18.1",
+        "react": "^0.14 || ^15.5.4 || ^16.1.1",
+        "react-dom": "^0.14 || ^15.5.4 || ^16.1.1"
       }
     },
     "node_modules/react-dom": {
@@ -21560,6 +24030,10 @@
       "dependencies": {
         "normalize-wheel": "^1.0.1",
         "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-easy-crop/node_modules/tslib": {
@@ -21579,6 +24053,9 @@
       "integrity": "sha512-Er940DxWoObfIqPrZNfwXKugjxMIuk1LAuEzn23gytzV6hKS/sw108wibi9QubfMN4h+nrlje8eUCSbQRJo2fQ==",
       "dependencies": {
         "moment": ">=1.6.0"
+      },
+      "peerDependencies": {
+        "moment": ">=1.6.0"
       }
     },
     "node_modules/react-outside-click-handler": {
@@ -21591,6 +24068,10 @@
         "document.contains": "^1.0.1",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || >=15",
+        "react-dom": "^0.14 || >=15"
       }
     },
     "node_modules/react-portal": {
@@ -21599,12 +24080,18 @@
       "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
       "dependencies": {
         "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
       }
     },
     "node_modules/react-resize-aware": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
-      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
+      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==",
+      "peerDependencies": {
+        "react": "^16.8.0"
+      }
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.14.1",
@@ -21614,6 +24101,9 @@
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-spring": {
@@ -21623,6 +24113,10 @@
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
       }
     },
     "node_modules/react-test-renderer": {
@@ -21635,6 +24129,9 @@
         "react-is": "^17.0.2",
         "react-shallow-renderer": "^16.13.1",
         "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
@@ -21646,7 +24143,10 @@
     "node_modules/react-use-gesture": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
-      "integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
+      "integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==",
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/react-with-direction": {
       "version": "1.3.1",
@@ -21661,6 +24161,10 @@
         "object.assign": "^4.1.0",
         "object.values": "^1.0.4",
         "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15 || ^16",
+        "react-dom": "^0.14 || ^15 || ^16"
       }
     },
     "node_modules/react-with-direction/node_modules/deepmerge": {
@@ -21680,6 +24184,10 @@
         "object.assign": "^4.1.0",
         "prop-types": "^15.6.2",
         "react-with-direction": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14",
+        "react-with-direction": "^1.1.0"
       }
     },
     "node_modules/react-with-styles-interface-css": {
@@ -21689,6 +24197,9 @@
       "dependencies": {
         "array.prototype.flat": "^1.2.1",
         "global-cache": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react-with-styles": "^3.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -21842,6 +24353,14 @@
         "reakit-system": "^0.15.1",
         "reakit-utils": "^0.15.1",
         "reakit-warning": "^0.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/reakit"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/reakit-system": {
@@ -21850,12 +24369,20 @@
       "integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
       "dependencies": {
         "reakit-utils": "^0.15.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/reakit-utils": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
-      "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
+      "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
     },
     "node_modules/reakit-warning": {
       "version": "0.6.1",
@@ -21863,6 +24390,9 @@
       "integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
       "dependencies": {
         "reakit-utils": "^0.15.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/rechoir": {
@@ -21901,8 +24431,7 @@
     "node_modules/redux-multi": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
-      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI=",
-      "dev": true
+      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
     },
     "node_modules/reflect.ownkeys": {
       "version": "0.2.0",
@@ -21965,6 +24494,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -21974,6 +24506,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/regexpu-core": {
@@ -22038,6 +24573,10 @@
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-stringify": {
@@ -22047,6 +24586,10 @@
       "dev": true,
       "dependencies": {
         "mdast-util-to-markdown": "^0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/is-buffer": {
@@ -22054,6 +24597,20 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "engines": {
         "node": ">=4"
       }
@@ -22074,6 +24631,10 @@
       "dev": true,
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/unified": {
@@ -22088,6 +24649,10 @@
         "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/unist-util-stringify-position": {
@@ -22097,6 +24662,10 @@
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/vfile": {
@@ -22109,6 +24678,10 @@
         "is-buffer": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0",
         "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/vfile-message": {
@@ -22119,6 +24692,10 @@
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rememo": {
@@ -22154,6 +24731,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -22191,12 +24769,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
@@ -22205,6 +24787,9 @@
       },
       "engines": {
         "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native/node_modules/tough-cookie": {
@@ -22237,6 +24822,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -22246,7 +24832,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22263,8 +24848,7 @@
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/requireindex": {
       "version": "1.2.0",
@@ -22282,6 +24866,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-bin": {
@@ -22339,6 +24926,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/restore-cursor": {
@@ -22510,6 +25098,20 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -22549,7 +25151,21 @@
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-json-parse": {
       "version": "1.0.1",
@@ -22575,6 +25191,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "dev": true,
       "dependencies": {
         "@cnakazawa/watch": "^1.0.3",
@@ -22766,6 +25383,27 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0",
+        "sass": "^1.3.0",
+        "webpack": "^4.36.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
       }
     },
     "node_modules/sass-loader/node_modules/schema-utils": {
@@ -22780,6 +25418,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/sass-loader/node_modules/semver": {
@@ -22836,6 +25478,10 @@
       },
       "engines": {
         "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/select": {
@@ -22847,7 +25493,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -22870,8 +25515,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -22993,7 +25637,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "dev": true,
       "dependencies": {
         "yargs": "^14.2"
       },
@@ -23010,6 +25653,9 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -23021,8 +25667,7 @@
     "node_modules/simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-      "dev": true
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -23080,6 +25725,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
@@ -23092,6 +25740,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/color-convert": {
@@ -23453,6 +26104,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23718,7 +26374,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -23742,6 +26397,9 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.padend": {
@@ -23756,6 +26414,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -23770,6 +26431,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend": {
@@ -23779,6 +26443,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
@@ -23788,6 +26455,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-object": {
@@ -23817,7 +26487,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -23891,6 +26560,20 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
     },
+    "node_modules/style-value-types": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/style-value-types/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/stylehacks": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.0.tgz",
@@ -23902,6 +26585,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/stylelint": {
@@ -23964,13 +26650,20 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/stylelint"
       }
     },
     "node_modules/stylelint-config-recommended": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
       "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": ">=10.1.0"
+      }
     },
     "node_modules/stylelint-config-recommended-scss": {
       "version": "4.3.0",
@@ -23979,13 +26672,20 @@
       "dev": true,
       "dependencies": {
         "stylelint-config-recommended": "^5.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+        "stylelint-scss": "^3.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss/node_modules/stylelint-config-recommended": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
       "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^13.13.0"
+      }
     },
     "node_modules/stylelint-scss": {
       "version": "3.20.1",
@@ -24001,6 +26701,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "peerDependencies": {
+        "stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
       }
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
@@ -24022,6 +26725,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/stylelint/node_modules/balanced-match": {
@@ -24041,6 +26747,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/stylelint/node_modules/color-convert": {
@@ -24176,6 +26885,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylelint/node_modules/meow/node_modules/type-fest": {
@@ -24185,6 +26897,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylelint/node_modules/normalize-package-data": {
@@ -24235,6 +26950,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/stylelint/node_modules/postcss/node_modules/ansi-styles": {
@@ -24329,6 +27048,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylelint/node_modules/read-pkg/node_modules/hosted-git-info": {
@@ -24482,6 +27204,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/sugarss/node_modules/source-map": {
@@ -24603,6 +27329,9 @@
         "domhandler": "^4.2.0",
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/svgo/node_modules/css-tree": {
@@ -24625,6 +27354,9 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/svgo/node_modules/dom-serializer": {
@@ -24636,13 +27368,22 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/svgo/node_modules/domhandler": {
       "version": "4.2.0",
@@ -24654,6 +27395,9 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/domutils": {
@@ -24665,6 +27409,9 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/mdn-data": {
@@ -24680,6 +27427,9 @@
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/source-map": {
@@ -24724,6 +27474,10 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/table/node_modules/ansi-regex": {
@@ -24876,6 +27630,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/terser": {
@@ -24938,6 +27695,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.27.0 || ^5.0.0"
       }
     },
     "node_modules/thread-loader/node_modules/loader-runner": {
@@ -24961,6 +27725,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/throat": {
@@ -25196,8 +27964,7 @@
     "node_modules/traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -25233,7 +28000,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.11.0",
@@ -25275,6 +28046,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/tty-browserify": {
@@ -25366,6 +28140,9 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -25492,13 +28269,21 @@
       "dev": true,
       "dependencies": {
         "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-find-all-after/node_modules/unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
       "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -25593,6 +28378,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url": {
@@ -25617,6 +28403,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "file-loader": "*",
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "file-loader": {
+          "optional": true
+        }
       }
     },
     "node_modules/url-loader/node_modules/schema-utils": {
@@ -25631,6 +28430,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/url/node_modules/punycode": {
@@ -25651,7 +28454,10 @@
     "node_modules/use-memo-one": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -25678,6 +28484,9 @@
         "es-abstract": "^1.17.2",
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/util/node_modules/inherits": {
@@ -25749,7 +28558,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
       "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -25849,11 +28662,11 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
+        "chokidar": "^3.4.1",
         "watchpack-chokidar2": "^2.0.1"
       }
     },
@@ -25940,13 +28753,13 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "optional": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -25955,6 +28768,9 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/fill-range": {
@@ -25990,6 +28806,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -26204,6 +29021,18 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-bundle-analyzer": {
@@ -26260,6 +29089,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
@@ -26273,6 +29105,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/color-convert": {
@@ -26346,6 +29181,9 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x"
       }
     },
     "node_modules/webpack-cli/node_modules/cross-spawn": {
@@ -26854,6 +29692,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack/node_modules/to-regex-range": {
@@ -26902,6 +29743,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/webpackbar/node_modules/ansi-regex": {
@@ -26923,6 +29767,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/webpackbar/node_modules/color-convert": {
@@ -26959,6 +29806,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpackbar/node_modules/is-fullwidth-code-point": {
@@ -27118,13 +29968,15 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -27148,7 +30000,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -27183,6 +30034,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {
@@ -27209,8 +30072,7 @@
     "node_modules/y18n": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-      "dev": true
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -27230,7 +30092,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
       "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "dev": true,
       "dependencies": {
         "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
@@ -27249,7 +30110,6 @@
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
       "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-      "dev": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -27272,13 +30132,20 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   },
   "dependencies": {
@@ -27302,14 +30169,12 @@
     "@babel/compat-data": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
-      "dev": true
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
     },
     "@babel/core": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
       "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.0",
@@ -27332,7 +30197,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
       "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.15.0",
         "jsesc": "^2.5.1",
@@ -27362,7 +30226,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
       "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -27423,7 +30286,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
       "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.14.5",
         "@babel/template": "^7.14.5",
@@ -27434,7 +30296,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
       "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -27443,7 +30304,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
       "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -27452,7 +30312,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
       "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.15.0"
       }
@@ -27469,7 +30328,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
       "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-replace-supers": "^7.15.0",
@@ -27485,7 +30343,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
       "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -27510,7 +30367,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
       "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.15.0",
         "@babel/helper-optimise-call-expression": "^7.14.5",
@@ -27522,7 +30378,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
       "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.8"
       }
@@ -27540,7 +30395,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
       "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -27553,8 +30407,7 @@
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.13.0",
@@ -27572,7 +30425,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
       "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.8",
@@ -27592,8 +30444,7 @@
     "@babel/parser": {
       "version": "7.15.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
-      "dev": true
+      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.13.12",
@@ -28408,7 +31259,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
       "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -28419,7 +31269,6 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
       "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.15.0",
@@ -28536,7 +31385,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@emotion/memoize": "0.7.4"
@@ -28548,14 +31396,14 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/react": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.0.tgz",
-      "integrity": "sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz",
+      "integrity": "sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.4.0",
         "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.0.1",
+        "@emotion/sheet": "^1.0.2",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "hoist-non-react-statics": "^3.3.1"
@@ -28574,9 +31422,9 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
-      "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
+      "integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
     },
     "@emotion/styled": {
       "version": "11.3.0",
@@ -30220,7 +33068,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
       "integrity": "sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@wordpress/babel-preset-default": {
       "version": "6.3.1",
@@ -30260,7 +33109,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.2.1.tgz",
       "integrity": "sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -30361,7 +33209,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.1.tgz",
       "integrity": "sha512-TKLGqFiysDKtLnc0pjPD1AOU5fg0LX12XfrK9Ke6QmCP2q7e57+9ZM9SRzXQ2U8GRgsIiwhjzi31R2HQGXqYng==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -30468,16 +33315,16 @@
       }
     },
     "@wordpress/core-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-4.0.0.tgz",
-      "integrity": "sha512-VLA2IzI4DnVVRlHLuqHEXGRM6GRSrZWILTPiA2p2ttmaD73N+MB3rLzvJVl6WpOpnDfdquOFVFMLTEZBIpLt9g==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-4.0.1.tgz",
+      "integrity": "sha512-+Qirkpm83WjKsFZ4JjP0tlNqN+Qz07xEtKCrJPxRxAJlZn+OU5AW6DqOWCxJ3kWDjy0RYVG7jd5nueDTdb1N4A==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/data-controls": "^2.2.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
+        "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/html-entities": "^3.2.1",
         "@wordpress/i18n": "^4.2.1",
@@ -30487,12 +33334,95 @@
         "lodash": "^4.17.21",
         "rememo": "^3.0.0",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@wordpress/blocks": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+          "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/autop": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/shortcode": "^3.2.1",
+            "hpq": "^1.3.0",
+            "lodash": "^4.17.21",
+            "rememo": "^3.0.0",
+            "showdown": "^1.9.1",
+            "simple-html-tokenizer": "^0.5.7",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+          "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/primitives": "^3.0.0"
+          }
+        }
       }
     },
     "@wordpress/data": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.0.tgz",
       "integrity": "sha512-fkub4wwdD2z7Ctn0syvNfDKodBeRlq/BCHObuklGAPu8hiyB7Fzel7VqHK11u77K+5fEO5UMYzqif1HDdICQOw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/compose": "^5.0.0",
@@ -30510,15 +33440,57 @@
       }
     },
     "@wordpress/data-controls": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.1.tgz",
-      "integrity": "sha512-w4LScjPn7i4IBUlnsucXkOFqIKOVQu+7MZaL82JbYPro0t5tMtnlq0ZUtWXuZcvUOtOyw8XH8jEnluzqJWVM8Q==",
-      "dev": true,
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.2.tgz",
+      "integrity": "sha512-kbHESAHt5nixx9ROaxSK0dP1R345qbutqLRclh+9ZwGfAoHWtn6ggagd9tzkoO8eG3Fzne5/psvGW0tCXo9Dtg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/deprecated": "^3.2.1"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        }
       }
     },
     "@wordpress/date": {
@@ -30551,9 +33523,9 @@
       }
     },
     "@wordpress/dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.1.tgz",
-      "integrity": "sha512-sl1MzQT8nvUfmRSrZgsLyfQo7wGFxZlLOzmAGMD4bUX/x40ZYAmsGc7E9zn7jnaqOmpbXKviUy0nBZiYGpfc2w==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.2.tgz",
+      "integrity": "sha512-FRhnTsRO5/+fDBDU+Hs8WvMLd5+2eFgnu1jKCoumywqBx7WPJv6b3g5xFsiKliaj7aP1Jk0t55nYHPNMgfwBwA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -30620,57 +33592,6 @@
         "uuid": "8.3.0"
       },
       "dependencies": {
-        "framer-motion": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.11.tgz",
-          "integrity": "sha512-7N67I8PUNH3OT0RTlNB672k5UiuWg5B17c+9Lc6BjICRo66gKeiq/Hy091lWCqNuSLEO59F9z39zxb3wMg6Tjg==",
-          "dev": true,
-          "requires": {
-            "@emotion/is-prop-valid": "^0.8.2",
-            "framesync": "5.3.0",
-            "hey-listen": "^1.0.8",
-            "popmotion": "9.3.5",
-            "style-value-types": "4.1.4",
-            "tslib": "^2.1.0"
-          }
-        },
-        "framesync": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
-          "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "popmotion": {
-          "version": "9.3.5",
-          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.5.tgz",
-          "integrity": "sha512-Lr2rq8OP0j8D7CO2/6eO17ALeFCxjx1hfTGbMg+TLqFj+KZSGOoj6gRBVTzDINGqo6LQrORQSSSDaCL5OrB3bw==",
-          "dev": true,
-          "requires": {
-            "framesync": "5.3.0",
-            "hey-listen": "^1.0.8",
-            "style-value-types": "4.1.4",
-            "tslib": "^2.1.0"
-          }
-        },
-        "style-value-types": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
-          "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
-          "dev": true,
-          "requires": {
-            "hey-listen": "^1.0.8",
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        },
         "uuid": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
@@ -30680,37 +33601,37 @@
       }
     },
     "@wordpress/editor": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-11.0.0.tgz",
-      "integrity": "sha512-/LNtzn/OWfKV1xyFoWdOIC7cMPFyxIUYgH/AbuLrknwJhwPqPTDYxuuXuBRFrJEbYnQar+Phf8cG/xTRfKlcrA==",
-      "dev": true,
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-11.0.1.tgz",
+      "integrity": "sha512-MgLaIGKV8IssJm3LZO1/NU+Pgwu+xgEpibZjsoHL4Wk3PaNs24NydbrjruOWcwagRz5exJ0luXc8zx7pf/r4nw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
+        "@wordpress/a11y": "^3.2.1",
         "@wordpress/api-fetch": "^5.2.1",
         "@wordpress/autop": "^3.2.1",
         "@wordpress/blob": "^3.2.1",
-        "@wordpress/block-editor": "^7.0.0",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/core-data": "^4.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/data-controls": "^2.2.1",
+        "@wordpress/block-editor": "^7.0.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/core-data": "^4.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/data-controls": "^2.2.2",
         "@wordpress/date": "^4.2.1",
         "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/hooks": "^3.2.0",
         "@wordpress/html-entities": "^3.2.1",
         "@wordpress/i18n": "^4.2.1",
-        "@wordpress/icons": "^5.0.0",
+        "@wordpress/icons": "^5.0.1",
         "@wordpress/is-shallow-equal": "^4.2.0",
-        "@wordpress/keyboard-shortcuts": "^3.0.0",
+        "@wordpress/keyboard-shortcuts": "^3.0.1",
         "@wordpress/keycodes": "^3.2.1",
         "@wordpress/media-utils": "^3.0.0",
-        "@wordpress/notices": "^3.2.1",
-        "@wordpress/reusable-blocks": "^3.0.0",
-        "@wordpress/rich-text": "^5.0.0",
-        "@wordpress/server-side-render": "^3.0.0",
+        "@wordpress/notices": "^3.2.2",
+        "@wordpress/reusable-blocks": "^3.0.1",
+        "@wordpress/rich-text": "^5.0.1",
+        "@wordpress/server-side-render": "^3.0.1",
         "@wordpress/url": "^3.2.1",
         "@wordpress/wordcount": "^3.2.1",
         "classnames": "^2.3.1",
@@ -30718,6 +33639,179 @@
         "memize": "^1.1.0",
         "react-autosize-textarea": "^7.1.0",
         "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/block-editor": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-7.0.1.tgz",
+          "integrity": "sha512-StOJtgFWkvDLy/EPBxIfv2KKA2oBMIkGNnNCif/VMSrCXgw9z8+/q7eJPVR1/rqCI/a/dlwZzD5VGED3Dgw/Ig==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/a11y": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/blocks": "^11.0.1",
+            "@wordpress/components": "^16.0.0",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/data-controls": "^2.2.2",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keyboard-shortcuts": "^3.0.1",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/notices": "^3.2.2",
+            "@wordpress/rich-text": "^5.0.1",
+            "@wordpress/shortcode": "^3.2.1",
+            "@wordpress/token-list": "^2.2.0",
+            "@wordpress/url": "^3.2.1",
+            "@wordpress/warning": "^2.2.1",
+            "@wordpress/wordcount": "^3.2.1",
+            "classnames": "^2.3.1",
+            "css-mediaquery": "^0.1.2",
+            "diff": "^4.0.2",
+            "dom-scroll-into-view": "^1.2.1",
+            "inherits": "^2.0.3",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "react-autosize-textarea": "^7.1.0",
+            "react-spring": "^8.0.19",
+            "redux-multi": "^0.1.12",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "traverse": "^0.6.6"
+          }
+        },
+        "@wordpress/blocks": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+          "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/autop": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/shortcode": "^3.2.1",
+            "hpq": "^1.3.0",
+            "lodash": "^4.17.21",
+            "rememo": "^3.0.0",
+            "showdown": "^1.9.1",
+            "simple-html-tokenizer": "^0.5.7",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+          "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.4.0",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.4.1",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/date": "^4.2.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/primitives": "^3.0.0",
+            "@wordpress/rich-text": "^5.0.1",
+            "@wordpress/warning": "^2.2.1",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "framer-motion": "^4.1.17",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-colorful": "^5.3.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+          "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/primitives": "^3.0.0"
+          }
+        }
       }
     },
     "@wordpress/element": {
@@ -30815,12 +33909,6 @@
           "requires": {
             "type-fest": "^0.8.1"
           }
-        },
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
         },
         "semver": {
           "version": "7.3.5",
@@ -30995,18 +34083,60 @@
       }
     },
     "@wordpress/keyboard-shortcuts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.0.tgz",
-      "integrity": "sha512-C25tPSTYhbM5ImnQyS0FvGlOnS2R4yJov0bs7RSJeg7M7xqJtqBN3AEWq1iXkomeL+1z7jmV2N9gsHCoyxo1Wg==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.1.tgz",
+      "integrity": "sha512-uyHhK5w2FXIdwE3Z6PwmHhrX84UI8UAmfAaZZ3ZAiMEMOWiu0Ck+vpSNcKUG5Pibm8piH+/ZaXrFVLJvpTe3aw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/keycodes": "^3.2.1",
         "lodash": "^4.17.21",
         "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        }
       }
     },
     "@wordpress/keycodes": {
@@ -31023,7 +34153,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-3.0.0.tgz",
       "integrity": "sha512-oMs71qObEAFyYjBo8DDRrVf0+v8B4y1lNGWTb4FfXTx6e1tX12hi0tR0sKvRZJR/zmmpCMkJrAeWy3u3n7Cokw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
@@ -31034,22 +34163,65 @@
       }
     },
     "@wordpress/notices": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.1.tgz",
-      "integrity": "sha512-BQHbaswaVEozE2qcIemauX9tnOdxhfDkQuP318zImAlwIHRF5ZGpAsx+ETBjlMrwDJufAm8+xHRmjk1lyesdUw==",
-      "dev": true,
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.2.tgz",
+      "integrity": "sha512-8RoaNpoVi6xTwwNKTHSmoSSomPDNEgI8t3fW7FxuVushXq/TbNb+YOING5M7ABJqNUEygRoQO7Zldm89PDwQYw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/a11y": "^3.2.1",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/data": "^6.0.1",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        }
       }
     },
     "@wordpress/npm-package-json-lint-config": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.1.0.tgz",
       "integrity": "sha512-FjXL5GbpmI/wXXcpCf2sKosVIVuWjUuHmDbwcMzd0SClcudo9QjDRdVe35We+js8eQLPgB9hsG4Cty6cAFFxsQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@wordpress/plugins": {
       "version": "4.0.0",
@@ -31129,34 +34301,206 @@
       }
     },
     "@wordpress/reusable-blocks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-3.0.0.tgz",
-      "integrity": "sha512-UNhh9rfqWzX0OHtCzzOv9K49UwNVJ/MyUHxg42X7zEAGRo/CxSNRaxiV5IE0YDvFpqIY+PouPsOV89L2Ez32bQ==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-3.0.1.tgz",
+      "integrity": "sha512-KuW3j3Ao5EEDij9ehfUxU6qJcOa9a9nL5QMShBsVJbT40HbEw3qvq8Y5AcIrbFGf/kJJL6KkYyakvCJnQicfkg==",
       "requires": {
-        "@wordpress/block-editor": "^7.0.0",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/core-data": "^4.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/block-editor": "^7.0.1",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/core-data": "^4.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/i18n": "^4.2.1",
-        "@wordpress/icons": "^5.0.0",
-        "@wordpress/notices": "^3.2.1",
+        "@wordpress/icons": "^5.0.1",
+        "@wordpress/notices": "^3.2.2",
         "@wordpress/url": "^3.2.1",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@wordpress/block-editor": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-7.0.1.tgz",
+          "integrity": "sha512-StOJtgFWkvDLy/EPBxIfv2KKA2oBMIkGNnNCif/VMSrCXgw9z8+/q7eJPVR1/rqCI/a/dlwZzD5VGED3Dgw/Ig==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/a11y": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/blocks": "^11.0.1",
+            "@wordpress/components": "^16.0.0",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/data-controls": "^2.2.2",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keyboard-shortcuts": "^3.0.1",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/notices": "^3.2.2",
+            "@wordpress/rich-text": "^5.0.1",
+            "@wordpress/shortcode": "^3.2.1",
+            "@wordpress/token-list": "^2.2.0",
+            "@wordpress/url": "^3.2.1",
+            "@wordpress/warning": "^2.2.1",
+            "@wordpress/wordcount": "^3.2.1",
+            "classnames": "^2.3.1",
+            "css-mediaquery": "^0.1.2",
+            "diff": "^4.0.2",
+            "dom-scroll-into-view": "^1.2.1",
+            "inherits": "^2.0.3",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "react-autosize-textarea": "^7.1.0",
+            "react-spring": "^8.0.19",
+            "redux-multi": "^0.1.12",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "traverse": "^0.6.6"
+          }
+        },
+        "@wordpress/blocks": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+          "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/autop": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/shortcode": "^3.2.1",
+            "hpq": "^1.3.0",
+            "lodash": "^4.17.21",
+            "rememo": "^3.0.0",
+            "showdown": "^1.9.1",
+            "simple-html-tokenizer": "^0.5.7",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+          "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.4.0",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.4.1",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/date": "^4.2.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/primitives": "^3.0.0",
+            "@wordpress/rich-text": "^5.0.1",
+            "@wordpress/warning": "^2.2.1",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "framer-motion": "^4.1.17",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-colorful": "^5.3.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+          "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/primitives": "^3.0.0"
+          }
+        }
       }
     },
     "@wordpress/rich-text": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.0.0.tgz",
-      "integrity": "sha512-v+QQ10aW3z9MFyW2YaC2LyomVFf6IJXMqZSsUyxuQBrM5HvXvr2Wl0u2vIbv0ZsJZUYtWU0BjNJzHI1vD8/D6w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.0.1.tgz",
+      "integrity": "sha512-gQKKvpOw0BorVGHXkRQcrfDAlrj+sNVCr3cazvmxqCHRtcQlzi2Rgg8rRhqGcLl0xJkLGzVX1UM11S6h+cqUng==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
-        "@wordpress/dom": "^3.2.1",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
+        "@wordpress/dom": "^3.2.2",
         "@wordpress/element": "^4.0.0",
         "@wordpress/escape-html": "^2.2.1",
         "@wordpress/is-shallow-equal": "^4.2.0",
@@ -31165,6 +34509,49 @@
         "lodash": "^4.17.21",
         "memize": "^1.1.0",
         "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        }
       }
     },
     "@wordpress/scripts": {
@@ -31422,29 +34809,154 @@
       }
     },
     "@wordpress/server-side-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-3.0.0.tgz",
-      "integrity": "sha512-SFe9Tej1QbCuS7AyXUhGO27HyFUzlaA+6kXvyaovi7+2l03UrwX1+RpWknC3eiCqiBZKpxjSTLLFoEu/7hvs9Q==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-3.0.1.tgz",
+      "integrity": "sha512-DXn0I9sVlIS/0VEhKHWffZuX1iovlr6vjocxshVrbN/iL+4E4r7StSEX+1BXv2/NCFfUNpTF6P95V9YXM8qHkQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/api-fetch": "^5.2.1",
-        "@wordpress/blocks": "^11.0.0",
-        "@wordpress/components": "^15.0.0",
-        "@wordpress/compose": "^5.0.0",
-        "@wordpress/data": "^6.0.0",
+        "@wordpress/blocks": "^11.0.1",
+        "@wordpress/components": "^16.0.0",
+        "@wordpress/compose": "^5.0.1",
+        "@wordpress/data": "^6.0.1",
         "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/i18n": "^4.2.1",
         "@wordpress/url": "^3.2.1",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@wordpress/blocks": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.0.1.tgz",
+          "integrity": "sha512-ClnzE2afUqB4FQ/XrELXMKQvxHhn249MZgv+n/gJfrDy43/RhCQQ1wMgxjos7pKQm4dg/euMNcecKMj6X5fo7A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/autop": "^3.2.1",
+            "@wordpress/blob": "^3.2.1",
+            "@wordpress/block-serialization-default-parser": "^4.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/data": "^6.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/html-entities": "^3.2.1",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/shortcode": "^3.2.1",
+            "hpq": "^1.3.0",
+            "lodash": "^4.17.21",
+            "rememo": "^3.0.0",
+            "showdown": "^1.9.1",
+            "simple-html-tokenizer": "^0.5.7",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-16.0.0.tgz",
+          "integrity": "sha512-UqnOUaoA/YLmj8dEiFNphhP7QHZp2XvJCNjtb3wzexNDrBp4KDikmK1f4pt3BsNgaEMdu/YYzFvt4iMvi7417Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@emotion/cache": "^11.4.0",
+            "@emotion/css": "^11.1.3",
+            "@emotion/react": "^11.4.1",
+            "@emotion/styled": "^11.3.0",
+            "@emotion/utils": "1.0.0",
+            "@wordpress/a11y": "^3.2.1",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/date": "^4.2.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/hooks": "^3.2.0",
+            "@wordpress/i18n": "^4.2.1",
+            "@wordpress/icons": "^5.0.1",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/primitives": "^3.0.0",
+            "@wordpress/rich-text": "^5.0.1",
+            "@wordpress/warning": "^2.2.1",
+            "classnames": "^2.3.1",
+            "dom-scroll-into-view": "^1.2.1",
+            "downshift": "^6.0.15",
+            "framer-motion": "^4.1.17",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "moment": "^2.22.1",
+            "re-resizable": "^6.4.0",
+            "react-colorful": "^5.3.0",
+            "react-dates": "^17.1.1",
+            "react-resize-aware": "^3.1.0",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.8",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+          "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^5.0.1",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.1",
+            "@wordpress/redux-routine": "^4.2.1",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+          "integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/primitives": "^3.0.0"
+          }
+        }
       }
     },
     "@wordpress/shortcode": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.1.tgz",
       "integrity": "sha512-nVELegRjoy/ShrKx2julCSCHiXlp8NTPfxYQCqNomUJzosdqVg7hj/LGt1STu7vZIqPayS8iVG3V7d0s2kGAkg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21",
@@ -31466,7 +34978,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.2.0.tgz",
       "integrity": "sha512-0z6MhRv/pqxQcvTSeMAL69vcaxJ2J8U1Q5VeavHWnhtZ+nRglYNoE0yMLrEaeutoHeXOfWpY6baC91AgLDKE8A==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -31513,7 +35024,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.2.1.tgz",
       "integrity": "sha512-OBHR1QIuNC8RNrFJ1EnqWAJmaFCK71JDw8WvQWy2ZN7tAlzvKGofpmCWdOrP/JXGRhVpNzLGlyMoiGB0QmvYdw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
         "lodash": "^4.17.21"
@@ -31563,7 +35073,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -31622,13 +35133,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -31662,8 +35175,7 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -31974,8 +35486,7 @@
     "autosize": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
-      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==",
-      "dev": true
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -32527,7 +36038,6 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -32675,8 +36185,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -32704,8 +36213,7 @@
     "caniuse-lite": {
       "version": "1.0.30001248",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
-      "dev": true
+      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -33149,7 +36657,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -33258,8 +36765,7 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "colors": {
       "version": "1.1.2",
@@ -33308,8 +36814,7 @@
     "computed-style": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
-      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=",
-      "dev": true
+      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -33847,8 +37352,7 @@
     "css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
-      "dev": true
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "css-prefers-color-scheme": {
       "version": "3.1.1",
@@ -34008,7 +37512,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.0.tgz",
       "integrity": "sha512-xvxmTszdrvSyTACdPe8VU5J6p4sm3egpgw54dILvNqt5eBUv6TFjACLhSxtRuEsxYrgy8uDy269YjScO5aKbGA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -34123,7 +37628,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -34131,8 +37635,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -34332,8 +37835,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -34572,8 +38074,7 @@
     "electron-to-chromium": {
       "version": "1.3.736",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz",
-      "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig==",
-      "dev": true
+      "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -34607,8 +38108,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -34825,8 +38325,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -35119,7 +38618,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -35395,7 +38895,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36163,7 +39664,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -36486,6 +39986,41 @@
         "map-cache": "^0.2.2"
       }
     },
+    "framer-motion": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "framesync": "5.3.0",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.3.6",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "framesync": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
+      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -36648,14 +40183,12 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -36797,8 +40330,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "11.0.3",
@@ -37311,8 +40843,7 @@
     "hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "dev": true
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "highlight-words-core": {
       "version": "1.2.2",
@@ -37362,8 +40893,7 @@
     "hpq": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
-      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
-      "dev": true
+      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -37501,7 +41031,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -37633,8 +41164,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -37922,8 +41452,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -39163,7 +42692,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -40077,8 +43607,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -40125,7 +43654,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -40324,7 +43852,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
       "integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
-      "dev": true,
       "requires": {
         "computed-style": "~0.1.3"
       }
@@ -40676,7 +44203,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -41559,8 +45085,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -41726,8 +45251,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -41943,8 +45467,7 @@
     "node-releases": {
       "version": "1.1.71",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
-      "dev": true
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -42444,7 +45967,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -42453,7 +45975,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -42467,8 +45988,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.11",
@@ -42611,8 +46131,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -42848,6 +46367,24 @@
       "dev": true,
       "requires": {
         "irregular-plurals": "^3.2.0"
+      }
+    },
+    "popmotion": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
+      "requires": {
+        "framesync": "5.3.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "4.1.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "portfinder": {
@@ -43338,25 +46875,29 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.0.tgz",
       "integrity": "sha512-Umig6Gxs8m20RihiXY6QkePd6mp4FxkA1Dg+f/Kd6uw0gEMfKRjDeQOyFkLibexbJJGHpE3lrN/Q0R9SMrUMbQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.0.tgz",
       "integrity": "sha512-vEJJ+Y3pFUnO1FyCBA6PSisGjHtnphL3V6GsNvkASq/VkP3OX5/No5RYXXLxHa2QegStNzg6HYrYdo71uR4caQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.0.tgz",
       "integrity": "sha512-+wigy099Y1xZxG36WG5L1f2zeH1oicntkJEW4TDIqKKDO2g9XVB3OhoiHTu08rDEjLnbcab4rw0BAccwi2VjiQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.0.tgz",
       "integrity": "sha512-hybnScTaZM2iEA6kzVQ6Spozy7kVdLw+lGw8hftLlBEzt93uzXoltkYp9u0tI8xbfhxDLTOOzHsHQCkYdmzRUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -43996,7 +47537,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -44077,7 +47619,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.0.tgz",
       "integrity": "sha512-pqsCkgo9KmQP0ew6DqSA+uP9YN6EfsW20pQ3JU5JoQge09Z6Too4qU0TNDsTNWuEaP8SWsMp+19l15210MsDZQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.0",
@@ -44682,7 +48225,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-unique-selectors": {
       "version": "5.0.0",
@@ -44716,6 +48260,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -45003,7 +48553,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -45146,12 +48697,17 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
       "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-      "dev": true,
       "requires": {
         "autosize": "^4.0.2",
         "line-height": "^0.3.1",
         "prop-types": "^15.5.6"
       }
+    },
+    "react-colorful": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.3.0.tgz",
+      "integrity": "sha512-zWE5E88zmjPXFhv6mGnRZqKin9s5vip1O3IIGynY9EhZxN8MATUxZkT3e/9OwTEm4DjQBXc6PFWP6AetY+Px+A==",
+      "requires": {}
     },
     "react-dates": {
       "version": "17.2.0",
@@ -45237,7 +48793,8 @@
     "react-resize-aware": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
-      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
+      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==",
+      "requires": {}
     },
     "react-shallow-renderer": {
       "version": "16.14.1",
@@ -45281,7 +48838,8 @@
     "react-use-gesture": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
-      "integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
+      "integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==",
+      "requires": {}
     },
     "react-with-direction": {
       "version": "1.3.1",
@@ -45460,7 +49018,8 @@
     "reakit-utils": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
-      "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
+      "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q==",
+      "requires": {}
     },
     "reakit-warning": {
       "version": "0.6.1",
@@ -45500,8 +49059,7 @@
     "redux-multi": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
-      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI=",
-      "dev": true
+      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -45798,8 +49356,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -45810,8 +49367,7 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requireindex": {
       "version": "1.2.0",
@@ -46300,8 +49856,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -46321,8 +49876,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -46424,7 +49978,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "dev": true,
       "requires": {
         "yargs": "^14.2"
       }
@@ -46449,8 +50002,7 @@
     "simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-      "dev": true
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -47067,7 +50619,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -47153,7 +50704,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       }
@@ -47205,6 +50755,22 @@
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
+    },
+    "style-value-types": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+      "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "stylehacks": {
       "version": "5.0.0",
@@ -47639,7 +51205,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
       "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recommended-scss": {
       "version": "4.3.0",
@@ -47654,7 +51221,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
           "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -48299,8 +51867,7 @@
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -48690,7 +52257,8 @@
     "use-memo-one": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",
@@ -49918,8 +53486,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -49940,7 +53507,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -49969,7 +53535,8 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -49992,8 +53559,7 @@
     "y18n": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-      "dev": true
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -50010,7 +53576,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
       "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "dev": true,
       "requires": {
         "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
@@ -50029,7 +53594,6 @@
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
       "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@wordpress/compose": "5.0.0",
     "@wordpress/date": "4.2.1",
     "@wordpress/dom-ready": "3.2.1",
+    "@wordpress/editor": "11.0.1",
     "@wordpress/element": "4.0.0",
     "@wordpress/escape-html": "2.2.1",
     "@wordpress/html-entities": "3.2.1",

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -166,6 +166,7 @@ class Test_AMP_Post_Meta_Box extends TestCase {
 				'wp-compose',
 				'wp-data',
 				'wp-edit-post',
+				'wp-editor',
 				'wp-element',
 				'wp-hooks',
 				'wp-i18n',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

Related to https://github.com/Automattic/wp-calypso/issues/55566
> The UI for the Featured Image section of the sidebar should be the same in the two scenarios pictured above.

Currently, we can set featured image directly in Post Setting section. If we don't set any featured image and want to publish the post, we will see the notice and encourage to set the featured image. However, we cannot set the featured image immediately at that point. So, adding `PostFeaturedImage` to `PrePublishPanel` to make user able to set it immediately.

### Screenshots

https://user-images.githubusercontent.com/13596067/130896166-8f20f5c9-f2c4-4364-b279-7a228fc945d8.mov

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).



