### PR TITLE
Support converting YouTube iframes with 100% width to `amp-youtube` with `fixed-height` layout

### DIFF
--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -91,6 +91,7 @@ abstract class AMP_Base_Embed_Handler {
 	 * Get regex pattern for matching HTML attributes from a given tag name.
 	 *
 	 * @since 1.5.0
+	 * @todo This does not currently work with single-quoted attribute values or non-quoted attributes.
 	 *
 	 * @param string   $html            HTML source haystack.
 	 * @param string   $tag_name        Tag name.


### PR DESCRIPTION
## Summary

Fixes #6834

The new `AMP_YouTube_Embed_Handler::amend_fixed_height_layout()` method here is not ideal as it is only a partial implementation of the more robust `AMP_Base_Sanitizer::set_layout()` method. It would be better if `AMP_Base_Sanitizer::set_layout()` could be extracted into a trait (along with the methods it depends on) so that it could be reused both by `AMP_Base_Sanitizer` and `AMP_Base_Embed_Handler`. But this would expand the scope and necessitate some larger refactoring.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
