### PR TITLE
Add WebP and SVG as accepted image formats for a post featured image

### DIFF
--- a/assets/src/common/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/common/components/higher-order/with-featured-image-notice.js
@@ -40,7 +40,7 @@ export default createHigherOrderComponent(
 			return (
 				<>
 					<Notice
-						status="notice"
+						status="warning"
 						isDismissible={ false }
 					>
 						{ errors.map( ( errorMessage, index ) => {

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -89,7 +89,7 @@ export const validateFeaturedImage = ( media, dimensions, required ) => {
 
 	if ( ! [ 'image/png', 'image/gif', 'image/jpeg', 'image/webp', 'image/svg+xml' ].includes( media.mime_type ) ) {
 		errors.push(
-			/* translators: 1: JPEG, 2: PNG. 3: GIF, 4: WebP, 5: SVG */
+			/* translators: List of image formats */
 			sprintf( __( 'The featured image must be of either %1$s, %2$s, %3$s, %4$s, or %5$s format.', 'amp' ), 'JPEG', 'PNG', 'GIF', 'WebP', 'SVG' ),
 		);
 	}

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -87,10 +87,10 @@ export const validateFeaturedImage = ( media, dimensions, required ) => {
 
 	const errors = [];
 
-	if ( ! [ 'image/png', 'image/gif', 'image/jpeg' ].includes( media.mime_type ) ) {
+	if ( ! [ 'image/png', 'image/gif', 'image/jpeg', 'image/webp', 'image/svg+xml' ].includes( media.mime_type ) ) {
 		errors.push(
-			/* translators: 1: .jpg, 2: .png. 3: .gif */
-			sprintf( __( 'The featured image must be in %1$s, %2$s, or %3$s format.', 'amp' ), '.jpg', '.png', '.gif' ),
+			/* translators: 1: JPEG, 2: PNG. 3: GIF, 4: WebP, 5: SVG */
+			sprintf( __( 'The featured image must be of either %1$s, %2$s, %3$s, %4$s, or %5$s format.', 'amp' ), 'JPEG', 'PNG', 'GIF', 'WebP', 'SVG' ),
 		);
 	}
 

--- a/assets/src/common/helpers/test/validateFeaturedImage.js
+++ b/assets/src/common/helpers/test/validateFeaturedImage.js
@@ -20,7 +20,7 @@ describe( 'validateFeaturedImage', () => {
 			{ width: 10, height: 10 },
 			false,
 		);
-		expect( isValid ).toStrictEqual( [ 'The featured image must be in .jpg, .png, or .gif format.' ] );
+		expect( isValid ).toStrictEqual( [ 'The featured image must be of either JPEG, PNG, GIF, WebP, or SVG format.' ] );
 	} );
 
 	it( 'returns an error if the featured image is too small', () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

- Adds WebP and SVG as accepted image formats for featured images
- Use image format names in error message instead of file extensions
- Display featured image errors as a warning instead of as a notice

Fixes #6536

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
