### PR TITLE
Update AMP toolbox to v0.9.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.9.2",
+    "ampproject/amp-toolbox": "0.9.3",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81d14dc3514fb12af3807087e9422b8c",
+    "content-hash": "bdf879c80ebfac326fc27ad56b03a742",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.9.2",
+            "version": "0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "80c7f1a69f18fc90dfeaeeb7e6516e1b52f5da9d"
+                "reference": "b4c723a53d9bc5737ab67fba23d8162150d98eea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/80c7f1a69f18fc90dfeaeeb7e6516e1b52f5da9d",
-                "reference": "80c7f1a69f18fc90dfeaeeb7e6516e1b52f5da9d",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/b4c723a53d9bc5737ab67fba23d8162150d98eea",
+                "reference": "b4c723a53d9bc5737ab67fba23d8162150d98eea",
                 "shasum": ""
             },
             "require": {
@@ -76,9 +76,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.9.2"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.9.3"
             },
-            "time": "2021-12-07T17:08:09+00:00"
+            "time": "2021-12-14T21:26:08+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -292,7 +292,7 @@
     "packages-dev": [
         {
             "name": "ampproject/php-css-parser-install-plugin",
-            "version": "dev-fix/update-amp-toolbox-to-0.9.2",
+            "version": "dev-fix/update-amp-toolbox-0.9.3",
             "dist": {
                 "type": "path",
                 "url": "./php-css-parser-install-composer-plugin",


### PR DESCRIPTION
## Summary

This PR updates the AMP toolbox dependency to v0.9.3.

This should fix a bug with regular expressions breaking down on large SVGs. See https://github.com/ampproject/amp-toolbox-php/issues/441

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
