### PR TITLE
Add dark mode support in twenty twenty-one theme

### DIFF
--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -120,9 +120,6 @@ class AMP_Template_Customizer {
 		$self->set_refresh_setting_transport();
 		$self->remove_cover_template_section();
 		$self->remove_homepage_settings_section();
-		if ( get_template() === 'twentytwentyone' ) {
-			add_action( 'customize_controls_print_footer_scripts', [ $self, 'add_dark_mode_toggler_button_notice' ] );
-		}
 		return $self;
 	}
 
@@ -233,23 +230,6 @@ class AMP_Template_Customizer {
 		if ( count( array_diff( $control_ids, $static_front_page_control_ids ) ) === 0 ) {
 			$this->wp_customize->remove_section( $section_id );
 		}
-	}
-
-	/**
-	 * Add notice that the dark mode toggler button is not currently available on AMP pages.
-	 */
-	public function add_dark_mode_toggler_button_notice() {
-		$message = __( 'While dark mode works on AMP pages, the toggle button is not currently available. It appears here only for preview purposes.', 'amp' );
-		?>
-		<script>
-			wp.customize.control( 'respect_user_color_preference', function ( control ) {
-				control.notifications.add( new wp.customize.Notification( 'amp_dark_mode_toggler_availability_notice', {
-					message: <?php echo wp_json_encode( $message ); ?>,
-					type: 'info'
-				} ) );
-			} );
-		</script>
-		<?php
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1958,7 +1958,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				// AMP provides a global API "AMP.toggleTheme()" to support dark theme by toggling a BODY element class.
 				// However, for dark mode in the Twenty Twenty-One theme, the class needs to be toggled on HTML and BODY elements because the CSS variables are set at the root level.
 				// In AMP we cannot toggle HTML classes. So here we are changing the location where CSS variables are defined from `:root` to the BODY element.
-				$styles = str_replace( ':root {', 'body {', $styles );
+				if ( get_theme_mod( 'respect_user_color_preference', false ) ) {
+					$styles = str_replace( ':root {', 'body {', $styles );
+				}
 
 				// Append extra rules needed for nav menus according to changes made to the document during sanitization.
 				$styles .= '

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -84,36 +84,31 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		switch ( $theme_slug ) {
 			case 'twentytwentyone':
 				$config = [
-					'dequeue_scripts'                  => [
+					'dequeue_scripts'                      => [
 						'twenty-twenty-one-responsive-embeds-script',
 						'twenty-twenty-one-primary-navigation-script',
 					],
-					'remove_actions'                   => [
+					'remove_actions'                       => [
 						'wp_print_footer_scripts' => [
 							'twenty_twenty_one_skip_link_focus_fix', // Unnecessary since part of the AMP runtime.
 						],
 						'wp_footer'               => [
 							'twentytwentyone_add_ie_class',
 							'twenty_twenty_one_supports_js', // AMP is essentially no-js, with any interactivity added explicitly via amp-bind.
+							[
+								'Twenty_Twenty_One_Dark_Mode',
+								'the_switch',
+								10,
+							],
 						],
 					],
-					'amend_twentytwentyone_styles'     => [],
+					'amend_twentytwentyone_styles'         => [],
 					'amend_twentytwentyone_sub_menu_toggles' => [],
-					'add_twentytwentyone_mobile_modal' => [],
-					'add_twentytwentyone_sub_menu_fix' => [],
+					'add_twentytwentyone_mobile_modal'     => [],
+					'add_twentytwentyone_sub_menu_fix'     => [],
+					'add_twentytwentyone_dark_mode_toggle' => [],
+					'amend_twentytwentyone_dark_mode_styles' => [],
 				];
-
-				// Dark mode button toggle is only supported in the Customizer for now.
-				// A notice is added to the Customizer control in AMP_Template_Customizer::add_dark_mode_toggler_button_notice() via AMP_Template_Customizer::init().
-				if ( is_customize_preview() ) {
-					// Make dark mode toggle AMP compatible.
-					$config['add_twentytwentyone_dark_mode_toggle'] = [];
-				} else {
-					// Amend the dark mode stylesheet to only apply its rules when the user's system supports dark mode.
-					$config['amend_twentytwentyone_dark_mode_styles'] = [];
-					// Prevent the dark mode toggle and its accompanying script from being inlined.
-					$config['remove_actions']['wp_footer'][] = [ 'Twenty_Twenty_One_Dark_Mode', 'the_switch', 10 ];
-				}
 
 				return $config;
 
@@ -1890,11 +1885,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Amend the Twenty Twenty-One dark mode stylesheet to only apply the relevant rules when the user has requested
-	 * the system use a dark color theme.
-	 *
-	 * Note: Dark mode will only be available when the user's system supports it. The dark mode toggle is not available
-	 * on the frontend as yet since there is no feasible AMP-compatible way to store and unserialize user's preferences.
+	 * Amend the Twenty Twenty-One dark mode stylesheet to only apply the relevant rules when the user has enables
+	 * dark mode support from the customizer options.
 	 */
 	public static function amend_twentytwentyone_dark_mode_styles() {
 		add_action(
@@ -1924,13 +1916,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				$styles = file_get_contents( $dark_mode_css_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-				// Restrict rules to only when the user has requested the system use a dark color theme.
-				$new_styles = str_replace( '@media only screen', '@media only screen and (prefers-color-scheme: dark)', $styles );
 				// Allow for rules to override the light theme related rules.
-				$new_styles = str_replace( '.is-dark-theme.is-dark-theme', ':root', $new_styles );
-				$new_styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference:not(._) body', $new_styles );
+				$styles = str_replace( '.is-dark-theme.is-dark-theme', 'body.is-dark-theme', $styles );
+				$styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference body.is-dark-theme', $styles );
 
-				wp_add_inline_style( $theme_style_handle, $new_styles );
+				wp_add_inline_style( $theme_style_handle, $styles );
 			},
 			11
 		);
@@ -1965,6 +1955,15 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$dependency->src = false;
 
 				$styles = file_get_contents( $css_file ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+				/*
+				* To support dark theme mode.
+				*
+				* The AMP provide a global API "AMP.toggleTheme()" to support dark theme by toggling a class in the body element.
+				* However, For dark mode in the "Twenty twenty one" theme, The class need to be toggled in HTML and body element because of CSS variables set at the root level.
+				* In AMP we can not toggle class in HTML element. So here we are changing the location where CSS variables are defined from `:root` to the body element.
+				*/
+				$styles = str_replace( ':root {', 'body {', $styles );
 
 				// Append extra rules needed for nav menus according to changes made to the document during sanitization.
 				$styles .= '
@@ -2022,32 +2021,76 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
 	 * Make the dark mode toggle in the Twenty Twenty-One theme AMP compatible.
-	 *
-	 * Note: This is only shown within the Customizer preview for now, as there is no feasible way of persisting and
-	 * unserializing the user's preference when they switch to dark (or light) mode.
 	 */
 	public function add_twentytwentyone_dark_mode_toggle() {
-		$button = $this->dom->getElementById( 'dark-mode-toggler' );
+		// First check if dark mode is enabled.
+		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', false );
 
-		if ( ! $button ) {
+		if ( ! $should_respect_color_scheme ) {
 			return;
 		}
 
+		$button = $this->dom->getElementById( 'dark-mode-toggler' );
+
+		if ( ! $button ) {
+			// Create button element for dark mode toggle.
+			// Dark mode toggle button html and js has been stripped due to removing `the_switch` function.
+			$button = AMP_DOM_Utils::create_node(
+				$this->dom,
+				'button',
+				[
+					'id'    => 'dark-mode-toggler',
+					'class' => 'fixed-bottom',
+				]
+			);
+		}
+
+		$button->nodeValue = __( 'Dark Mode:', 'amp' );
+
+		// Create span tag to show `On` for dark mode.
+		$button_text_on = $this->dom->createElement( 'span' );
+		$button_text_on->setAttribute( 'class', 'dark-mode-button-on' );
+		$button_text_on->nodeValue = __( 'On', 'amp' );
+
+		// Create span tag to show `Off` for dark mode.
+		$button_text_off = $this->dom->createElement( 'span' );
+		$button_text_off->setAttribute( 'class', 'dark-mode-button-off' );
+		$button_text_off->nodeValue = __( 'Off', 'amp' );
+
+		// Add button_text_{On, Off} to button.
+		$button->appendChild( $button_text_on );
+		$button->appendChild( $button_text_off );
+
+		// Add button to body.
+		$this->dom->body->appendChild( $button );
+
 		$style              = $this->dom->createElement( 'style' );
-		$style->textContent = '.no-js #dark-mode-toggler { display: block; }';
+		$style->textContent = sprintf( // We need to add these styles to show On and Off to the user.
+			'
+				.no-js #dark-mode-toggler { display: block; }
+				#dark-mode-toggler > span {
+					margin-%s: 5px;
+				}
+				.dark-mode-button-on {
+					display: none;
+				}
+				body.is-dark-theme .dark-mode-button-on {
+					display: inline-block;
+				}
+				body.is-dark-theme .dark-mode-button-off {
+					display: none;
+				}
+			',
+			is_rtl() ? 'right' : 'left'
+		);
 		$this->dom->head->appendChild( $style );
 
 		$toggle_class = 'is-dark-theme';
-		$state_id     = str_replace( '-', '_', $toggle_class );
 
-		$body_id     = $this->dom->getElementId( $this->dom->body );
-		$document_id = $this->dom->getElementId( $this->dom->documentElement );
+		// Add data-prefers-dark-mode-class in body to use toggleTheme component.
+		$this->dom->body->setAttribute( 'data-prefers-dark-mode-class', $toggle_class );
 
-		AMP_DOM_Utils::add_amp_action( $button, 'tap', "AMP.setState({{$state_id}: !{$state_id}})" );
-		AMP_DOM_Utils::add_amp_action( $button, 'tap', "{$body_id}.toggleClass(class='{$toggle_class}')" );
-		AMP_DOM_Utils::add_amp_action( $button, 'tap', "{$document_id}.toggleClass(class='{$toggle_class}')" );
-
-		$button->setAttribute( 'data-amp-bind-aria-pressed', "{$state_id} ? 'true' : 'false'" );
+		AMP_DOM_Utils::add_amp_action( $button, 'tap', 'AMP.toggleTheme()' );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -8,6 +8,7 @@
 
 use AmpProject\Amp;
 use AmpProject\Html\Attribute;
+use AmpProject\Html\Tag;
 use AmpProject\Html\Role;
 
 /**
@@ -2027,31 +2028,28 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$button = $this->dom->getElementById( 'dark-mode-toggler' );
-
-		if ( ! $button ) {
-			// Create button element for dark mode toggle.
-			// Dark mode toggle button html and js has been stripped due to removing `the_switch` function.
-			$button = AMP_DOM_Utils::create_node(
-				$this->dom,
-				'button',
-				[
-					'id'    => 'dark-mode-toggler',
-					'class' => 'fixed-bottom',
-				]
-			);
-		}
+		// Create button element for dark mode toggle.
+		// Dark mode toggle button html and js has been omitted due to removing `the_switch` function.
+		$button = AMP_DOM_Utils::create_node(
+			$this->dom,
+			Tag::BUTTON,
+			[
+				Attribute::ID     => 'dark-mode-toggler',
+				Attribute::CLASS_ => 'fixed-bottom',
+			]
+		);
+		$this->dom->body->appendChild( $button );
 
 		$button->nodeValue = __( 'Dark Mode:', 'amp' );
 
 		// Create span tag to show `On` for dark mode.
-		$button_text_on = $this->dom->createElement( 'span' );
-		$button_text_on->setAttribute( 'class', 'dark-mode-button-on' );
+		$button_text_on = $this->dom->createElement( Tag::SPAN );
+		$button_text_on->setAttribute( Attribute::CLASS_, 'dark-mode-button-on' );
 		$button_text_on->nodeValue = __( 'On', 'amp' );
 
 		// Create span tag to show `Off` for dark mode.
-		$button_text_off = $this->dom->createElement( 'span' );
-		$button_text_off->setAttribute( 'class', 'dark-mode-button-off' );
+		$button_text_off = $this->dom->createElement( Tag::SPAN );
+		$button_text_off->setAttribute( Attribute::CLASS_, 'dark-mode-button-off' );
 		$button_text_off->nodeValue = __( 'Off', 'amp' );
 
 		// Add button_text_{On, Off} to button.
@@ -2061,7 +2059,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		// Add button to body.
 		$this->dom->body->appendChild( $button );
 
-		$style              = $this->dom->createElement( 'style' );
+		$style = $this->dom->createElement( Tag::STYLE );
+		$style->setAttribute( Attribute::ID, 'amp-twentytwentyone-dark-mode-toggle-styles' );
 		$style->textContent = sprintf( // We need to add these styles to show On and Off to the user.
 			'
 				.no-js #dark-mode-toggler { display: block; }

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2040,17 +2040,20 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		);
 		$this->dom->body->appendChild( $button );
 
-		$button->nodeValue = __( 'Dark Mode:', 'amp' );
+		/* translators: %s: On/Off */
+		$dark_mode_label = __( 'Dark Mode: %s', 'twentytwentyone' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		$dark_mode_off   = sprintf( $dark_mode_label, __( 'Off', 'twentytwentyone' ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+		$dark_mode_on    = sprintf( $dark_mode_label, __( 'On', 'twentytwentyone' ) ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 
 		// Create span tag to show `On` for dark mode.
 		$button_text_on = $this->dom->createElement( Tag::SPAN );
 		$button_text_on->setAttribute( Attribute::CLASS_, 'dark-mode-button-on' );
-		$button_text_on->nodeValue = __( 'On', 'amp' );
+		$button_text_on->nodeValue = $dark_mode_on;
 
 		// Create span tag to show `Off` for dark mode.
 		$button_text_off = $this->dom->createElement( Tag::SPAN );
 		$button_text_off->setAttribute( Attribute::CLASS_, 'dark-mode-button-off' );
-		$button_text_off->nodeValue = __( 'Off', 'amp' );
+		$button_text_off->nodeValue = $dark_mode_off;
 
 		// Add button_text_{On, Off} to button.
 		$button->appendChild( $button_text_on );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1956,13 +1956,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				$styles = file_get_contents( $css_file ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-				/*
-				* To support dark theme mode.
-				*
-				* The AMP provide a global API "AMP.toggleTheme()" to support dark theme by toggling a class in the body element.
-				* However, For dark mode in the "Twenty twenty one" theme, The class need to be toggled in HTML and body element because of CSS variables set at the root level.
-				* In AMP we can not toggle class in HTML element. So here we are changing the location where CSS variables are defined from `:root` to the body element.
-				*/
+				// AMP provides a global API "AMP.toggleTheme()" to support dark theme by toggling a BODY element class.
+				// However, for dark mode in the Twenty Twenty-One theme, the class needs to be toggled on HTML and BODY elements because the CSS variables are set at the root level.
+				// In AMP we cannot toggle HTML classes. So here we are changing the location where CSS variables are defined from `:root` to the BODY element.
 				$styles = str_replace( ':root {', 'body {', $styles );
 
 				// Append extra rules needed for nav menus according to changes made to the document during sanitization.

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -2038,7 +2038,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				Attribute::CLASS_ => 'fixed-bottom',
 			]
 		);
-		$this->dom->body->appendChild( $button );
 
 		/* translators: %s: On/Off */
 		$dark_mode_label = __( 'Dark Mode: %s', 'twentytwentyone' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
@@ -2066,7 +2065,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$style->setAttribute( Attribute::ID, 'amp-twentytwentyone-dark-mode-toggle-styles' );
 		$style->textContent = sprintf( // We need to add these styles to show On and Off to the user.
 			'
-				.no-js #dark-mode-toggler { display: block; }
+				.no-js #dark-mode-toggler {
+					display: block;
+				}
 				#dark-mode-toggler > span {
 					margin-%s: 5px;
 				}

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1917,7 +1917,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$styles = file_get_contents( $dark_mode_css_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 				// Allow for rules to override the light theme related rules.
-				$styles = str_replace( '.is-dark-theme.is-dark-theme', 'body.is-dark-theme', $styles );
 				$styles = str_replace( '.respect-color-scheme-preference.is-dark-theme body', '.respect-color-scheme-preference body.is-dark-theme', $styles );
 
 				wp_add_inline_style( $theme_style_handle, $styles );

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -581,6 +581,16 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
+		// If using the toggleTheme component, get the theme's dark mode class.
+		// See usage of toggleTheme in <https://github.com/ampproject/amphtml/pull/36958>.
+		$dark_mode_class = $this->dom->body->getAttribute( 'data-prefers-dark-mode-class' );
+
+		// Prevent dark mode class from being tree-shaken.
+		if ( $dark_mode_class ) {
+			$class_names[] = $dark_mode_class;
+		}
+
+
 		$this->used_class_names = array_fill_keys( $class_names, true );
 		return $this->used_class_names;
 	}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -590,7 +590,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$class_names[] = $dark_mode_class;
 		}
 
-
 		$this->used_class_names = array_fill_keys( $class_names, true );
 		return $this->used_class_names;
 	}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -588,6 +588,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		// Prevent dark mode class from being tree-shaken.
 		if ( $dark_mode_class ) {
 			$class_names[] = $dark_mode_class;
+		} else {
+			$class_names[] = 'amp-dark-mode';
 		}
 
 		$this->used_class_names = array_fill_keys( $class_names, true );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2063,12 +2063,12 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 	}
 
 	/**
-	 * Test that auto-removal (tree shaking) does not remove rules for classes mentioned in class and [class] attributes.
+	 * Test that auto-removal (tree shaking) does not remove rules for classes mentioned in class and [class] attributes and the dark mode config.
 	 *
 	 * @covers AMP_Style_Sanitizer::get_used_class_names()
 	 * @covers AMP_Style_Sanitizer::finalize_stylesheet_group()
 	 */
-	public function test_class_amp_bind_preservation() {
+	public function test_class_amp_bind_dark_mode_preservation() {
 		ob_start();
 		?>
 		<html amp>
@@ -2081,9 +2081,10 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				<style>.sidebar2.visible, .sidebar2.displayed, .sidebar2.shown { display:block }</style>
 				<style>.sidebar3.open, .sidebar3.abierto { display:block }</style>
 				<style>.sidebar3.cerrado { display:none }</style>
+				<style>body.is-dark-theme { background:black; color:white; }</style>
 				<style>.nothing { visibility:hidden; }</style>
 			</head>
-			<body>
+			<body data-prefers-dark-mode-class="is-dark-theme">
 				<amp-state id="mySidebar">
 					<script type="application/json">
 						{
@@ -2124,6 +2125,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				'.sidebar2.visible,.sidebar2.shown{display:block}',
 				'.sidebar3.open,.sidebar3.abierto{display:block}',
 				'.sidebar3.cerrado{display:none}',
+				'body.is-dark-theme{background:black;color:white}',
 				'',
 			],
 			$actual_stylesheets

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -532,7 +532,6 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 		$after = implode( '', $extra['after'] );
 
 		$replacements = [
-			'.is-dark-theme.is-dark-theme' => 'body.is-dark-theme',
 			'.respect-color-scheme-preference.is-dark-theme body' => '.respect-color-scheme-preference body.is-dark-theme',
 		];
 		foreach ( $replacements as $search => $replacement ) {

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -540,15 +540,28 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 		}
 	}
 
-	/** @covers ::amend_twentytwentyone_styles() */
-	public function test_amend_twentytwentyone_styles() {
+	/** @return array */
+	public function get_respect_user_color_preference_data() {
+		return [
+			'enabled'  => [ true ],
+			'disabled' => [ false ],
+		];
+	}
+
+	/**
+	 * @covers ::amend_twentytwentyone_styles()
+	 *
+	 * @dataProvider get_respect_user_color_preference_data
+	 * @param bool $enabled Enabled.
+	 */
+	public function test_amend_twentytwentyone_styles( $enabled ) {
 		$theme_slug = 'twentytwentyone';
 		if ( ! wp_get_theme( $theme_slug )->exists() ) {
 			$this->markTestSkipped();
-			return;
 		}
 
 		switch_theme( $theme_slug );
+		set_theme_mod( 'respect_user_color_preference', $enabled );
 
 		$style_handle = 'twenty-twenty-one-style';
 		wp_enqueue_style( $style_handle, get_theme_file_path( 'style.css' ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
@@ -563,6 +576,12 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 		$this->assertStringContainsString( '@media only screen and (max-width: 481px)', $after );
 		$this->assertStringContainsString( 'button[overflow]:hover', $after );
 		$this->assertStringEndsWith( '/*first*/', $after );
+
+		if ( $enabled ) {
+			$this->assertRegExp( '#/\* Variables \*/\s*body\s*{#', $after );
+		} else {
+			$this->assertRegExp( '#/\* Variables \*/\s*:root\s*{#', $after );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -8,7 +8,6 @@
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\Dom\Document;
 use AmpProject\Dom\Element;
-use AmpProject\Html\Attribute;
 use AmpProject\Html\Tag;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\TestCase;
@@ -716,10 +715,8 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 		$this->assertStringContainsString( '.no-js #dark-mode-toggler', $style->textContent );
 
 		$this->assertEquals(
-			'<button id="dark-mode-toggler" class="fixed-bottom" on="tap:AMP.toggleTheme()">Dark Mode:<span class="dark-mode-button-on">On</span><span class="dark-mode-button-off">Off</span></button>',
+			'<button id="dark-mode-toggler" class="fixed-bottom" on="tap:AMP.toggleTheme()"><span class="dark-mode-button-on">Dark Mode: On</span><span class="dark-mode-button-off">Dark Mode: Off</span></button>',
 			$dom->saveHTML( $button )
 		);
-
-		remove_filter( 'theme_mod_respect_user_color_preference', '__return_true' );
 	}
 }

--- a/tests/php/test-class-amp-template-customizer.php
+++ b/tests/php/test-class-amp-template-customizer.php
@@ -193,7 +193,6 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		$this->assertFalse( has_action( 'customize_controls_print_footer_scripts', [ $instance, 'print_legacy_controls_templates' ] ) );
 		$this->assertFalse( has_action( 'customize_preview_init', [ $instance, 'init_legacy_preview' ] ) );
 		$this->assertFalse( has_action( 'customize_controls_enqueue_scripts', [ $instance, 'add_legacy_customizer_scripts' ] ) );
-		$this->assertFalse( has_action( 'customize_controls_print_footer_scripts', [ $instance, 'add_dark_mode_toggler_button_notice' ] ) );
 
 		foreach ( [ $header_video_setting, $external_header_video_setting ] as $setting ) {
 			$this->assertEquals( 'refresh', $setting->transport );
@@ -225,24 +224,6 @@ class Test_AMP_Template_Customizer extends DependencyInjectedTestCase {
 		$_GET['url']                   = home_url( '/foo/' );
 		$instance->set_reader_preview_url();
 		$this->assertEquals( home_url( '/foo/' ), $wp_customize->get_preview_url() );
-	}
-
-	/**
-	 * @covers AMP_Template_Customizer::init()
-	 * @covers AMP_Template_Customizer::add_dark_mode_toggler_button_notice()
-	 */
-	public function test_init_for_twentytwentyone() {
-		if ( ! wp_get_theme( 'twentytwentyone' )->exists() ) {
-			$this->markTestSkipped();
-		}
-		switch_theme( 'twentytwentyone' );
-
-		$wp_customize = $this->get_customize_manager();
-		$instance     = AMP_Template_Customizer::init( $wp_customize );
-		$this->assertEquals( 10, has_action( 'customize_controls_print_footer_scripts', [ $instance, 'add_dark_mode_toggler_button_notice' ] ) );
-
-		$output = get_echo( [ $instance, 'add_dark_mode_toggler_button_notice' ] );
-		$this->assertStringContainsString( 'wp.customize.control', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6783

- Add support to toggle dark and light mode using `AMP.toggleTheme` component
- Add dark mode class name to `$class_names[]` so that dark mode class used by `AMP.toggleTheme` can be prevented from being tree-shaken.
- Remove the dark mode toggler button notice from the dark mode customizer.

See recorded screencast

https://user-images.githubusercontent.com/54371619/151298952-51f21071-f94e-4f3a-b755-4b47a1e05968.mp4



## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
