### PR TITLE
Fix height of Video blocks when native `video` is used

### DIFF
--- a/assets/css/src/amp-default.css
+++ b/assets/css/src/amp-default.css
@@ -82,6 +82,15 @@ amp-carousel .amp-wp-gallery-caption {
 }
 
 /*
+ * Ensure the aspect-ratio is respected when added by \AMP_Core_Block_Handler::ampify_video_block(). This is only needed
+ * when in the loose sandboxing level where a <video> is not converted into <amp-video>, and yet the width/height are
+ * both being added. See also <https://github.com/WordPress/gutenberg/pull/37052>.
+ */
+.wp-block-video video {
+	height: auto;
+}
+
+/*
  * Ensure the button used to expand AMP components is placed in the bottom left hand corner of the component,
  * where it's most likely to be seen.
  */

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -201,13 +201,26 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		$meta_data = wp_get_attachment_metadata( $block['attrs']['id'] );
-		if ( isset( $meta_data['width'], $meta_data['height'] ) ) {
-			$block_content = preg_replace(
-				'/(?<=<video\s)/',
-				sprintf( 'width="%d" height="%d" ', $meta_data['width'], $meta_data['height'] ),
-				$block_content
-			);
+		if ( ! isset( $meta_data['width'], $meta_data['height'] ) ) {
+			return $block_content;
 		}
+
+		$block_content = preg_replace_callback(
+			'/(?<=<video)\s[^>]+/',
+			static function ( $matches ) use ( $meta_data ) {
+				$attrs = $matches[0];
+				if ( ! preg_match( '/\s(width|height|style)=/', $attrs ) ) {
+					$attrs .= sprintf(
+						' width="%1$d" height="%2$d" style="aspect-ratio:%1$d/%2$d"',
+						$meta_data['width'],
+						$meta_data['height']
+					);
+				}
+				return $attrs;
+			},
+			$block_content,
+			1
+		);
 
 		return $block_content;
 	}

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -160,6 +160,27 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			}
 			$new_attributes = $this->set_layout( $new_attributes );
 
+			// Strip out redundant aspect-ratio style which was added in AMP_Core_Block_Handler::ampify_video_block().
+			if ( isset( $new_attributes[ Attribute::STYLE ], $new_attributes[ Attribute::WIDTH ], $new_attributes[ Attribute::HEIGHT ] ) ) {
+				$styles = $this->parse_style_string( $new_attributes[ Attribute::STYLE ] );
+				if (
+					isset( $styles[ Attribute::ASPECT_RATIO ] )
+					&&
+					(
+						preg_replace( '/\s/', '', $styles[ Attribute::ASPECT_RATIO ] )
+						===
+						sprintf( '%d/%d', $new_attributes[ Attribute::WIDTH ], $new_attributes[ Attribute::HEIGHT ] )
+					)
+				) {
+					unset( $styles[ Attribute::ASPECT_RATIO ] );
+					if ( empty( $styles ) ) {
+						unset( $new_attributes[ Attribute::STYLE ] );
+					} else {
+						$new_attributes[ Attribute::STYLE ] = $this->reassemble_style_string( $styles );
+					}
+				}
+			}
+
 			// Remove the ID from the original node so that PHP DOM doesn't fail to set it on the replacement element.
 			$node->removeAttribute( Attribute::ID );
 

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -82,6 +82,22 @@ class AMP_Video_Converter_Test extends TestCase {
 				],
 			],
 
+			'video_with_aspect-ratio' => [
+				'<video width="300" height="500" style="aspect-ratio: 300 / 500" src="https://example.com/video.mp4"></video>',
+				'<amp-video width="300" height="500" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
+			'video_with_aspect-ratio_and_more' => [
+				'<video width="300" height="500" style="border: solid 1px red; aspect-ratio: 300/500; outline: solid 1px blue;" src="https://example.com/video.mp4"></video>',
+				'<amp-video width="300" height="500" style="border:solid 1px red;outline:solid 1px blue" src="https://example.com/video.mp4" layout="intrinsic"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
+				[
+					'add_noscript_fallback' => false,
+				],
+			],
+
 			'video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4"></video>',
 				'<amp-video src="https://example.com/file.mp4" class="amp-wp-unknown-size" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -152,7 +152,7 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 
 		$content = apply_filters( 'the_content', get_post( $post_id )->post_content );
 
-		$this->assertStringContainsString( '<video width="560" height="320" ', $content );
+		$this->assertStringContainsString( 'width="560" height="320" style="aspect-ratio:560/320"', $content );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Builds on top of #6761.

### Add `height:auto` to `video` in Video Block

First of all, this addresses findings from @dhaval-parekh in https://github.com/ampproject/amp-wp/issues/6443#issuecomment-979068011 whereby when a page is in the loose sandboxing level where a Video block's `video` is not not converted into `amp-video`, the result is the video having excessive height due to the `width` and `height` being supplied when the dimensions are absent. As noted in https://github.com/ampproject/amp-wp/issues/6443#issuecomment-984289338 this is something I've started to explore as a fix in Gutenberg via https://github.com/WordPress/gutenberg/pull/30092, but for now the issue can be fixed by adding the `height:auto` style to `.wp-block-video video` in the `amp-default.css` stylesheet.

Non-AMP | AMP L1 w/ `video` Before 👎  | AMP w/ `video` After 👍  | AMP with `amp-video` after 👍
--------|--------------------------|-----------------------|--------------------------
<img width="645" alt="non-amp-horizontal-video" src="https://user-images.githubusercontent.com/134745/144699965-c038ef21-5d47-499c-bb86-189669528876.png"> | <img width="643" alt="amp-native-video-without-height-auto" src="https://user-images.githubusercontent.com/134745/144699967-97a04174-8ed0-48ab-9b21-45f663a262f5.png"> | <img width="642" alt="amp-native-video-with-height-auto" src="https://user-images.githubusercontent.com/134745/144699969-399adca3-3163-4740-971b-6010cb7b5bbd.png"> | <img width="642" alt="amp-video-component-with-height-auto" src="https://user-images.githubusercontent.com/134745/144699970-49fdfb91-86c7-4cc2-a2d4-f7b2dc60741e.png">

### Add `aspect-ratio` to native `video` in Video Block

In https://github.com/WordPress/gutenberg/pull/37052#issuecomment-984334664 I discovered that even though a `video` has its `width` and `height` defined, it will still have layout shifting happening. In Chromium it appears that the default `aspect-ratio` has only been [implemented for `img`](https://bugs.chromium.org/p/chromium/issues/detail?id=979891#c9) and not for `video`. In fact, it doesn't seem that the `width` and `height` on `video` do anything in Chromium at the moment. Therefore, in order to prevent layout shift from happening for `video`, it is currently necessary to add an explicit `aspect-ratio` style to the element.

#### Non-AMP

https://user-images.githubusercontent.com/134745/144700285-66874efa-5555-4511-b2c4-308eac7d06fe.mov

#### Before: AMP L1 with native `video` and `width`/`height` but no `aspect-ratio` 👎 

https://user-images.githubusercontent.com/134745/144700291-b851d230-8667-46c6-a0ad-828e14d32a89.mov

#### After: AMP L1 with native `video` and `width`/`height` _and_ `aspect-ratio` 👍 

https://user-images.githubusercontent.com/134745/144700300-9290fde3-c0c3-48ca-a3e7-f94fe67cad0d.mov

This renders exactly in AMP L3 with `amp-video`: no layout shift!

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
