### PR TITLE
Propagate width/height styles as width/height attributes when setting layout

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -422,31 +422,24 @@ abstract class AMP_Base_Sanitizer {
 
 			// Make sure the width and height styles are copied to the width and height attributes since AMP will ultimately inline them as styles.
 			$pending_attributes = [];
-			$last_unit          = null;
+			$seen_units         = [];
 			foreach ( wp_array_slice_assoc( $styles, [ 'height', 'width' ] ) as $dimension => $value ) {
 				$value = $this->sanitize_dimension( $value, $dimension );
 				if ( '' === $value ) {
 					continue;
 				}
 
-				$this_unit = null;
 				if ( 'auto' !== $value ) {
 					$this_unit = preg_replace( '/^.*\d/', '', $value );
 					if ( ! $this_unit ) {
 						$this_unit = 'px';
 					}
-				}
-
-				// If the units do not match, then we have to abort since AMP requires this.
-				if ( $last_unit && $this_unit && $last_unit !== $this_unit ) {
-					$pending_attributes = [];
-					break;
+					$seen_units[ $this_unit ] = true;
 				}
 
 				$pending_attributes[ $dimension ] = $value;
-				$last_unit                        = $this_unit;
 			}
-			if ( $pending_attributes ) {
+			if ( $pending_attributes && count( $seen_units ) <= 1 ) {
 				$attributes = array_merge( $attributes, $pending_attributes );
 			}
 		}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -414,6 +414,15 @@ abstract class AMP_Base_Sanitizer {
 				$attributes['layout'] = 'fill';
 				return $attributes;
 			}
+
+			// If the width and height styles are provided (in percentage of pixels), override the width/height attributes.
+			$px_or_percentage_unit_pattern = '/^(\d+(?:\.\d+)?%|\d+(?:\.\d+)?(?=px))/';
+			if ( isset( $styles['height'] ) && preg_match( $px_or_percentage_unit_pattern, $styles['height'], $matches ) ) {
+				$attributes['height'] = $matches[1];
+			}
+			if ( isset( $styles['width'] ) && preg_match( $px_or_percentage_unit_pattern, $styles['width'], $matches ) ) {
+				$attributes['width'] = $matches[1];
+			}
 		}
 
 		if ( isset( $attributes['width'], $attributes['height'] ) && '100%' === $attributes['width'] && '100%' === $attributes['height'] ) {

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -144,6 +144,22 @@ class AMP_Iframe_Converter_Test extends TestCase {
 				',
 			],
 
+			'iframe_with_percentage_width_style_and_pixel_height_style' => [
+				'<iframe style="width: 100%; height: 200px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 100%; height: 200px;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="200" width="auto" layout="fixed-height" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			'iframe_with_pixel_width_style_and_pixel_height_style' => [
+				'<iframe style="width: 200.25px; height: 200.75px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 200.25px; height: 200.75px;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="200.75" width="200.25" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
 			'iframe_with_width_only'                    => [
 				'<iframe src="https://example.com/video/132886713" width="600"></iframe>',
 				'

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -144,7 +144,7 @@ class AMP_Iframe_Converter_Test extends TestCase {
 				',
 			],
 
-			'iframe_with_percentage_width_style_and_pixel_height_style' => [
+			'iframe_with_100_percentage_width_style_and_pixel_height_style' => [
 				'<iframe style="width: 100%; height: 200px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
 				'<amp-iframe style="width: 100%; height: 200px;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="200" width="auto" layout="fixed-height" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation"></amp-iframe>',
 				[
@@ -155,6 +155,42 @@ class AMP_Iframe_Converter_Test extends TestCase {
 			'iframe_with_pixel_width_style_and_pixel_height_style' => [
 				'<iframe style="width: 200.25px; height: 200.75px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
 				'<amp-iframe style="width: 200.25px; height: 200.75px;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="200.75" width="200.25" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			'iframe_with_vh_width_style_and_vh_height_style' => [
+				'<iframe style="width: 25vh; height:50vh" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 25vh; height:50vh" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="50vh" width="25vh" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			// Note: This case has width=auto instead of width=50% because percentages aren't allowed in AMP. Nevertheless,
+			// the original 50% width will still apply since fixed-height has max-width:100%.
+			'iframe_with_50_percentage_width_style_and_pixel_height_style' => [
+				'<iframe style="width: 50%; height: 200px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 50%; height: 200px;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="200" layout="fixed-height" width="auto" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			// AMP requires units to be the same, so when they are not, skip propagating.
+			'iframe_with_50_em_width_style_and_20vh_height_style' => [
+				'<iframe style="width: 50em; height: 20vh;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 50em; height: 20vh;" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="400" layout="fixed-height" width="auto" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation"></amp-iframe>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			// The pt unit is not supported in AMP so the result is fallback values for width and height.
+			'iframe_with_pt_width_style_and_pt_height_style' => [
+				'<iframe style="width: 123pt; height:50pt" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>',
+				'<amp-iframe style="width: 123pt; height:50pt" frameborder="0" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" height="400" layout="fixed-height" width="auto" sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation"></amp-iframe>',
 				[
 					'add_noscript_fallback' => false,
 				],
@@ -647,6 +683,8 @@ class AMP_Iframe_Converter_Test extends TestCase {
 	 * @covers ::get_origin_from_url()
 	 * @covers ::build_placeholder()
 	 * @covers ::sanitize_boolean_digit()
+	 * @covers \AMP_Base_Sanitizer::set_layout()
+	 * @covers \AMP_Base_Sanitizer::sanitize_dimension()
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -305,13 +305,13 @@ class AMP_Base_Sanitizer_Test extends TestCase {
 
 			'100%_width__with_max' => [
 				[ '100%', 'width' ],
-				600,
+				'auto',
 				[ 'content_max_width' => 600 ],
 			],
 
 			'100%_width__no_max'   => [
 				[ '100%', 'width' ],
-				'',
+				'auto',
 			],
 
 			'50%_width__with_max'  => [


### PR DESCRIPTION
## Summary

Addresses issue raised in [support topic](https://wordpress.org/support/topic/amp-iframe-forcing-400px-height).

The `AMP_Base_Sanitizer::set_layout()` method was extracting `width`/`height` styles, but it was only considering the `100%` value case. This ensures that other values are also propagated to the resulting `width`/`height` attributes on the AMP element.

Given this markup:

```html
<iframe style="width: 100%; height: 200px;" frameborder="no" scrolling="no" src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1"></iframe>
```

Before:

```html
<amp-iframe
		style="width: 100%; height: 200px;"
		frameborder="0"
		scrolling="no"
		src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" 
		height="400"
		layout="fixed-height" 
		width="auto"
		sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation">
</amp-iframe>
```

After:

```html
<amp-iframe 
		style="width: 100%; height: 200px;"
		frameborder="0"
		scrolling="no" 
		src="https://player.captivate.fm/episode/495621d8-6f05-4d95-bbaa-369a9a6189e1" 
		height="200"
		width="auto" 
		layout="fixed-height" 
		sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation-by-user-activation">
</amp-iframe>
```

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
