### PR TITLE
Implement WP 5.9 change to remove empty query string when removing endpoint from a URL that contains a URL fragment

### DIFF
--- a/src/PairedUrl.php
+++ b/src/PairedUrl.php
@@ -24,7 +24,9 @@ final class PairedUrl implements Service {
 	 * @return string URL.
 	 */
 	public function remove_query_var( $url ) {
-		return remove_query_arg( amp_get_slug(), $url );
+		$url = remove_query_arg( amp_get_slug(), $url );
+		$url = str_replace( '?#', '#', $url ); // See <https://core.trac.wordpress.org/ticket/44499>.
+		return $url;
 	}
 
 	/**

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -654,7 +654,7 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 		$this->assertEquals( 'https://example.com/foo/', amp_remove_paired_endpoint( 'https://example.com/foo/?amp' ) );
 		$this->assertEquals( 'https://example.com/foo/', amp_remove_paired_endpoint( 'https://example.com/foo/?amp=1' ) );
 		$this->assertEquals( 'https://example.com/foo/', amp_remove_paired_endpoint( 'https://example.com/foo/amp/?amp=1' ) );
-		$this->assertEquals( 'https://example.com/foo/?#bar', amp_remove_paired_endpoint( 'https://example.com/foo/?amp#bar' ) );
+		$this->assertEquals( 'https://example.com/foo/#bar', amp_remove_paired_endpoint( 'https://example.com/foo/?amp#bar' ) );
 		$this->assertEquals( 'https://example.com/foo/', amp_remove_paired_endpoint( 'https://example.com/foo/amp/' ) );
 		$this->assertEquals( 'https://example.com/foo/?blaz', amp_remove_paired_endpoint( 'https://example.com/foo/amp/?blaz' ) );
 	}


### PR DESCRIPTION
## Summary

The `remove_query_arg()` function before WP 5.9 would end up leaving `?#` when all query vars were removed. This implements the core change in 5.9 to strip out that extraneous `?` in older versions as well.

See https://core.trac.wordpress.org/ticket/44499

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
