### PR TITLE
Ensure site is not scanned multiple times in Onboarding Wizard

### DIFF
--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -116,7 +116,7 @@ export function siteScanReducer( state, action ) {
 			};
 		}
 		case ACTION_SCANNABLE_URLS_RECEIVE: {
-			if ( ! action.scannableUrls || action.scannableUrls.length === 0 ) {
+			if ( ! action.scannableUrls || action.scannableUrls?.length === 0 ) {
 				return {
 					...state,
 					status: STATUS_COMPLETED,

--- a/assets/src/components/site-scan-context-provider/test/site-scan-reducer.js
+++ b/assets/src/components/site-scan-context-provider/test/site-scan-reducer.js
@@ -90,20 +90,33 @@ describe( 'siteScanReducer', () => {
 	 * ACTION_SCANNABLE_URLS_RECEIVE
 	 */
 	it( 'returns correct state for ACTION_SCANNABLE_URLS_RECEIVE', () => {
-		expect( siteScanReducer( {}, {
+		expect( siteScanReducer( { scanOnce: false, scansCount: 0 }, {
 			type: ACTION_SCANNABLE_URLS_RECEIVE,
 			scannableUrls: [],
 		} ) ).toStrictEqual( {
 			status: STATUS_COMPLETED,
-			scannableUrls: [],
+			scanOnce: false,
+			scansCount: 0,
 		} );
 
-		expect( siteScanReducer( {}, {
+		expect( siteScanReducer( { scanOnce: false, scansCount: 2 }, {
 			type: ACTION_SCANNABLE_URLS_RECEIVE,
 			scannableUrls: [ 'foo', 'bar' ],
 		} ) ).toStrictEqual( {
 			status: STATUS_READY,
 			scannableUrls: [ 'foo', 'bar' ],
+			scanOnce: false,
+			scansCount: 2,
+		} );
+
+		expect( siteScanReducer( { scanOnce: true, scansCount: 1 }, {
+			type: ACTION_SCANNABLE_URLS_RECEIVE,
+			scannableUrls: [ 'foo', 'bar' ],
+		} ) ).toStrictEqual( {
+			status: STATUS_COMPLETED,
+			scannableUrls: [ 'foo', 'bar' ],
+			scanOnce: true,
+			scansCount: 1,
 		} );
 	} );
 
@@ -129,6 +142,8 @@ describe( 'siteScanReducer', () => {
 	] )( 'returns correct state for ACTION_SCAN_INITIALIZE when initial status is %s', ( status ) => {
 		expect( siteScanReducer( {
 			status,
+			scanOnce: false,
+			scansCount: 0,
 			scannableUrls: [ 'foo', 'bar' ],
 			urlIndexesPendingScan: [],
 		}, {
@@ -136,8 +151,33 @@ describe( 'siteScanReducer', () => {
 		} ) ).toStrictEqual( {
 			status: STATUS_IDLE,
 			currentlyScannedUrlIndexes: [],
+			scanOnce: false,
+			scansCount: 1,
 			scannableUrls: [ 'foo', 'bar' ],
 			urlIndexesPendingScan: [ 0, 1 ],
+		} );
+	} );
+
+	it.each( [
+		STATUS_CANCELLED,
+		STATUS_COMPLETED,
+		STATUS_FAILED,
+		STATUS_READY,
+	] )( 'returns correct state for ACTION_SCAN_INITIALIZE when initial status is %s and scan should be done just once', ( status ) => {
+		expect( siteScanReducer( {
+			status,
+			scanOnce: true,
+			scansCount: 1,
+			scannableUrls: [ 'foo', 'bar' ],
+			urlIndexesPendingScan: [],
+		}, {
+			type: ACTION_SCAN_INITIALIZE,
+		} ) ).toStrictEqual( {
+			status: STATUS_COMPLETED,
+			scanOnce: true,
+			scansCount: 1,
+			scannableUrls: [ 'foo', 'bar' ],
+			urlIndexesPendingScan: [],
 		} );
 	} );
 

--- a/assets/src/onboarding-wizard/index.js
+++ b/assets/src/onboarding-wizard/index.js
@@ -82,6 +82,7 @@ export function Providers( { children } ) {
 									fetchCachedValidationErrors={ false }
 									resetOnOptionsChange={ true }
 									scannableUrlsRestPath={ SCANNABLE_URLS_REST_PATH }
+									scanOnce={ true }
 									validateNonce={ VALIDATE_NONCE }
 								>
 									<NavigationContextProvider pages={ PAGES }>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6741

This PR hardens the Site Scan checks in the Onboarding Wizard in order to prevent multiple scans happening when going back to the Site Scan step.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
