### PR TITLE
Add preload background images from hero cover blocks when parallax used 

### DIFF
--- a/src/Optimizer/Transformer/DetermineHeroImages.php
+++ b/src/Optimizer/Transformer/DetermineHeroImages.php
@@ -67,7 +67,7 @@ final class DetermineHeroImages implements Transformer {
 	 *
 	 * @var string
 	 */
-	const CSS_BACKGROUND_IMAGE_URL_REGEX_PATTERN = '/background-image\s*:\s*url\(\s*(?<url>[^)]*\s*)/i';
+	const CSS_BACKGROUND_IMAGE_URL_REGEX_PATTERN = '/background-image\s*:\s*url\(\s*[\'"]?(?<url>.*?)[\'"]?\s*\)/i';
 
 	/**
 	 * Apply transformations to the provided DOM document.

--- a/src/Optimizer/Transformer/DetermineHeroImages.php
+++ b/src/Optimizer/Transformer/DetermineHeroImages.php
@@ -207,7 +207,7 @@ final class DetermineHeroImages implements Transformer {
 			preg_match( self::CSS_BACKGROUND_IMAGE_URL_REGEX_PATTERN, $style, $matches );
 
 			if ( ! empty( $matches['url'] ) ) {
-				$image->setAttribute( Attribute::MEDIA, $matches['url'] );
+				$image->setAttribute( Attribute::MEDIA, 'screen' );
 				return $image;
 			}
 		}

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -267,6 +267,34 @@ final class DetermineHeroImagesTest extends TestCase {
 					. '</div>'
 				),
 			],
+
+			'detect first cover block with parallax'       => [
+				$input(
+					'<div class="entry-content">'
+					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)"><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
+					. '</div>'
+				),
+				$output(
+					'<div class="entry-content">'
+					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)" media="https://example.com/cover-block-1.jpg" data-hero-candidate><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
+					. '</div>'
+				),
+			],
+
+			'detect first normal cover block when there are two cover block' => [
+				$input(
+					'<div class="entry-content">'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)"><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
+					. '</div>'
+				),
+				$output(
+					'<div class="entry-content">'
+					. '<div class="wp-block-cover has-dark-gray-background-color has-background-dim has-custom-content-position is-position-center-left" style="min-height:100vh"><amp-img width="2000" height="1199" class="wp-block-cover__image-background wp-image-2266" alt="" src="https://example.com/cover-block-1.jpg" style="object-position:100% 98%" data-hero-candidate data-object-fit="cover" data-object-position="100% 98%"></amp-img><div class="wp-block-cover__inner-container"><p class="has-text-align-left has-large-font-size">Cover Image with bottom-right positioning, full height, end left-aligned text.</p></div></div>'
+					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)"><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
+					. '</div>'
+				),
+			],
 		];
 	}
 

--- a/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
+++ b/tests/php/src/Optimizer/Transformer/DetermineHeroImagesTest.php
@@ -276,7 +276,7 @@ final class DetermineHeroImagesTest extends TestCase {
 				),
 				$output(
 					'<div class="entry-content">'
-					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)" media="https://example.com/cover-block-1.jpg" data-hero-candidate><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
+					. '<div class="wp-block-cover alignfull is-light has-parallax" style="background-image:url(https://example.com/cover-block-1.jpg)" media="screen" data-hero-candidate><span aria-hidden="true" class="wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><p class="has-text-align-center" style="font-size:58px;text-transform:capitalize">Hello World !</p></div></div>'
 					. '</div>'
 				),
 			],


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6806 

This PR will add preload tag for an image which used in the hero cover block with parallax.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
