### PR TITLE
Enable AMP admin menu in admin bar for WordPress version prior to 5.6

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -5,7 +5,6 @@
  * @package AMP
  */
 
-use AmpProject\AmpWP\Admin\OptionsMenu;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Icon;
 use AmpProject\AmpWP\Option;
@@ -482,8 +481,10 @@ class AMP_Validation_Manager {
 			$wp_admin_bar->add_node( $validate_item );
 		}
 
+		$is_option_menu_enabled = (bool) apply_filters( 'amp_options_menu_is_enabled', true );
+
 		// Add settings link to admin bar.
-		if ( OptionsMenu::is_needed() && current_user_can( 'manage_options' ) ) {
+		if ( $is_option_menu_enabled && current_user_can( 'manage_options' ) ) {
 			$wp_admin_bar->add_node(
 				[
 					'parent' => 'amp',

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Admin\OptionsMenu;
 use AmpProject\AmpWP\DevTools\UserAccess;
 use AmpProject\AmpWP\Icon;
 use AmpProject\AmpWP\Option;
@@ -376,7 +377,17 @@ class AMP_Validation_Manager {
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar.
 	 */
 	public static function add_admin_bar_menu_items( $wp_admin_bar ) {
-		if ( is_admin() || ! self::get_dev_tools_user_access()->is_user_enabled() || ! amp_is_available() ) {
+
+		$user            = wp_get_current_user();
+		$is_user_enabled = (
+			$user instanceof WP_User
+			&&
+			self::has_cap( $user )
+			&&
+			self::get_dev_tools_user_access()->get_user_enabled( $user )
+		);
+
+		if ( is_admin() || ! $is_user_enabled || ! amp_is_available() ) {
 			self::$amp_admin_bar_item_added = false;
 			return;
 		}
@@ -472,7 +483,7 @@ class AMP_Validation_Manager {
 		}
 
 		// Add settings link to admin bar.
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( OptionsMenu::is_needed() && current_user_can( 'manage_options' ) ) {
 			$wp_admin_bar->add_node(
 				[
 					'parent' => 'amp',

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -492,28 +492,20 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
-		if ( ( new DependencySupport() )->has_support() ) {
-			$this->assertIsObject( $node );
-		} else {
-			$this->assertNull( $node );
-		}
+		$this->assertIsObject( $node );
 
 		// Admin bar item available in paired mode.
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$root_node = $admin_bar->get_node( 'amp' );
-		if ( ( new DependencySupport() )->has_support() ) {
-			$this->assertIsObject( $root_node );
-			$this->assertEqualSets( [ QueryVar::AMP ], array_keys( $this->get_url_query_vars( $root_node->href ) ) );
+		$this->assertIsObject( $root_node );
+		$this->assertEqualSets( [ QueryVar::AMP ], array_keys( $this->get_url_query_vars( $root_node->href ) ) );
 
-			$view_item = $admin_bar->get_node( 'amp-view' );
-			$this->assertIsObject( $view_item );
-			$this->assertEqualSets( [ QueryVar::AMP ], array_keys( $this->get_url_query_vars( $view_item->href ) ) );
-			$this->assertIsObject( $admin_bar->get_node( 'amp-validity' ) );
-		} else {
-			$this->assertNull( $root_node );
-		}
+		$view_item = $admin_bar->get_node( 'amp-view' );
+		$this->assertIsObject( $view_item );
+		$this->assertEqualSets( [ QueryVar::AMP ], array_keys( $this->get_url_query_vars( $view_item->href ) ) );
+		$this->assertIsObject( $admin_bar->get_node( 'amp-validity' ) );
 
 		// Lastly, confirm that the settings item is added if the user is an admin.
 		wp_set_current_user( 0 );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -441,16 +441,6 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 	public function test_add_admin_bar_menu_items() {
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 
-		if ( ! ( new DependencySupport() )->has_support() ) {
-			wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-			AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
-			$admin_bar = new WP_Admin_Bar();
-			AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
-			$this->assertNull( $admin_bar->get_node( 'amp' ) );
-			$this->assertNull( $admin_bar->get_node( 'amp-view' ) );
-			return;
-		}
-
 		$this->accept_sanitization_by_default( false );
 
 		// No admin bar item when user lacks capability.

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -536,6 +536,11 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 		$this->assertTrue( current_user_can( 'manage_options' ) );
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$this->assertObjectHasAttribute( 'href', $admin_bar->get_node( 'amp-settings' ) );
+
+		add_filter( 'amp_options_menu_is_enabled', '__return_false' );
+		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
+		$this->assertObjectHasAttribute( 'href', $admin_bar->get_node( 'amp-settings' ) );
+		remove_filter( 'amp_options_menu_is_enabled', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

Fixes #6793 

This PR will enable the admin menu item from admin bar for the WordPress version prior to 5.6

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
