### PR TITLE
Add validation error source attribution for script translations and `wp_editor()`

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1028,25 +1028,22 @@ class AMP_Validation_Manager {
 				if ( $matches['handle'] !== $style_handle ) {
 					continue;
 				}
-				foreach ( self::$enqueued_style_sources as $enqueued_style_sources_handle => $enqueued_style_sources ) {
-					if (
-						$enqueued_style_sources_handle !== $style_handle
-						&&
-						wp_styles()->query( $enqueued_style_sources_handle, 'done' )
-						&&
-						self::has_dependency( wp_styles(), $enqueued_style_sources_handle, $style_handle )
-					) {
-						$sources = array_merge(
-							array_map(
-								static function ( $enqueued_style_source ) use ( $style_handle ) {
-									$enqueued_style_source['dependency_handle'] = $style_handle;
-									return $enqueued_style_source;
-								},
-								$enqueued_style_sources
-							),
-							$sources
-						);
-					}
+
+				foreach (
+					self::find_done_dependent_handles( wp_styles(), $style_handle, array_keys( self::$enqueued_style_sources ) )
+					as
+					$enqueued_style_sources_handle
+				) {
+					$sources = array_merge(
+						array_map(
+							static function ( $enqueued_style_source ) use ( $style_handle ) {
+								$enqueued_style_source['dependency_handle'] = $style_handle;
+								return $enqueued_style_source;
+							},
+							self::$enqueued_style_sources[ $enqueued_style_sources_handle ]
+						),
+						$sources
+					);
 				}
 			}
 		}
@@ -1100,25 +1097,22 @@ class AMP_Validation_Manager {
 					if ( ! self::is_matching_script( $node, $script_handle ) ) {
 						continue;
 					}
-					foreach ( self::$enqueued_script_sources as $enqueued_script_sources_handle => $enqueued_script_sources ) {
-						if (
-							$enqueued_script_sources_handle !== $script_handle
-							&&
-							wp_scripts()->query( $enqueued_script_sources_handle, 'done' )
-							&&
-							self::has_dependency( wp_scripts(), $enqueued_script_sources_handle, $script_handle )
-						) {
-							$sources = array_merge(
-								array_map(
-									static function ( $enqueued_script_source ) use ( $script_handle ) {
-										$enqueued_script_source['dependency_handle'] = $script_handle;
-										return $enqueued_script_source;
-									},
-									$enqueued_script_sources
-								),
-								$sources
-							);
-						}
+
+					foreach (
+						self::find_done_dependent_handles( wp_scripts(), $script_handle, array_keys( self::$enqueued_script_sources ) )
+						as
+						$enqueued_script_sources_handle
+					) {
+						$sources = array_merge(
+							array_map(
+								static function ( $enqueued_script_source ) use ( $script_handle ) {
+									$enqueued_script_source['dependency_handle'] = $script_handle;
+									return $enqueued_script_source;
+								},
+								self::$enqueued_script_sources[ $enqueued_script_sources_handle ]
+							),
+							$sources
+						);
 					}
 				}
 			} elseif ( $node->firstChild instanceof DOMText ) {
@@ -1141,25 +1135,22 @@ class AMP_Validation_Manager {
 					if ( isset( self::$enqueued_script_sources[ $script_handle ] ) ) {
 						$sources = array_merge( $sources, self::$enqueued_script_sources[ $script_handle ] );
 					}
-					foreach ( self::$enqueued_script_sources as $enqueued_script_sources_handle => $enqueued_script_sources ) {
-						if (
-							$enqueued_script_sources_handle !== $script_handle
-							&&
-							wp_scripts()->query( $enqueued_script_sources_handle, 'done' )
-							&&
-							self::has_dependency( wp_scripts(), $enqueued_script_sources_handle, $script_handle )
-						) {
-							$sources = array_merge(
-								array_map(
-									static function ( $enqueued_script_source ) use ( $script_handle ) {
-										$enqueued_script_source['dependency_handle'] = $script_handle;
-										return $enqueued_script_source;
-									},
-									$enqueued_script_sources
-								),
-								$sources
-							);
-						}
+
+					foreach (
+						self::find_done_dependent_handles( wp_scripts(), $script_handle, array_keys( self::$enqueued_script_sources ) )
+						as
+						$enqueued_script_sources_handle
+					) {
+						$sources = array_merge(
+							array_map(
+								static function ( $enqueued_script_source ) use ( $script_handle ) {
+									$enqueued_script_source['dependency_handle'] = $script_handle;
+									return $enqueued_script_source;
+								},
+								self::$enqueued_script_sources[ $enqueued_script_sources_handle ]
+							),
+							$sources
+						);
 					}
 				} else {
 					// Identify the inline script sources.
@@ -1185,25 +1176,22 @@ class AMP_Validation_Manager {
 							if ( isset( self::$enqueued_script_sources[ $script_handle ] ) ) {
 								$sources = array_merge( $sources, self::$enqueued_script_sources[ $script_handle ] );
 							}
-							foreach ( self::$enqueued_script_sources as $enqueued_script_sources_handle => $enqueued_script_sources ) {
-								if (
-									$enqueued_script_sources_handle !== $script_handle
-									&&
-									wp_scripts()->query( $enqueued_script_sources_handle, 'done' )
-									&&
-									self::has_dependency( wp_scripts(), $enqueued_script_sources_handle, $script_handle )
-								) {
-									$sources = array_merge(
-										array_map(
-											static function ( $enqueued_script_source ) use ( $script_handle ) {
-												$enqueued_script_source['dependency_handle'] = $script_handle;
-												return $enqueued_script_source;
-											},
-											$enqueued_script_sources
-										),
-										$sources
-									);
-								}
+
+							foreach (
+								self::find_done_dependent_handles( wp_scripts(), $script_handle, array_keys( self::$enqueued_script_sources ) )
+								as
+								$enqueued_script_sources_handle
+							) {
+								$sources = array_merge(
+									array_map(
+										static function ( $enqueued_script_source ) use ( $script_handle ) {
+											$enqueued_script_source['dependency_handle'] = $script_handle;
+											return $enqueued_script_source;
+										},
+										self::$enqueued_script_sources[ $enqueued_script_sources_handle ]
+									),
+									$sources
+								);
 							}
 						}
 					}
@@ -1221,6 +1209,30 @@ class AMP_Validation_Manager {
 		$sources = array_values( array_unique( $sources, SORT_REGULAR ) );
 
 		return $sources;
+	}
+
+	/**
+	 * Find dependent handles that have been printed.
+	 *
+	 * @param WP_Dependencies $dependencies Dependencies.
+	 * @param string          $handle Handle.
+	 * @param string[]        $enqueued_handles Enqueued handles.
+	 * @return string[] Found handles.
+	 */
+	private static function find_done_dependent_handles( WP_Dependencies $dependencies, $handle, $enqueued_handles ) {
+		$dependent_handles = [];
+		foreach ( $enqueued_handles as $enqueued_handle ) {
+			if (
+				$handle !== $enqueued_handle
+				&&
+				wp_scripts()->query( $enqueued_handle, 'done' )
+				&&
+				self::has_dependency( $dependencies, $enqueued_handle, $handle )
+			) {
+				$dependent_handles[] = $enqueued_handle;
+			}
+		}
+		return $dependent_handles;
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1208,6 +1208,13 @@ class AMP_Validation_Manager {
 						}
 					}
 				}
+
+				// Add indirect sources for inline scripts added by wp_editor().
+				foreach ( $sources as $source ) {
+					if ( isset( $source['function'] ) && '_WP_Editors::editor_js' === $source['function'] ) {
+						$sources = array_merge( $sources, self::$wp_editor_sources );
+					}
+				}
 			}
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -5,7 +5,6 @@
  * @package AMP
  */
 
-use AmpProject\AmpWP\DevTools\FileReflection;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Icon;
 use AmpProject\AmpWP\Option;
@@ -696,16 +695,10 @@ class AMP_Validation_Manager {
 		add_filter( 'embed_oembed_html', [ __CLASS__, 'decorate_embed_source' ], PHP_INT_MAX, 3 );
 		add_filter( 'the_content', [ __CLASS__, 'add_block_source_comments' ], 8 ); // The do_blocks() function runs at priority 9.
 
-		// @todo add_filter( 'the_editor_content' ); // Flag all enqueued TinyMCE scripts as being sourced by the callback.
-		// @todo add_filter( 'quicktags_settings' ); // Flag all enqueued Quicktags scripts as being sourced by the callback.
-
 		add_filter(
 			'the_editor',
 			function ( $editor ) {
 				$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Only way to find theme/plugin responsible for calling.
-
-//				error_log( json_encode( self::$hook_source_stack, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-//				return $editor;
 
 				$file_reflection = Services::get( 'dev_tools.file_reflection' );
 
@@ -722,53 +715,7 @@ class AMP_Validation_Manager {
 						}
 						break;
 					}
-//
-//					continue;
-//
-//					$source = $file_reflection->get_file_source( $call_stack['file'] );
-//					if (
-//						empty( $source )
-//						||
-//						FileReflection::TYPE_CORE === $source[ FileReflection::SOURCE_TYPE ]
-//						||
-//						(
-//							FileReflection::TYPE_PLUGIN === $source[ FileReflection::SOURCE_TYPE ]
-//							&&
-//							'amp' === $source[ FileReflection::SOURCE_NAME ]
-//						)
-//					) {
-//						continue;
-//					}
-//
-//					error_log( json_encode( $call_stack, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-//
-//					error_log( json_encode( $source, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-//
-//
-//
-//
-//					if ( '{closure}' === $call_stack['function'] ) {
-//
-//					}
-
-
-//					if ( '{closure}' === $call_stack['function'] ) {
-//						$called_functions[] = 'Closure::__invoke';
-//					} elseif ( isset( $call_stack['class'] ) ) {
-//						$called_functions[] = sprintf( '%s::%s', $call_stack['class'], $call_stack['function'] );
-//					} else {
-//						$called_functions[] = $call_stack['function'];
-//					}
 				}
-//
-//				self::$wp_editor_backtraces[] = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-//
-//
-//				$callback_reflection = Services::get( 'dev_tools.callback_reflection' );
-//				$callback_source     = $callback_reflection->get_source( $render_callback );
-//
-//				$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-//				error_log( json_encode( $backtrace, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 
 				return $editor;
 			}
@@ -1401,16 +1348,6 @@ class AMP_Validation_Manager {
 					'_WP_Editors::force_uncompressed_tinymce' === $source['function']
 				) {
 					$indirect_sources = self::$wp_editor_sources;
-				}
-
-				if ( '_WP_Editors::force_uncompressed_tinymce' === $source['function'] ) {
-					error_log('boom');
-					error_log( json_encode( $source, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-				}
-
-				if ( '_WP_Editors::editor_js' === $source['function'] ) {
-					error_log('var ajaxurl =??');
-					error_log( json_encode( $indirect_sources, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 				}
 
 				/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1519,12 +1519,7 @@ class AMP_Validation_Manager {
 
 		// Check if any functions in call stack are output buffering display handlers.
 		$called_functions = [];
-		if ( defined( 'DEBUG_BACKTRACE_IGNORE_ARGS' ) ) {
-			$arg = DEBUG_BACKTRACE_IGNORE_ARGS; // phpcs:ignore PHPCompatibility.Constants.NewConstants.debug_backtrace_ignore_argsFound
-		} else {
-			$arg = false;
-		}
-		$backtrace = debug_backtrace( $arg ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Only way to find out if we are in a buffering display handler.
+		$backtrace        = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Only way to find out if we are in a buffering display handler.
 		foreach ( $backtrace as $call_stack ) {
 			if ( '{closure}' === $call_stack['function'] ) {
 				$called_functions[] = 'Closure::__invoke';

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1223,9 +1223,9 @@ class AMP_Validation_Manager {
 		$dependent_handles = [];
 		foreach ( $enqueued_handles as $enqueued_handle ) {
 			if (
-				$handle !== $enqueued_handle
+				$enqueued_handle !== $handle
 				&&
-				wp_scripts()->query( $enqueued_handle, 'done' )
+				$dependencies->query( $enqueued_handle, 'done' )
 				&&
 				self::has_dependency( $dependencies, $enqueued_handle, $handle )
 			) {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1434,13 +1434,7 @@ class AMP_Validation_Manager {
 				}
 
 				$indirect_sources = [];
-				if (
-					'_WP_Editors::enqueue_scripts' === $source['function']
-					||
-					'_WP_Editors::editor_js' === $source['function'] // @todo This is actually printing script! So there is no handle.
-					||
-					'_WP_Editors::force_uncompressed_tinymce' === $source['function']
-				) {
+				if ( '_WP_Editors::enqueue_scripts' === $source['function'] ) {
 					$indirect_sources = self::$wp_editor_sources;
 				}
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1050,10 +1050,19 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					add_action(
 						'wp_enqueue_scripts',
 						static function () {
+							wp_register_script(
+								'bar',
+								'https://example.com/bar.js',
+								[],
+								'0.1',
+								true
+							);
+							wp_add_inline_script( 'bar', '/*Hello after Bar!*/', 'after' );
+
 							wp_enqueue_script(
 								'baz',
 								'https://example.com/baz.js',
-								[],
+								[ 'bar' ],
 								'0.1',
 								true
 							);
@@ -1061,8 +1070,26 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 						}
 					);
 				},
-				'//script[ contains( text(), "Hello before Baz!" ) ]',
-				function ( $sources ) {
+				[
+					'//script[ contains( text(), "Hello after Bar!" ) ]',
+					'//script[ contains( text(), "Hello before Baz!" ) ]',
+				],
+				function ( ...$sources_sets ) {
+					$this->assertCount( 2, $sources_sets );
+					$this->assertArraySubset(
+						[
+							'type'            => 'plugin',
+							'name'            => 'amp',
+							'function'        => '{closure}',
+							'hook'            => 'wp_enqueue_scripts',
+							'priority'        => 10,
+							'dependency_type' => 'script',
+							'extra_key'       => 'after',
+							'text'            => '/*Hello after Bar!*/',
+							'handle'          => 'bar',
+						],
+						$sources_sets[0][2]
+					);
 					$this->assertArraySubset(
 						[
 							'type'            => 'plugin',
@@ -1075,7 +1102,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 							'text'            => '/*Hello before Baz!*/',
 							'handle'          => 'baz',
 						],
-						$sources[2]
+						$sources_sets[1][2]
 					);
 				},
 			],
@@ -1153,7 +1180,18 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			],
 
 			'wp_editor_has_scripts_attributed'           => [
-				static function () {
+				function () {
+					if ( version_compare( get_bloginfo( 'version' ), '5.2', '<=' ) ) {
+						$this->markTestSkipped( 'The script ID attribute was only added to inline scripts in WP 5.2.' );
+					}
+
+					add_action(
+						'wp_enqueue_scripts',
+						static function () {
+							wp_add_inline_script( 'jquery-core', '/*After before-jquery*/', 'before' );
+							wp_add_inline_script( 'jquery-core', '/*After after-jquery*/', 'after' );
+						}
+					);
 					add_action(
 						'wp_body_open',
 						static function () {
@@ -1162,6 +1200,8 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					);
 				},
 				[
+					'//script[ @id = "jquery-core-js-before" ]',
+					'//script[ @id = "jquery-core-js-after" ]',
 					'//script[ @id = "wp-dom-ready-js" ]',
 					'//script[ @id = "wp-dom-ready-js-translations" ]',
 					'//script[ @id = "quicktags-js" ]',
@@ -1169,7 +1209,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'//script[ contains( text(), "window.wpActiveEditor" ) ]',
 				],
 				function ( ...$sources_sets ) {
-					$this->assertCount( 5, $sources_sets );
+					$this->assertCount( 7, $sources_sets );
 					foreach ( $sources_sets as $sources ) {
 						$amp_source_count = 0;
 						foreach ( $sources as $source ) {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -609,8 +609,9 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		$this->assertEquals( 10, has_action( 'all', [ self::TESTED_CLASS, 'wrap_hook_callbacks' ] ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_content', [ self::TESTED_CLASS, 'decorate_filter_source' ] ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_excerpt', [ self::TESTED_CLASS, 'decorate_filter_source' ] ) );
-		$this->assertEquals( PHP_INT_MAX, has_action( 'do_shortcode_tag', [ self::TESTED_CLASS, 'decorate_shortcode_source' ] ) );
-		$this->assertEquals( 8, has_action( 'the_content', [ self::TESTED_CLASS, 'add_block_source_comments' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'do_shortcode_tag', [ self::TESTED_CLASS, 'decorate_shortcode_source' ] ) );
+		$this->assertEquals( 8, has_filter( 'the_content', [ self::TESTED_CLASS, 'add_block_source_comments' ] ) );
+		$this->assertEquals( 10, has_filter( 'the_editor', [ self::TESTED_CLASS, 'filter_the_editor_to_detect_sources' ] ) );
 	}
 
 	/**
@@ -1229,6 +1230,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 *
 	 * @dataProvider get_locate_sources_data
 	 * @covers AMP_Validation_Manager::locate_sources()
+	 * @covers AMP_Validation_Manager::filter_the_editor_to_detect_sources()
 	 * @covers AMP_Validation_Callback_Wrapper
 	 *
 	 * @param callable        $callback Callback set up (add actions).

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1214,7 +1214,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 				<?php wp_head(); ?>
 			</head>
 			<body>
-				<?php wp_body_open(); ?>
+				<?php do_action( 'wp_body_open' ); ?>
 				<?php wp_footer(); ?>
 			</body>
 		</html>

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1166,19 +1166,6 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	 * @param callable $assert   Function to assert the expected sources.
 	 */
 	public function test_locate_sources_e2e( $callback, $xpath, $assert ) {
-		// @todo Remove once https://github.com/WordPress/gutenberg/pull/23104 is in a release.
-		// Temporarily fixes an issue with PHP errors being thrown in Gutenberg v8.3.0 on PHP 7.4.
-		$theme_features = [
-			'editor-color-palette',
-			'editor-gradient-presets',
-			'editor-font-sizes',
-		];
-		foreach ( $theme_features as $theme_feature ) {
-			if ( ! current_theme_supports( $theme_feature ) ) {
-				add_theme_support( $theme_feature, [] );
-			}
-		}
-
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Validation_Manager::add_validation_error_sourcing();
 		$callback();


### PR DESCRIPTION
## Summary

Given a site in Transitional mode, with the  and the bbPress plugin active there being an “Interesting Stuff” forum created, as well as an “Enqueue Foo” plugin active that does the following:

```php
<?php
/**
 * Plugin Name: Enqueue Foo
 */

add_action(
	'wp_enqueue_scripts',
	function () {
		wp_register_script( 'bar', plugin_dir_url( __FILE__ ) . 'bar.js', [], false, true );
		wp_set_script_translations( 'bar', 'bar' );

		wp_enqueue_script( 'foo', plugin_dir_url( __FILE__ ) . 'foo.js', [ 'bar' ], false, true );
		wp_set_script_translations( 'foo', 'foo' );
	}
);
```

Attempting to validate a singular forum page at `/forums/forum/interesting-stuff/amp/` results in the following difference with this PR:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/139752494-d20897ea-f870-4626-802a-a6bdcad28564.png) | ![image](https://user-images.githubusercontent.com/134745/139752516-e63b0b98-a9e8-4b70-afbb-6aff4cdd76df.png)

Instead of scripts being unexpectedly attributed to `wp-includes`:

* Script translations are now properly attributed to the plugin that caused them to be added to the page. Fixes #4750.
* When a template file causes a script to be enqueued (as opposed to a hook) specifically in the case of bbPress calling `wp_editor()`, the editor scripts are now attributed to the plugin that caused them to be added. Fixes #6668.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
