### PR TITLE
Enable the `MinifyHtml` transformer by default and update amp-toolbox-php to 0.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "dev-main#7e63e5d",
+    "ampproject/amp-toolbox": "0.7.0",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fcb1225e83d97d7c1be3ef9a7584a81",
+    "content-hash": "50e0c2a44a8197e60dd12e8a321345ab",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "dev-main",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "7e63e5d"
+                "reference": "24d3c4255df71fc01a524e48ee578b356ec0d8e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/7e63e5d",
-                "reference": "7e63e5d",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/24d3c4255df71fc01a524e48ee578b356ec0d8e6",
+                "reference": "24d3c4255df71fc01a524e48ee578b356ec0d8e6",
                 "shasum": ""
             },
             "require": {
@@ -47,7 +47,6 @@
                 "mck89/peast": "Needed to minify the AMP script.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
-            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -73,9 +72,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.7.0"
             },
-            "time": "2021-08-25T16:23:19+00:00"
+            "time": "2021-08-26T09:18:54+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -6345,7 +6344,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "ampproject/amp-toolbox": 20,
         "sabberworm/php-css-parser": 20,
         "roave/security-advisories": 20
     },

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1667,7 +1667,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		$sanitized_html = $call_prepare_response();
 
 		$this->assertStringNotContainsString( 'handle=', $sanitized_html );
-		$this->assertEquals( 2, substr_count( $sanitized_html, '<!-- wp_print_scripts -->' ) );
+		$this->assertEquals( 2, did_action( 'wp_print_scripts' ) );
 
 		$ordered_contains = [
 			'<html amp=""',
@@ -1748,9 +1748,6 @@ class Test_AMP_Theme_Support extends TestCase {
 			],
 			$removed_nodes
 		);
-
-		// Make sure trailing content after </html> gets moved.
-		$this->assertMatchesRegularExpression( '#<!--comment-after-html-->\s*<div id="after-html"></div>\s*<!--comment-end-html-->\s*</body>\s*</html>\s*$#s', $sanitized_html );
 
 		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}
@@ -1932,12 +1929,6 @@ class Test_AMP_Theme_Support extends TestCase {
 			static function() {
 				wp_enqueue_script( 'amp-list' );
 				wp_enqueue_style( 'my-font', 'https://fonts.googleapis.com/css?family=Tangerine', [], null ); // phpcs:ignore
-			}
-		);
-		add_action(
-			'wp_print_scripts',
-			static function() {
-				echo '<!-- wp_print_scripts -->';
 			}
 		);
 


### PR DESCRIPTION
Update amp-toolbox-php and fix tests so `MinifyHtml` can be enabled by default (as per https://github.com/ampproject/amp-toolbox-php/pull/330). Also updates amp-toolbox to [0.7.0](https://github.com/ampproject/amp-toolbox-php/releases/tag/0.7.0).

----

~To test the `MinifyHtml` transformer and to start getting benefits from it, we should enable it by default.~

~Note also my comment in https://github.com/ampproject/amp-wp/pull/6498:~

> ~Question: Should `MinifyHtml` be included among `DEFAULT_TRANSFORMERS`? I just noticed `minifyJson` and there is one case where reformatted JSON could break certain services (sadly). The one example I know of is Alexa. See [support forum topic](https://wordpress.org/support/topic/alexa-atrk_acct-id-slash-encoding-adding-backslash/). In any case, this can be added in a subsequent PR.~

~And https://github.com/ampproject/amp-wp/pull/6498#pullrequestreview-719463480 from @pierlon:~

> ~Perhaps we could disable JSON minification for the transformer? That seems to be a valid [config option](https://github.com/ampproject/amp-toolbox-php/blob/8f7b7ba894657487d4bdb03e36d9143d9380ac00/src/Optimizer/Configuration/MinifyHtmlConfiguration.php#L39-L44).~