### PR TITLE
Use intrinsic as default layout for video instead of responsive layout

### DIFF
--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -156,7 +156,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 			$new_attributes = $this->filter_attachment_layout_attributes( $node, $new_attributes, $layout );
 			if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['width'] ) && ! empty( $new_attributes['height'] ) ) {
-				$new_attributes['layout'] = 'responsive';
+				$new_attributes['layout'] = 'intrinsic';
 			}
 			$new_attributes = $this->set_layout( $new_attributes );
 

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -68,7 +68,7 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'simple_video' => [
 				'<video id="vid" width="300" height="300" src="https://example.com/video.mp4" playsinline webkit-playsinline></video>',
-				'<amp-video id="vid" width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" playsinline></video></noscript></amp-video>',
+				'<amp-video id="vid" width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" playsinline></video></noscript></amp-video>',
 				[
 					'add_noscript_fallback' => true,
 				],
@@ -76,7 +76,7 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'simple_video_without_noscript' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
 				[
 					'add_noscript_fallback' => false,
 				],
@@ -89,12 +89,12 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'video_with_autoplay' => [
 				'<video src="https://example.com/file.mp4" autoplay muted width="160" height="80"></video>',
-				'<amp-video src="https://example.com/file.mp4" autoplay width="160" height="80" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" autoplay width="160" height="80"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" autoplay width="160" height="80" layout="intrinsic"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" autoplay width="160" height="80"></video></noscript></amp-video>',
 			],
 
 			'local_video_without_dimensions' => [
 				sprintf( '<video src="%s"></video>', '{{video_url}}' ),
-				sprintf( '<amp-video src="%1$s" width="560" height="320" layout="responsive"><a href="%1$s" fallback="">%1$s</a><noscript><video src="%1$s"></video></noscript></amp-video>', '{{video_url}}' ),
+				sprintf( '<amp-video src="%1$s" width="560" height="320" layout="intrinsic"><a href="%1$s" fallback="">%1$s</a><noscript><video src="%1$s"></video></noscript></amp-video>', '{{video_url}}' ),
 			],
 
 			'local_video_without_dimensions_and_native' => [
@@ -137,32 +137,32 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'autoplay_attribute' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
 			],
 
 			'autoplay_attribute__false' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
 			],
 
 			'video_with_allowlisted_attributes__enabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true"></video></noscript></amp-video>',
 			],
 
 			'video_with_allowlisted_attributes__disabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false"></video></noscript></amp-video>',
 			],
 
 			'video_with_custom_attribute' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" onclick="foo()" data-foo="bar"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			],
 
 			'video_with_sizes_attribute_is_overridden' => [
 				'<video width="300" height="200" src="https://example.com/file.mp4"></video>',
-				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="intrinsic"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			],
 
 			'video_with_children' => [
@@ -173,7 +173,7 @@ class AMP_Video_Converter_Test extends TestCase {
 					</video>
 				',
 				'
-					<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive">
+					<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="intrinsic">
 						<source src="https://example.com/video.mp4" type="video/mp4">
 						<source src="https://example.com/video.ogv" type="video/ogg">
 						<a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a>
@@ -199,7 +199,7 @@ class AMP_Video_Converter_Test extends TestCase {
 
 			'video_with_noloading_from_editor' => [
 				'<figure data-amp-noloading="true"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
-				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
+				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="intrinsic"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
 			],
 
 			'multiple_same_video' => [
@@ -210,10 +210,10 @@ class AMP_Video_Converter_Test extends TestCase {
 					<video src="https://example.com/video.mp4" width="480" height="300"></video>
 				',
 				'
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
 				',
 			],
 
@@ -224,15 +224,15 @@ class AMP_Video_Converter_Test extends TestCase {
 					<video src="https://example.com/video3.webm" height="100" width="200"></video>
 				',
 				'
-					<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video1.mp4" fallback="">https://example.com/video1.mp4</a><noscript><video src="https://example.com/video1.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"><a href="https://example.com/video2.ogv" fallback="">https://example.com/video2.ogv</a><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"><a href="https://example.com/video3.webm" fallback="">https://example.com/video3.webm</a><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="intrinsic"><a href="https://example.com/video1.mp4" fallback="">https://example.com/video1.mp4</a><noscript><video src="https://example.com/video1.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="intrinsic"><a href="https://example.com/video2.ogv" fallback="">https://example.com/video2.ogv</a><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="intrinsic"><a href="https://example.com/video3.webm" fallback="">https://example.com/video3.webm</a><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
 				',
 			],
 
 			'https_not_required' => [
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			],
 
 			'http_video_with_children' => [
@@ -245,7 +245,7 @@ class AMP_Video_Converter_Test extends TestCase {
 					</video>
 				',
 				'
-					<amp-video width="480" height="300" poster="https://example.com/poster.jpeg" layout="responsive">
+					<amp-video width="480" height="300" poster="https://example.com/poster.jpeg" layout="intrinsic">
 						<source src="https://example.com/video.mp4" type="video/mp4">
 						<source src="https://example.com/video.ogv" type="video/ogg">
 						<track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt">
@@ -262,13 +262,13 @@ class AMP_Video_Converter_Test extends TestCase {
 			],
 
 			'amp_video_with_fallback' => [
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 				null,
 			],
 
 			'video_with_fallback' => [
 				'<div id="player"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></div>',
-				'<div id="player"><!--noscript--><amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video><!--/noscript--></div>',
+				'<div id="player"><!--noscript--><amp-video width="300" height="300" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video><!--/noscript--></div>',
 			],
 
 			'test_with_dev_mode' => [

--- a/tests/php/test-class-amp-content-sanitizer.php
+++ b/tests/php/test-class-amp-content-sanitizer.php
@@ -72,7 +72,7 @@ class Test_AMP_Content_Sanitizer extends TestCase {
 	public function test_sanitize_all() {
 		$source_html     = '<video style="outline: solid 1px red;" src="https://example.com/foo.mp4" width="100" height="200"></video>';
 		$expected_return = [
-			'<amp-video src="https://example.com/foo.mp4" width="100" height="200" layout="responsive" data-amp-original-style="outline: solid 1px red;" class="amp-wp-9f6e771"><a href="https://example.com/foo.mp4" fallback="">https://example.com/foo.mp4</a><noscript><video src="https://example.com/foo.mp4" width="100" height="200"></video></noscript></amp-video>',
+			'<amp-video src="https://example.com/foo.mp4" width="100" height="200" layout="intrinsic" data-amp-original-style="outline: solid 1px red;" class="amp-wp-9f6e771"><a href="https://example.com/foo.mp4" fallback="">https://example.com/foo.mp4</a><noscript><video src="https://example.com/foo.mp4" width="100" height="200"></video></noscript></amp-video>',
 			[ 'amp-video' => true ],
 			[ ':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-9f6e771{outline:solid 1px red}' ],
 		];


### PR DESCRIPTION
## Summary

When we first implemented the video sanitizer, we chose the responsive layout because intrinsic was not initially available. Support for the intrinsic layout was added to `amp-video` in https://github.com/ampproject/amphtml/pull/28349, but we didn't make the same change to the video sanitizer since it didn't seem necessary, even though we do use intrinsic as the default layout in the image sanitizer. However, I found a reason why it is needed. Namely, when a video is set to align left or right, it fails to render as responsive:

Non-AMP | AMP Before 👎  | AMP After 👍 
--------|------------|-----------
<img width="598" alt="Screen Shot 2021-12-03 at 18 42 37" src="https://user-images.githubusercontent.com/134745/144694272-1c29dd9a-19e7-4cf6-9ecb-3cd3651b17bd.png"> | <img width="597" alt="Screen Shot 2021-12-03 at 18 43 13" src="https://user-images.githubusercontent.com/134745/144694275-99245538-7578-4703-9503-4bfdd7931257.png"> | <img width="599" alt="Screen Shot 2021-12-03 at 18 43 30" src="https://user-images.githubusercontent.com/134745/144694278-180efdd2-ef60-4fd1-bcda-316a993d98b1.png">

Here's the markup I'm testing with:

```html
<!-- wp:video {"id":1690,"align":"center"} -->
<figure class="wp-block-video aligncenter" id="bard"><video controls src="https://wordpressdev.lndo.site/content/uploads/2013/12/2014-slider-mobile-behavior.mov"></video><figcaption>No align.</figcaption></figure>
<!-- /wp:video -->

<!-- wp:video {"id":1690,"align":"left"} -->
<figure class="wp-block-video alignleft" id="bard"><video controls src="https://wordpressdev.lndo.site/content/uploads/2013/12/2014-slider-mobile-behavior.mov"></video><figcaption>Align left</figcaption></figure>
<!-- /wp:video -->

<!-- wp:paragraph -->
<p>This is a paragraph with a video floated to the left!</p>
<!-- /wp:paragraph -->

<!-- wp:video {"id":1690,"align":"full"} -->
<figure class="wp-block-video alignfull" id="bard"><video controls src="https://wordpressdev.lndo.site/content/uploads/2013/12/2014-slider-mobile-behavior.mov"></video><figcaption>Full width</figcaption></figure>
<!-- /wp:video -->
```

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
