### PR TITLE
Use Contact Form 7 instead of Autoptimize or Akismet for AMP-incompatible plugin in E2E tests

### DIFF
--- a/tests/e2e/specs/admin/site-scan-panel.js
+++ b/tests/e2e/specs/admin/site-scan-panel.js
@@ -26,7 +26,7 @@ describe( 'AMP settings screen Site Scan panel', () => {
 
 	beforeAll( async () => {
 		await installTheme( 'hestia' );
-		await installPlugin( 'akismet' );
+		await installPlugin( 'contact-form-7' );
 
 		await cleanUpSettings();
 
@@ -36,7 +36,7 @@ describe( 'AMP settings screen Site Scan panel', () => {
 
 	afterAll( async () => {
 		await deleteTheme( 'hestia', { newThemeSlug: 'twentytwenty' } );
-		await uninstallPlugin( 'akismet' );
+		await uninstallPlugin( 'contact-form-7' );
 
 		await cleanUpSettings();
 	} );
@@ -94,25 +94,25 @@ describe( 'AMP settings screen Site Scan panel', () => {
 		await expect( page ).toMatchElement( '.site-scan-results--themes .site-scan-results__source-name', { text: /Hestia/ } );
 	} );
 
-	it( 'lists Autoptimize plugin as causing AMP incompatibility', async () => {
+	it( 'lists Contact Form 7 plugin as causing AMP incompatibility', async () => {
 		await activateTheme( 'twentytwenty' );
-		await activatePlugin( 'akismet' );
+		await activatePlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
 		await triggerSiteRescan();
 
 		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__heading[data-badge-content="1"]', { text: /^Plugins/, timeout } );
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Autoptimize/ } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Contact Form 7/ } );
 
 		await expect( page ).not.toMatchElement( '.site-scan-results--themes' );
 
-		await deactivatePlugin( 'akismet' );
+		await deactivatePlugin( 'contact-form-7' );
 	} );
 
-	it( 'lists Hestia theme and Autoptimize plugin for causing AMP incompatibilities', async () => {
+	it( 'lists Hestia theme and Contact Form 7 plugin for causing AMP incompatibilities', async () => {
 		await activateTheme( 'hestia' );
-		await activatePlugin( 'akismet' );
+		await activatePlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
@@ -125,43 +125,43 @@ describe( 'AMP settings screen Site Scan panel', () => {
 		expect( totalIssuesCount ).toBe( 2 );
 
 		await expect( page ).toMatchElement( '.site-scan-results--themes .site-scan-results__source-name', { text: /Hestia/ } );
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Autoptimize/ } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Contact Form 7/ } );
 
-		await deactivatePlugin( 'akismet' );
+		await deactivatePlugin( 'contact-form-7' );
 	} );
 
 	it( 'displays a notice if a plugin has been deactivated or removed', async () => {
 		await activateTheme( 'twentytwenty' );
-		await activatePlugin( 'akismet' );
+		await activatePlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
 		await triggerSiteRescan();
 
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Autoptimize/, timeout } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Contact Form 7/, timeout } );
 
 		// Deactivate the plugin and test.
-		await deactivatePlugin( 'akismet' );
+		await deactivatePlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Autoptimize/ } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Contact Form 7/ } );
 		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-notice', { text: /This plugin has been deactivated since last site scan./ } );
 
 		// Uninstall the plugin and test.
-		await uninstallPlugin( 'akismet' );
+		await uninstallPlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-slug', { text: /akismet/ } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-slug', { text: /contact-form-7/ } );
 		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-notice', { text: /This plugin has been uninstalled since last site scan./ } );
 
 		// Clean up.
-		await installPlugin( 'akismet' );
+		await installPlugin( 'contact-form-7' );
 	} );
 
 	it( 'automatically triggers a scan if Plugin Suppression option has changed', async () => {
-		await activatePlugin( 'akismet' );
+		await activatePlugin( 'contact-form-7' );
 
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 
@@ -181,6 +181,6 @@ describe( 'AMP settings screen Site Scan panel', () => {
 			isAmpFirst: false,
 		} );
 
-		await deactivatePlugin( 'akismet' );
+		await deactivatePlugin( 'contact-form-7' );
 	} );
 } );

--- a/tests/e2e/specs/amp-onboarding/site-scan.js
+++ b/tests/e2e/specs/amp-onboarding/site-scan.js
@@ -26,12 +26,12 @@ import {
 describe( 'Onboarding Wizard Site Scan Step', () => {
 	beforeAll( async () => {
 		await installTheme( 'hestia' );
-		await installPlugin( 'akismet' );
+		await installPlugin( 'contact-form-7' );
 	} );
 
 	afterAll( async () => {
 		await deleteTheme( 'hestia', { newThemeSlug: 'twentytwenty' } );
-		await uninstallPlugin( 'akismet' );
+		await uninstallPlugin( 'contact-form-7' );
 	} );
 
 	it( 'should start a site scan immediately', async () => {
@@ -57,7 +57,7 @@ describe( 'Onboarding Wizard Site Scan Step', () => {
 
 	it( 'should list out plugin and theme issues after the scan', async () => {
 		await activateTheme( 'hestia' );
-		await activatePlugin( 'akismet' );
+		await activatePlugin( 'contact-form-7' );
 
 		await moveToSiteScanScreen( { technical: true } );
 
@@ -76,12 +76,12 @@ describe( 'Onboarding Wizard Site Scan Step', () => {
 		expect( totalIssuesCount ).toBe( 2 );
 
 		await expect( page ).toMatchElement( '.site-scan-results--themes .site-scan-results__source-name', { text: /Hestia/ } );
-		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Autoptimize/ } );
+		await expect( page ).toMatchElement( '.site-scan-results--plugins .site-scan-results__source-name', { text: /Contact Form 7/ } );
 
 		await testNextButton( { text: 'Next' } );
 		await testPreviousButton( { text: 'Previous' } );
 
-		await deactivatePlugin( 'akismet' );
+		await deactivatePlugin( 'contact-form-7' );
 		await activateTheme( 'twentytwenty' );
 	} );
 } );


### PR DESCRIPTION
This is a follow-up to https://github.com/ampproject/amp-wp/pull/6745/commits/b69d8263703b6d30412f84cbfe3da205279a0ab0 in https://github.com/ampproject/amp-wp/pull/6745.