### PR TITLE
Improve Sandboxing info in AMP admin bar menu item

### DIFF
--- a/src/Sandboxing.php
+++ b/src/Sandboxing.php
@@ -271,9 +271,10 @@ final class Sandboxing implements Service, Registerable {
 			$amp_link = $dom->xpath->query( './a', $amp_admin_bar_menu_item )->item( 0 );
 			if ( $amp_link instanceof Element ) {
 				$span = $dom->createElement( Tag::SPAN );
-				$amp_link->appendChild( $dom->createTextNode( ' ' ) );
-				$span->textContent = $text;
 				$span->setAttribute( Attribute::TITLE, $title );
+				$span->textContent = $text;
+
+				$amp_link->appendChild( $dom->createTextNode( ' ' ) );
 				$amp_link->appendChild( $span );
 			}
 
@@ -281,15 +282,17 @@ final class Sandboxing implements Service, Registerable {
 			if ( $amp_submenu_ul instanceof Element ) {
 				$level_li = $dom->createElement( Tag::LI );
 				$level_li->setAttribute( Attribute::ID, 'wp-admin-bar-amp-sandboxing-level' );
+
 				$link = $dom->createElement( Tag::A );
 				$link->setAttribute( Attribute::CLASS_, 'ab-item' );
+				$link->textContent = $title;
 				if ( current_user_can( 'manage_options' ) ) {
 					$link->setAttribute(
 						Attribute::HREF,
 						add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, admin_url( 'admin.php' ) ) . '#sandboxing'
 					);
 				}
-				$link->textContent = $title;
+
 				$level_li->appendChild( $link );
 				$amp_submenu_ul->appendChild( $level_li );
 			}

--- a/tests/php/src/SandboxingTest.php
+++ b/tests/php/src/SandboxingTest.php
@@ -266,7 +266,25 @@ class SandboxingTest extends DependencyInjectedTestCase {
 						<script async nomodule src="https://cdn.ampproject.org/v0.js" crossorigin="anonymous"></script>
 						<meta name="generator" content="AMP Plugin v2.1; foo=bar">
 					</head>
-					<body>%s</body>
+					<body>
+						%s
+
+						<div id="wpadminbar" class="nojq">
+							<div class="quicklinks" id="wp-toolbar" role="navigation" aria-label="Toolbar">
+								<ul id="wp-admin-bar-root-default" class="ab-top-menu">
+									<li id="wp-admin-bar-amp" class="menupop">
+										<a class="ab-item" aria-haspopup="true" href="#" title="Validate URL"><span id="amp-admin-bar-item-status-icon" class="ab-icon amp-icon amp-valid"></span> AMP</a>
+										<div class="ab-sub-wrapper">
+											<ul id="wp-admin-bar-amp-default" class="ab-submenu">
+												<li id="wp-admin-bar-amp-settings"><a class="ab-item" href="#">Settings</a></li>
+												<li id="wp-admin-bar-amp-support"><a class="ab-item" href="#">Get support</a></li>
+											</ul>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</body>
 				</html>
 				',
 				$body
@@ -291,6 +309,16 @@ class SandboxingTest extends DependencyInjectedTestCase {
 		foreach ( $expressions as $expression ) {
 			$this->assertEquals( $expected_required_amp_markup ? 1 : 0, $dom->xpath->query( $expression )->length, $expression );
 		}
+
+		$root_path = '//div[ @id = "wpadminbar" ]//li[ @id = "wp-admin-bar-amp" ]';
+		$this->assertInstanceOf(
+			Element::class,
+			$dom->xpath->query( $root_path . '/a/span[ contains( @title, "Sandboxing level" ) ]' )->item( 0 )
+		);
+		$this->assertInstanceOf(
+			Element::class,
+			$dom->xpath->query( $root_path . '//li[ @id = "wp-admin-bar-amp-sandboxing-level" ]//a[ @href and contains( ., "Sandboxing level" ) ]' )->item( 0 )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

I realized the AMP admin menu item was not entirely clear when the Sandboxing experiment is enabled. I've improved the tooltip for the number emoji and I've added a submenu item which contains the same text, with a link to the Sandboxing drawer on the Settings screen:

![image](https://user-images.githubusercontent.com/134745/144982197-314f514a-fd14-4a86-b524-abefb99a908b.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
