### PR TITLE
Fix test to account for `gutenberg_render_layout_support_flag()`

### DIFF
--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1382,6 +1382,9 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 		$rendered_block = do_blocks( AMP_Validation_Manager::add_block_source_comments( $content ) );
 
+		// Remove class name injected by gutenberg_render_layout_support_flag().
+		$rendered_block = preg_replace( '/(?<= class=")wp-container-\w+ /', '', $rendered_block );
+
 		$expected = str_replace(
 			[
 				'{{post_id}}',


### PR DESCRIPTION
## Summary

In https://github.com/WordPress/gutenberg/pull/37360 the `gutenberg_render_layout_support_flag()` function started injecting class names like `wp-container-61e99d185b96f` in the Columns block (as part of Gutenberg 12.3). This broke a unit test when for checking the expected output. So this PR just strips that class back out if it was added.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
