### PR TITLE
Revamp comments handling for sandboxing levels

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1417,26 +1417,6 @@ function amp_is_native_img_used() {
 }
 
 /**
- * Determine whether to allow native `POST` forms without conversion to use the `action-xhr` attribute and use the amp-form component.
- *
- * @since 2.2
- * @link https://github.com/ampproject/amphtml/issues/27638
- *
- * @return bool Whether to allow native `POST` forms.
- */
-function amp_is_native_post_form_allowed() {
-	/**
-	 * Filters whether to allow native `POST` forms without conversion to use the `action-xhr` attribute and use the amp-form component.
-	 *
-	 * @since 2.2
-	 * @link https://github.com/ampproject/amphtml/issues/27638
-	 *
-	 * @param bool $use_native Whether to allow native `POST` forms.
-	 */
-	return (bool) apply_filters( 'amp_native_post_form_allowed', false );
-}
-
-/**
  * Get content sanitizers.
  *
  * @since 0.7
@@ -1480,8 +1460,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT )
 	);
 
-	$native_img_used           = amp_is_native_img_used();
-	$native_post_forms_allowed = amp_is_native_post_form_allowed();
+	$native_img_used = amp_is_native_img_used();
 
 	$sanitizers = [
 		// Embed sanitization must come first because it strips out custom scripts associated with embeds.
@@ -1516,9 +1495,7 @@ function amp_get_content_sanitizers( $post = null ) {
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
 			'native_img_used'    => $native_img_used,
 		],
-		AMP_Form_Sanitizer::class              => [
-			'native_post_forms_allowed' => $native_post_forms_allowed,
-		],
+		AMP_Form_Sanitizer::class              => [],
 		AMP_Video_Sanitizer::class             => [],
 		AMP_Audio_Sanitizer::class             => [],
 		AMP_Object_Sanitizer::class            => [],
@@ -1641,7 +1618,7 @@ function amp_get_content_sanitizers( $post = null ) {
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
 		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
-		AMP_Comments_Sanitizer::class, // Must come before AMP_Script_Sanitizer since it either removes comment-rely.js or marks it as PX-verified.
+		AMP_Comments_Sanitizer::class, // Must come before AMP_Script_Sanitizer since it either removes comment-rely.js or marks it as PX-verified. Also must come before the AMP_Form_Sanitizer.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for image, video, audio, form, and style.
 		AMP_Srcset_Sanitizer::class,
 		AMP_Img_Sanitizer::class,

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1595,6 +1595,11 @@ function amp_get_content_sanitizers( $post = null ) {
 		 */
 		$dev_mode_xpaths = (array) apply_filters( 'amp_dev_mode_element_xpaths', [] );
 
+		// Prevent removal of script output by wp_comment_form_unfiltered_html_nonce().
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$dev_mode_xpaths[] = '//script[ preceding-sibling::input[ @name = "_wp_unfiltered_html_comment_disabled" ] and contains( text(), "_wp_unfiltered_html_comment_disabled" ) ]';
+		}
+
 		if ( is_admin_bar_showing() ) {
 			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]';
 			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]//*';

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1500,6 +1500,11 @@ function amp_get_content_sanitizers( $post = null ) {
 			'native_img_used' => $native_img_used,
 		],
 
+		AMP_Comments_Sanitizer::class          => [
+			'thread_comments'    => (bool) get_option( 'thread_comments' ),
+			'comments_live_list' => ! empty( $theme_support_args['comments_live_list'] ),
+		],
+
 		// The AMP_Script_Sanitizer runs here because based on whether it allows custom scripts
 		// to be kept, it may impact the behavior of other sanitizers. For example, if custom
 		// scripts are kept then this is a signal that tree shaking in AMP_Style_Sanitizer cannot be
@@ -1513,9 +1518,6 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		AMP_Form_Sanitizer::class              => [
 			'native_post_forms_allowed' => $native_post_forms_allowed,
-		],
-		AMP_Comments_Sanitizer::class          => [
-			'comments_live_list' => ! empty( $theme_support_args['comments_live_list'] ),
 		],
 		AMP_Video_Sanitizer::class             => [],
 		AMP_Audio_Sanitizer::class             => [],
@@ -1598,7 +1600,7 @@ function amp_get_content_sanitizers( $post = null ) {
 
 		// Prevent removal of script output by wp_comment_form_unfiltered_html_nonce().
 		if ( current_user_can( 'unfiltered_html' ) ) {
-			$dev_mode_xpaths[] = '//script[ preceding-sibling::input[ @name = "_wp_unfiltered_html_comment_disabled" ] and contains( text(), "_wp_unfiltered_html_comment_disabled" ) ]';
+			$dev_mode_xpaths[] = AMP_Comments_Sanitizer::UNFILTERED_HTML_COMMENT_SCRIPT_XPATH;
 		}
 
 		if ( is_admin_bar_showing() ) {
@@ -1644,11 +1646,11 @@ function amp_get_content_sanitizers( $post = null ) {
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
 		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
+		AMP_Comments_Sanitizer::class, // Must come before AMP_Script_Sanitizer since it removes comment-rely.js.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for image, video, audio, form, and style.
 		AMP_Srcset_Sanitizer::class,
 		AMP_Img_Sanitizer::class,
 		AMP_Form_Sanitizer::class,
-		AMP_Comments_Sanitizer::class,
 		AMP_Video_Sanitizer::class,
 		AMP_Audio_Sanitizer::class,
 		AMP_Object_Sanitizer::class,

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1491,12 +1491,6 @@ function amp_get_content_sanitizers( $post = null ) {
 		AMP_O2_Player_Sanitizer::class         => [],
 		AMP_Playbuzz_Sanitizer::class          => [],
 
-		// The AMP_Script_Sanitizer runs here because based on whether it allows custom scripts
-		// to be kept, it may impact the behavior of other sanitizers. For example, if custom
-		// scripts are kept then this is a signal that tree shaking in AMP_Style_Sanitizer cannot be
-		// performed.
-		AMP_Script_Sanitizer::class            => [],
-
 		AMP_Core_Theme_Sanitizer::class        => [
 			'template'        => get_template(),
 			'stylesheet'      => get_stylesheet(),
@@ -1505,6 +1499,13 @@ function amp_get_content_sanitizers( $post = null ) {
 			],
 			'native_img_used' => $native_img_used,
 		],
+
+		// The AMP_Script_Sanitizer runs here because based on whether it allows custom scripts
+		// to be kept, it may impact the behavior of other sanitizers. For example, if custom
+		// scripts are kept then this is a signal that tree shaking in AMP_Style_Sanitizer cannot be
+		// performed.
+		AMP_Script_Sanitizer::class            => [],
+
 		AMP_Srcset_Sanitizer::class            => [],
 		AMP_Img_Sanitizer::class               => [
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
@@ -1642,8 +1643,8 @@ function amp_get_content_sanitizers( $post = null ) {
 
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
+		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for image, video, audio, form, and style.
-		AMP_Core_Theme_Sanitizer::class,
 		AMP_Srcset_Sanitizer::class,
 		AMP_Img_Sanitizer::class,
 		AMP_Form_Sanitizer::class,

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1598,11 +1598,6 @@ function amp_get_content_sanitizers( $post = null ) {
 		 */
 		$dev_mode_xpaths = (array) apply_filters( 'amp_dev_mode_element_xpaths', [] );
 
-		// Prevent removal of script output by wp_comment_form_unfiltered_html_nonce().
-		if ( current_user_can( 'unfiltered_html' ) ) {
-			$dev_mode_xpaths[] = AMP_Comments_Sanitizer::UNFILTERED_HTML_COMMENT_SCRIPT_XPATH;
-		}
-
 		if ( is_admin_bar_showing() ) {
 			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]';
 			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]//*';
@@ -1646,7 +1641,7 @@ function amp_get_content_sanitizers( $post = null ) {
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
 		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
-		AMP_Comments_Sanitizer::class, // Must come before AMP_Script_Sanitizer since it removes comment-rely.js.
+		AMP_Comments_Sanitizer::class, // Must come before AMP_Script_Sanitizer since it either removes comment-rely.js or marks it as PX-verified.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for image, video, audio, form, and style.
 		AMP_Srcset_Sanitizer::class,
 		AMP_Img_Sanitizer::class,

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -898,14 +898,9 @@ class AMP_Theme_Support {
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		add_action( 'template_redirect', [ __CLASS__, 'start_output_buffering' ], $priority );
 
-		// Commenting hooks.
-		// @todo When custom scripts appear on the page, this logic should be skipped. To do so, this would require moving the logic to the AMP_Comments_Sanitizer.
-//		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ], PHP_INT_MAX );
-//		add_filter( 'comment_reply_link', [ __CLASS__, 'filter_comment_reply_link' ], 10, 4 );
-//		add_filter( 'cancel_comment_reply_link', [ __CLASS__, 'filter_cancel_comment_reply_link' ], 10, 3 );
-//		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'include_layout_in_wp_kses_allowed_html' ], 10 );
 		add_filter( 'get_header_image_tag', [ __CLASS__, 'amend_header_image_with_video_header' ], PHP_INT_MAX );
+		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ); // @todo The AMP_Comments_Sanitizer should add data-ampdevmode since user would be logged-in.
 		add_action(
 			'wp_print_footer_scripts',
 			static function() {
@@ -913,12 +908,6 @@ class AMP_Theme_Support {
 			},
 			0
 		);
-//		add_action(
-//			'wp_enqueue_scripts',
-//			static function() {
-//				wp_dequeue_script( 'comment-reply' ); // Handled largely by AMP_Comments_Sanitizer and *reply* methods in this class.
-//			}
-//		);
 	}
 
 	/**
@@ -1058,11 +1047,13 @@ class AMP_Theme_Support {
 	 * Get the ID for the amp-state.
 	 *
 	 * @since 0.7
+	 * @deprecated Logic moved to AMP_Comments_Sanitizer.
 	 *
 	 * @param int $post_id Post ID.
 	 * @return string ID for amp-state.
 	 */
 	public static function get_comment_form_state_id( $post_id ) {
+		_deprecated_function( __METHOD__, '2.2' );
 		return sprintf( 'commentform_post_%d', $post_id );
 	}
 
@@ -1071,12 +1062,13 @@ class AMP_Theme_Support {
 	 *
 	 * @since 0.7
 	 * @see comment_form()
-	 * @todo When custom scripts appear on the page, this logic should be skipped. To do so, this would require moving the logic to the AMP_Comments_Sanitizer.
+	 * @deprecated Logic moved to AMP_Comments_Sanitizer.
 	 *
 	 * @param array $default_args Comment form arg defaults.
 	 * @return array Filtered comment form args.
 	 */
 	public static function filter_comment_form_defaults( $default_args ) {
+		_deprecated_function( __METHOD__, '2.2' );
 
 		// Obtain the actual args provided to the comment_form() function since it is not available in the filter.
 		$args      = [];
@@ -1123,7 +1115,7 @@ class AMP_Theme_Support {
 	 *
 	 * @since 0.7
 	 * @see get_comment_reply_link()
-	 * @todo When custom scripts appear on the page, this logic should be skipped. To do so, this would require moving the logic to the AMP_Comments_Sanitizer.
+	 * @deprecated Logic moved to AMP_Comments_Sanitizer.
 	 *
 	 * @param string     $link    The HTML markup for the comment reply link.
 	 * @param array      $args    An array of arguments overriding the defaults.
@@ -1131,6 +1123,7 @@ class AMP_Theme_Support {
 	 * @return string Comment reply link.
 	 */
 	public static function filter_comment_reply_link( $link, $args, $comment ) {
+		_deprecated_function( __METHOD__, '2.2' );
 
 		// Continue to show default link to wp-login when user is not logged-in.
 		if ( get_option( 'comment_registration' ) && ! is_user_logged_in() ) {
@@ -1163,7 +1156,7 @@ class AMP_Theme_Support {
 	 *
 	 * @since 0.7
 	 * @see get_cancel_comment_reply_link()
-	 * @todo When custom scripts appear on the page, this logic should be skipped. To do so, this would require moving the logic to the AMP_Comments_Sanitizer.
+	 * @deprecated Logic moved to AMP_Comments_Sanitizer.
 	 *
 	 * @param string $formatted_link The HTML-formatted cancel comment reply link.
 	 * @param string $link           Cancel comment reply link URL.
@@ -1171,6 +1164,8 @@ class AMP_Theme_Support {
 	 * @return string Cancel reply link.
 	 */
 	public static function filter_cancel_comment_reply_link( $formatted_link, $link, $text ) {
+		_deprecated_function( __METHOD__, '2.2' );
+
 		if ( empty( $text ) ) {
 			$text = __( 'Click here to cancel reply.', 'default' );
 		}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -900,7 +900,6 @@ class AMP_Theme_Support {
 
 		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'include_layout_in_wp_kses_allowed_html' ], 10 );
 		add_filter( 'get_header_image_tag', [ __CLASS__, 'amend_header_image_with_video_header' ], PHP_INT_MAX );
-		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ); // @todo The AMP_Comments_Sanitizer should add data-ampdevmode since user would be logged-in, or else the this script should be allowed whenever comment-reply is also allowed.
 		add_action(
 			'wp_print_footer_scripts',
 			static function() {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -900,10 +900,10 @@ class AMP_Theme_Support {
 
 		// Commenting hooks.
 		// @todo When custom scripts appear on the page, this logic should be skipped. To do so, this would require moving the logic to the AMP_Comments_Sanitizer.
-		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ], PHP_INT_MAX );
-		add_filter( 'comment_reply_link', [ __CLASS__, 'filter_comment_reply_link' ], 10, 4 );
-		add_filter( 'cancel_comment_reply_link', [ __CLASS__, 'filter_cancel_comment_reply_link' ], 10, 3 );
-		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
+//		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ], PHP_INT_MAX );
+//		add_filter( 'comment_reply_link', [ __CLASS__, 'filter_comment_reply_link' ], 10, 4 );
+//		add_filter( 'cancel_comment_reply_link', [ __CLASS__, 'filter_cancel_comment_reply_link' ], 10, 3 );
+//		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'include_layout_in_wp_kses_allowed_html' ], 10 );
 		add_filter( 'get_header_image_tag', [ __CLASS__, 'amend_header_image_with_video_header' ], PHP_INT_MAX );
 		add_action(
@@ -913,12 +913,12 @@ class AMP_Theme_Support {
 			},
 			0
 		);
-		add_action(
-			'wp_enqueue_scripts',
-			static function() {
-				wp_dequeue_script( 'comment-reply' ); // Handled largely by AMP_Comments_Sanitizer and *reply* methods in this class.
-			}
-		);
+//		add_action(
+//			'wp_enqueue_scripts',
+//			static function() {
+//				wp_dequeue_script( 'comment-reply' ); // Handled largely by AMP_Comments_Sanitizer and *reply* methods in this class.
+//			}
+//		);
 	}
 
 	/**
@@ -1097,6 +1097,7 @@ class AMP_Theme_Support {
 			}
 		}
 
+		// @todo See <https://github.com/ampproject/amp-wp/issues/2489>.
 		$state_id     = self::get_comment_form_state_id( get_the_ID() );
 		$text_binding = sprintf(
 			'%s.replyToName ? %s : %s',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2153,6 +2153,9 @@ class AMP_Theme_Support {
 			$dom->documentElement->hasAttribute( AMP_Validation_Manager::AMP_NON_VALID_DOC_ATTRIBUTE )
 			||
 			( $dom->documentElement->hasAttribute( DevMode::DEV_MODE_ATTRIBUTE ) && ! is_user_logged_in() )
+			||
+			// @todo It would be preferable if we didn't have to do this query since we've already encountered an attribute.
+			$dom->xpath->query( sprintf( '//*/@%s | //*/@%s', AMP_Validation_Manager::PX_VERIFIED_TAG_ATTRIBUTE, AMP_Validation_Manager::PX_VERIFIED_ATTRS_ATTRIBUTE ) )->length > 0
 		) {
 			$dom->documentElement->removeAttribute( Attribute::AMP );
 			$dom->documentElement->removeAttribute( Attribute::AMP_EMOJI );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -900,7 +900,7 @@ class AMP_Theme_Support {
 
 		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'include_layout_in_wp_kses_allowed_html' ], 10 );
 		add_filter( 'get_header_image_tag', [ __CLASS__, 'amend_header_image_with_video_header' ], PHP_INT_MAX );
-		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ); // @todo The AMP_Comments_Sanitizer should add data-ampdevmode since user would be logged-in.
+		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ); // @todo The AMP_Comments_Sanitizer should add data-ampdevmode since user would be logged-in, or else the this script should be allowed whenever comment-reply is also allowed.
 		add_action(
 			'wp_print_footer_scripts',
 			static function() {
@@ -1089,7 +1089,6 @@ class AMP_Theme_Support {
 			}
 		}
 
-		// @todo See <https://github.com/ampproject/amp-wp/issues/2489>.
 		$state_id     = self::get_comment_form_state_id( get_the_ID() );
 		$text_binding = sprintf(
 			'%s.replyToName ? %s : %s',

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -506,6 +506,15 @@ abstract class AMP_Base_Sanitizer {
 			return false;
 		}
 
+		// Prevent removing a tag which was verified for PX.
+		if (
+			$node instanceof DOMElement
+			&&
+			$node->hasAttribute( AMP_Validation_Manager::PX_VERIFIED_TAG_ATTRIBUTE )
+		) {
+			return false;
+		}
+
 		// Prevent double-reporting nodes that are rejected for sanitization.
 		if ( isset( $this->nodes_to_keep[ $node->nodeName ] ) && in_array( $node, $this->nodes_to_keep[ $node->nodeName ], true ) ) {
 			return false;
@@ -575,6 +584,19 @@ abstract class AMP_Base_Sanitizer {
 			in_array(
 				$node->nodeName,
 				preg_split( '/\s+/', $element->getAttribute( AMP_Validation_Manager::AMP_UNVALIDATED_ATTRS_ATTRIBUTE ) ),
+				true
+			)
+		) {
+			return false;
+		}
+
+		// Prevent removing an attribute which was verified for PX.
+		if (
+			$element->hasAttribute( AMP_Validation_Manager::PX_VERIFIED_ATTRS_ATTRIBUTE )
+			&&
+			in_array(
+				$node->nodeName,
+				preg_split( '/\s+/', $element->getAttribute( AMP_Validation_Manager::PX_VERIFIED_ATTRS_ATTRIBUTE ) ),
 				true
 			)
 		) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -141,9 +141,22 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Get args.
+	 *
+	 * @since 2.2
+	 *
+	 * @return array Args.
+	 */
+	public function get_args() {
+		return $this->args;
+	}
+
+	/**
 	 * Update args.
 	 *
 	 * Merges the supplied args with the existing args.
+	 *
+	 * @since 2.2
 	 *
 	 * @param array $args Args.
 	 */

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -263,7 +263,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			$comment_reply_link->setAttribute(
 				Attribute::ON,
 				sprintf(
-					'tap:AMP.setState(%s)',
+					'tap:AMP.setState(%s),comment.focus',
 					wp_json_encode( $comment_reply_state, JSON_UNESCAPED_UNICODE )
 				)
 			);

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -45,13 +45,11 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 	protected $DEFAULT_ARGS = [
 		'comment_live_list'        => false, // @todo See <https://github.com/ampproject/amp-wp/issues/4624>.
 		'thread_comments'          => false, // By default maps to thread_comments option.
-		'allow_commenting_scripts' => false, // @todo Change this to allow_native_comments which also adds px-verified to comment form instead of validation error.
+		'allow_commenting_scripts' => false,
 	];
 
 	/**
 	 * Pre-process the comment form and comment list for AMP.
-	 *
-	 * @todo Fix https://github.com/ampproject/amp-wp/issues/6231
 	 *
 	 * @since 0.7
 	 */

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -247,9 +247,11 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			/** @var DOMElement $comment_reply_link */
 
 			$comment_reply_state = [
-				'replyTo' => $comment_reply_link->getAttribute( 'data-replyto' ),
-				'values'  => [
-					'comment_parent' => $comment_reply_link->getAttribute( 'data-commentid' ),
+				$state_id => [
+					'replyTo' => $comment_reply_link->getAttribute( 'data-replyto' ),
+					'values'  => [
+						'comment_parent' => $comment_reply_link->getAttribute( 'data-commentid' ),
+					],
 				],
 			];
 
@@ -261,8 +263,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			$comment_reply_link->setAttribute(
 				Attribute::ON,
 				sprintf(
-					'tap:AMP.setState({%s:%s})',
-					wp_json_encode( $state_id ),
+					'tap:AMP.setState(%s)',
 					wp_json_encode( $comment_reply_state, JSON_UNESCAPED_UNICODE )
 				)
 			);

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -43,7 +43,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [
-		'comment_live_list'        => false, // @todo See <https://github.com/ampproject/amp-wp/issues/4624>.
+		'comments_live_list'       => false,
 		'thread_comments'          => false, // By default maps to thread_comments option.
 		'allow_commenting_scripts' => false,
 	];
@@ -65,7 +65,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		if ( ! empty( $this->args['comments_live_list'] ) ) {
+		if ( $this->args['comments_live_list'] ) {
 			$comments = $this->dom->xpath->query( '//amp-live-list/*[ @items ]/*[ starts-with( @id, "comment-" ) ]' );
 
 			foreach ( $comments as $comment ) {

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -15,6 +15,7 @@ use AmpProject\Tag;
  *
  * Strips and corrects attributes in forms.
  *
+ * @todo When comment-reply is on the page, this should be skipped.
  * @internal
  */
 class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
@@ -117,20 +118,12 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 		$form_state = [
 			'values'     => [],
 			'submitting' => false,
-			'replyTo'    => '', // @todo This should rather be just replyToText.
+			'replyTo'    => '',
 		];
 
 		$comment_parent_id = null;
 		if ( ! empty( $form_fields['comment_parent'] ) ) {
 			$comment_parent_id = (int) $form_fields['comment_parent'][0]->getAttribute( Attribute::VALUE );
-
-			// @todo Obtain replyTo?
-			if ( $comment_id ) {
-//				$reply_comment = get_comment( $comment_id );
-//				if ( $reply_comment ) {
-//					$form_state['replyToName'] = $reply_comment->comment_author;
-//				}
-			}
 		}
 
 		$amp_bind_attr_format = Amp::BIND_DATA_ATTR_PREFIX . '%s';
@@ -198,7 +191,6 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 		];
 		$comment_form->setAttribute( Attribute::ON, implode( ';', $on ) );
 
-		// @todo DO the filter_comment_form_defaults.
 		$reply_heading_element   = $this->dom->getElementById( 'reply-title' );
 		$reply_heading_text_node = null;
 		$reply_link_to_parent    = null;
@@ -220,15 +212,12 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 				$reply_heading_text_span->nextSibling
 			);
 
-			// @todo Consider replytocom. $comment_parent_id
+			// Note: if the replytocom query parameter was set, then the existing value will already be a replyTo value.
+			// Nevertheless, the link will have the replytocom arg removed, so clicking on the link will cause
+			// navigation to a page that has the nameless heading text.
 			$text_binding = sprintf(
 				'%1$s.replyTo ? %1$s.replyTo : %2$s',
 				$state_id,
-//				str_replace(
-//					'%s',
-//					sprintf( '" + %s.replyToName + "', $state_id ),
-//					wp_json_encode( $default_args['title_reply_to'], JSON_UNESCAPED_UNICODE )
-//				),
 				wp_json_encode( $reply_heading_text_node->nodeValue, JSON_UNESCAPED_UNICODE )
 			);
 
@@ -295,17 +284,6 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 				sprintf( '%s.values.comment_parent == "0"', $state_id )
 			);
 		}
-
-
-//		$reply_heading_text_node =
-//		if ( $reply_heading_element ) {
-//
-//
-//			var replyHeadingElement  = getElementById( config.commentReplyTitleId );
-//			var replyHeadingTextNode = replyHeadingElement && replyHeadingElement.firstChild;
-//			var replyLinkToParent    = replyHeadingTextNode && replyHeadingTextNode.nextSibling;
-//
-//		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -54,8 +54,10 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [
-		'unwrap_noscripts'    => true,
-		'sanitize_js_scripts' => false,
+		'unwrap_noscripts'       => true,
+		'sanitize_js_scripts'    => false,
+		'allow_comment_reply_js' => false, // @todo Support this.
+		// @todo Have a callback which indicates whether scripts are bento-friendly. The comment-reply is one such script which is allowed in moderate.
 	];
 
 	/**
@@ -104,6 +106,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		if ( ! empty( $this->args['sanitize_js_scripts'] ) ) {
+			// @todo This should automatically add defer to script#comment-reply-js if no other scripts had it as a dependency.
 			$this->sanitize_js_script_elements();
 		}
 
@@ -118,8 +121,10 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 		// associated style rules.
 		// @todo There should be an attribute on script tags that opt-in to keeping tree shaking and/or to indicate what class names need to be included.
 		// @todo Depending on the size of the underlying stylesheets, this may need to retain the use of external styles to prevent inlining excessive CSS. This may involve writing minified CSS to disk, or skipping style processing altogether if no selector conversions are needed.
+		// @todo Prevent inclusion of comment-reply.js alone from causing this.
 		if ( $this->kept_script_count > 0 ) {
 			$sanitizer_arg_updates = [
+				// @todo If comment-reply.js was on the page (likely best detected via wp_script_is('comment-reply', 'done')), then AMP_Comment_Sanitizer should know.
 				AMP_Style_Sanitizer::class             => [ 'skip_tree_shaking' => true ],
 				AMP_Img_Sanitizer::class               => [ 'native_img_used' => true ],
 				AMP_Video_Sanitizer::class             => [ 'native_video_used' => true ],

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -901,6 +901,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		 * in document order. DOMNode::compareDocumentPosition() is not yet implemented.
 		 */
 
+		// @todo Also consider skipping the processing of link and style elements that have data-px-verified-tag.
 		$dev_mode_predicate = '';
 		if ( DevMode::isActiveForDocument( $this->dom ) ) {
 			$dev_mode_predicate = sprintf( ' and not ( @%s )', AMP_Rule_Spec::DEV_MODE_ATTRIBUTE );

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3341,10 +3341,10 @@ class AMP_Validation_Error_Taxonomy {
 					'<code>' . esc_html( $validation_error['node_name'] ) . '</code>'
 				);
 
-			case AMP_Form_Sanitizer::FORM_HAS_POST_METHOD_WITHOUT_ACTION_XHR_ATTR:
+			case AMP_Form_Sanitizer::POST_FORM_HAS_ACTION_XHR_WHEN_NATIVE_USED:
 				return sprintf(
 					/* translators: %1$s is 'POST', %2$s is 'action-xhr' */
-					esc_html__( 'Form has %1$s method without %2$s attribute. (Mark as kept to prevent conversion to AMP.)', 'amp' ),
+					esc_html__( 'Native %1$s form has %2$s attribute.', 'amp' ),
 					'<code>POST</code>',
 					'<code>action-xhr</code>'
 				);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -85,6 +85,16 @@ class AMP_Validation_Manager {
 	const AMP_UNVALIDATED_TAG_ATTRIBUTE = 'data-amp-unvalidated-tag';
 
 	/**
+	 * HTML attribute to indicate an tag/element has been verified for PX.
+	 *
+	 * The difference here with `data-amp-unvalidated-tag` is that the PX-verified means that the tag will work
+	 * properly Bento components and CSS tree shaking.
+	 *
+	 * @var string
+	 */
+	const PX_VERIFIED_TAG_ATTRIBUTE = 'data-px-verified-tag';
+
+	/**
 	 * HTML attribute to indicate one or more attributes are exempted from AMP validation.
 	 *
 	 * @todo Consider 'exempt' instead of 'unvalidated'.
@@ -92,6 +102,13 @@ class AMP_Validation_Manager {
 	 * @var string
 	 */
 	const AMP_UNVALIDATED_ATTRS_ATTRIBUTE = 'data-amp-unvalidated-attrs';
+
+	/**
+	 * HTML attribute to indicate one or more attributes have been verified for PX from AMP validation.
+	 *
+	 * @var string
+	 */
+	const PX_VERIFIED_ATTRS_ATTRIBUTE = 'data-px-verified-attrs';
 
 	/**
 	 * The errors encountered when validating.

--- a/src/SandboxingLevels.php
+++ b/src/SandboxingLevels.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AMP_Form_Sanitizer;
+use AMP_Comments_Sanitizer;
 use AMP_Script_Sanitizer;
 
 /**
@@ -145,10 +146,9 @@ final class SandboxingLevels implements Service, Registerable, Conditional {
 			static function ( $sanitizers ) use ( $sandboxing_level ) {
 				$sanitizers[ AMP_Script_Sanitizer::class ]['sanitize_js_scripts'] = true;
 
-				// @todo This:
-				// if ( $sandboxing_level < 3 ) {
-				// $sanitizers[ AMP_Script_Sanitizer::class ]['allow_comment_reply_js'] = true;
-				// }
+				if ( $sandboxing_level < 3 ) {
+					$sanitizers[ AMP_Comments_Sanitizer::class ]['allow_commenting_scripts'] = true;
+				}
 				return $sanitizers;
 			}
 		);

--- a/src/SandboxingLevels.php
+++ b/src/SandboxingLevels.php
@@ -142,8 +142,13 @@ final class SandboxingLevels implements Service, Registerable, Conditional {
 		// Opt-in to the new script sanitization logic in the script sanitizer.
 		add_filter(
 			'amp_content_sanitizers',
-			static function ( $sanitizers ) {
+			static function ( $sanitizers ) use ( $sandboxing_level ) {
 				$sanitizers[ AMP_Script_Sanitizer::class ]['sanitize_js_scripts'] = true;
+
+				// @todo This:
+				// if ( $sandboxing_level < 3 ) {
+				// $sanitizers[ AMP_Script_Sanitizer::class ]['allow_comment_reply_js'] = true;
+				// }
 				return $sanitizers;
 			}
 		);

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -194,33 +194,23 @@ class AMP_Form_Sanitizer_Test extends TestCase {
 					'add_dev_mode' => true,
 				],
 			],
-			'form_with_post_action_converted' => [
-				'<form method="post" action="http://example.com"></form>',
-				'<form method="post" action-xhr="//example.com?_wp_amp_action_xhr_converted=1" target="_top">' . $form_templates . '</form>',
-				[
-					'native_post_forms_allowed' => true,
-				],
-				[ AMP_Form_Sanitizer::FORM_HAS_POST_METHOD_WITHOUT_ACTION_XHR_ATTR ],
-			],
-			'form_with_post_action_kept' => [
+			'native_form_with_post_action' => [
 				'<form method="post" action="http://example.com"></form>',
 				sprintf( '<form method="post" action="http://example.com" %s></form>', AMP_Validation_Manager::AMP_UNVALIDATED_TAG_ATTRIBUTE ),
 				[
-					'native_post_forms_allowed' => true,
-					'keep_post_forms'           => true,
-					'expected_non_valid_doc'    => true,
-				],
-				[ AMP_Form_Sanitizer::FORM_HAS_POST_METHOD_WITHOUT_ACTION_XHR_ATTR ],
-			],
-			'form_with_post_action-xhr_ok' => [
-				'<form method="post" action-xhr="http://example.com"></form>',
-				'<form method="post" action-xhr="//example.com" target="_top"></form>',
-				[
-					'native_post_forms_allowed' => true,
-					'keep_post_forms'           => true,
-					'expected_non_valid_doc'    => false,
+					'native_post_forms_used' => true,
+					'expected_non_valid_doc' => true,
 				],
 				[],
+			],
+			'native_form_with_post_action-xhr' => [
+				'<form method="post" action-xhr="http://example.com"></form>',
+				'',
+				[
+					'native_post_forms_used' => true,
+					'expected_non_valid_doc' => false,
+				],
+				[ AMP_Form_Sanitizer::POST_FORM_HAS_ACTION_XHR_WHEN_NATIVE_USED ],
 			],
 		];
 	}
@@ -243,13 +233,9 @@ class AMP_Form_Sanitizer_Test extends TestCase {
 			$dom->documentElement->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
 		}
 
-		$actual_errors = [];
-
-		$args['validation_error_callback'] = static function( $error ) use ( &$actual_errors, $args ) {
+		$actual_errors                     = [];
+		$args['validation_error_callback'] = static function( $error ) use ( &$actual_errors ) {
 			$actual_errors[] = $error;
-			if ( AMP_Form_Sanitizer::FORM_HAS_POST_METHOD_WITHOUT_ACTION_XHR_ATTR === $error['code'] && ! empty( $args['keep_post_forms'] ) ) {
-				return false;
-			}
 			return true;
 		};
 

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1702,21 +1702,6 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 	}
 
 	/**
-	 * Test amp_is_native_post_form_allowed().
-	 *
-	 * @covers ::amp_is_native_post_form_allowed()
-	 */
-	public function test_amp_is_native_post_form_allowed() {
-		$this->assertFalse( amp_is_native_post_form_allowed(), 'Expected to be disabled by default for now.' );
-
-		add_filter( 'amp_native_post_form_allowed', '__return_true' );
-		$this->assertTrue( amp_is_native_post_form_allowed() );
-
-		add_filter( 'amp_native_post_form_allowed', '__return_false', 20 );
-		$this->assertFalse( amp_is_native_post_form_allowed() );
-	}
-
-	/**
 	 * Test deprecated $post param for amp_get_content_embed_handlers().
 	 *
 	 * @covers ::amp_get_content_embed_handlers()

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1770,6 +1770,10 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 			array_search( 'Even_After_Validating_Sanitizer', $ordered_sanitizers, true ),
 			array_search( AMP_Script_Sanitizer::class, $ordered_sanitizers, true )
 		);
+		$this->assertGreaterThan(
+			array_search( AMP_Core_Theme_Sanitizer::class, $ordered_sanitizers, true ),
+			array_search( AMP_Script_Sanitizer::class, $ordered_sanitizers, true )
+		);
 		$this->assertEquals( AMP_Layout_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 4 ] );
 		$this->assertEquals( AMP_Style_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
 		$this->assertEquals( AMP_Meta_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 2 ] );

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -434,7 +434,7 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			AMP_Form_Sanitizer::class              => new AMP_Form_Sanitizer(
 				$dom,
 				[
-					'native_post_forms_allowed' => false, // Overridden by AMP_Script_Sanitizer when there is a kept script.
+					'native_post_forms_used'    => false, // Overridden by AMP_Script_Sanitizer when there is a kept script.
 					'validation_error_callback' => function () use ( $remove_custom_scripts ) {
 						return $remove_custom_scripts;
 					},

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -779,9 +779,6 @@ class Test_AMP_Theme_Support extends TestCase {
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		$this->assertEquals( $priority, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
 
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_form_defaults', [ self::TESTED_CLASS, 'filter_comment_form_defaults' ] ) );
-		$this->assertEquals( 10, has_filter( 'comment_reply_link', [ self::TESTED_CLASS, 'filter_comment_reply_link' ] ) );
-		$this->assertEquals( 10, has_filter( 'cancel_comment_reply_link', [ self::TESTED_CLASS, 'filter_cancel_comment_reply_link' ] ) );
 		$this->assertFalse( has_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'get_header_image_tag', [ self::TESTED_CLASS, 'amend_header_image_with_video_header' ] ) );
 	}
@@ -881,6 +878,7 @@ class Test_AMP_Theme_Support extends TestCase {
 	 * Test get_comment_form_state_id.
 	 *
 	 * @covers AMP_Theme_Support::get_comment_form_state_id()
+	 * @expectedDeprecated AMP_Theme_Support::get_comment_form_state_id
 	 */
 	public function test_get_comment_form_state_id() {
 		$post_id = 54;
@@ -893,6 +891,8 @@ class Test_AMP_Theme_Support extends TestCase {
 	 * Test filter_comment_form_defaults.
 	 *
 	 * @covers AMP_Theme_Support::filter_comment_form_defaults()
+	 * @expectedDeprecated AMP_Theme_Support::filter_comment_form_defaults
+	 * @expectedDeprecated AMP_Theme_Support::get_comment_form_state_id
 	 */
 	public function test_filter_comment_form_defaults() {
 		global $post;
@@ -914,6 +914,8 @@ class Test_AMP_Theme_Support extends TestCase {
 	 * Test filter_comment_reply_link.
 	 *
 	 * @covers AMP_Theme_Support::filter_comment_reply_link()
+	 * @expectedDeprecated AMP_Theme_Support::filter_comment_reply_link
+	 * @expectedDeprecated AMP_Theme_Support::get_comment_form_state_id
 	 */
 	public function test_filter_comment_reply_link() {
 		global $post;
@@ -949,6 +951,8 @@ class Test_AMP_Theme_Support extends TestCase {
 	 * Test filter_cancel_comment_reply_link.
 	 *
 	 * @covers AMP_Theme_Support::filter_cancel_comment_reply_link()
+	 * @expectedDeprecated AMP_Theme_Support::filter_cancel_comment_reply_link
+	 * @expectedDeprecated AMP_Theme_Support::get_comment_form_state_id
 	 */
 	public function test_filter_cancel_comment_reply_link() {
 		global $post;

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -779,7 +779,6 @@ class Test_AMP_Theme_Support extends TestCase {
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		$this->assertEquals( $priority, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
 
-		$this->assertFalse( has_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'get_header_image_tag', [ self::TESTED_CLASS, 'amend_header_image_with_video_header' ] ) );
 	}
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1870,19 +1870,14 @@ class Test_AMP_Theme_Support extends TestCase {
 		$this->set_template_mode( AMP_Theme_Support::STANDARD_MODE_SLUG );
 
 		add_filter(
-			'amp_validation_error_default_sanitized',
-			static function ( $sanitized, $error ) use ( $converted ) {
-				if ( AMP_Form_Sanitizer::FORM_HAS_POST_METHOD_WITHOUT_ACTION_XHR_ATTR === $error['code'] ) {
-					$sanitized = $converted;
-				}
-				return $sanitized;
-			},
-			10,
-			2
+			'amp_content_sanitizers',
+			static function ( $sanitizers ) use ( $converted ) {
+				$sanitizers[ AMP_Form_Sanitizer::class ]['native_post_forms_used'] = ! $converted;
+				return $sanitizers;
+			}
 		);
 
 		wp();
-		add_filter( 'amp_native_post_form_allowed', '__return_true' );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();
 		ob_start();


### PR DESCRIPTION
Amends #6546.

This includes the full fix for https://github.com/ampproject/amp-wp/issues/2489 going beyond the short-term fix introduced in https://github.com/ampproject/amp-wp/pull/4388. 

Upon clicking a link to reply to a comment by “admin”:

Non-AMP w/ JS | Non-AMP w/o JS | AMP Before 👎   | AMP After 👍 
-----------|-------|-------|----------
![image](https://user-images.githubusercontent.com/134745/131239883-273f7393-c491-441f-9087-e61b5d291d61.png) | ![image](https://user-images.githubusercontent.com/134745/131239919-8d643bd4-ea43-44be-9368-530b52ae5ac4.png) | ![image](https://user-images.githubusercontent.com/134745/131239873-12be8848-46af-46cb-b917-9469dbae0007.png) | ![image](https://user-images.githubusercontent.com/134745/131239898-30cdce90-273c-4532-91fd-16cc665ffa23.png)

Also fixes https://github.com/ampproject/amp-wp/issues/6231.
Fixes #4624.