### PR TITLE
Fix selection of Reader theme causing validated URLs to always be stale

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1193,7 +1193,13 @@ class AMP_Validated_URL_Post_Type {
 		$plugin_registry = Services::get( 'plugin_registry' );
 
 		$theme     = [];
-		$theme_obj = wp_get_theme();
+		$theme_obj = null;
+		if ( Services::get( 'reader_theme_loader' )->is_enabled() ) {
+			$theme_obj = Services::get( 'reader_theme_loader' )->get_reader_theme();
+		}
+		if ( ! $theme_obj instanceof WP_Theme ) {
+			$theme_obj = wp_get_theme();
+		}
 		if ( ! $theme_obj->errors() ) {
 			$theme[ $theme_obj->get_stylesheet() ] = $theme_obj->get( 'Version' );
 

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -835,6 +835,22 @@ class Test_AMP_Validated_URL_Post_Type extends TestCase {
 			],
 			$new_env['options']
 		);
+
+		$reader_theme = wp_get_theme( 'twentysixteen' );
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
+		AMP_Options_Manager::update_option( Option::READER_THEME, $reader_theme->get_stylesheet() );
+		$reader_env = AMP_Validated_URL_Post_Type::get_validated_environment();
+		$this->assertEquals( [ $reader_theme->get_stylesheet() => $reader_theme->get( 'Version' ) ], $reader_env['theme'] );
+		$this->assertEquals(
+			[
+				Option::THEME_SUPPORT           => AMP_Theme_Support::READER_MODE_SLUG,
+				Option::ALL_TEMPLATES_SUPPORTED => false,
+				Option::READER_THEME            => $reader_theme->get_stylesheet(),
+				Option::SUPPORTED_POST_TYPES    => [ 'post', 'page' ],
+				Option::SUPPORTED_TEMPLATES     => [ 'is_singular' ],
+			],
+			$reader_env['options']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

I've selected Reader mode and chose a Reader theme:

![image](https://user-images.githubusercontent.com/134745/145346061-4ed2c1b1-5049-4fe4-ab41-12e52e2a9197.png)

Upon doing a Site Scan, the stale message goes away. But after I reload, the stale message appears:

![image](https://user-images.githubusercontent.com/134745/145346141-6c9c886c-307a-41f3-aed0-62a038c066e3.png)

Going to the AMP Validated URLs screen shows that all the just-scanned URLs are stale:

![image](https://user-images.githubusercontent.com/134745/145346406-724c73f2-f9be-4803-bf46-5ea688bc6e5c.png)

My active theme is `twentyseventeen` and my Reader theme is `twentythirteen`, and I can see that  `AMP_Validated_URL_Post_Type::get_post_staleness()` is returning unexpectedly:

```json
{
    "theme": {
        "new": [
            "twentyseventeen"
        ],
        "old": [
            "twentythirteen"
        ]
    }
}
```

Clearly `\AMP_Validated_URL_Post_Type::get_validated_environment()` is not taking Reader themes into account. This fixes that.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
