### PR TITLE
Fix test in WP 5.9-beta1: Cast term IDs to integers instead of using `sanitize_key()`

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -362,7 +362,7 @@ class AMP_Validation_Error_Taxonomy {
 		$term = get_term( (int) $term_id, self::TAXONOMY_SLUG );
 
 		// Skip if the term count was not actually 0.
-		if ( ! $term || 0 !== $term->count ) {
+		if ( ! $term instanceof WP_Term || 0 !== $term->count ) {
 			return false;
 		}
 
@@ -2867,8 +2867,8 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		$action              = sanitize_key( $_REQUEST['action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$term_ids            = isset( $_POST['delete_tags'] ) ? array_map( 'sanitize_key', $_POST['delete_tags'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$single_term_id      = isset( $_GET['term_id'] ) ? sanitize_key( $_GET['term_id'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$term_ids            = isset( $_POST['delete_tags'] ) ? array_filter( array_map( 'intval', (array) $_POST['delete_tags'] ) ) : []; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$single_term_id      = isset( $_GET['term_id'] ) ? (int) $_GET['term_id'] : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$redirect_query_args = [
 			'action'       => 'edit',
 			'amp_actioned' => $action,

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1404,7 +1404,7 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 
 		// Because the action is incorrect, the tested method should exit and not update the validation error term.
 		$_REQUEST['action']   = 'incorrect-action';
-		$_POST['delete_tags'] = [ $error_term->term_id ];
+		$_POST['delete_tags'] = [ (string) $error_term->term_id ];
 		$correct_post_type    = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertEquals( get_term( $error_term->term_id )->term_group, $initial_accepted_status );
 


### PR DESCRIPTION
## Summary

In one place (as far as I can tell) we were using `sanitize_key()` to sanitize a term ID as input. This worked fine up until WordPress 5.9-beta1, specifically [r52292](https://core.trac.wordpress.org/changeset/52292) in which any non-string inputs to `sanitize_key()` are made into empty strings. This broke `Test_AMP_Validation_Error_Taxonomy::test_handle_single_url_page_bulk_and_inline_actions()` which was simulating the POST input data with integer instead of string:

https://github.com/ampproject/amp-wp/blob/35bf862d4878d07714b162929bf19d0d8844e051/tests/php/validation/test-class-amp-validation-error-taxonomy.php#L1407

The effect of this was to cause `AMP_Validation_Error_Taxonomy::handle_single_url_page_bulk_and_inline_actions()` to fail here:

https://github.com/ampproject/amp-wp/blob/35bf862d4878d07714b162929bf19d0d8844e051/includes/validation/class-amp-validation-error-taxonomy.php#L2870

Since `$_POST['delete_tags']` here was an array of integer(s), and since `sanitize_key()` now converts non-strings to an empty string, the result was `$term_ids` being `[ '' ]`. This `$term_ids` array then is non-empty, resulting in the first condition passing:

https://github.com/ampproject/amp-wp/blob/35bf862d4878d07714b162929bf19d0d8844e051/includes/validation/class-amp-validation-error-taxonomy.php#L2877-L2880

That `handle_validation_error_update` method then tried to loop over the `$term_ids` and passed that empty string into `delete_empty_term`:

https://github.com/ampproject/amp-wp/blob/35bf862d4878d07714b162929bf19d0d8844e051/includes/validation/class-amp-validation-error-taxonomy.php#L2919-L2920

Calling that method then failed because it casted the `$term_id` (an empty string) to an integer resulting in `0` being passed to `get_term()`, and the return value was a `WP_Error` instance not the expected `WP_Term` or `false` instance.

https://github.com/ampproject/amp-wp/blob/35bf862d4878d07714b162929bf19d0d8844e051/includes/validation/class-amp-validation-error-taxonomy.php#L361-L367

This showed up in a test failure as:

```
1) Test_AMP_Validation_Error_Taxonomy::test_handle_single_url_page_bulk_and_inline_actions
Failed asserting that 'Undefined property: WP_Error::$count' contains "Cannot modify header information".
```

So this PR fixes the test by:

0. Populating the test input with a string term ID which is what would be coming from the browser.
1. Using the more appropriate input sanitization method up front, using an `int` cast and `intval()` call.
2. Hardening `delete_empty_term` to bail if the return value of `get_term()` is not a `WP_Term` instance.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
