### PR TITLE
Update Composer to use AMP toolbox v0.10.0

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -202,6 +202,7 @@ jobs:
       - name: Normalize composer.json
         run: |
           composer require --no-interaction --dev ergebnis/composer-normalize --ignore-platform-reqs
+          composer config --no-interaction --no-plugins allow-plugins.ergebnis/composer-normalize true
           composer --no-interaction normalize --dry-run
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -76,16 +76,16 @@
     ]
   },
   "config": {
-    "platform": {
-      "php": "5.6.20"
-    },
-    "sort-packages": true,
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "civicrm/composer-downloads-plugin": true,
       "ampproject/php-css-parser-install-plugin": true,
       "cweagans/composer-patches": true
-    }
+    },
+    "platform": {
+      "php": "5.6.20"
+    },
+    "sort-packages": true
   },
   "extra": {
     "downloads": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.9.3",
+    "ampproject/amp-toolbox": "0.10.0",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#bfdd976"
@@ -79,7 +79,13 @@
     "platform": {
       "php": "5.6.20"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "civicrm/composer-downloads-plugin": true,
+      "ampproject/php-css-parser-install-plugin": true,
+      "cweagans/composer-patches": true
+    }
   },
   "extra": {
     "downloads": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdf879c80ebfac326fc27ad56b03a742",
+    "content-hash": "300c329c12165e6c58cdf53a2052743f",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.9.3",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "b4c723a53d9bc5737ab67fba23d8162150d98eea"
+                "reference": "be395b7ecee168318a6f5048e875a4c0d1eb52bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/b4c723a53d9bc5737ab67fba23d8162150d98eea",
-                "reference": "b4c723a53d9bc5737ab67fba23d8162150d98eea",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/be395b7ecee168318a6f5048e875a4c0d1eb52bf",
+                "reference": "be395b7ecee168318a6f5048e875a4c0d1eb52bf",
                 "shasum": ""
             },
             "require": {
@@ -76,9 +76,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.9.3"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.10.0"
             },
-            "time": "2021-12-14T21:26:08+00:00"
+            "time": "2022-01-07T17:03:36+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -292,7 +292,7 @@
     "packages-dev": [
         {
             "name": "ampproject/php-css-parser-install-plugin",
-            "version": "dev-fix/update-amp-toolbox-0.9.3",
+            "version": "dev-add/update-to-amp-toolbox-0.10.0",
             "dist": {
                 "type": "path",
                 "url": "./php-css-parser-install-composer-plugin",
@@ -6412,5 +6412,5 @@
     "platform-overrides": {
         "php": "5.6.20"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## Summary

This PR updates the AMP Toolbox dependency to use the [release v0.10.0](https://github.com/ampproject/amp-toolbox-php/releases/tag/0.10.0).

It also adds explicit permissions to the Composer file for the required plugins to be run, to avoid Composer warnings introduced with the addition of the [`allow-plugins` configuration setting](https://getcomposer.org/doc/06-config.md#allow-plugins).

Furthermore, it adapts the linting workflow to allow for the `composer-normalize` plugin to be run without warnings.

cc/ @swissspidy 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
