### PR TITLE
Remove `muted` attribute from `amp-video` and its `video` fallback when `autoplay` is present

### DIFF
--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -315,7 +315,11 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		if ( isset( $out['autoplay'] ) ) {
+		/*
+		 * The amp-video will forcibly be muted whenever it is set to autoplay.
+		 * So omit the `muted` attribute if it exists.
+		 */
+		if ( isset( $out['autoplay'], $out['muted'] ) ) {
 			unset( $out['muted'] );
 		}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -63,6 +63,9 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 		if ( $this->args['add_noscript_fallback'] ) {
 			$this->initialize_noscript_allowed_attributes( self::$tag );
+
+			// Omit muted from noscript > video since it causes deprecation warnings in validator.
+			unset( $this->noscript_fallback_allowed_attributes['muted'] );
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
@@ -310,6 +313,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 				default:
 					$out[ $name ] = $value;
 			}
+		}
+
+		if ( isset( $out['autoplay'] ) ) {
+			unset( $out['muted'] );
 		}
 
 		return $out;

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -63,8 +63,8 @@ class AMP_Video_Converter_Test extends TestCase {
 			],
 
 			'video_with_autoplay' => [
-				'<video src="https://example.com/file.mp4" autoplay="true" muted="muted"></video>',
-				'<amp-video src="https://example.com/file.mp4" autoplay height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" autoplay="true"></video></noscript></amp-video>',
+				'<video src="https://example.com/file.mp4" autoplay muted width="160" height="80"></video>',
+				'<amp-video src="https://example.com/file.mp4" autoplay width="160" height="80" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" autoplay width="160" height="80"></video></noscript></amp-video>',
 			],
 
 			'local_video_without_dimensions' => [

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -109,12 +109,12 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'video_with_allowlisted_attributes__enabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true"></video></noscript></amp-video>',
 			],
 
 			'video_with_allowlisted_attributes__disabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false"></video></noscript></amp-video>',
 			],
 
 			'video_with_custom_attribute' => [

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -62,6 +62,11 @@ class AMP_Video_Converter_Test extends TestCase {
 				'<amp-video src="https://example.com/file.mp4" class="amp-wp-unknown-size" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
+			'video_with_autoplay' => [
+				'<video src="https://example.com/file.mp4" autoplay="true" muted="muted"></video>',
+				'<amp-video src="https://example.com/file.mp4" autoplay height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" autoplay="true"></video></noscript></amp-video>',
+			],
+
 			'local_video_without_dimensions' => [
 				sprintf( '<video src="%s"></video>', '{{video_url}}' ),
 				sprintf( '<amp-video src="%1$s" width="560" height="320" layout="responsive"><a href="%1$s" fallback="">%1$s</a><noscript><video src="%1$s"></video></noscript></amp-video>', '{{video_url}}' ),


### PR DESCRIPTION
This cherry-picks the PHP changes from #6547 to prevent an AMP validation warning from appearing when an `amp-video > noscript > video` element has `autoplay` while also `muted` attribute. 