### PR TITLE
Use `block-editor` store name directly to prevent JS errors

### DIFF
--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -9,7 +9,7 @@ import { isFunction, isObject, isString } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, PanelBody } from '@wordpress/components';
-import { InspectorControls, store as blockEditorStore } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { select, useSelect } from '@wordpress/data';
 import { cloneElement, isValidElement } from '@wordpress/element';
 
@@ -280,7 +280,7 @@ const ImageBlockLayoutAttributes = ( props ) => {
 	const { clientId } = props;
 
 	const isGalleryBlockChild = useSelect( ( _select ) => {
-		return _select( blockEditorStore ).getBlockParentsByBlockName( clientId, 'core/gallery' ).length > 0;
+		return _select( 'core/block-editor' ).getBlockParentsByBlockName( clientId, 'core/gallery' ).length > 0;
 	}, [ clientId ] );
 
 	if ( isGalleryBlockChild ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes [#6832](https://github.com/ampproject/amp-wp/issues/6832#issuecomment-1025729522)

In a recent change to how media core blocks are handled (#6832), a block editor data store name has been imported from a JS module.

Since data store names were not exported by `@wordpress` packages in WordPress 5.6 and earlier, a console error is thrown on older versions of WordPress when creating or editing an Image block, as per https://github.com/ampproject/amp-wp/issues/6832#issuecomment-1025729522.

This PR replaces an imported store name with a hardcoded string.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
