### PR TITLE
[2.1] Update amphtml spec to 2110152252000

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -502,7 +502,6 @@ def ParseRules(repo_directory, out_dir):
 			if 'bento' not in extensions_versions[extension_name]:
 				logging.info( 'Warning: bento_supported_version found but bento not meta not obtained for ' + extension_name )
 			elif extension_script_list[0]['tag_spec']['extension_spec']['bento_supported_version'][0] != extensions_versions[extension_name]['bento']['version']:
-				bento_supported_version = extension_script_list[0]['tag_spec']['extension_spec']['bento_supported_version'][0]
 				logging.info( 'Warning: bento_supported_version does not match the bento meta version for ' + extension_name )
 
 			# Remove redundant information.

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -471,7 +471,7 @@ def ParseRules(repo_directory, out_dir):
 		if extensions_versions[ extension['name'] ]['latest'] is not None and extensions_versions[ extension['name'] ]['latest'] != extension['latestVersion']:
 			logging.info('Warning: latestVersion mismatch for ' + extension['name'])
 		extensions_versions[ extension['name'] ]['latest'] = extension['latestVersion']
-		if 'options' in extension and 'wrapper' in extension['options'] and extension['options']['wrapper'] == 'bento':
+		if 'options' in extension and ( ( 'bento' in extension['options'] and extension['options']['bento'] ) or ( 'wrapper' in extension['options'] and extension['options']['wrapper'] == 'bento' ) ):
 			extensions_versions[ extension['name'] ]['bento'] = {
 				'version': extension['version'],
 				'has_css': extension['options'].get( 'hasCss', False ),
@@ -496,6 +496,17 @@ def ParseRules(repo_directory, out_dir):
 		if 'bento' in extensions_versions[extension_name] and extensions_versions[extension_name]['bento']['version'] not in validator_versions:
 			logging.info( 'Skipping bento for ' + extension_name + ' since version ' + extensions_versions[extension_name]['bento']['version'] + ' is not yet valid' )
 			del extensions_versions[extension_name]['bento']
+
+		# Verify bento_supported_version matches the version info in the bundle file.
+		if 'bento_supported_version' in extension_script_list[0]['tag_spec']['extension_spec']:
+			if 'bento' not in extensions_versions[extension_name]:
+				logging.info( 'Warning: bento_supported_version found but bento not meta not obtained for ' + extension_name )
+			elif extension_script_list[0]['tag_spec']['extension_spec']['bento_supported_version'][0] != extensions_versions[extension_name]['bento']['version']:
+				bento_supported_version = extension_script_list[0]['tag_spec']['extension_spec']['bento_supported_version'][0]
+				logging.info( 'Warning: bento_supported_version does not match the bento meta version for ' + extension_name )
+
+			# Remove redundant information.
+			del extension_script_list[0]['tag_spec']['extension_spec']['bento_supported_version']
 
 		validator_versions = sorted( validator_versions, key=lambda version: map(int, version.split('.') ) )
 		extension_script_list[0]['tag_spec']['extension_spec']['version'] = validator_versions

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -264,6 +264,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-state',
 			'amp-story-360',
 			'amp-story-auto-analytics',
+			'amp-story-captions',
 			'amp-story-interactive-binary-poll',
 			'amp-story-interactive-img-poll',
 			'amp-story-interactive-img-quiz',
@@ -445,6 +446,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-render',
 			'amp-riddle-quiz',
 			'amp-soundcloud',
+			'amp-selector',
 			'amp-springboard-player',
 			'amp-timeago',
 			'amp-twitter',
@@ -473,6 +475,7 @@ class AMP_Allowed_Tags_Generated {
 			'col',
 			'colgroup',
 			'data',
+			'datalist',
 			'dd',
 			'defs',
 			'del',
@@ -492,8 +495,10 @@ class AMP_Allowed_Tags_Generated {
 			'femergenode',
 			'feoffset',
 			'figcaption',
+			'fieldset',
 			'figure',
 			'filter',
+			'form',
 			'footer',
 			'g',
 			'glyph',
@@ -510,8 +515,11 @@ class AMP_Allowed_Tags_Generated {
 			'hr',
 			'i',
 			'image',
+			'input',
 			'ins',
 			'kbd',
+			'label',
+			'legend',
 			'li',
 			'line',
 			'lineargradient',
@@ -520,14 +528,19 @@ class AMP_Allowed_Tags_Generated {
 			'marker',
 			'mask',
 			'metadata',
+			'meter',
 			'nav',
 			'ol',
+			'optgroup',
+			'option',
+			'output',
 			'p',
 			'path',
 			'pattern',
 			'polygon',
 			'polyline',
 			'pre',
+			'progress',
 			'q',
 			'radialgradient',
 			'rect',
@@ -538,6 +551,7 @@ class AMP_Allowed_Tags_Generated {
 			's',
 			'samp',
 			'section',
+			'select',
 			'small',
 			'solidcolor',
 			'source',
@@ -554,6 +568,7 @@ class AMP_Allowed_Tags_Generated {
 			'td',
 			'template',
 			'text',
+			'textarea',
 			'textpath',
 			'tfoot',
 			'th',
@@ -948,7 +963,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with type=custom',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/main/ads/custom.md',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/main/ads/vendors/custom.md',
 				),
 			),
 			array(
@@ -6253,6 +6268,39 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-story-captions' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							4,
+						),
+					),
+					'child_tags' => array(
+						'mandatory_num_child_tags' => 0,
+					),
+					'mandatory_ancestor' => 'amp-story',
+					'requires_extension' => array(
+						'amp-story-captions',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-captions',
+				),
+			),
+		),
 		'amp-story-consent' => array(
 			array(
 				'attr_spec_list' => array(
@@ -6938,12 +6986,33 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'amp-story-panning-media' => array(
 			array(
-				'attr_spec_list' => array(),
+				'attr_spec_list' => array(
+					'data-x' => array(
+						'value_regex' => '-?(0|[0-9]?\\d\\.?\\d*%|100%)',
+					),
+					'data-y' => array(
+						'value_regex' => '-?(0|[0-9]?\\d\\.?\\d*%|100%)',
+					),
+					'data-zoom' => array(
+						'value_regex' => '\\d+\\.?\\d*',
+					),
+					'lock-bounds' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
 				'tag_spec' => array(
 					'amp_layout' => array(
 						'supported_layouts' => array(
 							6,
 						),
+					),
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'amp-img',
+						),
+						'mandatory_num_child_tags' => 1,
 					),
 					'mandatory_ancestor' => 'amp-story-grid-layer',
 					'requires_extension' => array(
@@ -7562,6 +7631,11 @@ class AMP_Allowed_Tags_Generated {
 					'cache' => array(
 						'value' => array(
 							'google',
+						),
+					),
+					'captions-id' => array(
+						'requires_extension' => array(
+							'amp-story-captions',
 						),
 					),
 					'controls' => array(
@@ -13526,11 +13600,15 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
-					'mandatory' => true,
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'style',
+						),
+						'mandatory_min_num_child_tags' => 1,
+					),
 					'mandatory_parent' => 'head',
-					'spec_name' => 'noscript enclosure for boilerplate',
+					'spec_name' => 'noscript enclosure for amp style tags',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites',
-					'unique' => true,
 				),
 			),
 			array(
@@ -14287,7 +14365,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine script',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
@@ -14330,7 +14407,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine script (LTS)',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#required-markup',
@@ -16068,7 +16144,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'bento' => array(
-							'has_css' => false,
+							'has_css' => true,
 							'version' => '1.0',
 						),
 						'latest' => '0.1',
@@ -16104,7 +16180,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'bento' => array(
-							'has_css' => false,
+							'has_css' => true,
 							'version' => '1.0',
 						),
 						'latest' => '0.1',
@@ -16232,6 +16308,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-embedly-card',
 						'requires_usage' => true,
@@ -16740,11 +16820,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-iframe',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
 				),
@@ -17320,11 +17405,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-mathml',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
 				),
@@ -18137,11 +18227,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-sidebar',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
 				),
@@ -18266,6 +18361,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '0.1',
 						'name' => 'amp-soundcloud',
 						'requires_usage' => true,
@@ -18456,6 +18555,37 @@ class AMP_Allowed_Tags_Generated {
 					'extension_spec' => array(
 						'latest' => '0.1',
 						'name' => 'amp-story-auto-analytics',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'latest' => '0.1',
+						'name' => 'amp-story-captions',
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
@@ -19138,6 +19268,10 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'bento' => array(
+							'has_css' => true,
+							'version' => '1.0',
+						),
 						'latest' => '1.0',
 						'name' => 'amp-wordpress-embed',
 						'requires_usage' => true,
@@ -19692,7 +19826,6 @@ class AMP_Allowed_Tags_Generated {
 					'doc_css_bytes' => false,
 				),
 				'tag_spec' => array(
-					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'head > style[amp-boilerplate]',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites',
@@ -19715,7 +19848,6 @@ class AMP_Allowed_Tags_Generated {
 					'doc_css_bytes' => false,
 				),
 				'tag_spec' => array(
-					'mandatory' => true,
 					'mandatory_ancestor' => 'head',
 					'mandatory_parent' => 'noscript',
 					'spec_name' => 'noscript > style[amp-boilerplate]',
@@ -19756,6 +19888,55 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
 					'spec_name' => 'style[amp-keyframes]',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-noscript' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/css',
+						),
+					),
+				),
+				'cdata' => array(
+					'css_spec' => array(
+						'allowed_at_rules' => array(
+							'media',
+							'page',
+							'supports',
+							'-moz-document',
+						),
+						'declaration' => array(),
+						'validate_keyframes' => false,
+					),
+					'disallowed_cdata_regex' => array(
+						array(
+							'error_message' => 'html comments',
+							'regex' => '<!--',
+						),
+						array(
+							'error_message' => 'CSS i-amphtml- name prefix',
+							'regex' => '(^|\\W)i-amphtml-',
+						),
+					),
+					'doc_css_bytes' => true,
+					'max_bytes' => 10000,
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#maximum-size',
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'head',
+					'mandatory_parent' => 'noscript',
+					'spec_name' => 'style amp-noscript',
+					'spec_url' => 'https://github.com/ampproject/amphtml/issues/20609',
 					'unique' => true,
 				),
 			),

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1378,6 +1378,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 			'amp-story-360'             => 'v0/amp-story-360-0.1.js',
 			'amp-story-auto-ads'        => 'v0/amp-story-auto-ads-0.1.js',
 			'amp-story-auto-analytics'  => 'v0/amp-story-auto-analytics-0.1.js',
+			'amp-story-captions'        => 'v0/amp-story-captions-0.1.js',
 			'amp-story-interactive'     => 'v0/amp-story-interactive-0.1.js',
 			'amp-story-panning-media'   => 'v0/amp-story-panning-media-0.1.js',
 			'amp-story-player'          => 'v0/amp-story-player-0.1.js',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -894,6 +894,10 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 			},
 		];
 
+		// Run the script sanitizer to unwrap noscript elements.
+		$sanitizer = new AMP_Script_Sanitizer( $dom, $args );
+		$sanitizer->sanitize();
+
 		$sanitizer = new AMP_Style_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -108,7 +108,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 				[
 					[
 						'code'                 => AMP_Tag_And_Attribute_Sanitizer::WRONG_PARENT_TAG,
-						'spec_name'            => 'noscript enclosure for boilerplate',
+						'spec_name'            => 'noscript enclosure for amp style tags',
 						'required_parent_name' => 'head',
 					],
 				],
@@ -632,12 +632,14 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 							</amp-story-page>
 							<amp-story-page id="cover">
 								<amp-story-grid-layer template="fill">
-							 		<amp-story-panning-media layout="fill"></amp-story-panning-media>
+									<amp-story-panning-media layout="fill">
+										<amp-img src="https://example.com/img.jpg" layout="fill"></amp-img>
+									</amp-story-panning-media>
 								</amp-story-grid-layer>
 								<amp-story-page-outlink layout="nodisplay" cta-image="https://example.com/img/logo.jpg" cta-accent-color="navy" cta-accent-element="background">
 									<a href="https://www.google.com/search?q=why+do+cats+purr+so+loud" title="Link Description"></a>
 								</amp-story-page-outlink>
-						 	</amp-story-page>
+							</amp-story-page>
 							<amp-story-social-share layout="nodisplay">
 								<script type="application/json">{"shareProviders": ["facebook","whatsapp"]}</script>
 							</amp-story-social-share>

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -592,6 +592,19 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 									</amp-twitter>
 								</amp-story-page-attachment>
 							</amp-story-page>
+							<amp-story-page id="page1" auto-advance-after="video">
+								<amp-story-grid-layer template="fill">
+									<amp-video id="video" src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4" poster="https://example.com/poster.jpg" width="1280" height="720" layout="responsive" autoplay captions-id="captions">
+										<track kind="subtitles" src="https://example.com/captions.vtt" srclang="en" default>
+									</amp-video>
+								</amp-story-grid-layer>
+								<amp-story-grid-layer template="vertical" class="bottom">
+									<div class="scrim">
+										<amp-story-captions id="captions" layout="fixed-height" height="100"></amp-story-captions>
+										<div class="static-text">This element is always below captions and never overlaps.</div>
+									</div>
+								</amp-story-grid-layer>
+							</amp-story-page>
 							<amp-story-page id="interactive-poll">
 								<amp-story-grid-layer template="fill">
 									<amp-story-interactive-poll id="correct-poll" endpoint="https://webstoriesinteractivity-beta.web.app/api/v1" theme="dark" chip-style="shadow" class="nice-quiz" prompt-text="What country do you like the most?" option-1-text="France" option-1-confetti="🇺🇾" option-1-results-category="Dog" option-2-text="Spain" option-2-confetti="🇺🇾" option-2-results-category="Cat" option-3-text="Uruguay" option-3-confetti="🇺🇾" option-3-results-category="Bunny" option-4-text="Brazil" option-4-confetti="🇺🇾" option-4-results-category="Mouse">
@@ -649,6 +662,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 							'amp-story-panning-media',
 							'amp-date-display',
 							'amp-mustache',
+							'amp-story-captions',
 						],
 						[
 							[


### PR DESCRIPTION
Cherry-picks https://github.com/ampproject/amp-wp/pull/6651 (with modifications) onto `2.1` branch.