### PR TITLE
Mark wp-polyfill as a dev mode script for Paired Browsing

### DIFF
--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -225,7 +225,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional, Delaye
 		// Mark enqueued script for AMP dev mode so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
 		$dev_mode_handles = array_merge(
-			[ $handle, 'wp-i18n', 'wp-hooks', 'regenerator-runtime' ],
+			[ $handle, 'wp-i18n', 'wp-hooks', 'regenerator-runtime', 'wp-polyfill' ],
 			$dependencies
 		);
 		add_filter(


### PR DESCRIPTION
## Summary

I found that in WordPress 5.9-alpha, the `wp-i18n` script now has `wp-polyfill` as a dependency. With Paired Browsing active, this was now causing a validation error:

![image](https://user-images.githubusercontent.com/134745/141921574-20a8562f-7792-4e36-9f4a-68378bfed173.png)

So this PR adds `wp-polyfill` to the list of scripts which are automatically included as part of dev mode when paired browsing is active.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
