### PR TITLE
Fix block validation errors caused by amp-fit-text deprecation

### DIFF
--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -84,7 +84,7 @@ export const removeAmpFitTextFromBlocks = ( settings, name ) => {
 			}
 		}
 
-		settings.deprecated.unshift( {
+		settings.deprecated.push( {
 			supports: settings.supports,
 			attributes: {
 				...( settings.attributes || {} ),

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -77,6 +77,13 @@ export const removeAmpFitTextFromBlocks = ( settings, name ) => {
 			settings.deprecated = [];
 		}
 
+		// Prevent adding deprecation a second time.
+		for ( const deprecated of settings.deprecated ) {
+			if ( deprecated.attributes && deprecated.attributes.ampFitText ) {
+				return settings;
+			}
+		}
+
 		settings.deprecated.unshift( {
 			supports: settings.supports,
 			attributes: {


### PR DESCRIPTION
## Summary

I noticed that the deprecation of `amp-fit-text` (#5729) started causing block validation errors to show up when the Twenty Seventeen theme is active as of WordPress 5.8.3 and 5.9. In 5.9 when I open the block inserter and select the Patterns tab and select Twenty Seventeen from the dropdown, I get these errors in the console:

> ![image](https://user-images.githubusercontent.com/134745/151865129-99622e40-1e31-494d-aac5-f135282d53ed.png)

And the Services pattern shows those errors in the preview:

> ![image](https://user-images.githubusercontent.com/134745/151865183-901c516b-97eb-4d3e-afd8-b42ed6ea43a0.png)

In WordPress 5.8.3 I see these errors and even more just when I open the editor without even opening the block inserter, with many mentioning `<amp-fit-text>` explicitly:

> ![image](https://user-images.githubusercontent.com/134745/151865531-7b57d81c-3a36-45cd-abf8-7443a385933a.png)

I have no idea why this would be happening since the `isEligible` function for our `amp-fit-text` deprecation definition is returning `false`. Nevertheless, I did notice that we were adding up six identical copies of our deprecation definition as the filter is being applied multiple times it seems. I found that ensuring the definition is only added once will prevent the errors from happening. I also found that using `push` instead of `unshift` also fixes the issue. Since our `amp-fit-text` deprecation should be relatively rare, I decided to use `push` as well.

Any insights into _why_ this is happening and why the fix works would be much appreciated!

For reference, here is a paragraph block using `amp-fit-text`:

```html
<!-- wp:paragraph {"ampFitText":true} -->
<amp-fit-text layout="fixed-height" min-font-size="5" max-font-size="100" height="100"><p>This is fit-text!!</p></amp-fit-text>
<!-- /wp:paragraph -->
```

This should still be migrated successfully as follows:

```html
<!-- wp:paragraph -->
<p>This is fit-text!!</p>
<!-- /wp:paragraph -->
```

> ![image](https://user-images.githubusercontent.com/134745/151866711-c867ae99-62c3-4e46-bc82-87867b0a9b51.png)

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
