### PR TITLE
Optimize reading tail of error log

### DIFF
--- a/src/Admin/SupportScreen.php
+++ b/src/Admin/SupportScreen.php
@@ -173,7 +173,7 @@ class SupportScreen implements Conditional, Service, Registerable {
 			];
 		}
 
-		$support_data = $this->injector->make( SupportData::class, [ 'args' => $args ] );
+		$support_data = $this->injector->make( SupportData::class, compact( 'args' ) );
 		$data         = $support_data->get_data();
 
 		wp_add_inline_script(

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -361,7 +361,7 @@ class SupportData {
 		$file         = @fopen( $error_log_path, 'r' );
 		$lines        = [];
 		$current_line = '';
-		$position     = - 2;
+		$position     = -2;
 
 		if ( is_resource( $file ) ) {
 
@@ -372,7 +372,7 @@ class SupportData {
 					$lines[]      = $current_line;
 					$current_line = '';
 
-					if ( count( $lines ) >= $max_lines ) {
+					if ( count( $lines ) > $max_lines ) {
 						break;
 					}
 				} else {

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -355,24 +355,37 @@ class SupportData {
 			];
 		}
 
-		$no_of_lines = 200;
+		$max_lines = 200;
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
-		$file  = @fopen( $error_log_path, 'r' );
-		$lines = [];
+		$file         = @fopen( $error_log_path, 'r' );
+		$lines        = [];
+		$current_line = '';
+		$position     = - 2;
 
 		if ( is_resource( $file ) ) {
-			while ( ! feof( $file ) ) {
-				$line       = fgets( $file );
-				$lines[]    = $line;
-				$line_count = count( $lines );
-				if ( $line_count > $no_of_lines ) {
-					array_shift( $lines );
+
+			while ( -1 !== fseek( $file, $position, SEEK_END ) ) {
+				$char = fgetc( $file );
+
+				if ( PHP_EOL === $char ) {
+					$lines[]      = $current_line;
+					$current_line = '';
+
+					if ( count( $lines ) >= $max_lines ) {
+						break;
+					}
+				} else {
+					$current_line = $char . $current_line;
 				}
+
+				$position--;
 			}
 
 			fclose( $file );
 		}
+
+		$lines = array_reverse( $lines );
 
 		return [
 			'log_errors' => ini_get( 'log_errors' ),

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -361,7 +361,7 @@ class SupportData {
 		$file         = @fopen( $error_log_path, 'r' );
 		$lines        = [];
 		$current_line = '';
-		$position     = -2;
+		$position     = 0;
 
 		if ( is_resource( $file ) ) {
 
@@ -382,9 +382,12 @@ class SupportData {
 				$position--;
 			}
 
+			$lines[] = $current_line;
+
 			fclose( $file );
 		}
 
+		$lines = array_filter( $lines );
 		$lines = array_reverse( $lines );
 
 		return [

--- a/tests/php/src/Support/SupportDataTest.php
+++ b/tests/php/src/Support/SupportDataTest.php
@@ -31,8 +31,14 @@ class SupportDataTest extends DependencyInjectedTestCase {
 	 */
 	public $instance;
 
+	/** @var array */
+	private $previous_ini_config = [
+		'error_log'  => null,
+		'log_errors' => null,
+	];
+
 	/**
-	 * Setup.
+	 * Set up.
 	 *
 	 * @inheritdoc
 	 */
@@ -41,6 +47,22 @@ class SupportDataTest extends DependencyInjectedTestCase {
 		parent::setUp();
 
 		$this->instance = $this->injector->make( SupportData::class );
+
+		foreach ( array_keys( $this->previous_ini_config ) as $key ) {
+			$this->previous_ini_config[ $key ] = ini_get( $key );
+		}
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		foreach ( $this->previous_ini_config as $key => $value ) {
+			ini_set( $key, $value ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+		}
 	}
 
 	/**
@@ -300,10 +322,8 @@ class SupportDataTest extends DependencyInjectedTestCase {
 		$this->assertArrayHasKey( 'log_errors', $output );
 		$this->assertArrayHasKey( 'contents', $output );
 
-		$previous_log_errors_config = ini_get( 'log_errors' );
-		$previous_error_log_config  = ini_get( 'error_log' );
-
 		$log_path = $this->temp_filename();
+		$this->assertTrue( is_writable( $log_path ) );
 
 		ini_set( 'log_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
 		ini_set( 'error_log', $log_path ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
@@ -322,11 +342,6 @@ class SupportDataTest extends DependencyInjectedTestCase {
 
 		file_put_contents( $log_path, $input_content );
 		$output = $instance->get_error_log();
-
-		// Reset config.
-		ini_set( 'log_errors', $previous_log_errors_config ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
-		ini_set( 'error_log', $previous_error_log_config ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
-		$this->unlink( $log_path );
 
 		$this->assertEquals( $expected_content, $output['contents'] );
 	}

--- a/tests/php/src/Support/SupportDataTest.php
+++ b/tests/php/src/Support/SupportDataTest.php
@@ -300,6 +300,38 @@ class SupportDataTest extends DependencyInjectedTestCase {
 		$this->assertArrayHasKey( 'log_errors', $output );
 		$this->assertArrayHasKey( 'contents', $output );
 
+		$previous_config = [
+			'log_errors' => ini_get( 'log_errors' ),
+			'error_log'  => ini_get( 'error_log' ),
+		];
+
+		$log_path = WP_CONTENT_DIR . '/debug.log';
+
+		ini_set( 'log_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+		ini_set( 'error_log', $log_path ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+
+		$input_content    = '';
+		$expected_content = '';
+
+		for ( $i = 1; $i <= 300; $i ++ ) {
+			$input_content .= "Line: $i\n";
+		}
+
+		for ( $i = 101; $i <= 300; $i ++ ) {
+			$expected_content .= "Line: $i\n";
+		}
+		$expected_content = trim( $expected_content, "\n" );
+
+		file_put_contents( $log_path, $input_content );
+		$output = $instance->get_error_log();
+
+		$this->assertEquals( $expected_content, $output['contents'] );
+
+		$this->unlink( $log_path );
+
+		// Reset config.
+		ini_set( 'log_errors', $previous_config['log_errors'] ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+		ini_set( 'error_log', $previous_config['error_log'] ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
 	}
 
 	/**

--- a/tests/php/src/Support/SupportDataTest.php
+++ b/tests/php/src/Support/SupportDataTest.php
@@ -300,12 +300,10 @@ class SupportDataTest extends DependencyInjectedTestCase {
 		$this->assertArrayHasKey( 'log_errors', $output );
 		$this->assertArrayHasKey( 'contents', $output );
 
-		$previous_config = [
-			'log_errors' => ini_get( 'log_errors' ),
-			'error_log'  => ini_get( 'error_log' ),
-		];
+		$previous_log_errors_config = ini_get( 'log_errors' );
+		$previous_error_log_config  = ini_get( 'error_log' );
 
-		$log_path = WP_CONTENT_DIR . '/debug.log';
+		$log_path = $this->temp_filename();
 
 		ini_set( 'log_errors', 1 ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
 		ini_set( 'error_log', $log_path ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
@@ -325,13 +323,12 @@ class SupportDataTest extends DependencyInjectedTestCase {
 		file_put_contents( $log_path, $input_content );
 		$output = $instance->get_error_log();
 
-		$this->assertEquals( $expected_content, $output['contents'] );
-
+		// Reset config.
+		ini_set( 'log_errors', $previous_log_errors_config ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+		ini_set( 'error_log', $previous_error_log_config ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
 		$this->unlink( $log_path );
 
-		// Reset config.
-		ini_set( 'log_errors', $previous_config['log_errors'] ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
-		ini_set( 'error_log', $previous_config['error_log'] ); // phpcs:ignore WordPress.PHP.IniSet.log_errors_Blacklisted, WordPress.PHP.IniSet.Risky
+		$this->assertEquals( $expected_content, $output['contents'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Related: #5939
Amends: #6627 

- Optimize logic to read error log for support requests.
- Addresses the feedback from #6627 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
