### PR TITLE
Update amphtml spec to 2111242025000

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -7789,6 +7789,9 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
+					'volume' => array(
+						'value_regex' => '^((0?\\.[1-9]+)?|1(\\.0*)?)$',
+					),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -10854,6 +10857,7 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
+					'xssi-prefix' => array(),
 				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
@@ -13327,6 +13331,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'content' => array(),
 					'itemprop' => array(),
+					'media' => array(),
 					'name' => array(
 						'disallowed_value_regex' => '(^|\\s)(amp-.*|amp4ads-.*|apple-itunes-app|content-disposition|revisit-after|viewport)(\\s|$)',
 					),

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -61,6 +61,10 @@ class AMP_Form_Sanitizer_Test extends TestCase {
 				'<form method="get" action="http://example.org/example-page/"></form>',
 				'<form method="get" action="//example.org/example-page/" target="_top"></form>',
 			],
+			'form_with_get_method_and_action_xhr' => [
+				'<form method="get" action="//example.org/example-page/" action-xhr="//example.org/wp-json/foo/submissions/" xssi-prefix=")]}"></form>',
+				'<form method="get" action="//example.org/example-page/" target="_top" action-xhr="//example.org/wp-json/foo/submissions/" xssi-prefix=")]}"></form>',
+			],
 			'form_with_http_action_and_port' => [
 				'<form method="get" action="http://example.org:8080/example-page/"></form>',
 				'<form method="get" action="//example.org:8080/example-page/" target="_top"></form>',

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -553,7 +553,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 									<h2 scale-start="1.0" scale-end="200.1" translate-x="100px" translate-y="200px">Scaled</h2>
 									<amp-twitter width="375" height="472" layout="responsive" data-tweetid="885634330868850689"></amp-twitter>
 									<amp-twitter interactive width="375" height="472" layout="responsive" data-tweetid="885634330868850689"></amp-twitter>
-									<amp-video autoplay loop width="720" height="960" poster="https://amp.dev/static/samples/img/story_video_dog_cover.jpg" layout="responsive" cache="google">
+									<amp-video autoplay volume="0.5" loop width="720" height="960" poster="https://amp.dev/static/samples/img/story_video_dog_cover.jpg" layout="responsive" cache="google">
 										<source src="https://amp.dev/static/samples/video/story_video_dog.mp4" type="video/mp4">
 									</amp-video>
 									<amp-date-display datetime="2017-08-02T15:05:05.000" layout="fixed" width="360" height="20"><template type="amp-mustache"><div>{{dayName}} {{day}} {{monthName}} {{year}} {{hourTwoDigit}}:{{minuteTwoDigit}}:{{secondTwoDigit}}</div></template></amp-date-display>
@@ -3451,6 +3451,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends TestCase {
 			],
 			'meta_story_meta_tags'                    => [
 				'<html amp><head><meta charset="utf-8"><meta name="amp-story-generator-name" content="Web Stories for WordPress"><meta name="amp-story-generator-version" content="1.2.3"></head><body></body></html>',
+				null, // No change.
+			],
+			'meta_theme_color'                    => [
+				'<html amp><head><meta charset="utf-8"><meta name="theme-color" content="#ecd96f" media="(prefers-color-scheme: light)"><meta name="theme-color" content="#0b3e05" media="(prefers-color-scheme: dark)"></head><body></body></html>',
 				null, // No change.
 			],
 			'link_without_valid_mandatory_href'       => [


### PR DESCRIPTION
Previously https://github.com/ampproject/amp-wp/pull/6712. 

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`).
- [x] Examine diff for changelog.
- [x] Examine upstream diff to ensure nothing was missed.
- [x] ~Update spec generator as needed based on spec format changes.~
- [x] ~Modify validating sanitizer based on changes to spec, if needed.~
- [x] Add tests for key changes, if needed.

## Changelog

* Allow `media` attribute on the `meta` tag. See https://github.com/ampproject/amphtml/pull/36652.
* Add `volume` attribute to `amp-story >> amp-video`.
* Add `xssi-prefix` attribute to `FORM [method=GET]`.

## Details

```bash
(
    PREV_VERSION=2110290545003;
    THIS_VERSION=2111242025000;
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- build-system/compile/bundles.config.extensions.json $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details><summary>Diff 2110290545003...2111242025000</summary>

```diff
diff --git a/build-system/compile/bundles.config.extensions.json b/build-system/compile/bundles.config.extensions.json
index 147581beb6..385948f1a3 100644
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -529,14 +529,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-inline-gallery",
-        "amp-inline-gallery-captions",
-        "amp-inline-gallery-pagination",
-        "amp-inline-gallery-slide",
-        "amp-inline-gallery-thumbnails"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -545,9 +538,6 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "cssBinaries": [
-        "amp-inline-gallery-pagination"
-      ],
       "npm": true,
       "bento": true
     }
@@ -976,20 +966,7 @@
     "version": "1.0",
     "latestVersion": "1.0",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-consent",
-        "amp-story-draggable-drawer-header",
-        "amp-story-form",
-        "amp-story-hint",
-        "amp-story-info-dialog",
-        "amp-story-open-page-attachment",
-        "amp-story-share",
-        "amp-story-share-menu",
-        "amp-story-system-layer",
-        "amp-story-tooltip",
-        "amp-story-unsupported-browser-layer"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1005,15 +982,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-auto-ads-ad-badge",
-        "amp-story-auto-ads-attribution",
-        "amp-story-auto-ads-cta-button",
-        "amp-story-auto-ads-inabox",
-        "amp-story-auto-ads-progress-bar",
-        "amp-story-auto-ads-shared"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1050,19 +1019,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-interactive-binary-poll",
-        "amp-story-interactive-img",
-        "amp-story-interactive-img-poll",
-        "amp-story-interactive-img-quiz",
-        "amp-story-interactive-poll",
-        "amp-story-interactive-quiz",
-        "amp-story-interactive-results",
-        "amp-story-interactive-results-detailed",
-        "amp-story-interactive-slider",
-        "amp-story-interactive-disclaimer"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1086,12 +1043,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-shopping",
-        "amp-story-shopping-attachment",
-        "amp-story-shopping-tag"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1156,11 +1108,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-truncate-text",
-        "amp-truncate-text-shadow"
-      ]
+      "hasCss": true
     }
   },
   {
diff --git a/extensions/amp-video/validator-amp-video.protoascii b/extensions/amp-video/validator-amp-video.protoascii
index 2327ea1be7..5a66a7dd18 100644
--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -183,6 +183,12 @@ tags: {  # <amp-video> in amp-story
     name: "captions-id"
     requires_extension: "amp-story-captions"
   }
+  attrs: {
+    name: "volume"
+    # Disallow 0 to prevent shipping unnecessary audio track when the video is muted.
+    # Volume must be in the range [0.1, 1].
+    value_regex: "^((0?\\.[1-9]+)?|1(\\.0*)?)$"
+  }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
   spec_url: "https://amp.dev/documentation/components/amp-video/"
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index 3d3b1b9dfe..3dbf5014f3 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -313,6 +313,40 @@ tags: {
   attr_lists: "common-link-attrs"
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
 }
+# Allowlisted CSS provider
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "LINK"
+  spec_name: "link rel=stylesheet for amp-story-1.0 css"
+  descriptive_name: "link rel=stylesheet for amp-story-1.0 css"
+  mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
+  attrs: { name: "crossorigin" }  # SRI attribute (https://www.w3.org/TR/SRI/)
+  attrs: {
+    name: "href"
+    mandatory: true
+    value: "https://cdn.ampproject.org/v0/amp-story-1.0.css"
+    value: "https://cdn.ampproject.org/lts/v0/amp-story-1.0.css"
+  }
+  attrs: { name: "integrity" }  # SRI attribute (https://www.w3.org/TR/SRI/)
+  attrs: { name: "media" }
+  attrs: {
+    name: "rel"
+    mandatory: true
+    value_casei: "stylesheet"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/css"
+  }
+  attrs: {
+    name: "amp-extension"
+    mandatory: true
+    value_casei: "amp-story"
+  }
+}
 # Allowlisted font providers
 tags: {
   html_format: AMP
@@ -731,6 +765,7 @@ tags: {
         "viewport"
         ")(\\s|$)"
   }
+  attrs: { name: "media" } # For varying theme-color.
   attrs: { name: "property" }  # property is non-standard, but commonly seen.
   # scheme is used by Dublin Core, see issue #13993
   attrs: { name: "scheme" }
@@ -2350,6 +2385,7 @@ tags {  # <form method=GET ...>
     }
     disallowed_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "xssi-prefix" }
   attr_lists: "form-name-attr"
 }
 tags {  # <form method=POST ...>
```

</details>