### PR TITLE
Mark scripts output by `wp_comment_form_unfiltered_html_nonce()` and `wp_post_preview_js()` as being in AMP Dev Mode

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1608,6 +1608,11 @@ function amp_get_content_sanitizers( $post = null ) {
 			$dev_mode_xpaths[] = '//style[ @id = "custom-theme-colors" ]';
 		}
 
+		// Mark the script output by wp_comment_form_unfiltered_html_nonce() as being in dev mode.
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$dev_mode_xpaths[] = '//script[ not( @src ) and preceding-sibling::input[ @name = "_wp_unfiltered_html_comment_disabled" ] and contains( text(), "_wp_unfiltered_html_comment_disabled" ) ]';
+		}
+
 		$sanitizers = array_merge(
 			[
 				AMP_Dev_Mode_Sanitizer::class => [

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1613,6 +1613,14 @@ function amp_get_content_sanitizers( $post = null ) {
 			$dev_mode_xpaths[] = '//script[ not( @src ) and preceding-sibling::input[ @name = "_wp_unfiltered_html_comment_disabled" ] and contains( text(), "_wp_unfiltered_html_comment_disabled" ) ]';
 		}
 
+		// Mark the script output by wp_post_preview_js() as being in dev mode.
+		if ( is_preview() && get_queried_object() instanceof WP_Post ) {
+			$dev_mode_xpaths[] = sprintf(
+				'//script[ not( @src ) and contains( text(), "document.location.search" ) and contains( text(), "preview=true" ) and contains( text(), "unload" ) and contains( text(), "window.name" ) and contains( text(), "wp-preview-%d" ) ]',
+				get_queried_object_id()
+			);
+		}
+
 		$sanitizers = array_merge(
 			[
 				AMP_Dev_Mode_Sanitizer::class => [

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -845,9 +845,8 @@ class AMP_Theme_Support {
 	 */
 	public static function add_hooks() {
 
-		// Remove core actions which are invalid AMP.
-		remove_action( 'wp_head', 'wp_post_preview_js', 1 ); // @todo Instead of function, the script output by wp_post_preview_js() should get data-ampdevmode.
-		remove_action( 'wp_head', 'wp_oembed_add_host_js' ); // This is not needed when post embeds are embedded via <amp-wordpress-embed>. See <https://github.com/ampproject/amp-wp/issues/809>.
+		// This is not needed when post embeds are embedded via <amp-wordpress-embed>. See <https://github.com/ampproject/amp-wp/issues/809>.
+		remove_action( 'wp_head', 'wp_oembed_add_host_js' );
 
 		// Prevent emoji detection and emoji loading since platforms/browsers now support emoji natively (and Twemoji is not AMP-compatible).
 		add_filter( 'wp_resource_hints', [ __CLASS__, 'filter_resource_hints_to_remove_emoji_dns_prefetch' ], 10, 2 );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1806,6 +1806,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		remove_filter( 'amp_dev_mode_enabled', '__return_true' );
 
 		// Check that AMP_Dev_Mode_Sanitizer is registered once in dev mode, and now also with admin bar showing.
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		add_filter( 'show_admin_bar', '__return_true' );
 		$sanitizers = amp_get_content_sanitizers();
@@ -1819,6 +1820,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 					'//*[ @id = "wpadminbar" ]',
 					'//*[ @id = "wpadminbar" ]//*',
 					'//style[ @id = "admin-bar-inline-css" ]',
+					'//script[ not( @src ) and preceding-sibling::input[ @name = "_wp_unfiltered_html_comment_disabled" ] and contains( text(), "_wp_unfiltered_html_comment_disabled" ) ]',
 				]
 			),
 			$sanitizers[ AMP_Dev_Mode_Sanitizer::class ]['element_xpaths']

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -772,7 +772,6 @@ class Test_AMP_Theme_Support extends TestCase {
 	 */
 	public function test_add_hooks() {
 		AMP_Theme_Support::add_hooks();
-		$this->assertFalse( has_action( 'wp_head', 'wp_post_preview_js' ) );
 		$this->assertFalse( has_action( 'wp_head', 'wp_oembed_add_host_js' ) );
 
 		$this->assertEquals( 10, has_filter( 'wp_resource_hints', [ self::TESTED_CLASS, 'filter_resource_hints_to_remove_emoji_dns_prefetch' ] ) );


### PR DESCRIPTION
## Summary

When in Transitional mode, I started seeing a validation error for the `script` output by `wp_comment_form_unfiltered_html_nonce()`. This is a regression introduced by #6546, where this `script` is exempted from validation but currently only in Standard mode and when Sandboxing is enabled. This PR ensures that the script is exempted for using Dev Mode when Sandboxing is not enabled.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/140013236-8f6ec4f7-69fe-4331-9fbf-59bfa2aa8cd9.png) | ![image](https://user-images.githubusercontent.com/134745/140013328-685ea882-3962-42fd-8a4a-46722a1497cc.png)

This also takes the same approach to no longer suppress the script output by `wp_post_preview_js()` which is output when previewing a post.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
