### PR TITLE
Use `currentcolor` to conform to the latest stylelint rules

### DIFF
--- a/assets/src/block-validation/components/error/style.css
+++ b/assets/src/block-validation/components/error/style.css
@@ -32,7 +32,7 @@
 
 .amp-error__error-type-icon {
 	align-items: center;
-	background-color: currentColor;
+	background-color: currentcolor;
 	border: 1px solid;
 	border-radius: 12px;
 	color: #707070;
@@ -154,7 +154,7 @@
 }
 
 .amp-error__details-link svg path {
-	fill: currentColor;
+	fill: currentcolor;
 }
 
 /*

--- a/assets/src/css/core-components.css
+++ b/assets/src/css/core-components.css
@@ -11,7 +11,7 @@
 }
 
 .amp .components-button:not(.components-panel__body-toggle) svg {
-	fill: currentColor;
+	fill: currentcolor;
 	margin: 0 0.5rem;
 	height: 18px;
 	width: 18px;


### PR DESCRIPTION
## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
