### PR TITLE
Handle case in Site Scanning when no scannable URL is available

### DIFF
--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -116,7 +116,7 @@ export function siteScanReducer( state, action ) {
 			};
 		}
 		case ACTION_SCANNABLE_URLS_RECEIVE: {
-			const hasScannableUrls = action.scannableUrls?.length > 0;
+			const hasScannableUrls = Array.isArray( action.scannableUrls ) && action.scannableUrls.length > 0;
 			return {
 				...state,
 				status: ( state.scanOnce && state.scansCount > 0 ) || ! hasScannableUrls ? STATUS_COMPLETED : STATUS_READY,

--- a/assets/src/components/site-scan-context-provider/index.js
+++ b/assets/src/components/site-scan-context-provider/index.js
@@ -116,17 +116,11 @@ export function siteScanReducer( state, action ) {
 			};
 		}
 		case ACTION_SCANNABLE_URLS_RECEIVE: {
-			if ( ! action.scannableUrls || action.scannableUrls?.length === 0 ) {
-				return {
-					...state,
-					status: STATUS_COMPLETED,
-				};
-			}
-
+			const hasScannableUrls = action.scannableUrls?.length > 0;
 			return {
 				...state,
-				status: state.scanOnce && state.scansCount > 0 ? STATUS_COMPLETED : STATUS_READY,
-				scannableUrls: action.scannableUrls,
+				status: ( state.scanOnce && state.scansCount > 0 ) || ! hasScannableUrls ? STATUS_COMPLETED : STATUS_READY,
+				scannableUrls: hasScannableUrls ? action.scannableUrls : [],
 			};
 		}
 		case ACTION_SCAN_INITIALIZE: {

--- a/assets/src/components/site-scan-context-provider/test/site-scan-reducer.js
+++ b/assets/src/components/site-scan-context-provider/test/site-scan-reducer.js
@@ -95,6 +95,7 @@ describe( 'siteScanReducer', () => {
 			scannableUrls: [],
 		} ) ).toStrictEqual( {
 			status: STATUS_COMPLETED,
+			scannableUrls: [],
 			scanOnce: false,
 			scansCount: 0,
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6855

In the Reader mode, only post types are used for performing a site scan. If there are no posts, pages or other custom post types available for a scan, a request made to the `/wp-json/amp/v1/scannable-urls` endpoint returns an empty array.

With this change, an empty array is treated as a valid response so that the list of scannable URLs kept in the Site Scan state is emptied. This case is then handled gracefully on the frontend where an error message is rendered. The message says that there are no URLs available for a scan.

Even though the error message has already been part of the Site Scan UI, it was displayed only if there were no scannable URLs available initially, right after a page load.

![Screenshot 2022-01-26 at 14 11 36](https://user-images.githubusercontent.com/478735/151168929-7a7cccd9-5d74-4967-a4e9-6aa7ba70be2d.png)

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
