### PR TITLE
Improve Sandboxing

### DIFF
--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -44,6 +44,7 @@ import { PluginsContextProvider } from '../components/plugins-context-provider';
 import { ThemesContextProvider } from '../components/themes-context-provider';
 import { SiteScanContextProvider } from '../components/site-scan-context-provider';
 import { Welcome } from './welcome';
+import { SandboxingLevel } from './sandboxing-level';
 import { TemplateModes } from './template-modes';
 import { SupportedTemplates } from './supported-templates';
 import { SettingsFooter } from './settings-footer';
@@ -221,6 +222,7 @@ function Root( { appRoot } ) {
 				<h2 id="advanced-settings">
 					{ __( 'Advanced Settings', 'amp' ) }
 				</h2>
+				<SandboxingLevel focusedSection={ focusedSection } />
 				<AMPDrawer
 					heading={ (
 						<h3>

--- a/assets/src/settings-page/sandboxing-level.js
+++ b/assets/src/settings-page/sandboxing-level.js
@@ -44,7 +44,7 @@ export function SandboxingLevel( { focusedSection } ) {
 			initialOpen={ 'sandboxing-level' === focusedSection }
 		>
 			<p>
-				{ __( 'Try out a more flexible AMP by generating pages that use AMP components without requiring AMP validity! By selecting a sandboxing level, you are indicating the minimum degree of sanitization. For example, if you selected level 1 but have a page without any POST form and no custom scripts, it will still be served as valid AMP, the same as if you had selected level 3.', 'amp' ) }
+				{ __( 'Try out a more flexible AMP by generating pages that use AMP components without requiring AMP validity! By selecting a sandboxing level, you are indicating the minimum degree of sanitization. For example, if you selected the loose leve but have a page without any POST form and no custom scripts, it will still be served as valid AMP—the same as if you had selected the strict level.', 'amp' ) }
 			</p>
 			<ol>
 				<li>
@@ -60,7 +60,7 @@ export function SandboxingLevel( { focusedSection } ) {
 						<strong>
 							{ __( 'Loose:', 'amp' ) }
 						</strong>
-						{ ' ' + __( 'Do not remove any AMP-invalid markup by default, including custom scripts. CSS tree-shaking is disabled.', 'amp' ) }
+						{ ' ' + __( 'Do not remove any AMP-invalid markup by default, including custom scripts. CSS processing is disabled.', 'amp' ) }
 					</label>
 				</li>
 				<li>
@@ -76,7 +76,7 @@ export function SandboxingLevel( { focusedSection } ) {
 						<strong>
 							{ __( 'Moderate:', 'amp' ) }
 						</strong>
-						{ ' ' + __( 'Remove non-AMP markup, but allow POST forms. CSS tree shaking is enabled.', 'amp' ) }
+						{ ' ' + __( 'Remove anything invalid AMP except for POST forms, excessive CSS, and other PX-verified markup.', 'amp' ) }
 					</label>
 				</li>
 				<li>
@@ -92,7 +92,7 @@ export function SandboxingLevel( { focusedSection } ) {
 						<strong>
 							{ __( 'Strict:', 'amp' ) }
 						</strong>
-						{ ' ' + __( 'Require valid AMP.', 'amp' ) }
+						{ ' ' + __( 'Require valid AMP, removing all markup that causes validation errors.', 'amp' ) }
 					</label>
 				</li>
 

--- a/assets/src/settings-page/sandboxing-level.js
+++ b/assets/src/settings-page/sandboxing-level.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Options } from '../components/options-context-provider';
+import { AMPDrawer } from '../components/amp-drawer';
+import { STANDARD } from '../common/constants';
+
+/**
+ * Component rendering the sandboxing level.
+ *
+ * @param {Object} props                Component props.
+ * @param {string} props.focusedSection Focused section.
+ */
+export function SandboxingLevel( { focusedSection } ) {
+	const { updateOptions, editedOptions: {
+		sandboxing_level: sandboxingLevel,
+		theme_support: themeSupport,
+	} } = useContext( Options );
+
+	if ( ! sandboxingLevel || STANDARD !== themeSupport ) {
+		return null;
+	}
+
+	return (
+		<AMPDrawer
+			heading={ (
+				<h3>
+					{ __( 'Sandboxing Level (Experimental)', 'amp' ) }
+				</h3>
+			) }
+			hiddenTitle={ __( 'Sandboxing Level (Experimental)', 'amp' ) }
+			id="sandboxing-level"
+			initialOpen={ 'sandboxing-level' === focusedSection }
+		>
+			<p>
+				{ __( 'Try out a more flexible AMP by generating pages that use AMP components without requiring AMP validity! By selecting a sandboxing level, you are indicating the minimum degree of sanitization. For example, if you selected level 1 but have a page without any POST form and no custom scripts, it will still be served as valid AMP, the same as if you had selected level 3.', 'amp' ) }
+			</p>
+			<ol>
+				<li>
+					<input
+						type="radio"
+						id="sandboxing-level-1"
+						checked={ 1 === sandboxingLevel }
+						onChange={ () => {
+							updateOptions( { sandboxing_level: 1 } );
+						} }
+					/>
+					<label htmlFor="sandboxing-level-1">
+						<strong>
+							{ __( 'Loose:', 'amp' ) }
+						</strong>
+						{ ' ' + __( 'Do not remove any AMP-invalid markup by default, including custom scripts. CSS tree-shaking is disabled.', 'amp' ) }
+					</label>
+				</li>
+				<li>
+					<input
+						type="radio"
+						id="sandboxing-level-2"
+						checked={ 2 === sandboxingLevel }
+						onChange={ () => {
+							updateOptions( { sandboxing_level: 2 } );
+						} }
+					/>
+					<label htmlFor="sandboxing-level-2">
+						<strong>
+							{ __( 'Moderate:', 'amp' ) }
+						</strong>
+						{ ' ' + __( 'Remove non-AMP markup, but allow POST forms. CSS tree shaking is enabled.', 'amp' ) }
+					</label>
+				</li>
+				<li>
+					<input
+						type="radio"
+						id="sandboxing-level-3"
+						checked={ 3 === sandboxingLevel }
+						onChange={ () => {
+							updateOptions( { sandboxing_level: 3 } );
+						} }
+					/>
+					<label htmlFor="sandboxing-level-3">
+						<strong>
+							{ __( 'Strict:', 'amp' ) }
+						</strong>
+						{ ' ' + __( 'Require valid AMP.', 'amp' ) }
+					</label>
+				</li>
+
+			</ol>
+		</AMPDrawer>
+	);
+}
+SandboxingLevel.propTypes = {
+	focusedSection: PropTypes.string,
+};

--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -367,6 +367,7 @@ li.error-kept {
 	}
 }
 
+#sandboxing-level .amp-drawer__panel-body-inner,
 #site-scan .amp-drawer__panel-body-inner,
 #site-review .amp-drawer__panel-body-inner,
 #plugin-suppression .amp-drawer__panel-body-inner,
@@ -657,4 +658,32 @@ li.error-kept {
 
 .amp-other-settings p {
 	font-size: 0.875rem;
+}
+
+/* Sandboxing Level */
+#sandboxing-level .amp-drawer__panel-body-inner p {
+	font-size: 14px;
+	margin-top: 0;
+}
+
+#sandboxing-level .amp-drawer__panel-body-inner ol {
+	margin-top: 1.5rem;
+	margin-left: 0;
+}
+
+#sandboxing-level .amp-drawer__panel-body-inner li {
+	list-style-type: none;
+}
+
+#sandboxing-level .amp-drawer__panel-body-inner li:not(:last-child) {
+	margin-bottom: 12px;
+}
+
+#sandboxing-level .amp-drawer__panel-body-inner input[type="radio"] {
+	margin-right: 12px;
+}
+
+#sandboxing-level .amp-drawer__panel-body-inner input[type="radio"],
+#sandboxing-level .amp-drawer__panel-body-inner label {
+	vertical-align: middle;
 }

--- a/assets/src/settings-page/template-modes.js
+++ b/assets/src/settings-page/template-modes.js
@@ -62,10 +62,8 @@ function NotRecommendedNotice() {
 export function TemplateModes( { focusReaderThemes } ) {
 	const {
 		editedOptions: {
-			sandboxing_level: sandboxingLevel,
 			theme_support: editedThemeSupport,
 		},
-		updateOptions,
 	} = useContext( Options );
 	const { selectedTheme, templateModeWasOverridden } = useContext( ReaderThemes );
 	const { templateModeRecommendation, staleTemplateModeRecommendation } = useTemplateModeRecommendation();
@@ -106,71 +104,7 @@ export function TemplateModes( { focusReaderThemes } ) {
 				initialOpen={ false }
 				mode={ STANDARD }
 				labelExtra={ getLabelForTemplateMode( STANDARD ) }
-			>
-				{
-					sandboxingLevel && (
-						<fieldset>
-							<h4 className="title">
-								{ __( 'Sandboxing Level (Experimental)', 'amp' ) }
-							</h4>
-							<p>
-								{ __( 'Try out a more flexible AMP by generating pages that use AMP components without requiring AMP validity! By selecting a sandboxing level, you are indicating the minimum degree of sanitization. For example, if you selected level 1 but have a page without any POST form and no custom scripts, it will still be served as valid AMP, the same as if you had selected level 3.', 'amp' ) }
-							</p>
-							<ol>
-								<li>
-									<input
-										type="radio"
-										id="sandboxing-level-1"
-										checked={ 1 === sandboxingLevel }
-										onChange={ () => {
-											updateOptions( { sandboxing_level: 1 } );
-										} }
-									/>
-									<label htmlFor="sandboxing-level-1">
-										<strong>
-											{ __( 'Loose:', 'amp' ) }
-										</strong>
-										{ ' ' + __( 'Do not remove any AMP-invalid markup by default, including custom scripts. CSS tree-shaking is disabled.', 'amp' ) }
-									</label>
-								</li>
-								<li>
-									<input
-										type="radio"
-										id="sandboxing-level-2"
-										checked={ 2 === sandboxingLevel }
-										onChange={ () => {
-											updateOptions( { sandboxing_level: 2 } );
-										} }
-									/>
-									<label htmlFor="sandboxing-level-2">
-										<strong>
-											{ __( 'Moderate:', 'amp' ) }
-										</strong>
-										{ ' ' + __( 'Remove non-AMP markup, but allow POST forms. CSS tree shaking is enabled.', 'amp' ) }
-									</label>
-								</li>
-								<li>
-									<input
-										type="radio"
-										id="sandboxing-level-3"
-										checked={ 3 === sandboxingLevel }
-										onChange={ () => {
-											updateOptions( { sandboxing_level: 3 } );
-										} }
-									/>
-									<label htmlFor="sandboxing-level-3">
-										<strong>
-											{ __( 'Strict:', 'amp' ) }
-										</strong>
-										{ ' ' + __( 'Require valid AMP.', 'amp' ) }
-									</label>
-								</li>
-
-							</ol>
-						</fieldset>
-					)
-				}
-			</TemplateModeOption>
+			/>
 			<TemplateModeOption
 				details={ templateModeRecommendation?.[ TRANSITIONAL ]?.details }
 				detailsUrl="https://amp-wp.org/documentation/getting-started/transitional/"

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2177,9 +2177,16 @@ class AMP_Theme_Support {
 			}
 		}
 
-		if ( Sandboxing::is_needed() ) {
-			Services::get( 'sandboxing' )->finalize_document( $dom, $effective_sandboxing_level );
-		}
+		/**
+		 * Fires immediately before the DOM is serialized to send as the response body.
+		 *
+		 * @since 2.2
+		 * @internal
+		 *
+		 * @param Document $dom                        Document prior to serialization.
+		 * @param int      $effective_sandboxing_level Effective sandboxing level.
+		 */
+		do_action( 'amp_finalize_dom', $dom, $effective_sandboxing_level );
 
 		$response = $dom->saveHTML();
 

--- a/src/Sandboxing.php
+++ b/src/Sandboxing.php
@@ -200,10 +200,48 @@ final class Sandboxing implements Service, Registerable, Conditional {
 	}
 
 	/**
+	 * Remove required AMP markup if not used.
+	 *
+	 * @param Document $dom                        Document.
+	 * @param int      $effective_sandboxing_level Effective sandboxing level.
+	 */
+	private function remove_required_amp_markup_if_not_used( Document $dom, $effective_sandboxing_level ) {
+		if ( 3 === $effective_sandboxing_level ) {
+			// When valid AMP is the target, don't remove the scripts since it won't be valid AMP.
+			return;
+		}
+
+		$amp_scripts = $dom->xpath->query( '//script[ @custom-element or @custom-template ]' );
+		if ( $amp_scripts->length > 0 ) {
+			return;
+		}
+
+		// Remove runtime script(s).
+		$runtime_scripts = $dom->xpath->query( '//script[ @async and @src and starts-with( @src, "https://cdn.ampproject.org/" ) and contains( @src, "v0" ) ]' );
+		foreach ( $runtime_scripts as $runtime_script ) {
+			if ( $runtime_script instanceof Element ) {
+				$runtime_script->parentNode->removeChild( $runtime_script );
+			}
+		}
+
+		// Remove runtime style.
+		$runtime_style = $dom->xpath->query( './style[ @amp-runtime ]', $dom->head )->item( 0 );
+		if ( $runtime_style instanceof Element ) {
+			$dom->head->removeChild( $runtime_style );
+		}
+
+		// Remove preconnect link.
+		$preconnect_link = $dom->xpath->query( './link[ @href = "https://cdn.ampproject.org" ]', $dom->head )->item( 0 );
+		if ( $preconnect_link instanceof Element ) {
+			$dom->head->removeChild( $preconnect_link );
+		}
+	}
+
+	/**
 	 * Finalize document.
 	 *
-	 * @param Document $dom Document.
-	 * @param int|null $effective_sandboxing_level Effective sandboxing level.
+	 * @param Document $dom                        Document.
+	 * @param int      $effective_sandboxing_level Effective sandboxing level.
 	 */
 	public function finalize_document( Document $dom, $effective_sandboxing_level ) {
 		$actual_sandboxing_level = AMP_Options_Manager::get_option( self::OPTION_LEVEL );
@@ -212,6 +250,8 @@ final class Sandboxing implements Service, Registerable, Conditional {
 		if ( $meta_generator instanceof DOMAttr ) {
 			$meta_generator->nodeValue .= "; sandboxing-level={$actual_sandboxing_level}:{$effective_sandboxing_level}";
 		}
+
+		$this->remove_required_amp_markup_if_not_used( $dom, $effective_sandboxing_level );
 
 		$amp_admin_bar_menu_item = $dom->xpath->query( '//div[ @id = "wpadminbar" ]//li[ @id = "wp-admin-bar-amp" ]/a' )->item( 0 );
 		if ( $amp_admin_bar_menu_item instanceof Element ) {

--- a/src/Sandboxing.php
+++ b/src/Sandboxing.php
@@ -176,6 +176,8 @@ final class Sandboxing implements Service, Registerable, Conditional {
 				return $error;
 			}
 		);
+
+		add_action( 'amp_finalize_dom', [ $this, 'finalize_document' ], 10, 2 );
 	}
 
 	/**

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -110,6 +110,7 @@ class Test_AMP_Comments_Sanitizer extends TestCase {
 	 * @covers ::sanitize()
 	 * @covers ::ampify_threaded_comments()
 	 * @covers ::prepare_native_comment_reply()
+	 * @covers ::get_comment_reply_script()
 	 */
 	public function test_ampify_threaded_comments( $ampify_comment_threading, $comments_form_has_action_xhr, $expect_ampify_comment_threading ) {
 		if ( version_compare( get_bloginfo( 'version' ), '5.2', '<' ) ) {
@@ -228,6 +229,7 @@ class Test_AMP_Comments_Sanitizer extends TestCase {
 	/**
 	 * Test AMP_Comments_Sanitizer::add_amp_live_list_comment_attributes.
 	 *
+	 * @covers ::sanitize()
 	 * @covers ::add_amp_live_list_comment_attributes()
 	 */
 	public function test_add_amp_live_list_comment_attributes() {

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1682,7 +1682,21 @@ class Test_AMP_Theme_Support extends TestCase {
 			return AMP_Theme_Support::prepare_response( $original_html );
 		};
 
+		$amp_finalize_dom_count = did_action( 'amp_finalize_dom' );
+		add_action(
+			'amp_finalize_dom',
+			function ( $dom, $effective_sandboxing_level ) {
+				$this->assertInstanceOf( Document::class, $dom );
+				$this->assertIsInt( $effective_sandboxing_level );
+				$this->assertSame( 3, $effective_sandboxing_level );
+			},
+			10,
+			2
+		);
+
 		$sanitized_html = $call_prepare_response();
+
+		$this->assertSame( $amp_finalize_dom_count + 1, did_action( 'amp_finalize_dom' ) );
 
 		$this->assertStringNotContainsString( 'handle=', $sanitized_html );
 		$this->assertEquals( 2, did_action( 'wp_print_scripts' ) );
@@ -1922,7 +1936,22 @@ class Test_AMP_Theme_Support extends TestCase {
 			</body>
 		</html>
 		<?php
+
+		$amp_finalize_dom_count = did_action( 'amp_finalize_dom' );
+		add_action(
+			'amp_finalize_dom',
+			function ( $dom, $effective_sandboxing_level ) use ( $converted ) {
+				$this->assertInstanceOf( Document::class, $dom );
+				$this->assertIsInt( $effective_sandboxing_level );
+				$this->assertSame( $converted ? 3 : 2, $effective_sandboxing_level );
+			},
+			10,
+			2
+		);
+
 		$html = AMP_Theme_Support::prepare_response( ob_get_clean() );
+
+		$this->assertSame( $amp_finalize_dom_count + 1, did_action( 'amp_finalize_dom' ) );
 
 		$dom = Document::fromHtml( $html );
 


### PR DESCRIPTION
## Summary

This is a follow-up to #6546. Namely, it seeks to address key [Future Todos](https://github.com/ampproject/amp-wp/pull/6546#:~:text=off.%20Check%20improvement.-,Future%20Todos,-Address%20feedback%20from).

## Changes

* Move "Sandboxing Level" setting from being inside Standard mode drawer to being its own drawer among the Advanced Settings. The drawer is only displayed if the experiment is enabled and if Standard mode is selected.
* Prevent calling `Sandboxing::finalize_document()` if the experiment is not enabled. See https://github.com/ampproject/amp-wp/pull/6546#discussion_r728270169.
* Omit AMP runtime script (`v0.js` and `v0.mjs`), AMP runtime style, and AMP CDN preconnect `link` if they are not needed due to no other AMP scripts being on the page and valid AMP is not the target (level 3).
* Refactor threaded comment handling to remove an erroneously-enqueued `comment-reply` script when there isn't a comment form on the page. (Hestia is enqueueing this script whenever `is_singular()` and isn't checking if `comments_open() && get_option( 'thread_comments' )`.)

Before | After
-------|------
<img width="1119" alt="before" src="https://user-images.githubusercontent.com/134745/141414970-332019a8-1cc1-493f-b043-a92719d17f49.png"> | <img width="1132" alt="after" src="https://user-images.githubusercontent.com/134745/141414974-2ca2eb3b-c9f3-426b-b359-f301f7f20d23.png">


## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
