### PR TITLE
Do not rescan when going back to Site Scan step in Wizard

### DIFF
--- a/assets/src/components/site-scan-context-provider/__mocks__/index.js
+++ b/assets/src/components/site-scan-context-provider/__mocks__/index.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export const SiteScan = createContext();
+
+/**
+ * MOCK.
+ *
+ * @param {Object}  props
+ * @param {any}     props.children
+ * @param {boolean} props.hasSiteScanResults
+ * @param {boolean} props.isBusy
+ * @param {boolean} props.isCancelled
+ * @param {boolean} props.isCompleted
+ * @param {boolean} props.isFailed
+ * @param {boolean} props.isFetchingScannableUrls
+ * @param {boolean} props.isReady
+ * @param {boolean} props.isSiteScannable
+ * @param {boolean} props.stale
+ */
+export function SiteScanContextProvider( {
+	children,
+	hasSiteScanResults = false,
+	isBusy = false,
+	isCancelled = false,
+	isCompleted = false,
+	isFailed = false,
+	isFetchingScannableUrls = false,
+	isReady = true,
+	isSiteScannable = false,
+	stale = false,
+} ) {
+	return (
+		<SiteScan.Provider value={
+			{
+				cancelSiteScan: () => {},
+				fetchScannableUrls: () => {},
+				hasSiteScanResults,
+				isBusy,
+				isCancelled,
+				isCompleted,
+				isFailed,
+				isFetchingScannableUrls,
+				isReady,
+				isSiteScannable,
+				pluginsWithAmpIncompatibility: [],
+				previewPermalink: '',
+				scannableUrls: [],
+				scannedUrlsMaxIndex: -1,
+				stale,
+				startSiteScan: () => {},
+				themesWithAmpIncompatibility: [],
+			}
+		}>
+			{ children }
+		</SiteScan.Provider>
+	);
+}
+SiteScanContextProvider.propTypes = {
+	children: PropTypes.any,
+	hasSiteScanResults: PropTypes.bool,
+	isBusy: PropTypes.bool,
+	isCancelled: PropTypes.bool,
+	isCompleted: PropTypes.bool,
+	isFailed: PropTypes.bool,
+	isFetchingScannableUrls: PropTypes.bool,
+	isReady: PropTypes.bool,
+	isSiteScannable: PropTypes.bool,
+	stale: PropTypes.bool,
+};

--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -198,12 +198,14 @@ export function siteScanReducer( state, action ) {
  * @param {Object}  props                             Component props.
  * @param {?any}    props.children                    Component children.
  * @param {boolean} props.fetchCachedValidationErrors Whether to fetch cached validation errors on mount.
+ * @param {boolean} props.resetOnOptionsChange        Whether to reset scanner and refetch scannable URLs whenever AMP options are changed.
  * @param {string}  props.scannableUrlsRestPath       The REST path for interacting with the scannable URL resources.
  * @param {string}  props.validateNonce               The AMP validate nonce.
  */
 export function SiteScanContextProvider( {
 	children,
 	fetchCachedValidationErrors = false,
+	resetOnOptionsChange = false,
 	scannableUrlsRestPath,
 	validateNonce,
 } ) {
@@ -292,11 +294,11 @@ export function SiteScanContextProvider( {
 	 * refetch the scannable URLs.
 	 */
 	useEffect( () => {
-		if ( Object.keys( savedOptions ).length > 0 ) {
+		if ( resetOnOptionsChange && Object.keys( savedOptions ).length > 0 ) {
 			dispatch( { type: ACTION_SCAN_CANCEL } );
 			dispatch( { type: ACTION_SCANNABLE_URLS_REQUEST } );
 		}
-	}, [ savedOptions ] );
+	}, [ resetOnOptionsChange, savedOptions ] );
 
 	/**
 	 * Trigger site scan if the suppressed plugins list has changed and the
@@ -478,6 +480,7 @@ export function SiteScanContextProvider( {
 SiteScanContextProvider.propTypes = {
 	children: PropTypes.any,
 	fetchCachedValidationErrors: PropTypes.bool,
+	resetOnOptionsChange: PropTypes.bool,
 	scannableUrlsRestPath: PropTypes.string,
 	validateNonce: PropTypes.string,
 };

--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -466,7 +466,7 @@ export function SiteScanContextProvider( {
 				pluginsWithAmpIncompatibility,
 				previewPermalink,
 				scannableUrls,
-				scannedUrlsMaxIndex: Math.min( scannableUrls.length, ...urlIndexesPendingScan ) - 1,
+				scannedUrlsMaxIndex: ( [ STATUS_IN_PROGRESS, STATUS_IDLE ].includes( status ) ? Math.min( scannableUrls.length, ...urlIndexesPendingScan ) : 0 ) - 1,
 				stale,
 				startSiteScan,
 				themesWithAmpIncompatibility,

--- a/assets/src/onboarding-wizard/components/nav/index.js
+++ b/assets/src/onboarding-wizard/components/nav/index.js
@@ -21,6 +21,7 @@ import { Options } from '../../../components/options-context-provider';
 import { User } from '../../../components/user-context-provider';
 import { READER } from '../../../common/constants';
 import { ReaderThemes } from '../../../components/reader-themes-context-provider';
+import { SiteScan } from '../../../components/site-scan-context-provider';
 import { useWindowWidth } from '../../../utils/use-window-width';
 
 /**
@@ -66,6 +67,7 @@ export function Nav( { closeLink, finishLink } ) {
 	} = useContext( Options );
 	const { savingDeveloperToolsOption } = useContext( User );
 	const { downloadingTheme } = useContext( ReaderThemes );
+	const { isBusy } = useContext( SiteScan );
 
 	let nextText;
 	let nextLink;
@@ -103,6 +105,7 @@ export function Nav( { closeLink, finishLink } ) {
 						)
 						: (
 							<Button
+								disabled={ isBusy }
 								className="amp-settings-nav__prev"
 								onClick={ moveBack }
 							>

--- a/assets/src/onboarding-wizard/components/nav/test/index.js
+++ b/assets/src/onboarding-wizard/components/nav/test/index.js
@@ -18,11 +18,13 @@ import { NavigationContextProvider } from '../../navigation-context-provider';
 import { UserContextProvider } from '../../../../components/user-context-provider';
 import { OptionsContextProvider } from '../../../../components/options-context-provider';
 import { ReaderThemesContextProvider } from '../../../../components/reader-themes-context-provider';
+import { SiteScanContextProvider } from '../../../../components/site-scan-context-provider';
 import { STANDARD, READER } from '../../../../common/constants';
 
 jest.mock( '../../../../components/options-context-provider' );
 jest.mock( '../../../../components/reader-themes-context-provider' );
 jest.mock( '../../../../components/user-context-provider' );
+jest.mock( '../../../../components/site-scan-context-provider' );
 
 let container;
 
@@ -40,11 +42,13 @@ const testPages = [
 const Providers = ( { children, pages, themeSupport = READER, downloadingTheme = false } ) => (
 	<OptionsContextProvider themeSupport={ themeSupport }>
 		<UserContextProvider>
-			<NavigationContextProvider pages={ pages }>
-				<ReaderThemesContextProvider downloadingTheme={ downloadingTheme }>
-					{ children }
-				</ReaderThemesContextProvider>
-			</NavigationContextProvider>
+			<SiteScanContextProvider>
+				<NavigationContextProvider pages={ pages }>
+					<ReaderThemesContextProvider downloadingTheme={ downloadingTheme }>
+						{ children }
+					</ReaderThemesContextProvider>
+				</NavigationContextProvider>
+			</SiteScanContextProvider>
 		</UserContextProvider>
 	</OptionsContextProvider>
 );

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -88,6 +88,8 @@ export function Providers( { children } ) {
 									>
 										<TemplateModeOverrideContextProvider>
 											<SiteScanContextProvider
+												fetchCachedValidationErrors={ false }
+												resetOnOptionsChange={ false }
 												scannableUrlsRestPath={ SCANNABLE_URLS_REST_PATH }
 												validateNonce={ VALIDATE_NONCE }
 											>

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -97,6 +97,7 @@ function Providers( { children } ) {
 									<ThemesContextProvider hasErrorBoundary={ true }>
 										<SiteScanContextProvider
 											fetchCachedValidationErrors={ true }
+											resetOnOptionsChange={ true }
 											scannableUrlsRestPath={ SCANNABLE_URLS_REST_PATH }
 											validateNonce={ VALIDATE_NONCE }
 										>

--- a/tests/e2e/specs/amp-onboarding/site-scan.js
+++ b/tests/e2e/specs/amp-onboarding/site-scan.js
@@ -41,7 +41,7 @@ describe( 'Onboarding Wizard Site Scan Step', () => {
 			expect( page ).toMatchElement( '.amp-onboarding-wizard-panel h1', { text: 'Site Scan' } ),
 			expect( page ).toMatchElement( '.site-scan__heading', { text: 'Please wait a minute' } ),
 			testNextButton( { text: 'Next', disabled: true } ),
-			testPreviousButton( { text: 'Previous' } ),
+			testPreviousButton( { text: 'Previous', disabled: true } ),
 			testSiteScanning( {
 				statusElementClassName: 'site-scan__status',
 				isAmpFirst: true,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6741 

This PR prevents doing multiple scans in the Onboarding Wizard after saving options and going back to the Site Scan step.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
