### PR TITLE
Ampify responsive Navigation Block

### DIFF
--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -296,39 +296,37 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		$this->navigation_block_count++;
 		$modal_state_property = "modal_{$this->navigation_block_count}_expanded";
 
-		// Set `aria-expanded` value of submenus whenever AMP state changes if they are opened on click.
-		if ( ! empty( $block['attrs']['openSubmenusOnClick'] ) ) {
-			$submenu_toggles_count = 0;
-			$block_content         = preg_replace_callback(
-				'/(?<=<button)\s[^>]+/',
-				static function ( $matches ) use ( $modal_state_property, &$submenu_toggles_count ) {
-					$new_block_content = $matches[0];
+		// Set `aria-expanded` value of submenus whenever AMP state changes.
+		$submenu_toggles_count = 0;
+		$block_content         = preg_replace_callback(
+			'/(?<=<button)\s[^>]+/',
+			static function ( $matches ) use ( $modal_state_property, &$submenu_toggles_count ) {
+				$new_block_content = $matches[0];
 
-					if ( false === strpos( $new_block_content, 'wp-block-navigation-submenu__toggle' ) ) {
-						return $new_block_content;
-					}
+				if ( false === strpos( $new_block_content, 'wp-block-navigation-submenu__toggle' ) ) {
+					return $new_block_content;
+				}
 
-					$submenu_toggles_count++;
+				$submenu_toggles_count++;
 
-					$submenu_state_property = str_replace(
-						'expanded',
-						'submenu_' . $submenu_toggles_count . '_expanded',
-						$modal_state_property
-					);
+				$submenu_state_property = str_replace(
+					'expanded',
+					'submenu_' . $submenu_toggles_count . '_expanded',
+					$modal_state_property
+				);
 
-					// Set `aria-expanded` value of submenus whenever AMP state changes.
-					return str_replace(
-						' aria-expanded',
-						sprintf(
-							' on="tap:AMP.setState({ %1$s: !%1$s })" [aria-expanded]="%1$s ? \'true\' : \'false\'" aria-expanded',
-							$submenu_state_property
-						),
-						$new_block_content
-					);
-				},
-				$block_content
-			);
-		}
+				// Set `aria-expanded` value of submenus whenever AMP state changes.
+				return str_replace(
+					' aria-expanded',
+					sprintf(
+						' on="tap:AMP.setState({ %1$s: !%1$s })" [aria-expanded]="%1$s ? \'true\' : \'false\'" aria-expanded',
+						$submenu_state_property
+					),
+					$new_block_content
+				);
+			},
+			$block_content
+		);
 
 		// In case of the "Mobile" option value, the `overlayMenu` attribute is not set at all.
 		if ( ! empty( $block['attrs']['overlayMenu'] ) && 'never' === $block['attrs']['overlayMenu'] ) {

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -320,7 +320,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 					' aria-expanded',
 					sprintf(
 						' on="tap:AMP.setState({ %1$s: !%1$s })" [aria-expanded]="%1$s ? \'true\' : \'false\'" aria-expanded',
-						$submenu_state_property
+						esc_attr( $submenu_state_property )
 					),
 					$new_block_content
 				);
@@ -336,7 +336,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		// Replace micromodal toggle logic with AMP state and set modal state property name based on its ID.
 		$block_content = preg_replace(
 			'/\sdata-micromodal-trigger="modal-\w+"/',
-			sprintf( ' on="tap:AMP.setState({ %1$s: !%1$s })"', $modal_state_property ),
+			sprintf( ' on="tap:AMP.setState({ %1$s: !%1$s })"', esc_attr( $modal_state_property ) ),
 			$block_content
 		);
 
@@ -354,7 +354,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 				if ( false !== strpos( $new_block_content, ' data-micromodal-close' ) ) {
 					$new_block_content = str_replace(
 						' data-micromodal-close',
-						sprintf( ' on="tap:AMP.setState({ %1$s: !%1$s })"', $modal_state_property ),
+						sprintf( ' on="tap:AMP.setState({ %1$s: !%1$s })"', esc_attr( $modal_state_property ) ),
 						$new_block_content
 					);
 				}
@@ -364,7 +364,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 					' aria-expanded',
 					sprintf(
 						' [aria-expanded]="%s ? \'true\' : \'false\'" aria-expanded',
-						$modal_state_property
+						esc_attr( $modal_state_property )
 					),
 					$new_block_content
 				);
@@ -383,8 +383,8 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 					' class=',
 					sprintf(
 						' [aria-hidden]="%1$s ? \'false\' : \'true\'" aria-hidden="true" [class]="%1$s ? \'%2$s is-menu-open has-modal-open\' : \'%2$s\'" class=',
-						$modal_state_property,
-						$matches[1]
+						esc_attr( $modal_state_property ),
+						esc_attr( $matches[1] )
 					),
 					$matches[0]
 				);

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -308,9 +308,11 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 						return $new_block_content;
 					}
 
+					$submenu_toggles_count++;
+
 					$submenu_state_property = str_replace(
 						'expanded',
-						'submenu_' . $submenu_toggles_count++ . '_expanded',
+						'submenu_' . $submenu_toggles_count . '_expanded',
 						$modal_state_property
 					);
 
@@ -340,10 +342,9 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			$block_content
 		);
 
-		$submenu_toggles_count = 0;
-		$block_content         = preg_replace_callback(
+		$block_content = preg_replace_callback(
 			'/(?<=<button)\s[^>]+/',
-			static function ( $matches ) use ( $modal_state_property, &$submenu_toggles_count ) {
+			static function ( $matches ) use ( $modal_state_property ) {
 				$new_block_content = $matches[0];
 
 				// Skip submenu toggles.

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -375,17 +375,22 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		// Delete other micromodal-related data attributes.
 		$block_content = preg_replace( '/\sdata-micromodal-close/', '', $block_content );
 
-		// Toggle `aria-hidden` value whenever AMP state changes.
-		$block_content = preg_replace(
-			'/(?=\saria-hidden="\w+")/',
-			sprintf( ' [aria-hidden]="%s ? \'false\' : \'true\'"', $modal_state_property ),
-			$block_content
-		);
+		// Change a responsive container class name and aria-hidden value based on the AMP state.
+		$block_content = preg_replace_callback(
+			'/(?><.+\sclass="([^"]*wp-block-navigation__responsive-container(?>\s[^"]*)?)"[^>]*>)/',
+			static function ( $matches ) use ( $modal_state_property ) {
+				$new_block_content = str_replace(
+					' class=',
+					sprintf(
+						' [aria-hidden]="%1$s ? \'false\' : \'true\'" aria-hidden="true" [class]="%1$s ? \'%2$s is-menu-open has-modal-open\' : \'%2$s\'" class=',
+						$modal_state_property,
+						$matches[1]
+					),
+					$matches[0]
+				);
 
-		// Change a responsive container class name based on the AMP state.
-		$block_content = preg_replace(
-			'/(?=\sclass="(\s*wp-block-navigation__responsive-container(?>"|\s+[^"]*))")/',
-			sprintf( ' [class]="%s ? \'$1 is-menu-open has-modal-open\' : \'$1\'"', $modal_state_property ),
+				return $new_block_content;
+			},
 			$block_content
 		);
 

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -270,7 +270,7 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 	 */
 	public function get_ampify_navigation_block_test_data() {
 		return [
-			'navigation_block_mobile_overlay_menu_submenus_open_on_click'       => [
+			'navigation_block_mobile_overlay_menu_submenus_open_on_click' => [
 				'block_attrs'     => [
 					'openSubmenusOnClick' => true,
 				],
@@ -414,7 +414,7 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 					</nav>
 				',
 			],
-			'navigation_block_overlay_menu_always_shown'                        => [
+			'navigation_block_overlay_menu_always_shown' => [
 				'block_attrs'     => [
 					'overlayMenu'         => 'always',
 					'openSubmenusOnClick' => true,
@@ -488,7 +488,7 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 					</nav>
 				',
 			],
-			'navigation_block_overlay_menu_never_shown'                         => [
+			'navigation_block_overlay_menu_never_shown'  => [
 				'block_attrs'     => [
 					'overlayMenu'         => 'never',
 					'openSubmenusOnClick' => true,

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -554,8 +554,8 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 	 * @covers \AMP_Core_Block_Handler::dequeue_block_navigation_view_script()
 	 */
 	public function test_ampify_navigation_block( $block_attrs, $block_markup, $expected_markup ) {
-		if ( ! defined( 'GUTENBERG_VERSION' ) || version_compare( GUTENBERG_VERSION, '10.7', '<' ) ) {
-			$this->markTestSkipped( 'Requires Gutenberg 10.7 or higher.' );
+		if ( ! function_exists( 'render_block_core_navigation' ) ) {
+			$this->markTestSkipped( 'Navigation block does not exist.' );
 		}
 
 		$handler = new AMP_Core_Block_Handler();

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -43,6 +43,11 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 		if ( did_action( 'add_attachment' ) ) {
 			$this->remove_added_uploads();
 		}
+
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = null;
+		$wp_styles  = null;
+
 		parent::tearDown();
 	}
 
@@ -563,7 +568,9 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 		$handler->register_embed();
 
 		$script_handle = 'wp-block-navigation-view';
-		$this->assertTrue( wp_script_is( $script_handle, 'registered' ) );
+		if ( ! wp_script_is( $script_handle, 'registered' ) ) {
+			wp_register_script( $script_handle, 'view.js', [], '1.0', true );
+		}
 		wp_enqueue_script( $script_handle ); // Normally done by render_block_core_navigation().
 
 		$this->assertEqualMarkup(

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -266,6 +266,311 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 	}
 
 	/**
+	 * @return array[]
+	 */
+	public function get_ampify_navigation_block_test_data() {
+		return [
+			'navigation_block_mobile_overlay_menu_submenus_open_on_click' => [
+				'block_attrs'     => [
+					'openSubmenusOnClick' => true,
+				],
+				'block_content'   => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" data-micromodal-trigger="modal-61e6c935457bd">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div class="wp-block-navigation__responsive-container" style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+				'expected_markup' => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button [aria-expanded]="modal_1_expanded ? \'true\' : \'false\'" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div [aria-hidden]="modal_1_expanded ? \'false\' : \'true\'" aria-hidden="true" [class]="modal_1_expanded ? \'wp-block-navigation__responsive-container is-menu-open has-modal-open\' : \'wp-block-navigation__responsive-container\'" class="wp-block-navigation__responsive-container" style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1">
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })" class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_1_expanded: !modal_1_submenu_1_expanded })" [aria-expanded]="modal_1_submenu_1_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_2_expanded: !modal_1_submenu_2_expanded })" [aria-expanded]="modal_1_submenu_2_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+			],
+			'navigation_block_mobile_overlay_menu_submenus_open_on_hover_click' => [
+				'block_attrs'     => [],
+				'block_content'   => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" data-micromodal-trigger="modal-61e6c935457bd">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div class="wp-block-navigation__responsive-container" style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-hover-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-hover-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+				'expected_markup' => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button [aria-expanded]="modal_1_expanded ? \'true\' : \'false\'" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div [aria-hidden]="modal_1_expanded ? \'false\' : \'true\'" aria-hidden="true" [class]="modal_1_expanded ? \'wp-block-navigation__responsive-container is-menu-open has-modal-open\' : \'wp-block-navigation__responsive-container\'" class="wp-block-navigation__responsive-container" style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1">
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })" class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-hover-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_1_expanded: !modal_1_submenu_1_expanded })" [aria-expanded]="modal_1_submenu_1_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-hover-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_2_expanded: !modal_1_submenu_2_expanded })" [aria-expanded]="modal_1_submenu_2_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+			],
+			'navigation_block_overlay_menu_always_shown' => [
+				'block_attrs'     => [
+					'overlayMenu'         => 'always',
+					'openSubmenusOnClick' => true,
+				],
+				'block_content'   => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open always-shown" data-micromodal-trigger="modal-61e6c935457bd">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div class="wp-block-navigation__responsive-container hidden-by-default " style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+				'expected_markup' => '
+					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
+						<button [aria-expanded]="modal_1_expanded ? \'true\' : \'false\'" aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open always-shown" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })">
+							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
+						</button>
+						<div [aria-hidden]="modal_1_expanded ? \'false\' : \'true\'" aria-hidden="true" [class]="modal_1_expanded ? \'wp-block-navigation__responsive-container hidden-by-default  is-menu-open has-modal-open\' : \'wp-block-navigation__responsive-container hidden-by-default \'" class="wp-block-navigation__responsive-container hidden-by-default " style="" id="modal-61e6c935457bd">
+							<div class="wp-block-navigation__responsive-close" tabindex="-1">
+								<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-61e6c935457bd-title">
+									<button aria-label="Close menu" on="tap:AMP.setState({ modal_1_expanded: !modal_1_expanded })" class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
+									<div class="wp-block-navigation__responsive-container-content" id="modal-61e6c935457bd-content">
+										<ul class="wp-block-navigation__container">
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_1_expanded: !modal_1_submenu_1_expanded })" [aria-expanded]="modal_1_submenu_1_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+													<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+												<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_2_expanded: !modal_1_submenu_2_expanded })" [aria-expanded]="modal_1_submenu_2_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+												<ul class="wp-block-navigation__submenu-container">
+													<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+												</ul>
+											</li>
+											<li class=" wp-block-navigation-item wp-block-navigation-link">
+												<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</nav>
+				',
+			],
+			'navigation_block_overlay_menu_never_shown'  => [
+				'block_attrs'     => [
+					'overlayMenu'         => 'never',
+					'openSubmenusOnClick' => true,
+				],
+				'block_content'   => '
+					<nav class="wp-container-61e6c93546294 wp-block-navigation">
+						<ul class="wp-block-navigation__container">
+							<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+								<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+								<ul class="wp-block-navigation__submenu-container">
+									<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+									<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+								</ul>
+							</li>
+							<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+								<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+								<ul class="wp-block-navigation__submenu-container">
+									<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+								</ul>
+							</li>
+							<li class=" wp-block-navigation-item wp-block-navigation-link">
+								<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+							</li>
+						</ul>
+					</nav>
+				',
+				'expected_markup' => '
+					<nav class="wp-container-61e6c93546294 wp-block-navigation">
+						<ul class="wp-block-navigation__container">
+							<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+								<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_1_expanded: !modal_1_submenu_1_expanded })" [aria-expanded]="modal_1_submenu_1_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page A</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+								<ul class="wp-block-navigation__submenu-container">
+									<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a1"><span class="wp-block-navigation-item__label">Page A1</span></a></li>
+									<li class=" wp-block-navigation-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-a2"><span class="wp-block-navigation-item__label">Page A2</span></a></li>
+								</ul>
+							</li>
+							<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
+								<button class="wp-block-navigation-item__content wp-block-navigation-submenu__toggle" on="tap:AMP.setState({ modal_1_submenu_2_expanded: !modal_1_submenu_2_expanded })" [aria-expanded]="modal_1_submenu_2_expanded ? \'true\' : \'false\'" aria-expanded="false"><span class="wp-block-navigation-item__label">Page B</span><span class="wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span></button>
+								<ul class="wp-block-navigation__submenu-container">
+									<li class=" wp-block-navigation-item current-menu-item wp-block-navigation-link"><a class="wp-block-navigation-item__content" href="https://example.com/page-b1" aria-current="page"><span class="wp-block-navigation-item__label">Page B1</span></a></li>
+								</ul>
+							</li>
+							<li class=" wp-block-navigation-item wp-block-navigation-link">
+								<a class="wp-block-navigation-item__content" href="https://example.com/page-c"><span class="wp-block-navigation-item__label">Page C</span></a>
+							</li>
+						</ul>
+					</nav>
+				',
+			],
+		];
+	}
+
+	/**
+	 * Test ampifying a Navigation Block.
+	 *
+	 * @dataProvider get_ampify_navigation_block_test_data
+	 *
+	 * @param array  $block_attrs     Block attributes.
+	 * @param string $block_content   Block original content.
+	 * @param string $expected_markup Expected content.
+	 *
+	 * @covers \AMP_Core_Block_Handler::ampify_navigation_block()
+	 * @covers \AMP_Core_Block_Handler::dequeue_block_navigation_view_script()
+	 */
+	public function test_ampify_navigation_block( $block_attrs, $block_content, $expected_markup ) {
+		if ( ! defined( 'GUTENBERG_VERSION' ) || version_compare( GUTENBERG_VERSION, '10.7', '<' ) ) {
+			$this->markTestSkipped( 'Requires Gutenberg 10.7 or higher.' );
+		}
+
+		$handler = new AMP_Core_Block_Handler();
+		$handler->unregister_embed(); // Make sure we are on the initial clean state.
+		$handler->register_embed();
+
+		$this->assertFalse( wp_script_is( 'wp-block-navigation-view', 'enqueued' ) );
+
+		$this->assertStringContainsString(
+			$expected_markup,
+			$handler->ampify_navigation_block( $block_content, [ 'attrs' => $block_attrs ] )
+		);
+	}
+
+	/**
 	 * Test process_categories_widgets.
 	 *
 	 * @covers AMP_Core_Block_Handler::process_categories_widgets()

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -562,12 +562,19 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 		$handler->unregister_embed(); // Make sure we are on the initial clean state.
 		$handler->register_embed();
 
-		$this->assertFalse( wp_script_is( 'wp-block-navigation-view', 'enqueued' ) );
+		$script_handle = 'wp-block-navigation-view';
+		$this->assertTrue( wp_script_is( $script_handle, 'registered' ) );
+		wp_enqueue_script( $script_handle ); // Normally done by render_block_core_navigation().
 
 		$this->assertEqualMarkup(
 			$expected_markup,
 			$handler->ampify_navigation_block( $block_markup, [ 'attrs' => $block_attrs ] )
 		);
+
+		$this->assertEquals( 0, has_action( 'wp_print_scripts', [ $handler, 'dequeue_block_navigation_view_script' ] ) );
+		$this->assertEquals( 0, has_action( 'wp_print_footer_scripts', [ $handler, 'dequeue_block_navigation_view_script' ] ) );
+		$handler->dequeue_block_navigation_view_script();
+		$this->assertFalse( wp_script_is( $script_handle, 'enqueued' ) );
 	}
 
 	/**

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -270,11 +270,11 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 	 */
 	public function get_ampify_navigation_block_test_data() {
 		return [
-			'navigation_block_mobile_overlay_menu_submenus_open_on_click' => [
+			'navigation_block_mobile_overlay_menu_submenus_open_on_click'       => [
 				'block_attrs'     => [
 					'openSubmenusOnClick' => true,
 				],
-				'block_content'   => '
+				'block_markup'    => '
 					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
 						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" data-micromodal-trigger="modal-61e6c935457bd">
 							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
@@ -345,7 +345,7 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 			],
 			'navigation_block_mobile_overlay_menu_submenus_open_on_hover_click' => [
 				'block_attrs'     => [],
-				'block_content'   => '
+				'block_markup'    => '
 					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
 						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open" data-micromodal-trigger="modal-61e6c935457bd">
 							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
@@ -414,12 +414,12 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 					</nav>
 				',
 			],
-			'navigation_block_overlay_menu_always_shown' => [
+			'navigation_block_overlay_menu_always_shown'                        => [
 				'block_attrs'     => [
 					'overlayMenu'         => 'always',
 					'openSubmenusOnClick' => true,
 				],
-				'block_content'   => '
+				'block_markup'    => '
 					<nav class="wp-container-61e6c93546294 is-responsive wp-block-navigation">
 						<button aria-expanded="false" aria-haspopup="true" aria-label="Open menu" class="wp-block-navigation__responsive-container-open always-shown" data-micromodal-trigger="modal-61e6c935457bd">
 							<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>
@@ -488,12 +488,12 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 					</nav>
 				',
 			],
-			'navigation_block_overlay_menu_never_shown'  => [
+			'navigation_block_overlay_menu_never_shown'                         => [
 				'block_attrs'     => [
 					'overlayMenu'         => 'never',
 					'openSubmenusOnClick' => true,
 				],
-				'block_content'   => '
+				'block_markup'    => '
 					<nav class="wp-container-61e6c93546294 wp-block-navigation">
 						<ul class="wp-block-navigation__container">
 							<li class=" wp-block-navigation-item has-child open-on-click wp-block-navigation-submenu">
@@ -547,13 +547,13 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 	 * @dataProvider get_ampify_navigation_block_test_data
 	 *
 	 * @param array  $block_attrs     Block attributes.
-	 * @param string $block_content   Block original content.
+	 * @param string $block_markup    Block original markup.
 	 * @param string $expected_markup Expected content.
 	 *
 	 * @covers \AMP_Core_Block_Handler::ampify_navigation_block()
 	 * @covers \AMP_Core_Block_Handler::dequeue_block_navigation_view_script()
 	 */
-	public function test_ampify_navigation_block( $block_attrs, $block_content, $expected_markup ) {
+	public function test_ampify_navigation_block( $block_attrs, $block_markup, $expected_markup ) {
 		if ( ! defined( 'GUTENBERG_VERSION' ) || version_compare( GUTENBERG_VERSION, '10.7', '<' ) ) {
 			$this->markTestSkipped( 'Requires Gutenberg 10.7 or higher.' );
 		}
@@ -564,9 +564,9 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 
 		$this->assertFalse( wp_script_is( 'wp-block-navigation-view', 'enqueued' ) );
 
-		$this->assertStringContainsString(
+		$this->assertEqualMarkup(
 			$expected_markup,
-			$handler->ampify_navigation_block( $block_content, [ 'attrs' => $block_attrs ] )
+			$handler->ampify_navigation_block( $block_markup, [ 'attrs' => $block_attrs ] )
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6319
Closes #6744

This PR adds AMP support to the new [Responsive Navigation block](https://make.wordpress.org/core/2021/05/27/whats-new-in-gutenberg-10-7-26-may/#:~:text=responsive%20navigation%20block).

The key differences to the another solution proposed in #6744 are:
- The AMP implementation reuses most of the non-AMP version, most notably the CSS.
- `amp-bind` is used for toggling the appropriate class names and ARIA attributes (it replaces the `micromodal` logic from the original implementation).
- No `amp-lightbox` or `amp-sidebar` is used.
- In `AMP_Core_Block_Handler::ampify_navigation_block` no DOM tree manipulation is performed (only plain strings replacements).

When testing, it's important to use a menu that has at least one submenu (preferably more). It's because the submenus have their own toggle logic, independent of the overlay menu setting.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
