### PR TITLE
Optimize the process of deleting AMP data during uninstallation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,10 +77,10 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true,
-      "civicrm/composer-downloads-plugin": true,
       "ampproject/php-css-parser-install-plugin": true,
-      "cweagans/composer-patches": true
+      "civicrm/composer-downloads-plugin": true,
+      "cweagans/composer-patches": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "platform": {
       "php": "5.6.20"

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -110,12 +110,12 @@ function delete_terms() {
 		$wpdb->query(
 			$wpdb->prepare(
 				"
-			DELETE tm
-			FROM $wpdb->termmeta AS tm
-				INNER JOIN $wpdb->term_taxonomy AS tt
-					ON tm.term_id = tt.term_id
-			WHERE tt.taxonomy = %s;
-			",
+				DELETE tm
+				FROM $wpdb->termmeta AS tm
+					INNER JOIN $wpdb->term_taxonomy AS tt
+						ON tm.term_id = tt.term_id
+				WHERE tt.taxonomy = %s;
+				",
 				$taxonomy
 			)
 		);

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -75,6 +75,7 @@ function delete_posts() {
 		)
 	);
 
+	// Delete all amp_validated_url posts.
 	$wpdb->delete(
 		$wpdb->posts,
 		compact( 'post_type' )

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -56,6 +56,7 @@ function delete_user_metadata() {
  */
 function delete_posts() {
 
+	/** @var \wpdb */
 	global $wpdb;
 
 	$post_type = 'amp_validated_url';
@@ -92,24 +93,33 @@ function delete_posts() {
  */
 function delete_terms() {
 
+	// Abort if term splitting has not been done. This is done by WooCommerce so it's
+	// it's also done here for good measure, even though we require WP 4.9+.
+	if ( version_compare( get_bloginfo( 'version' ), '4.2', '<' ) ) {
+		return;
+	}
+
+	/** @var \wpdb */
 	global $wpdb;
 
 	$taxonomy = 'amp_validation_error';
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-	// Delete term meta.
-	$wpdb->query(
-		$wpdb->prepare(
-			"
+	// Delete term meta (added in WP 4.4).
+	if ( ! empty( $wpdb->termmeta ) ) {
+		$wpdb->query(
+			$wpdb->prepare(
+				"
 			DELETE tm
 			FROM $wpdb->termmeta AS tm
 				INNER JOIN $wpdb->term_taxonomy AS tt
 					ON tm.term_id = tt.term_id
 			WHERE tt.taxonomy = %s;
 			",
-			$taxonomy
-		)
-	);
+				$taxonomy
+			)
+		);
+	}
 
 	// Delete term relationship.
 	$wpdb->query(
@@ -161,6 +171,7 @@ function delete_transients() {
 		return;
 	}
 
+	/** @var \wpdb */
 	global $wpdb;
 
 	$transient_groups = [

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -65,7 +65,13 @@ function delete_posts() {
 	// Delete all post meta data related to "amp_validated_url" post_type.
 	$wpdb->query(
 		$wpdb->prepare(
-			"DELETE meta FROM $wpdb->postmeta AS meta INNER JOIN $wpdb->posts AS posts ON posts.ID = meta.post_id WHERE posts.post_type = %s;",
+			"
+			DELETE meta
+			FROM $wpdb->postmeta AS meta
+				INNER JOIN $wpdb->posts AS posts
+					ON posts.ID = meta.post_id
+			WHERE posts.post_type = %s;
+			",
 			$post_type
 		)
 	);
@@ -94,7 +100,13 @@ function delete_terms() {
 	// Delete term meta.
 	$wpdb->query(
 		$wpdb->prepare(
-			"DELETE tm from $wpdb->termmeta AS tm INNER JOIN $wpdb->term_taxonomy AS tt ON  tm.term_id = tt.term_id WHERE tt.taxonomy = %s;",
+			"
+			DELETE tm
+			FROM $wpdb->termmeta AS tm
+				INNER JOIN $wpdb->term_taxonomy AS tt
+					ON tm.term_id = tt.term_id
+			WHERE tt.taxonomy = %s;
+			",
 			$taxonomy
 		)
 	);
@@ -102,7 +114,13 @@ function delete_terms() {
 	// Delete term relationship.
 	$wpdb->query(
 		$wpdb->prepare(
-			"DELETE tr from $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy = %s;",
+			"
+			DELETE tr
+			FROM $wpdb->term_relationships AS tr
+				INNER JOIN $wpdb->term_taxonomy AS tt
+					ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			WHERE tt.taxonomy = %s;
+			",
 			$taxonomy
 		)
 	);
@@ -110,7 +128,13 @@ function delete_terms() {
 	// Delete terms.
 	$wpdb->query(
 		$wpdb->prepare(
-			"DELETE terms from $wpdb->terms AS terms INNER JOIN $wpdb->term_taxonomy AS tt ON  terms.term_id = tt.term_id WHERE tt.taxonomy = %s;",
+			"
+			DELETE terms
+			FROM $wpdb->terms AS terms
+				INNER JOIN $wpdb->term_taxonomy AS tt
+					ON terms.term_id = tt.term_id
+			WHERE tt.taxonomy = %s;
+			",
 			$taxonomy
 		)
 	);

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -59,17 +59,21 @@ function delete_posts() {
 
 	global $wpdb;
 
+	$post_type = 'amp_validated_url';
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	// Delete all post meta data related to "amp_validated_url" post_type.
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE meta FROM $wpdb->postmeta AS meta INNER JOIN $wpdb->posts AS posts ON posts.ID = meta.post_id WHERE posts.post_type = %s;",
+			$post_type
+		)
+	);
 
 	$wpdb->delete(
 		$wpdb->posts,
-		[
-			'post_type' => 'amp_validated_url',
-		]
+		compact( 'post_type' )
 	);
-
-	// Delete orphan post meta data.
-	$wpdb->query( "DELETE meta FROM $wpdb->postmeta AS meta LEFT JOIN $wpdb->posts AS posts ON posts.ID = meta.post_id WHERE posts.ID IS NULL;" );
 
 	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 }
@@ -84,24 +88,38 @@ function delete_terms() {
 
 	global $wpdb;
 
+	$taxonomy = 'amp_validation_error';
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
-	$wpdb->delete(
-		$wpdb->term_taxonomy,
-		[
-			'taxonomy' => 'amp_validation_error',
-		]
+	// Delete term meta.
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE tm from $wpdb->termmeta AS tm INNER JOIN $wpdb->term_taxonomy AS tt ON  tm.term_id = tt.term_id WHERE tt.taxonomy = %s;",
+			$taxonomy
+		)
 	);
 
-	// Delete orphan relationships.
-	$wpdb->query( "DELETE tr FROM $wpdb->term_relationships AS tr LEFT JOIN $wpdb->posts AS posts ON posts.ID = tr.object_id WHERE posts.ID IS NULL;" );
+	// Delete term relationship.
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE tr from $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy = %s;",
+			$taxonomy
+		)
+	);
 
-	// Delete orphan terms.
-	$wpdb->query( "DELETE t FROM $wpdb->terms AS t LEFT JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.term_id IS NULL;" );
+	// Delete terms.
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE terms from $wpdb->terms AS terms INNER JOIN $wpdb->term_taxonomy AS tt ON  terms.term_id = tt.term_id WHERE tt.taxonomy = %s;",
+			$taxonomy
+		)
+	);
 
-	// Delete orphan term meta.
-	$wpdb->query( "DELETE tm FROM $wpdb->termmeta AS tm LEFT JOIN $wpdb->term_taxonomy AS tt ON tm.term_id = tt.term_id WHERE tt.term_id IS NULL;" );
-
+	// Delete term taxonomy.
+	$wpdb->delete(
+		$wpdb->term_taxonomy,
+		compact( 'taxonomy' )
+	);
 	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -18,7 +18,6 @@ function delete_options() {
 
 	delete_option( 'amp-options' );
 	delete_option( 'amp_css_transient_monitor_time_series' );
-	delete_option( 'amp_customize_setting_modified_timestamps' );
 	delete_option( 'amp_url_validation_queue' ); // See Validation\URLValidationCron::OPTION_KEY.
 
 	$theme_mod_name = 'amp_customize_setting_modified_timestamps';

--- a/includes/uninstall-functions.php
+++ b/includes/uninstall-functions.php
@@ -40,23 +40,13 @@ function delete_options() {
  * @internal
  */
 function delete_user_metadata() {
-	global $wpdb;
-
-	$keys         = [
+	$keys = [
 		'amp_dev_tools_enabled',
 		'amp_review_panel_dismissed_for_template_mode',
 	];
-	$where_clause = [];
-
 	foreach ( $keys as $key ) {
-		$where_clause[] = $wpdb->prepare( ' meta_key = %s ', $key );
+		delete_metadata( 'user', 0, $key, '', true );
 	}
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Cannot cache result since we're deleting the records.
-	$wpdb->query(
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		"DELETE FROM $wpdb->usermeta WHERE " . implode( ' OR ', $where_clause )
-	);
 }
 
 /**

--- a/tests/php/test-uninstall.php
+++ b/tests/php/test-uninstall.php
@@ -97,14 +97,13 @@ class Test_Uninstall extends TestCase {
 		$post_tag_term_relationships_row_count = $wpdb->query( $wpdb->prepare( "SELECT * FROM {$wpdb->term_relationships} WHERE term_taxonomy_id = %d", $post_tag_term->term_id ) );
 		$this->assertGreaterThan( 0, $post_tag_term_relationships_row_count );
 
-		$theme_mod_name = 'amp_customize_setting_modified_timestamps';
 		set_theme_mod( 'color', 'blue' );
-		set_theme_mod( $theme_mod_name, [ 'color' => time() ] );
+		set_theme_mod( AMP_Template_Customizer::THEME_MOD_TIMESTAMPS_KEY, [ 'color' => time() ] );
 		update_option(
 			'theme_mods_foo',
 			[
-				'color'         => 'red',
-				$theme_mod_name => [
+				'color' => 'red',
+				AMP_Template_Customizer::THEME_MOD_TIMESTAMPS_KEY => [
 					'color' => time(),
 				],
 			]
@@ -215,10 +214,10 @@ class Test_Uninstall extends TestCase {
 		$this->assertEquals( $blog_name, get_option( 'blogname', false ) );
 
 		$this->assertEquals( 'blue', get_theme_mod( 'color' ) );
-		$this->assertFalse( get_theme_mod( $theme_mod_name ) );
+		$this->assertFalse( get_theme_mod( AMP_Template_Customizer::THEME_MOD_TIMESTAMPS_KEY ) );
 		$foo_theme_mods = get_option( 'theme_mods_foo' );
 		$this->assertEquals( 'red', $foo_theme_mods['color'] );
-		$this->assertArrayNotHasKey( $theme_mod_name, $foo_theme_mods );
+		$this->assertArrayNotHasKey( AMP_Template_Customizer::THEME_MOD_TIMESTAMPS_KEY, $foo_theme_mods );
 
 		foreach ( $transient_groups_to_remove as $transient_group ) {
 			$this->assertEmpty( get_transient( $transient_group ) );

--- a/tests/php/test-uninstall.php
+++ b/tests/php/test-uninstall.php
@@ -78,12 +78,12 @@ class Test_Uninstall extends TestCase {
 
 		$amp_error_term = $this->factory()->term->create_and_get(
 			[
-				'taxonomy' => 'amp_validation_error',
+				'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 			]
 		);
 
 		update_term_meta( $amp_error_term->term_id, $meta_key, $meta_value );
-		wp_add_object_terms( $amp_validated_post->ID, $amp_error_term->term_id, 'amp_validation_error' );
+		wp_add_object_terms( $amp_validated_post->ID, $amp_error_term->term_id, AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
 
 		$post_tag_term = $this->factory()->term->create_and_get(
 			[
@@ -155,7 +155,12 @@ class Test_Uninstall extends TestCase {
 
 		// Assert that there is no data left for `amp_validation_error` taxonomy.
 		$this->assertEmpty(
-			$wpdb->query( "SELECT * FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'amp_validation_error';" )
+			$wpdb->query(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->term_taxonomy} WHERE taxonomy = %s;",
+					AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG
+				)
+			)
 		);
 		$this->assertEmpty(
 			$wpdb->query(

--- a/tests/php/test-uninstall.php
+++ b/tests/php/test-uninstall.php
@@ -54,6 +54,7 @@ class Test_Uninstall extends TestCase {
 
 		foreach ( $users as $user ) {
 			update_user_meta( $user, 'amp_dev_tools_enabled', 'Yes' );
+			update_user_meta( $user, 'amp_review_panel_dismissed_for_template_mode', 'Yes' );
 			update_user_meta( $user, 'additional_user_meta', 'Yes' );
 		}
 
@@ -200,6 +201,7 @@ class Test_Uninstall extends TestCase {
 
 		foreach ( $users as $user ) {
 			$this->assertEmpty( get_user_meta( $user, 'amp_dev_tools_enabled', true ) );
+			$this->assertEmpty( get_user_meta( $user, 'amp_review_panel_dismissed_for_template_mode', true ) );
 			$this->assertEquals( 'Yes', get_user_meta( $user, 'additional_user_meta', true ) );
 		}
 	}

--- a/tests/php/test-uninstall.php
+++ b/tests/php/test-uninstall.php
@@ -566,20 +566,20 @@ class Test_Uninstall extends TestCase {
 		// Test 1: With option to keep AMP data ON.
 		AMP_Options_Manager::update_option( Option::DELETE_DATA_AT_UNINSTALL, false );
 
+		$num_queries_before = $wpdb->num_queries;
 		require AMP__DIR__ . '/uninstall.php';
-
 		$this->flush_cache();
-		// @todo Assert no deletions were run.
+		$this->assertEquals( $num_queries_before, $wpdb->num_queries );
 
 		$this->assertNotEmpty( get_option( AMP_Options_Manager::OPTION_NAME, false ) );
 
 		// Test 2: With option to keep AMP data OFF.
 		AMP_Options_Manager::update_option( Option::DELETE_DATA_AT_UNINSTALL, true );
 
+		$num_queries_before = $wpdb->num_queries;
 		require AMP__DIR__ . '/uninstall.php';
-		// @todo Assert that deletions were run.
-
 		$this->flush_cache();
+		$this->assertGreaterThan( $num_queries_before, $wpdb->num_queries );
 
 		// Assert that AMP related data does get deleted.
 		$this->assertEmpty( get_option( AMP_Options_Manager::OPTION_NAME, false ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6826 

This PR optimized the process of deleting AMP data during uninstallation. Instead of deleting posts and terms one by one with the WordPress function, it will run the DELETE query directly to the database to delete records.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
