### PR TITLE
Preload validation counts data if AMP submenu is expanded

### DIFF
--- a/assets/src/amp-validation/counts/index.js
+++ b/assets/src/amp-validation/counts/index.js
@@ -57,8 +57,8 @@ function setMenuItemCountValue( itemId, count ) {
  * Initializes the 'Validated URLs' and 'Error Index' menu items.
  */
 function initializeMenuItemCounts() {
-	setMenuItemIsLoading( 'new-error-index-count' );
-	setMenuItemIsLoading( 'new-validation-url-count' );
+	setMenuItemIsLoading( 'amp-new-error-index-count' );
+	setMenuItemIsLoading( 'amp-new-validation-url-count' );
 }
 
 /**
@@ -71,8 +71,8 @@ function initializeMenuItemCounts() {
 function updateMenuItemCounts( counts ) {
 	const { validated_urls: newValidatedUrlCount, errors: newErrorCount } = counts;
 
-	setMenuItemCountValue( 'new-error-index-count', newErrorCount );
-	setMenuItemCountValue( 'new-validation-url-count', newValidatedUrlCount );
+	setMenuItemCountValue( 'amp-new-error-index-count', newErrorCount );
+	setMenuItemCountValue( 'amp-new-validation-url-count', newValidatedUrlCount );
 }
 
 /**

--- a/assets/src/amp-validation/counts/index.js
+++ b/assets/src/amp-validation/counts/index.js
@@ -125,15 +125,13 @@ domReady( () => {
 		return;
 	}
 
+	initializeMenuItemCounts();
+
 	// If the AMP submenu is opened, fetch validation counts as soon as possible. Thanks to the preload middleware for
 	// `wp.apiFetch`, the validation count data should be available right away, so no actual HTTP request will be made.
 	if ( ampMenuItem.classList.contains( 'wp-menu-open' ) ) {
-		initializeMenuItemCounts();
 		fetchValidationCounts();
-
-		return;
+	} else {
+		createObserver( ampMenuItem );
 	}
-
-	initializeMenuItemCounts( true );
-	createObserver( ampMenuItem );
 } );

--- a/assets/src/amp-validation/counts/index.js
+++ b/assets/src/amp-validation/counts/index.js
@@ -11,15 +11,35 @@ import domReady from '@wordpress/dom-ready';
 import './style.css';
 
 /**
- * Updates a menu item with its count.
+ * Sets the loading state on a menu item.
+ *
+ * @param {string} itemId Menu item ID.
+ */
+function setMenuItemIsLoading( itemId ) {
+	const itemEl = document.getElementById( itemId );
+
+	if ( ! itemEl || itemEl.querySelector( '.amp-count-loading' ) ) {
+		return;
+	}
+
+	const loadingEl = document.createElement( 'span' );
+
+	loadingEl.classList.add( 'amp-count-loading' );
+	itemEl.classList.add( 'awaiting-mod' );
+
+	itemEl.append( loadingEl );
+}
+
+/**
+ * Sets a menu item count value.
  *
  * If the count is not a number or is `0`, the element that contains the count is instead removed (as it would be no
- * longer relevant). If the count is -1, a loading indicator will be added to the menu item.
+ * longer relevant).
  *
  * @param {string} itemId Menu item ID.
  * @param {number} count  Count to set.
  */
-function updateMenuItem( itemId, count ) {
+function setMenuItemCountValue( itemId, count ) {
 	const itemEl = document.getElementById( itemId );
 
 	if ( ! itemEl ) {
@@ -28,15 +48,8 @@ function updateMenuItem( itemId, count ) {
 
 	if ( isNaN( count ) || count === 0 ) {
 		itemEl.parentNode.removeChild( itemEl );
-	} else if ( count > 0 ) {
+	} else {
 		itemEl.textContent = count.toLocaleString();
-	} else if ( count === -1 && ! itemEl.querySelector( '.amp-count-loading' ) ) {
-		const loadingEl = document.createElement( 'span' );
-
-		loadingEl.classList.add( 'amp-count-loading' );
-		itemEl.classList.add( 'awaiting-mod' );
-
-		itemEl.append( loadingEl );
 	}
 }
 
@@ -44,8 +57,8 @@ function updateMenuItem( itemId, count ) {
  * Initializes the 'Validated URLs' and 'Error Index' menu items.
  */
 function initializeMenuItemCounts() {
-	updateMenuItem( 'new-error-index-count', -1 );
-	updateMenuItem( 'new-validation-url-count', -1 );
+	setMenuItemIsLoading( 'new-error-index-count' );
+	setMenuItemIsLoading( 'new-validation-url-count' );
 }
 
 /**
@@ -58,8 +71,8 @@ function initializeMenuItemCounts() {
 function updateMenuItemCounts( counts ) {
 	const { validated_urls: newValidatedUrlCount, errors: newErrorCount } = counts;
 
-	updateMenuItem( 'new-error-index-count', newErrorCount );
-	updateMenuItem( 'new-validation-url-count', newValidatedUrlCount );
+	setMenuItemCountValue( 'new-error-index-count', newErrorCount );
+	setMenuItemCountValue( 'new-validation-url-count', newValidatedUrlCount );
 }
 
 /**

--- a/assets/src/amp-validation/counts/style.css
+++ b/assets/src/amp-validation/counts/style.css
@@ -23,7 +23,7 @@
 	display: inline-block;
 }
 
-body.no-js #new-validation-url-count,
-body.no-js #new-error-index-count {
+body.no-js #amp-new-validation-url-count,
+body.no-js #amp-new-error-index-count {
 	display: none;
 }

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -469,7 +469,7 @@ class AMP_Validated_URL_Post_Type {
 
 				if ( ValidationCounts::is_needed() ) {
 					// Append markup to display a loading spinner while the unreviewed count is being fetched.
-					$submenu_item[0] .= ' <span id="new-validation-url-count"></span>';
+					$submenu_item[0] .= ' <span id="amp-new-validation-url-count"></span>';
 				}
 
 				break;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -469,7 +469,7 @@ class AMP_Validated_URL_Post_Type {
 
 				if ( ValidationCounts::is_needed() ) {
 					// Append markup to display a loading spinner while the unreviewed count is being fetched.
-					$submenu_item[0] .= ' <span id="new-validation-url-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
+					$submenu_item[0] .= ' <span id="new-validation-url-count"></span>';
 				}
 
 				break;

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1745,7 +1745,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( ValidationCounts::is_needed() ) {
 			// Append markup to display a loading spinner while the unreviewed count is being fetched.
-			$menu_item_label .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
+			$menu_item_label .= ' <span id="new-error-index-count"></span>';
 		}
 
 		$post_menu_slug = 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1745,7 +1745,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( ValidationCounts::is_needed() ) {
 			// Append markup to display a loading spinner while the unreviewed count is being fetched.
-			$menu_item_label .= ' <span id="new-error-index-count"></span>';
+			$menu_item_label .= ' <span id="amp-new-error-index-count"></span>';
 		}
 
 		$post_menu_slug = 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Class ValidatedUrlCounts.
+ * Class ValidationCounts.
  *
  * @package AmpProject\AmpWP
  */
 
 namespace AmpProject\AmpWP\Admin;
 
+use AMP_Options_Manager;
+use AMP_Validated_URL_Post_Type;
 use AmpProject\AmpWP\Infrastructure\Conditional;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\HasRequirements;
@@ -29,6 +31,22 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * @var string
 	 */
 	const ASSETS_HANDLE = 'amp-validation-counts';
+
+	/**
+	 * RESTPreloader instance.
+	 *
+	 * @var RESTPreloader
+	 */
+	private $rest_preloader;
+
+	/**
+	 * ValidationCounts constructor.
+	 *
+	 * @param RESTPreloader $rest_preloader An instance of the RESTPreloader class.
+	 */
+	public function __construct( RESTPreloader $rest_preloader ) {
+		$this->rest_preloader = $rest_preloader;
+	}
 
 	/**
 	 * Get the action to use for registering the service.
@@ -93,5 +111,23 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 			false,
 			$version
 		);
+
+		$this->maybe_add_preload_rest_paths();
+	}
+
+	/**
+	 * Adds REST paths to preload.
+	 *
+	 * Preload validation counts data on an admin screen that has the AMP Options page as a parent or on any admin
+	 * screen related to `amp_validation_error` post type (which includes the `amp_validation_error` taxonomy).
+	 */
+	protected function maybe_add_preload_rest_paths() {
+		if (
+			AMP_Options_Manager::OPTION_NAME === get_admin_page_parent()
+			||
+			AMP_Validated_URL_Post_Type::POST_TYPE_SLUG === get_current_screen()->post_type
+		) {
+			$this->rest_preloader->add_preloaded_path( '/amp/v1/unreviewed-validation-counts' );
+		}
 	}
 }

--- a/tests/php/src/Admin/ValidationCountsTest.php
+++ b/tests/php/src/Admin/ValidationCountsTest.php
@@ -10,6 +10,7 @@ namespace AmpProject\AmpWP\Tests\Admin;
 use AMP_Options_Manager;
 use AMP_Theme_Support;
 use AMP_Validated_URL_Post_Type;
+use AmpProject\AmpWP\Admin\RESTPreloader;
 use AmpProject\AmpWP\Admin\ValidationCounts;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Infrastructure\Conditional;
@@ -19,6 +20,7 @@ use AmpProject\AmpWP\Infrastructure\Registerable;
 use AmpProject\AmpWP\Infrastructure\Service;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Services;
+use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\TestCase;
 
 /**
@@ -27,6 +29,8 @@ use AmpProject\AmpWP\Tests\TestCase;
  * @coversDefaultClass \AmpProject\AmpWP\Admin\ValidationCounts
  */
 class ValidationCountsTest extends TestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * Test instance.
@@ -43,9 +47,13 @@ class ValidationCountsTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = new ValidationCounts();
+		set_current_screen( 'edit' );
+		get_current_screen()->post_type = 'post';
+
+		$this->instance = new ValidationCounts( new RESTPreloader() );
 	}
 
+	/** @covers ::__construct() */
 	public function test__construct() {
 		$this->assertInstanceOf( ValidationCounts::class, $this->instance );
 		$this->assertInstanceOf( Delayed::class, $this->instance );
@@ -131,5 +139,57 @@ class ValidationCountsTest extends TestCase {
 		unset( $_GET['post'], $_GET['post_type'], $_GET['taxonomy'], $_GET['action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		delete_user_meta( $admin_user->ID, UserAccess::USER_FIELD_DEVELOPER_TOOLS_ENABLED );
 		$this->assertTrue( ValidationCounts::is_needed() );
+	}
+
+	/** @return array */
+	public function maybe_add_preload_rest_paths_data() {
+		return [
+			'no_type_post'                => [
+				'screen'              => 'user',
+				'post_type'           => '',
+				'should_preload_path' => false,
+			],
+			'post_type_post'              => [
+				'screen'              => 'edit',
+				'post_type'           => 'post',
+				'should_preload_path' => false,
+			],
+			'post_type_page'              => [
+				'screen'              => 'edit',
+				'post_type'           => 'page',
+				'should_preload_path' => false,
+			],
+			'post_type_amp_validated_url' => [
+				'screen'              => 'edit',
+				'post_type'           => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
+				'should_preload_path' => true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider maybe_add_preload_rest_paths_data
+	 * @covers ::maybe_add_preload_rest_paths()
+	 */
+	public function test_maybe_add_preload_rest_paths( $screen, $post_type, $should_preload_path ) {
+		if ( ! function_exists( 'rest_preload_api_request' ) ) {
+			$this->markTestIncomplete( 'REST preload is not available so skipping.' );
+		}
+
+		set_current_screen( $screen );
+		if ( ! empty( $post_type ) ) {
+			get_current_screen()->post_type = $post_type;
+		}
+
+		$this->call_private_method( $this->instance, 'maybe_add_preload_rest_paths' );
+
+		$rest_preloader = $this->get_private_property( $this->instance, 'rest_preloader' );
+		$paths          = $this->get_private_property( $rest_preloader, 'paths' );
+
+		if ( $should_preload_path ) {
+			$this->assertContains( '/amp/v1/unreviewed-validation-counts', $paths );
+		} else {
+			$this->assertNotContains( '/amp/v1/unreviewed-validation-counts', $paths );
+		}
 	}
 }

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -170,7 +170,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 
 		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$this->assertSame( 'Validated URLs <span id="new-validation-url-count"></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+			$this->assertSame( 'Validated URLs <span id="amp-new-validation-url-count"></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		} else {
 			$this->assertSame( 'Validated URLs', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -170,7 +170,7 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 
 		AMP_Validated_URL_Post_Type::update_validated_url_menu_item();
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$this->assertSame( 'Validated URLs <span id="new-validation-url-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+			$this->assertSame( 'Validated URLs <span id="new-validation-url-count"></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		} else {
 			$this->assertSame( 'Validated URLs', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 		}

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1034,8 +1034,8 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 			'Error Index',
 		];
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$expected_submenu[0] .= ' <span id="new-error-index-count"></span>';
-			$expected_submenu[3] .= ' <span id="new-error-index-count"></span>';
+			$expected_submenu[0] .= ' <span id="amp-new-error-index-count"></span>';
+			$expected_submenu[3] .= ' <span id="amp-new-error-index-count"></span>';
 		}
 		$amp_options = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -1034,8 +1034,8 @@ class Test_AMP_Validation_Error_Taxonomy extends TestCase {
 			'Error Index',
 		];
 		if ( Services::get( 'dependency_support' )->has_support() ) {
-			$expected_submenu[0] .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
-			$expected_submenu[3] .= ' <span id="new-error-index-count" class="awaiting-mod"><span class="amp-count-loading"></span></span>';
+			$expected_submenu[0] .= ' <span id="new-error-index-count"></span>';
+			$expected_submenu[3] .= ' <span id="new-error-index-count"></span>';
 		}
 		$amp_options = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6765.

So far, the Validated URLs and Error Index counts (validation counts in short) in WP admin were fetched from the REST API whenever the AMP submenu has been expanded. This approach has been introduced in #5900 in order to limit server resources usage - it's useless to calculate the validation counts if the AMP submenu is never revealed.

As a side-effect, a UX issue as described in #6765 has been introduced. If the AMP submenu is initially expanded, e.g. a user is on the AMP Settings screen or is browsing Validated URLs, the validation counts are still fetched asynchronously from REST API causing a momentary flash of a loading spinner inside the red badge.

In this PR, we take advantage of `apiFetch` preload middleware for providing the validation counts on page load but *only if* the AMP submenu is initially expanded. For other cases, we keep use the same `MutationObserver`-based solution so that the validation counts are still not calculated needlessly.

**Before**

https://user-images.githubusercontent.com/478735/146003735-586f7526-cffd-46c0-b3c6-a1e4602aaea8.mp4

**After**

https://user-images.githubusercontent.com/478735/146003757-5d15cc7e-035e-44e0-9e4e-bf90440e3d0e.mp4

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
