### PR TITLE
Allow excessive CSS in Customizer preview

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1560,7 +1560,8 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		AMP_Block_Sanitizer::class             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
 		AMP_Style_Sanitizer::class             => [
-			'skip_tree_shaking' => is_customize_preview(),
+			'skip_tree_shaking'   => is_customize_preview(),
+			'allow_excessive_css' => is_customize_preview(),
 		],
 		AMP_Meta_Sanitizer::class              => [],
 		AMP_Layout_Sanitizer::class            => [],


### PR DESCRIPTION
## Summary

Fixes #6787

In a site with Transitional mode active and the Twenty Twenty theme active, going to an AMP page and clicking Customize:

Before | After
-------|------
<img width="936" alt="Screen Shot 2021-12-13 at 20 58 57" src="https://user-images.githubusercontent.com/134745/145936098-6f4eccaf-8ad9-43f1-b401-a78b46c21874.png"> | <img width="937" alt="Screen Shot 2021-12-13 at 20 59 11" src="https://user-images.githubusercontent.com/134745/145936103-d2c14d1b-0a52-4f24-a641-20776cd94925.png">

When validating a page outside the Customizer, tree shaking is still being performed:

<img width="1510" alt="Screen Shot 2021-12-13 at 20 59 37" src="https://user-images.githubusercontent.com/134745/145936106-fc210301-6cec-4eac-ad98-8e9b2c967ef2.png">

And given a plugin which adds excessive CSS and shows it is active by adding green outlines around all elements:

```php
<?php
/**
 * Plugin Name: Add Massive Stylesheet to Cause Excessive CSS
 */

function add_massive_stylesheet_to_cause_excessive_css() {
	echo '<style>';
	echo '* { outline: solid 2px rgba(0,255,0, 0.7); }';
	printf( 'body:after { content:"%s"; display:none; }', str_repeat( 'a', 75000 ) );
	echo '</style>';
}

add_action( 'wp_head', 'add_massive_stylesheet_to_cause_excessive_css' );
add_action( 'amp_post_template_head', 'add_massive_stylesheet_to_cause_excessive_css' );
```

When in Standard mode, the excessive CSS remains kept as expected, and excluded in Transitional/Reader as expected:

Standard | Transitional | Reader
---------|--------------|----------
![image](https://user-images.githubusercontent.com/134745/145936977-d1ada4a0-7481-4f14-92fe-5a1399c2d260.png) | ![image](https://user-images.githubusercontent.com/134745/145937052-cdd5a2fa-1778-410e-a59c-a85fe716e9a0.png) | ![image](https://user-images.githubusercontent.com/134745/145937073-7bbc078c-c44d-4c60-9361-e56a655e1468.png)

But in the AMP Customizer, the excessive CSS is kept as expected:

![image](https://user-images.githubusercontent.com/134745/145937161-0b658be6-6e3c-4892-b9b0-b20b77417772.png)

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
