### PR TITLE
Fix conditional services referencing not-yet registered services

### DIFF
--- a/tests/php/src/Fixture/DummyService.php
+++ b/tests/php/src/Fixture/DummyService.php
@@ -6,4 +6,13 @@ use AmpProject\AmpWP\Infrastructure\Service;
 
 final class DummyService implements Service {
 
+	/**
+	 * A method that can be triggered for tests.
+	 *
+	 * @return bool Always returns true.
+	 */
+	public function method_to_trigger()
+	{
+		return true;
+	}
 }

--- a/tests/php/src/Fixture/DummyServiceWithCondition.php
+++ b/tests/php/src/Fixture/DummyServiceWithCondition.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests\Fixture;
+
+use AmpProject\AmpWP\Infrastructure\Conditional;
+use AmpProject\AmpWP\Infrastructure\Service;
+
+class DummyServiceWithCondition implements Service, Conditional {
+
+	/**
+	 * Check whether the conditional object is currently needed.
+	 *
+	 * @return bool Whether the conditional object is needed.
+	 */
+	public static function is_needed()
+	{
+		return true;
+	}
+}

--- a/tests/php/src/Fixture/DummyServiceWithReferencingCondition.php
+++ b/tests/php/src/Fixture/DummyServiceWithReferencingCondition.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AmpProject\AmpWP\Tests\Fixture;
+
+use AmpProject\AmpWP\Infrastructure\Conditional;
+use AmpProject\AmpWP\Infrastructure\Service;
+use AmpProject\AmpWP\Services;
+
+class DummyServiceWithReferencingCondition implements Service, Conditional {
+
+	/**
+	 * Check whether the conditional object is currently needed.
+	 *
+	 * @return bool Whether the conditional object is needed.
+	 */
+	public static function is_needed()
+	{
+		/** @var DummyService $service */
+		$service = Services::get( 'service_a' );
+
+		return $service->method_to_trigger();
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds regression tests and a fix for https://github.com/ampproject/amp-wp/pull/6773/files#r767010989

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
