### PR TITLE
Update amp-toolbox-php to 7e63e5d with SSR support for Bento

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-main#b4eb9db",
+    "ampproject/amp-toolbox": "dev-main#7e63e5d",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86f5d58d49f586b8025e1a0eb9d9eaaf",
+    "content-hash": "5fcb1225e83d97d7c1be3ef9a7584a81",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "b4eb9db"
+                "reference": "7e63e5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/b4eb9db",
-                "reference": "b4eb9db",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/7e63e5d",
+                "reference": "7e63e5d",
                 "shasum": ""
             },
             "require": {
@@ -44,6 +44,7 @@
             "suggest": {
                 "ext-json": "Provides native implementation of json_encode()/json_decode().",
                 "ext-mbstring": "Used by Dom\\Document to convert encoding to UTF-8 if needed.",
+                "mck89/peast": "Needed to minify the AMP script.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
             "default-branch": true,
@@ -74,7 +75,7 @@
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
                 "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2021-08-20T05:28:17+00:00"
+            "time": "2021-08-25T16:23:19+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2156,13 +2156,6 @@ class AMP_Theme_Support {
 		add_filter(
 			'amp_enable_ssr',
 			static function () use ( $args ) {
-				// @codeCoverageIgnoreStart
-				// SSR currently does not work reliably with Bento. See <https://github.com/ampproject/amphtml/issues/35485>.
-				if ( amp_is_bento_enabled() ) {
-					return false;
-				}
-				// @codeCoverageIgnoreEnd
-
 				return array_key_exists( ConfigurationArgument::ENABLE_SSR, $args )
 					? $args[ ConfigurationArgument::ENABLE_SSR ]
 					: true;


### PR DESCRIPTION
After https://github.com/ampproject/amp-toolbox-php/pull/316 there is no longer a need to disable SSR for pages using Bento components.