### PR TITLE
Fix flaky E2E test

### DIFF
--- a/tests/e2e/specs/admin/amp-options.js
+++ b/tests/e2e/specs/admin/amp-options.js
@@ -113,8 +113,6 @@ describe( 'Saving', () => {
 	it( 'allows saving', async () => {
 		const testSave = async () => {
 			await expect( page ).toClick( 'button', { text: 'Save' } );
-			await page.waitForSelector( 'button[disabled].is-busy' );
-			await expect( page ).toMatchElement( 'button[disabled].is-busy', { text: 'Saving' } );
 			await expect( page ).toMatchElement( 'button[disabled]', { text: 'Save' } );
 			await expect( page ).toMatchElement( '.amp-save-success-notice', { text: 'Saved' } );
 		};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

[Example of E2E test failing](https://github.com/ampproject/amp-wp/pull/6456/checks?check_run_id=3635602821#step:12:17).

The issue with this E2E test stems from the "busy" state of the save button on the Settings page no longer being present on the page just after the settings are saved. Sometimes when the test is about to assert that the button is "busy", it has already reverted to its disabled state and so the test fails.

This PR removes the assertions related to confirming the busy state of the button since it is not guaranteed it will be present on the page at that point in time and is dependent on how quickly the settings are saved.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
