### PR TITLE
Fix prioritization of TT1 stylesheet after core theme sanitizer changes

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1034,7 +1034,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return preg_replace( '/^https?:/', '', $url );
 		};
 
-		if ( $node instanceof DOMElement && 'link' === $node->nodeName ) {
+		if ( $node instanceof DOMElement && 'link' === $node->tagName ) {
 			$element_id      = (string) $node->getAttribute( 'id' );
 			$schemeless_href = $remove_url_scheme( $node->getAttribute( 'href' ) );
 
@@ -1098,13 +1098,35 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			if ( 'print' === $node->getAttribute( 'media' ) ) {
 				$priority += $print_priority_base;
 			}
-		} elseif ( $node instanceof DOMElement && 'style' === $node->nodeName && $node->hasAttribute( 'id' ) ) {
-			$id                  = $node->getAttribute( 'id' );
-			$is_theme_inline_css = preg_match( '/^(?<handle>.+)-inline-css$/', $id, $matches ) && wp_style_is( $matches['handle'], 'registered' );
-			if ( $is_theme_inline_css && 0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_template_directory_uri() ) ) {
+		} elseif ( $node instanceof DOMElement && 'style' === $node->tagName && $node->hasAttribute( 'id' ) ) {
+			$id         = $node->getAttribute( 'id' );
+			$dependency = null;
+			if ( preg_match( '/^(?<handle>.+)-inline-css$/', $id, $matches ) ) {
+				$dependency = wp_styles()->query( $matches['handle'], 'registered' );
+			}
+
+			if (
+				$dependency
+				&&
+				(
+					0 === strpos( $dependency->src, get_template_directory_uri() )
+					||
+					// Add special case for core theme sanitizer which sets the src of the theme stylesheet to false
+					// in order to attach the amended stylesheet contents as an inline style for AMP-compatibility.
+					// See AMP_Core_Theme_Sanitizer::amend_twentytwentyone_styles() and
+					// AMP_Core_Theme_Sanitizer::amend_twentytwentyone_dark_mode_styles().
+					'twenty-twenty-one-style' === $dependency->handle
+				)
+			) {
 				// Parent theme inline style.
 				$priority = 2;
-			} elseif ( $is_theme_inline_css && get_stylesheet() !== get_template() && 0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_stylesheet_directory_uri() ) ) {
+			} elseif (
+				$dependency
+				&&
+				get_stylesheet() !== get_template()
+				&&
+				0 === strpos( $dependency->src, get_stylesheet_directory_uri() )
+			) {
 				// Child theme inline style.
 				$priority = 12;
 			} elseif ( 'admin-bar-inline-css' === $id ) {


### PR DESCRIPTION
## Summary

While working on #6624, I realized that in Twenty Twenty-One the theme stylesheet was getting excluded when a large plugin stylesheet was present earlier in the document. This ended up being a bug with the prioritization logic caused by the core theme sanitizer, where we set the `src` of the stylesheet to `false` to make an alias that isn't printed but which we then attach inline styles for the entire stylesheet source with fixes for AMP compatibility.

So this adds a special case for what the plugin uniquely does with the Twenty Twenty-One.

Considering the following plugin being active:

```php
<?php
/**
 * Plugin Name: Add Style To Beginning of Head
 */

add_action('wp_head', function () {
	?>
	<style>
		body:after {
			content: '<?php echo str_repeat( 'a', 28324 ) ?>';
		}
	</style>
	<?php
}, 0);
```

Before | After
-------|--------
<img width="1198" alt="Screen Shot 2021-09-28 at 12 29 42" src="https://user-images.githubusercontent.com/134745/135154611-3181fba9-3152-4008-a1d5-8e1e1d511cb8.png"> | <img width="1200" alt="Screen Shot 2021-09-28 at 12 29 57" src="https://user-images.githubusercontent.com/134745/135154616-bde95703-853e-4d51-89ac-b5e6fa0d57bc.png">

Notice the Twenty Twenty-One style now has the proper priority and thus it is not selected for exclusion.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
