### PR TITLE
Add service for entity registrant detection

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -35,6 +35,7 @@ namespace PHPSTORM_META {
 			'dev_tools.likely_culprit_detector'  => \AmpProject\AmpWP\DevTools\LikelyCulpritDetector::class,
 			'dev_tools.user_access'              => \AmpProject\AmpWP\DevTools\UserAccess::class,
 			'editor.editor_support'              => \AmpProject\AmpWP\Editor\EditorSupport::class,
+			'entity_registrant_detection'        => \AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager::class,
 			'extra_theme_and_plugin_headers'     => \AmpProject\AmpWP\ExtraThemeAndPluginHeaders::class,
 			'injector'                           => \AmpProject\AmpWP\Infrastructure\Injector::class,
 			'loading_error'                      => \AmpProject\AmpWP\LoadingError::class,

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -50,6 +50,7 @@ namespace PHPSTORM_META {
 			'plugin_suppression'                 => \AmpProject\AmpWP\PluginSuppression::class,
 			'reader_theme_loader'                => \AmpProject\AmpWP\ReaderThemeLoader::class,
 			'reader_theme_support_features'      => \AmpProject\AmpWP\ReaderThemeSupportFeatures::class,
+			'rest.entity_registrant_detection'   => \AmpProject\AmpWP\EntityRegistrantDetection\RestController::class,
 			'rest.options_controller'            => \AmpProject\AmpWP\OptionsRESTController::class,
 			'rest.scannable_urls_controller'     => \AmpProject\AmpWP\Validation\ScannableURLsRestController::class,
 			'rest.validation_counts_controller'  => \AmpProject\AmpWP\Validation\ValidationCountsRestController::class,

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -214,6 +214,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 			DependencySupport::class,
 			DevTools\CallbackReflection::class,
 			DevTools\FileReflection::class,
+			EntityRegistrantDetectionManager::class,
 			ReaderThemeLoader::class,
 			ReaderThemeSupportFeatures::class,
 			BackgroundTask\BackgroundTaskDeactivator::class,

--- a/src/AmpWpPlugin.php
+++ b/src/AmpWpPlugin.php
@@ -10,6 +10,7 @@ namespace AmpProject\AmpWP;
 use AmpProject\AmpWP\Admin;
 use AmpProject\AmpWP\BackgroundTask;
 use AmpProject\AmpWP\BackgroundTask\BackgroundTaskDeactivator;
+use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
 use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Infrastructure\ServiceBasedPlugin;
 use AmpProject\AmpWP\Instrumentation;
@@ -100,6 +101,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 		'dev_tools.likely_culprit_detector'  => DevTools\LikelyCulpritDetector::class,
 		'dev_tools.user_access'              => DevTools\UserAccess::class,
 		'editor.editor_support'              => Editor\EditorSupport::class,
+		'entity_registrant_detection'        => EntityRegistrantDetectionManager::class,
 		'extra_theme_and_plugin_headers'     => ExtraThemeAndPluginHeaders::class,
 		'loading_error'                      => LoadingError::class,
 		'mobile_redirection'                 => MobileRedirection::class,
@@ -113,6 +115,7 @@ final class AmpWpPlugin extends ServiceBasedPlugin {
 		'plugin_suppression'                 => PluginSuppression::class,
 		'reader_theme_loader'                => ReaderThemeLoader::class,
 		'reader_theme_support_features'      => ReaderThemeSupportFeatures::class,
+		'rest.entity_registrant_detection'   => EntityRegistrantDetection\RestController::class,
 		'rest.options_controller'            => OptionsRESTController::class,
 		'rest.scannable_urls_controller'     => Validation\ScannableURLsRestController::class,
 		'rest.validation_counts_controller'  => Validation\ValidationCountsRestController::class,

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Class CallbackWrapper.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection;
+
+use AmpProject\AmpWP\Services;
+use WP_Block_Type_Registry;
+
+/**
+ * Callback wrapper for EntityRegistrantDetection.
+ *
+ * @since   2.2
+ * @package AmpProject\AmpWP
+ * @internal
+ */
+class CallbackWrapper {
+
+	/**
+	 * Callback data.
+	 *
+	 * @var array
+	 */
+	protected $callback;
+
+	/**
+	 * Source of the function.
+	 *
+	 * @var array
+	 */
+	protected $source;
+
+	/**
+	 * List of registered entities by callback.
+	 *
+	 * @var array [
+	 *     @type array $post_type List of registered post types slug.
+	 *     @type array $taxonomy  List of registered taxonomy slug.
+	 *     @type array $block     List of registered block type.
+	 *     @type array $shortcode List of registered shortcode.
+	 * ]
+	 */
+	protected $registered_entities;
+
+	/**
+	 * AMP_Validation_Callback_Wrapper constructor.
+	 *
+	 * @param array $callback [
+	 *     The callback data.
+	 *     @type callable $function
+	 *     @type int      $accepted_args
+	 * ]
+	 */
+	public function __construct( $callback ) {
+
+		$this->callback            = $callback;
+		$this->registered_entities = [
+			'post_type' => [],
+			'taxonomy'  => [],
+			'block'     => [],
+			'shortcode' => [],
+		];
+	}
+
+	/**
+	 * Get callback function.
+	 *
+	 * @return callable
+	 */
+	public function get_callback_function() {
+
+		return $this->callback['function'];
+	}
+
+	/**
+	 * Invoke wrapped callback.
+	 *
+	 * @param array ...$args Args.
+	 *
+	 * @return mixed Response.
+	 */
+	public function __invoke( ...$args ) {
+
+		$this->prepare();
+
+		$result = call_user_func_array(
+			$this->get_callback_function(),
+			array_slice( $args, 0, (int) $this->callback['accepted_args'] )
+		);
+
+		$this->finalize();
+
+		return $result;
+	}
+
+	/**
+	 * Set the source of callback function.
+	 *
+	 * @return void
+	 */
+	protected function set_source() {
+
+		$callback_reflection = Services::get( 'dev_tools.callback_reflection' );
+		$this->source        = $callback_reflection->get_source( $this->get_callback_function() );
+
+		unset( $this->source['reflection'] );
+
+		if ( $this->callback['hook'] ) {
+			$this->source['hook'] = $this->callback['hook'];
+		}
+
+		if ( $this->callback['priority'] ) {
+			$this->source['priority'] = $this->callback['priority'];
+		}
+	}
+
+	/**
+	 * Collect the currently registered entities before executing the original function.
+	 *
+	 * @return void
+	 */
+	protected function prepare() {
+
+		$this->registered_entities = $this->get_registered_entities();
+	}
+
+	/**
+	 * Find the different of registered entities between before and after executing function.
+	 *
+	 * @return void
+	 */
+	protected function finalize() {
+
+		$final_registered_entities = $this->get_registered_entities();
+
+		foreach ( $this->registered_entities as $entity_type => $entities ) {
+
+			$different = array_diff(
+				$final_registered_entities[ $entity_type ],
+				$this->registered_entities[ $entity_type ]
+			);
+
+			if ( $different && empty( $this->source ) ) {
+				$this->set_source();
+			}
+
+			$this->registered_entities[ $entity_type ] = $different;
+
+			EntityRegistrantDetectionManager::add_source( $entity_type, $different, $this->source );
+		}
+
+	}
+
+	/**
+	 * Collect the currently registered entities.
+	 *
+	 * @return array [
+	 *     @type array $post_type List of registered post types slug.
+	 *     @type array $taxonomy  List of registered taxonomy slug.
+	 *     @type array $block     List of registered block type.
+	 *     @type array $shortcode List of registered shortcode.
+	 * ]
+	 */
+	protected function get_registered_entities() {
+
+		global $shortcode_tags;
+
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		return [
+			'post_type' => array_values( get_post_types() ),
+			'taxonomy'  => array_values( get_taxonomies() ),
+			'block'     => array_keys( $block_types ),
+			'shortcode' => array_keys( $shortcode_tags ),
+		];
+	}
+}

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -54,7 +54,7 @@ class CallbackWrapper implements ArrayAccess {
 	 *     @type callable $function
 	 *     @type int      $accepted_args
 	 *     @type int      $priority
-	 *     @type int      $hook
+	 *     @type string   $hook
 	 * ]
 	 */
 	public function __construct( $callback ) {
@@ -145,6 +145,7 @@ class CallbackWrapper implements ArrayAccess {
 				$final_registered_entities[ $entity_type ],
 				$this->registered_entities[ $entity_type ]
 			);
+			$different = array_values( $different );
 
 			if ( $different && empty( $this->source ) ) {
 				$this->set_source();

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -7,7 +7,7 @@
 
 namespace AmpProject\AmpWP\EntityRegistrantDetection;
 
-use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\DevTools\CallbackReflection;
 use ArrayAccess;
 use WP_Block_Type_Registry;
 
@@ -144,9 +144,25 @@ class CallbackWrapper implements ArrayAccess {
 	protected $registered_entities;
 
 	/**
+	 * Instance of EntityRegistrantDetectionManager.
+	 *
+	 * @var EntityRegistrantDetectionManager
+	 */
+	protected $detection_manager;
+
+	/**
+	 * Callback reflection.
+	 *
+	 * @var CallbackReflection
+	 */
+	protected $callback_reflection;
+
+	/**
 	 * AMP_Validation_Callback_Wrapper constructor.
 	 *
-	 * @param array $callback [
+	 * @param EntityRegistrantDetectionManager $detection_manager   Instance of EntityRegistrantDetectionManager.
+	 * @param CallbackReflection               $callback_reflection Instance of CallbackReflection.
+	 * @param array                            $callback            [
 	 *     The callback data.
 	 *     @type callable $function
 	 *     @type int      $accepted_args
@@ -154,8 +170,10 @@ class CallbackWrapper implements ArrayAccess {
 	 *     @type string   $hook
 	 * ]
 	 */
-	public function __construct( $callback ) {
+	public function __construct( EntityRegistrantDetectionManager $detection_manager, CallbackReflection $callback_reflection, $callback ) {
 
+		$this->detection_manager   = $detection_manager;
+		$this->callback_reflection = $callback_reflection;
 		$this->callback            = $callback;
 		$this->registered_entities = [
 			'post_type' => [],
@@ -203,8 +221,7 @@ class CallbackWrapper implements ArrayAccess {
 	 */
 	protected function set_source() {
 
-		$callback_reflection = Services::get( 'dev_tools.callback_reflection' );
-		$this->source        = $callback_reflection->get_source( $this->get_callback_function() );
+		$this->source = $this->callback_reflection->get_source( $this->get_callback_function() );
 
 		unset( $this->source['reflection'] );
 
@@ -251,7 +268,7 @@ class CallbackWrapper implements ArrayAccess {
 
 			$this->registered_entities[ $entity_type ] = $different;
 
-			EntityRegistrantDetectionManager::add_source( $entity_type, $different, $this->source );
+			$this->detection_manager->add_source( $entity_type, $different, $this->source );
 		}
 
 	}

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -97,7 +97,7 @@ class CallbackWrapper {
 	}
 
 	/**
-	 * Set the source of callback function.
+	 * Set the source of a callback function.
 	 *
 	 * @return void
 	 */
@@ -128,7 +128,7 @@ class CallbackWrapper {
 	}
 
 	/**
-	 * Find the different of registered entities between before and after executing function.
+	 * Find the difference of registered entities between before and after executing function.
 	 *
 	 * @return void
 	 */

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -8,6 +8,7 @@
 namespace AmpProject\AmpWP\EntityRegistrantDetection;
 
 use AmpProject\AmpWP\Services;
+use ArrayAccess;
 use WP_Block_Type_Registry;
 
 /**
@@ -17,7 +18,7 @@ use WP_Block_Type_Registry;
  * @package AmpProject\AmpWP
  * @internal
  */
-class CallbackWrapper {
+class CallbackWrapper implements ArrayAccess {
 
 	/**
 	 * Callback data.
@@ -52,6 +53,8 @@ class CallbackWrapper {
 	 *     The callback data.
 	 *     @type callable $function
 	 *     @type int      $accepted_args
+	 *     @type int      $priority
+	 *     @type int      $hook
 	 * ]
 	 */
 	public function __construct( $callback ) {
@@ -176,5 +179,70 @@ class CallbackWrapper {
 			'block'     => array_keys( $block_types ),
 			'shortcode' => array_keys( $shortcode_tags ),
 		];
+	}
+
+	/**
+	 * Offset exists.
+	 *
+	 * @param mixed $offset Offset.
+	 *
+	 * @return bool Exists.
+	 */
+	public function offsetExists( $offset ) {
+
+		if ( ! is_array( $this->callback ) ) {
+			return false;
+		}
+
+		return isset( $this->callback[ $offset ] );
+	}
+
+	/**
+	 * Offset get.
+	 *
+	 * @param mixed $offset Offset.
+	 *
+	 * @return mixed|null Value.
+	 */
+	public function offsetGet( $offset ) {
+
+		if ( is_array( $this->callback ) && isset( $this->callback[ $offset ] ) ) {
+			return $this->callback[ $offset ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Offset set.
+	 *
+	 * @param mixed $offset Offset.
+	 * @param mixed $value  Value.
+	 */
+	public function offsetSet( $offset, $value ) {
+
+		if ( ! is_array( $this->callback ) ) {
+			return;
+		}
+
+		if ( is_null( $offset ) ) {
+			$this->callback[] = $value;
+		} else {
+			$this->callback[ $offset ] = $value;
+		}
+	}
+
+	/**
+	 * Offset unset.
+	 *
+	 * @param mixed $offset Offset.
+	 */
+	public function offsetUnset( $offset ) {
+
+		if ( ! is_array( $this->callback ) ) {
+			return;
+		}
+
+		unset( $this->callback[ $offset ] );
 	}
 }

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -21,6 +21,103 @@ use WP_Block_Type_Registry;
 class CallbackWrapper implements ArrayAccess {
 
 	/**
+	 * List of default entities.
+	 *
+	 * @var array [
+	 *     @type array $post_type List of default post types slug.
+	 *     @type array $taxonomy  List of default taxonomy slug.
+	 *     @type array $block     List of default block type.
+	 *     @type array $shortcode List of default shortcode.
+	 * ]
+	 */
+	const DEFAULT_ENTITIES = [
+		'post_type' => [
+			'post',
+			'page',
+			'attachment',
+			'revision',
+			'nav_menu_item',
+		],
+		'taxonomy'  => [
+			'category',
+			'post_tag',
+			'nav_menu',
+			'post_format',
+		],
+		'block'     => [
+			'core/archives',
+			'core/block',
+			'core/calendar',
+			'core/categories',
+			'core/file',
+			'core/latest-comments',
+			'core/latest-posts',
+			'core/legacy-widget',
+			'core/loginout',
+			'core/page-list',
+			'core/post-content',
+			'core/post-date',
+			'core/post-excerpt',
+			'core/post-featured-image',
+			'core/post-terms',
+			'core/post-title',
+			'core/post-template',
+			'core/query',
+			'core/query-pagination',
+			'core/query-pagination-next',
+			'core/query-pagination-numbers',
+			'core/query-pagination-previous',
+			'core/query-title',
+			'core/rss',
+			'core/search',
+			'core/shortcode',
+			'core/site-tagline',
+			'core/site-logo',
+			'core/site-title',
+			'core/social-link',
+			'core/tag-cloud',
+			'core/audio',
+			'core/button',
+			'core/buttons',
+			'core/code',
+			'core/column',
+			'core/columns',
+			'core/cover',
+			'core/embed',
+			'core/freeform',
+			'core/gallery',
+			'core/group',
+			'core/heading',
+			'core/html',
+			'core/image',
+			'core/list',
+			'core/media-text',
+			'core/missing',
+			'core/more',
+			'core/nextpage',
+			'core/paragraph',
+			'core/preformatted',
+			'core/pullquote',
+			'core/quote',
+			'core/separator',
+			'core/social-links',
+			'core/spacer',
+			'core/table',
+			'core/text-columns',
+			'core/verse',
+			'core/video',
+		],
+		'shortcode' => [
+			'caption',
+			'gallery',
+			'audio',
+			'video',
+			'playlist',
+			'embed',
+		],
+	];
+
+	/**
 	 * Callback data.
 	 *
 	 * @var array
@@ -143,7 +240,8 @@ class CallbackWrapper implements ArrayAccess {
 
 			$different = array_diff(
 				$final_registered_entities[ $entity_type ],
-				$this->registered_entities[ $entity_type ]
+				$this->registered_entities[ $entity_type ],
+				self::DEFAULT_ENTITIES[ $entity_type ]
 			);
 			$different = array_values( $different );
 

--- a/src/EntityRegistrantDetection/CallbackWrapper.php
+++ b/src/EntityRegistrantDetection/CallbackWrapper.php
@@ -204,10 +204,8 @@ class CallbackWrapper implements ArrayAccess {
 
 		$this->prepare();
 
-		$result = call_user_func_array(
-			$this->get_callback_function(),
-			array_slice( $args, 0, (int) $this->callback['accepted_args'] )
-		);
+		$callback = $this->get_callback_function();
+		$result   = $callback( ...array_slice( $args, 0, (int) $this->callback['accepted_args'] ) );
 
 		$this->finalize();
 

--- a/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
+++ b/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Class EntityRegistrantDetection.
+ *
+ * @since   2.2
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection;
+
+use AmpProject\AmpWP\Infrastructure\Conditional;
+use AmpProject\AmpWP\Infrastructure\Delayed;
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use WP_Block_Type;
+use WP_Block_Type_Registry;
+use WP_Hook;
+use WP_Post_Type;
+use WP_Taxonomy;
+
+/**
+ * Service to find the source where entities are registered.
+ *
+ * @since   2.2
+ * @package AmpProject\AmpWP
+ * @internal
+ */
+class EntityRegistrantDetectionManager implements Service, Registerable, Delayed, Conditional {
+
+	/**
+	 * Query var for passing nonce value.
+	 *
+	 * @var string
+	 */
+	const NONCE_QUERY_VAR = 'amp_entity_registrant_detection_nonce';
+
+	/**
+	 * List of registered post-type.
+	 *
+	 * @var array
+	 */
+	public static $post_types_source = [];
+
+	/**
+	 * List of registered taxonomy.
+	 *
+	 * @var array
+	 */
+	public static $taxonomies_source = [];
+
+	/**
+	 * List of registered shortcode.
+	 *
+	 * @var array
+	 */
+	public static $shortcodes_source = [];
+
+	/**
+	 * List of registered block type.
+	 *
+	 * @var array
+	 */
+	public static $blocks_source = [];
+
+	/**
+	 * Get the action to use for registering the service.
+	 *
+	 * @return string Registration action to use.
+	 */
+	public static function get_registration_action() {
+
+		return 'plugins_loaded';
+	}
+
+	/**
+	 * Check whether the conditional object is currently needed.
+	 *
+	 * @return bool Whether need to enable service or not.
+	 */
+	public static function is_needed() {
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+		$nonce = isset( $_GET[ self::NONCE_QUERY_VAR ] ) ? wp_slash( $_GET[ self::NONCE_QUERY_VAR ] ) : '';
+
+		return ( current_user_can( 'manage_options' ) && self::verify_nonce( $nonce ) );
+	}
+
+	/**
+	 * Get nonce for performing for detecting entities registrants.
+	 *
+	 * The returned nonce is irrespective of the authenticated user.
+	 *
+	 * @return string Nonce.
+	 */
+	public static function get_nonce() {
+
+		return wp_hash( self::NONCE_QUERY_VAR . wp_nonce_tick(), 'nonce' );
+	}
+
+	/**
+	 * Verify nonce with the given value.
+	 *
+	 * @param string $value Value to verify nonce.
+	 *
+	 * @return bool True on success, Otherwise False.
+	 */
+	public static function verify_nonce( $value ) {
+
+		return hash_equals( $value, self::get_nonce() );
+	}
+
+	/**
+	 * Add source of entity registrant.
+	 *
+	 * @param string          $entity_type Type of entity. e.g. post_type, taxonomy, block, shortcode.
+	 * @param string|string[] $entities    Slug or list of slug of the entity.
+	 * @param array           $source      Source detail where entity is registered..
+	 *
+	 * @return bool True on success, Otherwise False.
+	 */
+	public static function add_source( $entity_type, $entities, $source ) {
+
+		$allowed_entity_types = [
+			'post_type',
+			'taxonomy',
+			'block',
+			'shortcode',
+		];
+
+		if (
+			empty( $entities ) ||
+			empty( $entity_type ) ||
+			! in_array( $entity_type, $allowed_entity_types, true )
+		) {
+			return false;
+		}
+
+		if ( ! is_array( $entities ) ) {
+			$entities = [ $entities ];
+		}
+
+		foreach ( $entities as $entity ) {
+			switch ( $entity_type ) {
+				case 'post_type':
+					$post_type = get_post_type_object( $entity );
+
+					if ( empty( $post_type ) || ! $post_type instanceof WP_Post_Type ) {
+						break;
+					}
+
+					self::$post_types_source[ $entity ] = [
+						'name'         => $post_type->label,
+						'slug'         => $post_type->name,
+						'description'  => $post_type->description,
+						'hierarchical' => $post_type->hierarchical,
+						'source'       => $source,
+					];
+					break;
+				case 'taxonomy':
+					$taxonomy = get_taxonomy( $entity );
+
+					if ( empty( $taxonomy ) || ! $taxonomy instanceof WP_Taxonomy ) {
+						break;
+					}
+
+					self::$taxonomies_source[ $entity ] = [
+						'name'         => $taxonomy->label,
+						'slug'         => $taxonomy->name,
+						'description'  => $taxonomy->description,
+						'hierarchical' => $taxonomy->hierarchical,
+						'source'       => $source,
+					];
+					break;
+				case 'block':
+					$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+					if ( empty( $block_types[ $entity ] ) || ! $block_types[ $entity ] instanceof WP_Block_Type ) {
+						break;
+					}
+
+					$block_type = $block_types[ $entity ];
+
+					self::$blocks_source[ $entity ] = [
+						'name'        => $block_type->name,
+						'title'       => $block_type->name,
+						'description' => $block_type->description,
+						'category'    => $block_type->category,
+						'attributes'  => $block_type->get_attributes(),
+						'is_dynamic'  => $block_type->is_dynamic(),
+						'source'      => $source,
+					];
+					break;
+				case 'shortcode':
+					self::$shortcodes_source[ $entity ] = [
+						'tag'    => $entity,
+						'source' => $source,
+					];
+					break;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Adds hooks.
+	 */
+	public function register() {
+
+		add_action( 'all', [ $this, 'wrap_hook_callbacks' ] );
+	}
+
+	/**
+	 * Wrap action/filter callback to given hook to check if callback registering any entity or not.
+	 *
+	 * @global WP_Hook[] $wp_filter
+	 *
+	 * @param string $hook Hook name for action or filter.
+	 *
+	 * @return void
+	 */
+	public function wrap_hook_callbacks( $hook ) {
+
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter[ $hook ] ) || 'shutdown' === $hook ) {
+			return;
+		}
+
+		foreach ( $wp_filter[ $hook ]->callbacks as $priority => &$callbacks ) {
+			foreach ( $callbacks as &$callback ) {
+				$callback['function'] = self::wrapped_callback(
+					array_merge(
+						$callback,
+						compact( 'priority', 'hook' )
+					)
+				);
+			}
+		}
+
+	}
+
+	/**
+	 * Wrap the given callable function.
+	 *
+	 * @param callable $callback Callback function.
+	 *
+	 * @return CallbackWrapper Instance of CallbackWrapper.
+	 */
+	protected static function wrapped_callback( $callback ) {
+
+		return ( ! $callback['function'] instanceof CallbackWrapper ) ? new CallbackWrapper( $callback ) : $callback['function'];
+	}
+}

--- a/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
+++ b/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
@@ -190,18 +190,20 @@ class EntityRegistrantDetectionManager implements Service, Registerable, Delayed
 					];
 					break;
 				case 'block':
-					$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
-
-					if ( empty( $block_types[ $entity ] ) || ! $block_types[ $entity ] instanceof WP_Block_Type ) {
+					if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
 						break;
 					}
 
-					$block_type = $block_types[ $entity ];
+					$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $entity );
+
+					if ( empty( $block_type ) || ! $block_type instanceof WP_Block_Type ) {
+						break;
+					}
 
 					$this->blocks_source[ $entity ] = [
 						'name'        => $block_type->name,
 						'title'       => $block_type->name,
-						'description' => $block_type->description,
+						'description' => $block_type->description ?: '',
 						'category'    => $block_type->category,
 						'attributes'  => $block_type->get_attributes(),
 						'is_dynamic'  => $block_type->is_dynamic(),

--- a/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
+++ b/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
@@ -204,7 +204,7 @@ class EntityRegistrantDetectionManager implements Service, Registerable, Delayed
 						'name'        => $block_type->name,
 						'title'       => isset( $block_type->title ) ? $block_type->title : '',
 						'description' => isset( $block_type->description ) ? $block_type->description : '',
-						'category'    => $block_type->category,
+						'category'    => isset( $block_type->category ) ? $block_type->category : '',
 						'attributes'  => $block_type->get_attributes(),
 						'is_dynamic'  => $block_type->is_dynamic(),
 						'source'      => $source,

--- a/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
+++ b/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
@@ -202,8 +202,8 @@ class EntityRegistrantDetectionManager implements Service, Registerable, Delayed
 
 					$this->blocks_source[ $entity ] = [
 						'name'        => $block_type->name,
-						'title'       => $block_type->name,
-						'description' => $block_type->description ?: '',
+						'title'       => isset( $block_type->title ) ? $block_type->title : '',
+						'description' => isset( $block_type->description ) ? $block_type->description : '',
 						'category'    => $block_type->category,
 						'attributes'  => $block_type->get_attributes(),
 						'is_dynamic'  => $block_type->is_dynamic(),

--- a/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
+++ b/src/EntityRegistrantDetection/EntityRegistrantDetectionManager.php
@@ -191,6 +191,12 @@ class EntityRegistrantDetectionManager implements Service, Registerable, Delayed
 					];
 					break;
 				case 'shortcode':
+					global $shortcode_tags;
+
+					if ( ! isset( $shortcode_tags[ $entity ] ) ) {
+						break;
+					}
+
 					self::$shortcodes_source[ $entity ] = [
 						'tag'    => $entity,
 						'source' => $source,

--- a/src/EntityRegistrantDetection/RestController.php
+++ b/src/EntityRegistrantDetection/RestController.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Rest endpoint for fetching entity registrant detail.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection;
+
+use AmpProject\AmpWP\Infrastructure\Delayed;
+use AmpProject\AmpWP\Infrastructure\Registerable;
+use AmpProject\AmpWP\Infrastructure\Service;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Response;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Class RestController
+ *
+ * @since   2.2
+ * @package AmpProject\AmpWP
+ */
+class RestController extends WP_REST_Controller implements Service, Registerable, Delayed {
+
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base;
+
+	/**
+	 * Cached results of get_item_schema.
+	 *
+	 * @var array
+	 */
+	protected $schema;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		$this->namespace = 'amp/v1';
+		$this->rest_base = 'entity-registrants';
+	}
+
+	/**
+	 * Get the action to use for registering the service.
+	 *
+	 * @return string Registration action to use.
+	 */
+	public static function get_registration_action() {
+
+		return 'rest_api_init';
+	}
+
+	/**
+	 * Registers all routes for the controller.
+	 */
+	public function register() {
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => [
+						EntityRegistrantDetectionManager::NONCE_QUERY_VAR => [
+							'description' => __( 'Nonce value.', 'amp' ),
+							'type'        => 'string',
+							'required'    => true,
+						],
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to get items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return bool|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+
+		$nonce_value = $request->get_param( EntityRegistrantDetectionManager::NONCE_QUERY_VAR );
+
+		if ( ! EntityRegistrantDetectionManager::verify_nonce( $nonce_value ) ) {
+			return new WP_Error(
+				'http_request_failed',
+				__( 'Nonce authentication failed.', 'amp' )
+			);
+		}
+
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Retrieves a collection of items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+
+		return rest_ensure_response(
+			[
+				'post_types' => EntityRegistrantDetectionManager::$post_types_source,
+				'taxonomies' => EntityRegistrantDetectionManager::$taxonomies_source,
+				'blocks'     => EntityRegistrantDetectionManager::$blocks_source,
+				'shortcodes' => EntityRegistrantDetectionManager::$shortcodes_source,
+			]
+		);
+	}
+}

--- a/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
+++ b/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
@@ -7,14 +7,16 @@
 
 namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
 
+use AmpProject\AmpWP\DevTools\CallbackReflection;
 use AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper;
+use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
-use AmpProject\AmpWP\Tests\TestCase;
 
 /**
  * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper
  */
-class CallbackWrapperTest extends TestCase {
+class CallbackWrapperTest extends DependencyInjectedTestCase {
 
 	use PrivateAccess;
 
@@ -30,17 +32,34 @@ class CallbackWrapperTest extends TestCase {
 	 *
 	 * @inheritdoc
 	 */
-	protected function setUp() {
+	public function setUp() {
 
 		parent::setUp();
 
-		$this->instance = new CallbackWrapper(
-			[
-				'function'      => [ __CLASS__, 'register_entities' ],
-				'accepted_args' => 0,
-				'priority'      => 10,
-				'hook'          => 'init',
-			]
+		$callback = [
+			'function'      => [ __CLASS__, 'register_entities' ],
+			'accepted_args' => 0,
+			'priority'      => 10,
+			'hook'          => 'init',
+		];
+
+		$this->instance = $this->injector->make( CallbackWrapper::class, compact( 'callback' ) );
+
+	}
+
+	/**
+	 * @covers ::__construct()
+	 */
+	public function test_construct() {
+
+		$this->assertInstanceOf(
+			EntityRegistrantDetectionManager::class,
+			$this->get_private_property( $this->instance, 'detection_manager' )
+		);
+
+		$this->assertInstanceOf(
+			CallbackReflection::class,
+			$this->get_private_property( $this->instance, 'callback_reflection' )
 		);
 
 	}

--- a/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
+++ b/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
@@ -48,6 +48,18 @@ class CallbackWrapperTest extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+
+		self::unregister_entities();
+	}
+
+	/**
 	 * @covers ::__construct()
 	 */
 	public function test_construct() {
@@ -81,6 +93,19 @@ class CallbackWrapperTest extends DependencyInjectedTestCase {
 				'render_callback' => '__return_empty_string',
 			]
 		);
+	}
+
+	/**
+	 * Unregister entities.
+	 */
+	public static function unregister_entities() {
+		unregister_post_type( 'amp_test_post_type' );
+
+		unregister_taxonomy( 'amp_test_taxonomy' );
+
+		remove_shortcode( 'amp_test_shortcode' );
+
+		unregister_block_type( 'amp/test-block' );
 	}
 
 	/**

--- a/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
+++ b/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper;
 use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use WP_Block_Type_Registry;
 
 /**
  * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper
@@ -19,6 +20,34 @@ use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 class CallbackWrapperTest extends DependencyInjectedTestCase {
 
 	use PrivateAccess;
+
+	/**
+	 * Post type slug.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'amp_test_post_type';
+
+	/**
+	 * Taxonomy slug.
+	 *
+	 * @var string
+	 */
+	const TAXONOMY = 'amp_test_taxonomy';
+
+	/**
+	 * Shortcode name.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE = 'amp_test_shortcode';
+
+	/**
+	 * Block type.
+	 *
+	 * @var string
+	 */
+	const BLOCK_TYPE = 'amp/test-block';
 
 	/**
 	 * Instance of CallbackWrapper
@@ -81,14 +110,14 @@ class CallbackWrapperTest extends DependencyInjectedTestCase {
 	 */
 	public static function register_entities() {
 
-		register_post_type( 'amp_test_post_type', [] );
+		register_post_type( self::POST_TYPE, [] );
 
-		register_taxonomy( 'amp_test_taxonomy', [] );
+		register_taxonomy( self::TAXONOMY, [] );
 
-		add_shortcode( 'amp_test_shortcode', '__return_empty_string' );
+		add_shortcode( self::SHORTCODE, '__return_empty_string' );
 
 		register_block_type(
-			'amp/test-block',
+			self::BLOCK_TYPE,
 			[
 				'render_callback' => '__return_empty_string',
 			]
@@ -99,13 +128,15 @@ class CallbackWrapperTest extends DependencyInjectedTestCase {
 	 * Unregister entities.
 	 */
 	public static function unregister_entities() {
-		unregister_post_type( 'amp_test_post_type' );
+		unregister_post_type( self::POST_TYPE );
 
-		unregister_taxonomy( 'amp_test_taxonomy' );
+		unregister_taxonomy( self::TAXONOMY );
 
-		remove_shortcode( 'amp_test_shortcode' );
+		remove_shortcode( self::SHORTCODE );
 
-		unregister_block_type( 'amp/test-block' );
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( self::BLOCK_TYPE ) ) {
+			unregister_block_type( self::BLOCK_TYPE );
+		}
 	}
 
 	/**
@@ -123,10 +154,10 @@ class CallbackWrapperTest extends DependencyInjectedTestCase {
 		$registered_entities = $this->get_private_property( $this->instance, 'registered_entities' );
 		$source              = $this->get_private_property( $this->instance, 'source' );
 
-		$this->assertContains( 'amp_test_post_type', $registered_entities['post_type'] );
-		$this->assertContains( 'amp_test_taxonomy', $registered_entities['taxonomy'] );
-		$this->assertContains( 'amp_test_shortcode', $registered_entities['shortcode'] );
-		$this->assertContains( 'amp/test-block', $registered_entities['block'] );
+		$this->assertContains( self::POST_TYPE, $registered_entities['post_type'] );
+		$this->assertContains( self::TAXONOMY, $registered_entities['taxonomy'] );
+		$this->assertContains( self::SHORTCODE, $registered_entities['shortcode'] );
+		$this->assertContains( self::BLOCK_TYPE, $registered_entities['block'] );
 
 		$this->assertArrayHasKey( 'function', $source );
 		$this->assertArrayHasKey( 'hook', $source );

--- a/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
+++ b/tests/php/src/EntityRegistrantDetection/CallbackWrapperTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Test cases for CallbackWrapper
+ *
+ * @package AmpProject\AmpWP\EntityRegistrantDetection\Tests
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
+
+use AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use AmpProject\AmpWP\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper
+ */
+class CallbackWrapperTest extends TestCase {
+
+	use PrivateAccess;
+
+	/**
+	 * Instance of CallbackWrapper
+	 *
+	 * @var CallbackWrapper
+	 */
+	public $instance;
+
+	/**
+	 * Set up.
+	 *
+	 * @inheritdoc
+	 */
+	protected function setUp() {
+
+		parent::setUp();
+
+		$this->instance = new CallbackWrapper(
+			[
+				'function'      => [ __CLASS__, 'register_entities' ],
+				'accepted_args' => 0,
+				'priority'      => 10,
+				'hook'          => 'init',
+			]
+		);
+
+	}
+
+	/**
+	 * Register entities.
+	 */
+	public static function register_entities() {
+
+		register_post_type( 'amp_test_post_type', [] );
+
+		register_taxonomy( 'amp_test_taxonomy', [] );
+
+		add_shortcode( 'amp_test_shortcode', '__return_empty_string' );
+
+		register_block_type(
+			'amp/test-block',
+			[
+				'render_callback' => '__return_empty_string',
+			]
+		);
+	}
+
+	/**
+	 * @covers ::__invoke()
+	 * @covers ::prepare()
+	 * @covers ::finalize()
+	 * @covers ::set_source()
+	 * @covers ::get_callback_function()
+	 * @covers ::get_registered_entities()
+	 */
+	public function test_callback_wrapper() {
+
+		call_user_func( $this->instance );
+
+		$registered_entities = $this->get_private_property( $this->instance, 'registered_entities' );
+		$source              = $this->get_private_property( $this->instance, 'source' );
+
+		$this->assertContains( 'amp_test_post_type', $registered_entities['post_type'] );
+		$this->assertContains( 'amp_test_taxonomy', $registered_entities['taxonomy'] );
+		$this->assertContains( 'amp_test_shortcode', $registered_entities['shortcode'] );
+		$this->assertContains( 'amp/test-block', $registered_entities['block'] );
+
+		$this->assertArrayHasKey( 'function', $source );
+		$this->assertArrayHasKey( 'hook', $source );
+		$this->assertArrayHasKey( 'priority', $source );
+	}
+
+	/**
+	 * @covers ::offsetExists()
+	 */
+	public function test_offsetExists() {
+
+		$this->assertTrue( isset( $this->instance['function'] ) );
+
+		$this->assertfalse( isset( $this->instance['invalid_offset'] ) );
+	}
+
+	/**
+	 * @covers ::offsetGet()
+	 */
+	public function test_offsetGet() {
+
+		$callback = $this->get_private_property( $this->instance, 'callback' );
+
+		$this->assertEquals( $callback['function'], $this->instance['function'] );
+
+		$this->assertNull( $this->instance['invalid_offset'] );
+	}
+
+	/**
+	 * @covers ::offsetSet()
+	 */
+	public function test_offsetSet() {
+
+		$original_function = $this->instance['function'];
+
+		$this->instance['function'] = '__return_empty_string';
+		$this->instance[]           = 'some_value';
+
+		$callback = $this->get_private_property( $this->instance, 'callback' );
+
+		$this->assertEquals( '__return_empty_string', $callback['function'] );
+		$this->assertEquals( 'some_value', $callback[0] );
+
+		unset( $this->instance[0] );
+		$this->instance['function'] = $original_function;
+	}
+
+	/**
+	 * @covers ::offsetUnset()
+	 */
+	public function test_offsetUnset() {
+		$original_function = $this->instance['function'];
+
+		unset( $this->instance['function'] );
+
+		$callback = $this->get_private_property( $this->instance, 'callback' );
+
+		$this->assertFalse( isset( $callback['function'] ) );
+
+		$this->instance['function'] = $original_function;
+	}
+}

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -9,6 +9,7 @@ namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
 
 use AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper;
 use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
+use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 
@@ -53,6 +54,17 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 			'hook'     => 'init',
 			'priority' => 5,
 		];
+	}
+
+	/**
+	 * @covers ::__construct()
+	 */
+	public function test_construct() {
+
+		$this->assertInstanceOf(
+			Injector::class,
+			$this->get_private_property( $this->instance, 'injector' )
+		);
 	}
 
 	/**
@@ -120,15 +132,15 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 	public function test_add_source_post_type() {
 
 		$this->assertFalse(
-			EntityRegistrantDetectionManager::add_source(
+			$this->instance->add_source(
 				'invalid_entity_type',
 				'invalid_entity',
 				$this->source
 			)
 		);
 
-		EntityRegistrantDetectionManager::add_source( 'post_type', 'invalid_post', $this->source );
-		EntityRegistrantDetectionManager::add_source( 'post_type', 'post', $this->source );
+		$this->instance->add_source( 'post_type', 'invalid_post', $this->source );
+		$this->instance->add_source( 'post_type', 'post', $this->source );
 
 		$post_types_source = $this->get_private_property( $this->instance, 'post_types_source' );
 
@@ -150,7 +162,7 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 	 */
 	public function test_add_source_taxonomy() {
 
-		EntityRegistrantDetectionManager::add_source( 'taxonomy', [ 'invalid_taxonomy', 'category' ], $this->source );
+		$this->instance->add_source( 'taxonomy', [ 'invalid_taxonomy', 'category' ], $this->source );
 
 		$taxonomies_source = $this->get_private_property( $this->instance, 'taxonomies_source' );
 
@@ -172,7 +184,7 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 	 */
 	public function test_add_source_shortcode() {
 
-		EntityRegistrantDetectionManager::add_source( 'shortcode', [ 'invalid_shortcode', 'gallery' ], $this->source );
+		$this->instance->add_source( 'shortcode', [ 'invalid_shortcode', 'gallery' ], $this->source );
 
 		$shortcodes_source = $this->get_private_property( $this->instance, 'shortcodes_source' );
 
@@ -193,7 +205,7 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 	 */
 	public function test_add_source_block() {
 
-		EntityRegistrantDetectionManager::add_source( 'block', [ 'invalid_block', 'core/button' ], $this->source );
+		$this->instance->add_source( 'block', [ 'invalid_block', 'core/button' ], $this->source );
 
 		$blocks_source = $this->get_private_property( $this->instance, 'blocks_source' );
 
@@ -209,6 +221,19 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 		);
 
 		$this->assertArrayHasKey( 'attributes', $blocks_source['core/button'] );
+	}
+
+	/**
+	 * @covers ::get_registered_entities()
+	 */
+	public function test_get_registered_entities() {
+
+		$output = $this->instance->get_registered_entities();
+
+		foreach ( [ 'post_types', 'taxonomies', 'blocks', 'shortcodes' ] as $entity_type ) {
+			$this->assertArrayHasKey( $entity_type, $output );
+		}
+
 	}
 
 	/**
@@ -271,8 +296,8 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 
 		$this->assertInstanceOf(
 			CallbackWrapper::class,
-			$this->call_private_static_method(
-				EntityRegistrantDetectionManager::class,
+			$this->call_private_method(
+				$this->instance,
 				'wrapped_callback',
 				[ $callable ]
 			)

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
 use AmpProject\AmpWP\Infrastructure\Injector;
 use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use WP_Block_Type_Registry;
 
 /**
  * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager
@@ -209,7 +210,10 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 			$this->markTestSkipped( 'Requires WordPress 5.0.' );
 		}
 
-		$this->instance->add_source( 'block', [ 'invalid_block', 'core/paragraph' ], $this->source );
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		$block_type  = array_shift( $block_types );
+
+		$this->instance->add_source( 'block', [ 'invalid_block', $block_type->name ], $this->source );
 
 		$blocks_source = $this->get_private_property( $this->instance, 'blocks_source' );
 
@@ -217,14 +221,14 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 
 		$this->assertArraySubset(
 			[
-				'name'   => 'core/paragraph',
-				'title'  => 'core/paragraph',
+				'name'   => $block_type->name,
+				'title'  => $block_type->title,
 				'source' => $this->source,
 			],
-			$blocks_source['core/paragraph']
+			$blocks_source[ $block_type->name ]
 		);
 
-		$this->assertArrayHasKey( 'attributes', $blocks_source['core/paragraph'] );
+		$this->assertArrayHasKey( 'attributes', $blocks_source[ $block_type->name ] );
 	}
 
 	/**

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Test case for EntityRegistrantDetectionManager
+ *
+ * @package AmpProject\AmpWP\Support\Tests
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
+
+use AmpProject\AmpWP\EntityRegistrantDetection\CallbackWrapper;
+use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+
+/**
+ * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager
+ */
+class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
+
+	use PrivateAccess;
+
+	/**
+	 * Instance of EntityRegistrantDetectionManager
+	 *
+	 * @var EntityRegistrantDetectionManager
+	 */
+	public $instance;
+
+	/**
+	 * Mocked source information.
+	 *
+	 * @var array
+	 */
+	public $source = [];
+
+	/**
+	 * Set up.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->instance = $this->injector->make( EntityRegistrantDetectionManager::class );
+
+		$this->source = [
+			'type'     => 'plugin',
+			'name'     => 'dummy-plugin',
+			'file'     => 'includes/entity-registration.php',
+			'line'     => 10,
+			'function' => 'dummy_function_name',
+			'hook'     => 'init',
+			'priority' => 5,
+		];
+	}
+
+	/**
+	 * @covers ::get_registration_action()
+	 */
+	public function test_get_registration_action() {
+
+		$this->assertEquals(
+			'plugins_loaded',
+			EntityRegistrantDetectionManager::get_registration_action()
+		);
+	}
+
+	/**
+	 * @covers ::is_needed()
+	 */
+	public function test_is_needed() {
+
+		$this->assertFalse( EntityRegistrantDetectionManager::is_needed() );
+
+		// Mock User.
+		wp_set_current_user(
+			self::factory()->user->create(
+				[
+					'role' => 'administrator',
+				]
+			)
+		);
+
+		$this->assertFalse( EntityRegistrantDetectionManager::is_needed() );
+
+		// Mock $_GET.
+		$_GET[ EntityRegistrantDetectionManager::NONCE_QUERY_VAR ] = EntityRegistrantDetectionManager::get_nonce();
+
+		$this->assertTrue( EntityRegistrantDetectionManager::is_needed() );
+
+		unset( $_GET[ EntityRegistrantDetectionManager::NONCE_QUERY_VAR ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * @covers ::get_nonce()
+	 */
+	public function test_get_nonce() {
+
+		$this->assertEquals(
+			wp_hash( EntityRegistrantDetectionManager::NONCE_QUERY_VAR . wp_nonce_tick(), 'nonce' ),
+			EntityRegistrantDetectionManager::get_nonce()
+		);
+	}
+
+	/**
+	 * @covers ::verify_nonce()
+	 */
+	public function test_verify_nonce() {
+
+		$this->assertFalse( EntityRegistrantDetectionManager::verify_nonce( 'invalid_nonce_value' ) );
+
+		$nonce = EntityRegistrantDetectionManager::get_nonce();
+		$this->assertTrue( EntityRegistrantDetectionManager::verify_nonce( $nonce ) );
+	}
+
+	/**
+	 * @covers ::add_source()
+	 */
+	public function test_add_source_post_type() {
+
+		$this->assertFalse(
+			EntityRegistrantDetectionManager::add_source(
+				'invalid_entity_type',
+				'invalid_entity',
+				$this->source
+			)
+		);
+
+		EntityRegistrantDetectionManager::add_source( 'post_type', 'invalid_post', $this->source );
+		EntityRegistrantDetectionManager::add_source( 'post_type', 'post', $this->source );
+
+		$post_types_source = $this->get_private_property( $this->instance, 'post_types_source' );
+
+		$this->assertArrayNotHasKey( 'invalid_post', $post_types_source );
+
+		$this->assertArraySubset(
+			[
+				'name'   => 'Posts',
+				'slug'   => 'post',
+				'source' => $this->source,
+			],
+			$post_types_source['post']
+		);
+
+	}
+
+	/**
+	 * @covers ::add_source()
+	 */
+	public function test_add_source_taxonomy() {
+
+		EntityRegistrantDetectionManager::add_source( 'taxonomy', [ 'invalid_taxonomy', 'category' ], $this->source );
+
+		$taxonomies_source = $this->get_private_property( $this->instance, 'taxonomies_source' );
+
+		$this->assertArrayNotHasKey( 'invalid_taxonomy', $taxonomies_source );
+
+		$this->assertArraySubset(
+			[
+				'name'   => 'Categories',
+				'slug'   => 'category',
+				'source' => $this->source,
+			],
+			$taxonomies_source['category']
+		);
+
+	}
+
+	/**
+	 * @covers ::add_source()
+	 */
+	public function test_add_source_shortcode() {
+
+		EntityRegistrantDetectionManager::add_source( 'shortcode', [ 'invalid_shortcode', 'gallery' ], $this->source );
+
+		$shortcodes_source = $this->get_private_property( $this->instance, 'shortcodes_source' );
+
+		$this->assertArrayNotHasKey( 'invalid_shortcode', $shortcodes_source );
+
+		$this->assertArraySubset(
+			[
+				'tag'    => 'gallery',
+				'source' => $this->source,
+			],
+			$shortcodes_source['gallery']
+		);
+
+	}
+
+	/**
+	 * @covers ::add_source()
+	 */
+	public function test_add_source_block() {
+
+		EntityRegistrantDetectionManager::add_source( 'block', [ 'invalid_block', 'core/button' ], $this->source );
+
+		$blocks_source = $this->get_private_property( $this->instance, 'blocks_source' );
+
+		$this->assertArrayNotHasKey( 'invalid_block', $blocks_source );
+
+		$this->assertArraySubset(
+			[
+				'name'   => 'core/button',
+				'title'  => 'core/button',
+				'source' => $this->source,
+			],
+			$blocks_source['core/button']
+		);
+
+		$this->assertArrayHasKey( 'attributes', $blocks_source['core/button'] );
+	}
+
+	/**
+	 * @covers ::register()
+	 */
+	public function test_register() {
+
+		$this->instance->register();
+
+		$int_min = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
+
+		$this->assertEquals(
+			$int_min,
+			has_action( 'all', [ $this->instance, 'wrap_hook_callbacks' ] )
+		);
+	}
+
+	/**
+	 * @covers ::wrap_hook_callbacks()
+	 */
+	public function test_wrap_hook_callbacks() {
+
+		global $wp_filter;
+
+		$previous_wp_filter = $wp_filter;
+
+		$this->instance->wrap_hook_callbacks( 'shutdown' );
+		$this->assertEquals( $previous_wp_filter['shutdown'], $wp_filter['shutdown'] );
+
+		add_action( 'init', [ __CLASS__, 'dummy_function' ] );
+
+		$this->instance->wrap_hook_callbacks( 'init' );
+
+		$this->assertInstanceOf(
+			CallbackWrapper::class,
+			$wp_filter['init']->callbacks[10][ __CLASS__ . '::dummy_function' ]['function']
+		);
+
+		remove_action( 'init', [ __CLASS__, 'dummy_function' ] );
+
+		$wp_filter = $previous_wp_filter;
+		unset( $previous_wp_filter );
+	}
+
+	/**
+	 * Dummy function.
+	 */
+	public static function dummy_function() {
+	}
+
+	/**
+	 * @covers ::wrapped_callback
+	 */
+	public function test_wrapped_callback() {
+
+		$callable = [
+			'function'      => __CLASS__ . '::dummy_function',
+			'accepted_args' => 0,
+		];
+
+		$this->assertInstanceOf(
+			CallbackWrapper::class,
+			$this->call_private_static_method(
+				EntityRegistrantDetectionManager::class,
+				'wrapped_callback',
+				[ $callable ]
+			)
+		);
+	}
+}

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -2,7 +2,7 @@
 /**
  * Test case for EntityRegistrantDetectionManager
  *
- * @package AmpProject\AmpWP\Support\Tests
+ * @package AmpProject\AmpWP\EntityRegistrantDetection\Tests
  */
 
 namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -224,7 +224,7 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 			$blocks_source['core/paragraph']
 		);
 
-		$this->assertArrayHasKey( 'attributes', $blocks_source['core/button'] );
+		$this->assertArrayHasKey( 'attributes', $blocks_source['core/paragraph'] );
 	}
 
 	/**

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -205,7 +205,11 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 	 */
 	public function test_add_source_block() {
 
-		$this->instance->add_source( 'block', [ 'invalid_block', 'core/button' ], $this->source );
+		if ( version_compare( get_bloginfo( 'version' ), '5.0.0', '<' ) ) {
+			$this->markTestSkipped( 'Requires WordPress 5.0.' );
+		}
+
+		$this->instance->add_source( 'block', [ 'invalid_block', 'core/paragraph' ], $this->source );
 
 		$blocks_source = $this->get_private_property( $this->instance, 'blocks_source' );
 
@@ -213,11 +217,11 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 
 		$this->assertArraySubset(
 			[
-				'name'   => 'core/button',
-				'title'  => 'core/button',
+				'name'   => 'core/paragraph',
+				'title'  => 'core/paragraph',
 				'source' => $this->source,
 			],
-			$blocks_source['core/button']
+			$blocks_source['core/paragraph']
 		);
 
 		$this->assertArrayHasKey( 'attributes', $blocks_source['core/button'] );

--- a/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/EntityRegistrantDetectionManagerTest.php
@@ -222,7 +222,7 @@ class EntityRegistrantDetectionManagerTest extends DependencyInjectedTestCase {
 		$this->assertArraySubset(
 			[
 				'name'   => $block_type->name,
-				'title'  => $block_type->title,
+				'title'  => isset( $block_type->title ) ? $block_type->title : '',
 				'source' => $this->source,
 			],
 			$blocks_source[ $block_type->name ]

--- a/tests/php/src/EntityRegistrantDetection/RestControllerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/RestControllerTest.php
@@ -2,7 +2,7 @@
 /**
  * Test case for RestController
  *
- * @package AmpProject\AmpWP\Support\Tests
+ * @package AmpProject\AmpWP\EntityRegistrantDetection\Tests
  */
 
 namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
@@ -71,6 +71,8 @@ class RestControllerTest extends DependencyInjectedTestCase {
 	 * @covers ::register()
 	 */
 	public function test_register() {
+
+		$this->instance->register();
 
 		$rest_server = rest_get_server();
 

--- a/tests/php/src/EntityRegistrantDetection/RestControllerTest.php
+++ b/tests/php/src/EntityRegistrantDetection/RestControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Test case for RestController
+ *
+ * @package AmpProject\AmpWP\Support\Tests
+ */
+
+namespace AmpProject\AmpWP\EntityRegistrantDetection\Tests;
+
+use AmpProject\AmpWP\EntityRegistrantDetection\EntityRegistrantDetectionManager;
+use AmpProject\AmpWP\EntityRegistrantDetection\RestController;
+use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * @coversDefaultClass \AmpProject\AmpWP\EntityRegistrantDetection\RestController
+ */
+class RestControllerTest extends DependencyInjectedTestCase {
+
+	use PrivateAccess;
+
+	/**
+	 * Instance of RestController
+	 *
+	 * @var RestController
+	 */
+	public $instance;
+
+	/**
+	 * Set up.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->instance = $this->injector->make( RestController::class );
+	}
+
+	/**
+	 * @covers ::__construct()
+	 */
+	public function test_construct() {
+
+		$this->assertEquals(
+			'amp/v1',
+			$this->get_private_property( $this->instance, 'namespace' )
+		);
+
+		$this->assertEquals(
+			'entity-registrants',
+			$this->get_private_property( $this->instance, 'rest_base' )
+		);
+	}
+
+	/**
+	 * @covers ::get_registration_action()
+	 */
+	public function test_get_registration_action() {
+
+		$this->assertEquals(
+			'rest_api_init',
+			RestController::get_registration_action()
+		);
+	}
+
+	/**
+	 * @covers ::register()
+	 */
+	public function test_register() {
+
+		$rest_server = rest_get_server();
+
+		$namespaces = $this->get_private_property( $rest_server, 'namespaces' );
+
+		$this->assertContains(
+			'amp/v1',
+			$rest_server->get_namespaces()
+		);
+
+		$this->assertContains(
+			'/amp/v1/entity-registrants',
+			array_keys( $namespaces['amp/v1'] )
+		);
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check()
+	 * @covers ::get_items()
+	 */
+	public function test_get_items() {
+
+		// Test 1: Missing parameter.
+		$request       = new WP_REST_Request( WP_REST_Server::READABLE, '/amp/v1/entity-registrants' );
+		$response      = rest_get_server()->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertEquals( 'rest_missing_callback_param', $response_data['code'] );
+
+		// Test 2: Invalid nonce.
+		$request->set_query_params(
+			[
+				EntityRegistrantDetectionManager::NONCE_QUERY_VAR => 'invalid_nonce',
+			]
+		);
+
+		$response      = rest_get_server()->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertEquals( 'http_request_failed', $response_data['code'] );
+
+		// Test 3: Valid nonce without user access.
+		$request->set_query_params(
+			[
+				EntityRegistrantDetectionManager::NONCE_QUERY_VAR => EntityRegistrantDetectionManager::get_nonce(),
+			]
+		);
+
+		$response      = rest_get_server()->dispatch( $request );
+		$response_data = $response->get_data();
+		$this->assertTrue( $response->is_error() );
+		$this->assertEquals( 'rest_forbidden', $response_data['code'] );
+
+		// Test 4: Valid nonce with user access.
+		wp_set_current_user(
+			self::factory()->user->create(
+				[
+					'role' => 'administrator',
+				]
+			)
+		);
+
+		$response      = rest_get_server()->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertFalse( $response->is_error() );
+
+		foreach ( [ 'post_types', 'taxonomies', 'blocks', 'shortcodes' ] as $entity_type ) {
+			$this->assertArrayHasKey( $entity_type, $response_data );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6516 

This PR adds new services "EntityRegistrantDetection", which detect the function which registers new entities such as post type, taxonomy, shortcode or block. And provide that info via REST endpoint.

**Sample REST response.**
```json
{
	"post_types":{
		"product":{
			"name":"Products",
			"slug":"product",
			"description":"This is where you can browse products in this store.",
			"hierarchical":false,
			"source":{
				"type":"plugin",
				"name":"woocommerce",
				"file":"includes\/class-wc-post-types.php",
				"line":286,
				"function":"WC_Post_Types::register_post_types",
				"hook":"init",
				"priority":5
			}
		},
	},
	"taxonomies":{
		"product_type":{
			"name":"Product type",
			"slug":"product_type",
			"description":"",
			"hierarchical":false,
			"source":{
				"type":"plugin",
				"name":"woocommerce",
				"file":"includes\/class-wc-post-types.php",
				"line":37,
				"function":"WC_Post_Types::register_taxonomies",
				"hook":"init",
				"priority":5
			}
		},
	},
	"blocks":{
		"woocommerce\/product-summary":{
			"name":"woocommerce\/product-summary",
			"title":"woocommerce\/product-summary",
			"description":"",
			"category":null,
			"attributes":[
				
			],
			"is_dynamic":true,
			"source":{
				"type":"plugin",
				"name":"woocommerce",
				"file":"packages\/woocommerce-blocks\/src\/BlockTypesController.php",
				"line":57,
				"function":"Automattic\\WooCommerce\\Blocks\\BlockTypesController::register_blocks",
				"hook":"init",
				"priority":10
			}
		},
	},
	"shortcodes":{
		"product":{
			"tag":"product",
			"source":{
				"type":"plugin",
				"name":"woocommerce",
				"file":"includes\/class-wc-shortcodes.php",
				"line":19,
				"function":"WC_Shortcodes::init",
				"hook":"init",
				"priority":10
			}
		},
	}
}
```

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
