### PR TITLE
Set `amp-wp-unknown-size` class and `object-fit=contain` for videos with unknown dimensions

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -267,7 +267,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 					$class = '';
 				}
 				if ( ! $dimensions ) {
-					$node->setAttribute( Attribute::OBJECT_FIT, 'contain' );
 					$class .= ' amp-wp-unknown-size';
 				}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -136,7 +136,6 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			if ( empty( $new_attributes['width'] ) && empty( $new_attributes['height'] ) ) {
-				$new_attributes[ Attribute::OBJECT_FIT ] = 'contain';
 				$new_attributes[ Attribute::CLASS_ ] = isset( $new_attributes[ Attribute::CLASS_ ] )
 					? $new_attributes[ Attribute::CLASS_ ] . ' amp-wp-unknown-size'
 					: 'amp-wp-unknown-size';

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\Attribute;
 use AmpProject\DevMode;
 
 /**
@@ -132,6 +133,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 				$fallback->setAttribute( 'fallback', '' );
 				$fallback->appendChild( $this->dom->createTextNode( $sources[0] ) );
 				$child_nodes[] = $fallback;
+			}
+
+			if ( empty( $new_attributes['width'] ) && empty( $new_attributes['height'] ) ) {
+				$new_attributes[ Attribute::OBJECT_FIT ] = 'contain';
+				$new_attributes[ Attribute::CLASS_ ] = isset( $new_attributes[ Attribute::CLASS_ ] )
+					? $new_attributes[ Attribute::CLASS_ ] . ' amp-wp-unknown-size'
+					: 'amp-wp-unknown-size';
 			}
 
 			$new_attributes = $this->filter_attachment_layout_attributes( $node, $new_attributes, $layout );

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -222,7 +222,7 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 
 			'image_with_bad_src_url_get_fallback_dims' => [
 				'<img src="https://example.com/404.png" />',
-				'<amp-img src="https://example.com/404.png" object-fit="contain" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '"></noscript></amp-img>',
+				'<amp-img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '"></noscript></amp-img>',
 			],
 
 			'gif_image_conversion'                     => [

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -78,8 +78,8 @@ class AMP_Video_Converter_Test extends TestCase {
 			],
 
 			'layout_fill_video_without_dimensions' => [
-				'<video src="https://example.com/file.mp4" layout="fill"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="fill" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<video src="https://example.com/file.mp4" layout="fill" class="some-file"></video>',
+				'<amp-video src="https://example.com/file.mp4" layout="fill" class="some-file amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'data_layout_fill_video_without_dimensions' => [

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -59,7 +59,7 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4"></video>',
-				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" object-fit="contain" class="amp-wp-unknown-size" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'local_video_without_dimensions' => [
@@ -79,22 +79,22 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'layout_fill_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="fill"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="fill"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="fill" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'data_layout_fill_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" data-amp-layout="fill"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="fill"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="fill" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'layout_nodisplay_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="nodisplay"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="nodisplay"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'layout_fixed_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="nodisplay"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="nodisplay"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'autoplay_attribute' => [

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -59,7 +59,7 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4"></video>',
-				'<amp-video src="https://example.com/file.mp4" object-fit="contain" class="amp-wp-unknown-size" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" class="amp-wp-unknown-size" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'local_video_without_dimensions' => [
@@ -79,22 +79,22 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'layout_fill_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="fill"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="fill" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="fill" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'data_layout_fill_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" data-amp-layout="fill"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="fill" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="fill" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'layout_nodisplay_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="nodisplay"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'layout_fixed_video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4" layout="nodisplay"></video>',
-				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" object-fit="contain" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" layout="nodisplay" class="amp-wp-unknown-size"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'autoplay_attribute' => [


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

Given a video block with an external source:

```html
<!-- wp:video {"autoplay":true,"loop":true,"muted":false,"src":"https://blog.amp.dev/wp-content/uploads/2021/08/ezgif.com-gif-maker-13.mp4"} -->
<figure class="wp-block-video"><video autoplay controls loop src="https://blog.amp.dev/wp-content/uploads/2021/08/ezgif.com-gif-maker-13.mp4"></video></figure>
<!-- /wp:video -->
```

Before | After
---|---
<img width="565" alt="image" src="https://user-images.githubusercontent.com/16200219/131200066-e8160c0f-d135-4468-8e7b-852969d41104.png"> | <img width="562" alt="image" src="https://user-images.githubusercontent.com/16200219/131200124-4394611a-de10-4eb8-aff5-cc9860efc881.png">

Fixes #6571

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
