### PR TITLE
Update amphtml spec to 2110212130002

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -887,8 +887,11 @@ class AMP_Allowed_Tags_Generated {
 					'sticky' => array(
 						'value' => array(
 							'',
-							'top',
 							'bottom',
+							'bottom-right',
+							'left',
+							'right',
+							'top',
 						),
 					),
 					'template' => array(),


### PR DESCRIPTION
Previously https://github.com/ampproject/amp-wp/pull/6651. 

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [ ] ~Update spec generator as needed based on spec format changes.~
- [ ] ~Modify validating sanitizer based on changes to spec, if needed.~
- [ ] ~Add tests for key changes, if needed.~

## Changelog

* Add allowed values for `sticky` attribute on `amp-ad`.

## Details

```bash
(
    PREV_VERSION=2110152252000;
    THIS_VERSION=2110212130002;
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- build-system/compile/bundles.config.extensions.json $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details><summary>Diff 2110152252000...2110212130002</summary>

```diff
diff --git a/build-system/compile/bundles.config.extensions.json b/build-system/compile/bundles.config.extensions.json
index dbe84fdbf2..c24d40329f 100644
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -594,6 +594,16 @@
     "version": "0.1",
     "latestVersion": "0.1"
   },
+  {
+    "name": "amp-jwplayer",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {
+      "hasCss": true,
+      "bento": true,
+      "npm": true
+    }
+  },
   {
     "name": "amp-kaltura-player",
     "version": "0.1",
diff --git a/extensions/amp-ad/validator-amp-ad.protoascii b/extensions/amp-ad/validator-amp-ad.protoascii
index d1e4f9f432..caa53380de 100644
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -52,8 +52,11 @@ tags: {  # <amp-ad>
   attrs: {
     name: "sticky"
     value: ""
-    value: "top"
     value: "bottom"
+    value: "bottom-right"
+    value: "left"
+    value: "right"
+    value: "top"
   }
   attrs: { name: "always-serve-npa" }
   attrs: { name: "block-rtc" }
```

</details>