### PR TITLE
Skip Technical Background step if there is no dependency support

### DIFF
--- a/assets/src/onboarding-wizard/components/navigation-context-provider.js
+++ b/assets/src/onboarding-wizard/components/navigation-context-provider.js
@@ -7,6 +7,8 @@ import { createContext, useState, useContext, useMemo } from '@wordpress/element
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { HAS_DEPENDENCY_SUPPORT } from 'amp-settings'; // From WP inline script.
+
 /**
  * Internal dependencies
  */
@@ -31,17 +33,16 @@ export function NavigationContextProvider( { children, pages } ) {
 
 	const { theme_support: themeSupport } = editedOptions;
 
-	const adaptedPages = useMemo( () => pages.filter( ( page ) => {
-		if ( READER !== themeSupport && 'theme-selection' === page.slug ) {
-			return false;
-		}
+	const adaptedPages = useMemo( () => pages.filter( ( page ) => (
+		// Do not show the Technical Background step is there is no dependency support.
+		! ( 'technical-background' === page.slug && ! HAS_DEPENDENCY_SUPPORT ) &&
 
-		if ( isSkipped && 'site-scan' === page.slug ) {
-			return false;
-		}
+		// If Site Scan should be skipped, do not show the relevant step in the Wizard.
+		! ( 'site-scan' === page.slug && isSkipped ) &&
 
-		return true;
-	} ), [ isSkipped, pages, themeSupport ] );
+		// Theme Selection page should be only accessible for the Reader template mode.
+		! ( 'theme-selection' === page.slug && READER !== themeSupport )
+	) ), [ isSkipped, pages, themeSupport ] );
 
 	const activePageIndex = adaptedPages.findIndex( ( adaptedPage ) => adaptedPage.slug === currentPage.slug );
 

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -11,6 +11,7 @@ namespace AmpProject\AmpWP\Admin;
 use AMP_Options_Manager;
 use AMP_Validated_URL_Post_Type;
 use AMP_Validation_Manager;
+use AmpProject\AmpWP\DependencySupport;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Infrastructure\Delayed;
 use AmpProject\AmpWP\Infrastructure\Registerable;
@@ -73,18 +74,27 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 	private $loading_error;
 
 	/**
+	 * DependencySupport instance.
+	 *
+	 * @var DependencySupport
+	 */
+	private $dependency_support;
+
+	/**
 	 * OnboardingWizardSubmenuPage constructor.
 	 *
-	 * @param GoogleFonts   $google_fonts   An instance of the GoogleFonts service.
-	 * @param ReaderThemes  $reader_themes  An instance of the ReaderThemes class.
-	 * @param RESTPreloader $rest_preloader An instance of the RESTPreloader class.
-	 * @param LoadingError  $loading_error  An instance of the LoadingError class.
+	 * @param GoogleFonts       $google_fonts       An instance of the GoogleFonts service.
+	 * @param ReaderThemes      $reader_themes      An instance of the ReaderThemes class.
+	 * @param RESTPreloader     $rest_preloader     An instance of the RESTPreloader class.
+	 * @param LoadingError      $loading_error      An instance of the LoadingError class.
+	 * @param DependencySupport $dependency_support An instance of the DependencySupport class.
 	 */
-	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader, LoadingError $loading_error ) {
-		$this->google_fonts   = $google_fonts;
-		$this->reader_themes  = $reader_themes;
-		$this->rest_preloader = $rest_preloader;
-		$this->loading_error  = $loading_error;
+	public function __construct( GoogleFonts $google_fonts, ReaderThemes $reader_themes, RESTPreloader $rest_preloader, LoadingError $loading_error, DependencySupport $dependency_support ) {
+		$this->google_fonts       = $google_fonts;
+		$this->reader_themes      = $reader_themes;
+		$this->rest_preloader     = $rest_preloader;
+		$this->loading_error      = $loading_error;
+		$this->dependency_support = $dependency_support;
 	}
 
 	/**
@@ -250,6 +260,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 				'screenshot'      => $theme->get_screenshot() ?: null,
 				'url'             => $theme->get( 'ThemeURI' ),
 			],
+			'HAS_DEPENDENCY_SUPPORT'             => $this->dependency_support->has_support(),
 			'USING_FALLBACK_READER_THEME'        => $this->reader_themes->using_fallback_theme(),
 			'SCANNABLE_URLS_REST_PATH'           => '/amp/v1/scannable-urls',
 			'SETTINGS_LINK'                      => $amp_settings_link,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6775.
Related: https://github.com/ampproject/amp-wp/pull/6773#discussion_r768249802.

On WP<5.6 Validation UI should not be accessible to the user due to issues with JS dependencies. One of the features that are not supported is the Dev Tools toggle on AMP Settings screen. In https://github.com/ampproject/amp-wp/commit/ff7e7b7839d45c74b57d926f8d6fda2054c569fa it's removed on older WP versions.

In the same way, the Technical Background step should be skipped in the Onboarding Wizard as it's not possible to store that option. This PR does exactly that.

| WP<5.6 | WP>=5.6 |
| --- | --- |
| ![Screenshot 2021-12-14 at 12 07 58](https://user-images.githubusercontent.com/478735/145987209-8ce3d33f-1246-49dd-9ffb-5c99264ec240.png) | ![Screenshot 2021-12-14 at 12 08 21](https://user-images.githubusercontent.com/478735/145987227-328fc2a6-d787-46e9-88d3-b1563f680e29.png) |


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
