### PR TITLE
Add external link icon for none wporg themes and plugins

### DIFF
--- a/assets/css/src/amp-admin.css
+++ b/assets/css/src/amp-admin.css
@@ -12,6 +12,11 @@
 	margin-left: 5px;
 }
 
+.theme-browser .theme .theme-screenshot img {
+	height: 100%;
+	object-fit: contain;
+}
+
 .amp-extension-card-message {
 	text-align: center;
 	padding: 0;

--- a/assets/css/src/amp-admin.css
+++ b/assets/css/src/amp-admin.css
@@ -6,6 +6,12 @@
 	position: relative;
 }
 
+.theme-browser .theme .dashicons-external,
+.plugin-action-buttons .dashicons-external {
+	vertical-align: text-bottom;
+	margin-left: 5px;
+}
+
 .amp-extension-card-message {
 	text-align: center;
 	padding: 0;

--- a/assets/css/src/amp-admin.css
+++ b/assets/css/src/amp-admin.css
@@ -41,12 +41,6 @@
 	width: 15px;
 }
 
-.theme-browser .theme {
-	float: none;
-	display: inline-block;
-	vertical-align: top;
-}
-
 .plugin-install-tab-amp-compatible .plugin-card-bottom {
 	display: none;
 }

--- a/assets/src/admin/theme-install/view/theme.js
+++ b/assets/src/admin/theme-install/view/theme.js
@@ -72,10 +72,14 @@ export default wpThemeView.extend( {
 		}
 
 		if ( slug && ! this.isWPORGTheme( slug ) ) {
+			const externalLinkIcon = document.createElement( 'span' );
+			externalLinkIcon.classList.add( 'dashicons' );
+			externalLinkIcon.classList.add( 'dashicons-external' );
+
 			const siteLinkButton = document.createElement( 'a' );
 			siteLinkButton.classList.add( 'button' );
 			siteLinkButton.classList.add( 'button-primary' );
-			siteLinkButton.append( __( 'Visit Site', 'amp' ) );
+			siteLinkButton.append( __( 'Visit Site', 'amp' ), externalLinkIcon );
 
 			if ( data?.preview_url ) {
 				siteLinkButton.href = data.preview_url;
@@ -100,7 +104,7 @@ export default wpThemeView.extend( {
 			const moreDetail = element.querySelector( '.more-details' );
 			if ( moreDetail ) {
 				moreDetail.textContent = ''; // Remove children.
-				moreDetail.append( __( 'Visit Site', 'amp' ) );
+				moreDetail.append( __( 'Visit Site', 'amp' ), externalLinkIcon.cloneNode( true ) );
 			}
 		}
 	},

--- a/assets/src/admin/theme-install/view/theme.js
+++ b/assets/src/admin/theme-install/view/theme.js
@@ -64,8 +64,7 @@ export default wpThemeView.extend( {
 					__( 'This is known to work well with the AMP plugin.', 'amp' ),
 				);
 
-				messageElement.append( iconElement );
-				messageElement.append( tooltipElement );
+				messageElement.append( iconElement, tooltipElement );
 
 				element.appendChild( messageElement );
 			} );
@@ -73,13 +72,16 @@ export default wpThemeView.extend( {
 
 		if ( slug && ! this.isWPORGTheme( slug ) ) {
 			const externalLinkIcon = document.createElement( 'span' );
-			externalLinkIcon.classList.add( 'dashicons' );
-			externalLinkIcon.classList.add( 'dashicons-external' );
+			externalLinkIcon.classList.add( 'dashicons', 'dashicons-external' );
+			externalLinkIcon.setAttribute( 'aria-hidden', 'true' );
+
+			const screenReaderText = document.createElement( 'span' );
+			screenReaderText.classList.add( 'screen-reader-text' );
+			screenReaderText.append( __( '(opens in a new tab)', 'amp' ) );
 
 			const siteLinkButton = document.createElement( 'a' );
-			siteLinkButton.classList.add( 'button' );
-			siteLinkButton.classList.add( 'button-primary' );
-			siteLinkButton.append( __( 'Visit Site', 'amp' ), externalLinkIcon );
+			siteLinkButton.classList.add( 'button', 'button-primary' );
+			siteLinkButton.append( __( 'Visit Site', 'amp' ), screenReaderText, externalLinkIcon );
 
 			if ( data?.preview_url ) {
 				siteLinkButton.href = data.preview_url;

--- a/src/Admin/AmpPlugins.php
+++ b/src/Admin/AmpPlugins.php
@@ -292,11 +292,11 @@ class AmpPlugins implements Conditional, Delayed, Service, Registerable {
 
 		if ( isset( $plugin['wporg'] ) && true !== $plugin['wporg'] ) {
 			$actions       = [];
-			$external_icon = '<span class="dashicons dashicons-external"></span>';
+			$external_icon = '<span aria-hidden="true" class="dashicons dashicons-external"></span>';
 
 			if ( ! empty( $plugin['homepage'] ) ) {
 				$actions[] = sprintf(
-					'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="%s">%s%s</a>',
+					'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="%s">%s<span class="screen-reader-text">(opens in a new tab)</span>%s</a>',
 					esc_url( $plugin['homepage'] ),
 					esc_attr(
 						/* translators: %s: Plugin name */

--- a/src/Admin/AmpPlugins.php
+++ b/src/Admin/AmpPlugins.php
@@ -291,17 +291,19 @@ class AmpPlugins implements Conditional, Delayed, Service, Registerable {
 	public function filter_action_links( $actions, $plugin ) {
 
 		if ( isset( $plugin['wporg'] ) && true !== $plugin['wporg'] ) {
-			$actions = [];
+			$actions       = [];
+			$external_icon = '<span class="dashicons dashicons-external"></span>';
 
 			if ( ! empty( $plugin['homepage'] ) ) {
 				$actions[] = sprintf(
-					'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="%s">%s</a>',
+					'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="%s">%s%s</a>',
 					esc_url( $plugin['homepage'] ),
 					esc_attr(
 						/* translators: %s: Plugin name */
 						sprintf( __( 'Site link of %s', 'amp' ), $plugin['name'] )
 					),
-					esc_html__( 'Visit site', 'amp' )
+					esc_html__( 'Visit site', 'amp' ),
+					$external_icon
 				);
 			}
 		}

--- a/tests/php/src/Admin/AmpPluginsTest.php
+++ b/tests/php/src/Admin/AmpPluginsTest.php
@@ -288,11 +288,11 @@ class AmpPluginsTest extends TestCase {
 		$this->assertIsArray( $output );
 		$this->assertEquals(
 			sprintf(
-				'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="Site link of %s">%s%s</a>',
+				'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="Site link of %s">%s<span class="screen-reader-text">(opens in a new tab)</span>%s</a>',
 				esc_url( $plugin_data['homepage'] ),
 				esc_html( $plugin_data['name'] ),
 				esc_html__( 'Visit site', 'amp' ),
-				'<span class="dashicons dashicons-external"></span>'
+				'<span aria-hidden="true" class="dashicons dashicons-external"></span>'
 			),
 			$output[0]
 		);

--- a/tests/php/src/Admin/AmpPluginsTest.php
+++ b/tests/php/src/Admin/AmpPluginsTest.php
@@ -288,10 +288,11 @@ class AmpPluginsTest extends TestCase {
 		$this->assertIsArray( $output );
 		$this->assertEquals(
 			sprintf(
-				'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="Site link of %s">%s</a>',
+				'<a href="%s" target="_blank" rel="noopener noreferrer" aria-label="Site link of %s">%s%s</a>',
 				esc_url( $plugin_data['homepage'] ),
 				esc_html( $plugin_data['name'] ),
-				esc_html__( 'Visit site', 'amp' )
+				esc_html__( 'Visit site', 'amp' ),
+				'<span class="dashicons dashicons-external"></span>'
 			),
 			$output[0]
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

Related #2313 

This PR adds an external link icon in the "Visit Site" button for none WordPress org plugin/theme in the "AMP Compatible" tab to indicate that the link may go to another site and not to the WordPress.org site.

Add new theme page

| Before                                                                                                                                   | After                                                                                                                                    |
|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="355" alt="image" src="https://user-images.githubusercontent.com/8168027/140992810-6dce9edf-c4af-43dd-8811-d90789cddb53.png"> | <img width="355" alt="image" src="https://user-images.githubusercontent.com/8168027/140991891-debaf400-a16c-4d64-bbac-90aac1620389.png"> |

Add new plugin page

| Before                                                                                                                                   | After                                                                                                                                    |
|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="494" alt="image" src="https://user-images.githubusercontent.com/8168027/140993035-5434defc-039f-4a82-ba24-255ceaf2ea84.png"> | <img width="497" alt="image" src="https://user-images.githubusercontent.com/8168027/140991971-658d88ee-f109-47c2-93f6-b371221aef62.png"> |

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
