### PR TITLE
Fix minor issues with async site scan on plugin activation

### DIFF
--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -316,12 +316,12 @@ export function SiteScanContextProvider( {
 	 */
 	const [ shouldDelayValidationRequest, setShouldDelayValidationRequest ] = useState( false );
 	useEffect( () => {
-		let clearTimeout;
+		let timeoutId;
 
 		if ( shouldDelayValidationRequest ) {
 			( async () => {
 				await new Promise( ( resolve ) => {
-					clearTimeout = setTimeout( resolve, CONCURRENT_VALIDATION_REQUESTS_WAIT_MS );
+					timeoutId = setTimeout( resolve, CONCURRENT_VALIDATION_REQUESTS_WAIT_MS );
 				} );
 
 				if ( true === hasUnmounted.current ) {
@@ -333,8 +333,8 @@ export function SiteScanContextProvider( {
 		}
 
 		return () => {
-			if ( typeof clearTimeout === 'function' ) {
-				clearTimeout();
+			if ( timeoutId ) {
+				clearTimeout( timeoutId );
 			}
 		};
 	}, [ shouldDelayValidationRequest ] );

--- a/tests/e2e/specs/admin/after-plugin-activation.js
+++ b/tests/e2e/specs/admin/after-plugin-activation.js
@@ -21,56 +21,54 @@ describe( 'After plugin activation', () => {
 		await page.waitForSelector( `tr[data-slug="${ slug }"] .deactivate a` );
 	}
 
-	describe( 'for a user', () => {
-		beforeAll( async () => {
-			await completeWizard( { mode: 'transitional' } );
-			await visitAdminPage( 'plugins.php', '' );
-		} );
+	beforeAll( async () => {
+		await completeWizard( { mode: 'transitional' } );
+		await visitAdminPage( 'plugins.php', '' );
+	} );
 
-		it( 'site scan is triggered automatically and displays no validation issues for AMP-compatible plugin', async () => {
+	it( 'site scan is triggered automatically and displays no validation issues for AMP-compatible plugin', async () => {
+		await deactivate( 'gutenberg' );
+
+		await expect( page ).not.toMatchElement( '#amp-site-scan-notice' );
+
+		await activate( 'gutenberg' );
+
+		await expect( page ).toMatchElement( '#amp-site-scan-notice' );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /Checking your site for AMP compatibility issues/ } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /No AMP compatibility issues detected/, timeout } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice .amp-admin-notice--success' );
+		await expect( page ).not.toMatchElement( '#amp-site-scan-notice summary' );
+		await expect( page ).not.toMatchElement( '#amp-site-scan-notice .amp-site-scan-notice__cta' );
+	} );
+
+	it.each( [
+		'with Gutenberg active',
+		'without Gutenberg active',
+	] )( 'site scan is triggered automatically and displays validation issues for AMP-incompatible plugin %s', async ( title ) => {
+		const withoutGutenberg = title.startsWith( 'without' );
+
+		//eslint-disable-next-line jest/no-if
+		if ( withoutGutenberg ) {
 			await deactivate( 'gutenberg' );
+		}
 
-			await expect( page ).not.toMatchElement( '#amp-site-scan-notice' );
+		await activate( 'e2e-tests-demo-plugin' );
 
+		await expect( page ).toMatchElement( '#amp-site-scan-notice' );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /Checking your site for AMP compatibility issues/ } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /AMP compatibility issues discovered with the following plugin:/, timeout } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice .amp-admin-notice--warning' );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice summary', { text: /E2E Tests Demo Plugin/ } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice .button', { text: /Review Plugin Suppression/ } );
+		await expect( page ).toMatchElement( '#amp-site-scan-notice .button', { text: /View AMP-Compatible Plugins/ } );
+
+		await deactivate( 'e2e-tests-demo-plugin' );
+
+		await expect( page ).not.toMatchElement( '#amp-site-scan-notice' );
+
+		//eslint-disable-next-line jest/no-if
+		if ( withoutGutenberg ) {
 			await activate( 'gutenberg' );
-
-			await expect( page ).toMatchElement( '#amp-site-scan-notice' );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /Checking your site for AMP compatibility issues/ } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /No AMP compatibility issues detected/, timeout } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice .amp-admin-notice--success' );
-			await expect( page ).not.toMatchElement( '#amp-site-scan-notice summary' );
-			await expect( page ).not.toMatchElement( '#amp-site-scan-notice .amp-site-scan-notice__cta' );
-		} );
-
-		it.each( [
-			'with Gutenberg active',
-			'without Gutenberg active',
-		] )( 'site scan is triggered automatically and displays validation issues for AMP-incompatible plugin %s', async ( title ) => {
-			const withoutGutenberg = title.startsWith( 'without' );
-
-			//eslint-disable-next-line jest/no-if
-			if ( withoutGutenberg ) {
-				await deactivate( 'gutenberg' );
-			}
-
-			await activate( 'e2e-tests-demo-plugin' );
-
-			await expect( page ).toMatchElement( '#amp-site-scan-notice' );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /Checking your site for AMP compatibility issues/ } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice p', { text: /AMP compatibility issues discovered with the following plugin:/, timeout } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice .amp-admin-notice--warning' );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice summary', { text: /E2E Tests Demo Plugin/ } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice .button', { text: /Review Plugin Suppression/ } );
-			await expect( page ).toMatchElement( '#amp-site-scan-notice .button', { text: /View AMP-Compatible Plugins/ } );
-
-			await deactivate( 'e2e-tests-demo-plugin' );
-
-			await expect( page ).not.toMatchElement( '#amp-site-scan-notice' );
-
-			//eslint-disable-next-line jest/no-if
-			if ( withoutGutenberg ) {
-				await activate( 'gutenberg' );
-			}
-		} );
+		}
 	} );
 } );


### PR DESCRIPTION
## Summary

This fixes some minor issues discovered after #6685 has been merged:

- Simplify the E2E test: it removes the nesting in `describe` calls. There's no change in the test code whatsoever https://github.com/ampproject/amp-wp/commit/f6c53f78d435dd342370983819c6e2e1d10891e4
- Clear timeout correctly: the `setTimeout` has not been cleared properly before https://github.com/ampproject/amp-wp/commit/ed39f61a25f7eff8038deb7142310c9a67eef93b

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
