### PR TITLE
Ensure `ampify_threaded_comments` runs when in Strict sandboxing

### DIFF
--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -76,7 +76,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Handle the comment reply script.
 		$comment_reply_script            = $this->get_comment_reply_script();
-		$should_ampify_comment_threading = false;
+		$should_ampify_comment_threading = 'always' === $this->args['ampify_comment_threading'];
 		if ( $comment_reply_script instanceof Element ) {
 			if ( 'never' === $this->args['ampify_comment_threading'] ) {
 				$this->prepare_native_comment_reply( $comment_reply_script );


### PR DESCRIPTION
## Summary

Fixes https://github.com/ampproject/amp-wp/issues/6443#issuecomment-988111135.

As discovered by @milindmore22, when a site is in the Strict level for Sandboxing, the ampification of threaded comments was failing to happen. This meant that the comment form lacked the expected `on="submit-success:commentform.clear,AMP.setState({ampCommentThreading: {"replyTo":"","commentParent":"0"}})"` attribute, and `amp-bind` was not being used for comment replies.

The issue is that in Strict mode, the script sanitizer will remove all scripts, including the `comment-reply` one:

https://github.com/ampproject/amp-wp/blob/45581445f921b338f63268642beb9e83e258f615/includes/sanitizers/class-amp-script-sanitizer.php#L60

https://github.com/ampproject/amp-wp/blob/45581445f921b338f63268642beb9e83e258f615/includes/sanitizers/class-amp-script-sanitizer.php#L348-L358

However, the comments sanitizer was using the presence of this script to determine whether to ampify commenting:

https://github.com/ampproject/amp-wp/blob/45581445f921b338f63268642beb9e83e258f615/includes/sanitizers/class-amp-comments-sanitizer.php#L78-L80

So we just need to replace the `false` with a `'always' === $this->args['ampify_comment_threading']` condition so that even when the script is not on the page, the ampification will be done.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
