### PR TITLE
Add E2E tests for core themes mobile menus

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -41,6 +41,16 @@ export const DEFAULT_BROWSER_VIEWPORT_SIZE = {
 };
 
 /**
+ * Mobile browser viewport size.
+ *
+ * @type {{width: number, height: number}}
+ */
+export const MOBILE_BROWSER_VIEWPORT_SIZE = {
+	width: 375,
+	height: 667,
+};
+
+/**
  * Set of console logging types observed to protect against unexpected yet
  * handled (i.e. not catastrophic) errors or warnings. Each key corresponds
  * to the Puppeteer ConsoleMessage type, its value the corresponding function

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import {
 	activateTheme,
 	clearLocalStorage,
+	createMenu,
+	deleteAllMenus,
 	enablePageDialogAccept,
 	installTheme,
 	isOfflineMode,
@@ -27,6 +29,16 @@ import { deactivatePlugin, installLocalPlugin } from '../utils/amp-settings-util
  * Environment variables
  */
 const { PUPPETEER_TIMEOUT } = process.env;
+
+/**
+ * Default browser viewport size.
+ *
+ * @type {{width: number, height: number}}
+ */
+export const DEFAULT_BROWSER_VIEWPORT_SIZE = {
+	width: 1600,
+	height: 1000,
+};
 
 /**
  * Set of console logging types observed to protect against unexpected yet
@@ -210,11 +222,8 @@ async function runAxeTestsForBlockEditor() {
 /**
  * Set up browser.
  */
-async function setupBrowser() {
-	await setBrowserViewport( {
-		width: 1600,
-		height: 1000,
-	} );
+export async function setupBrowser() {
+	await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
 }
 
 /**
@@ -229,6 +238,36 @@ async function createTestData() {
 			wp.apiFetch( { path: '/wp/v2/posts', method: 'POST', data: { title: 'Test Post 2', status: 'publish' } } ),
 		] );
 	} );
+}
+
+/**
+ * Create test posts so that the WordPress instance has some data.
+ */
+async function createTestMenus() {
+	await deleteAllMenus();
+	await createMenu(
+		{
+			name: 'Test Menu 1',
+		},
+		[
+			{
+				title: 'WordPress.org',
+				url: 'https://wordpress.org',
+				menu_order: 1,
+			},
+			{
+				title: 'Wikipedia.org',
+				url: 'https://wikipedia.org',
+				menu_order: 2,
+			},
+			{
+				title: 'Google',
+				url: 'https://google.com',
+				menu_order: 3,
+				parent: 1,
+			},
+		],
+	);
 }
 
 /**
@@ -260,6 +299,7 @@ beforeAll( async () => {
 	await setupThemesAndPlugins();
 	await trashAllPosts();
 	await createTestData();
+	await createTestMenus();
 	await cleanUpSettings();
 	await page.setDefaultNavigationTimeout( 10000 );
 	await page.setDefaultTimeout( 10000 );

--- a/tests/e2e/specs/core-themes/twentyfifteen.js
+++ b/tests/e2e/specs/core-themes/twentyfifteen.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Fifteen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentyfifteen' );
+		await activateTheme( 'twentyfifteen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '.site-header .secondary-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '.site-header .secondary-toggle' );
+			await expect( page ).toMatchElement( '.site-header .secondary-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: true } );
+
+			await expect( page ).toClick( '.site-header .secondary-toggle' );
+			await expect( page ).toMatchElement( '.site-header .secondary-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: false } );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toClick( '.site-header .secondary-toggle' );
+
+			const menuItemWithSubmenu = await page.$( '#site-navigation .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=true]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentyfourteen.js
+++ b/tests/e2e/specs/core-themes/twentyfourteen.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Fourteen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentyfourteen' );
+		await activateTheme( 'twentyfourteen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '#primary-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#primary-navigation .nav-menu', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '#primary-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#primary-navigation .menu-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#primary-navigation .nav-menu', { visible: true } );
+
+			// Submenus are expanded by default on twentyfourteen mobile.
+			await expect( page ).toMatchElement( '#primary-navigation .nav-menu .menu-item-has-children .sub-menu', { visible: true } );
+
+			await expect( page ).toClick( '#primary-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#primary-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#primary-navigation .nav-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentynineteen.js
+++ b/tests/e2e/specs/core-themes/twentynineteen.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activateTheme,
+	createURL,
+	installTheme,
+	setBrowserViewport,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Nineteen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentynineteen' );
+		await activateTheme( 'twentynineteen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'menu-1' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( 'small' );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toMatchElement( '.main-navigation' );
+
+			const menuItemWithSubmenu = await page.$( '.main-navigation .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.submenu-expand' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.submenu-expand' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentynineteen.js
+++ b/tests/e2e/specs/core-themes/twentynineteen.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	activateTheme,
-	createURL,
-	installTheme,
-	setBrowserViewport,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies

--- a/tests/e2e/specs/core-themes/twentynineteen.js
+++ b/tests/e2e/specs/core-themes/twentynineteen.js
@@ -14,7 +14,7 @@ import {
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
 import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
-import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Nineteen theme on AMP', () => {
 	beforeAll( async () => {
@@ -35,7 +35,7 @@ describe( 'Twenty Nineteen theme on AMP', () => {
 		} );
 
 		beforeEach( async () => {
-			await setBrowserViewport( 'small' );
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
 			await page.goto( createURL( '/' ) );
 			await page.waitForSelector( '#page' );
 		} );

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -49,7 +49,7 @@ describe( 'Twenty Seventeen theme on AMP', () => {
 			await expect( page ).toMatchElement( '#top-menu', { visible: false } );
 		} );
 
-		it( 'should be toggled on a button click', async () => {
+		it( 'should be togglable', async () => {
 			await expect( page ).toClick( '.main-navigation .menu-toggle' );
 			await expect( page ).toMatchElement( '.main-navigation .menu-toggle[aria-expanded=true]' );
 			await expect( page ).toMatchElement( '#top-menu', { visible: true } );

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -14,7 +14,7 @@ import {
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
 import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
-import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Seventeen theme on AMP', () => {
 	beforeAll( async () => {
@@ -35,7 +35,7 @@ describe( 'Twenty Seventeen theme on AMP', () => {
 		} );
 
 		beforeEach( async () => {
-			await setBrowserViewport( 'small' );
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
 			await page.goto( createURL( '/' ) );
 			await page.waitForSelector( '#page' );
 		} );

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -13,6 +13,7 @@ import {
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Seventeen theme on AMP', () => {
@@ -30,12 +31,7 @@ describe( 'Twenty Seventeen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
-			// Assign a test menu to Top Menu location.
-			await visitAdminPage( 'nav-menus.php', '' );
-			await page.waitForSelector( 'input[name="menu-locations[top]"]' );
-			await page.click( 'input[name="menu-locations[top]"]' );
-			await page.click( '#save_menu_footer' );
-			await page.waitForSelector( '#message', { text: /Test Menu 1 has been updated/ } );
+			await assignMenuToLocation( 'top' );
 		} );
 
 		beforeEach( async () => {

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	activateTheme,
-	createURL,
-	installTheme,
-	setBrowserViewport,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activateTheme,
+	createURL,
+	installTheme,
+	setBrowserViewport,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Seventeen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentyseventeen' );
+		await activateTheme( 'twentyseventeen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			// Assign a test menu to Top Menu location.
+			await visitAdminPage( 'nav-menus.php', '' );
+			await page.waitForSelector( 'input[name="menu-locations[top]"]' );
+			await page.click( 'input[name="menu-locations[top]"]' );
+			await page.click( '#save_menu_footer' );
+			await page.waitForSelector( '#message', { text: /Test Menu 1 has been updated/ } );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( 'small' );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '.main-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#top-menu', { visible: false } );
+		} );
+
+		it( 'should be toggled on a button click', async () => {
+			await expect( page ).toClick( '.main-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '.main-navigation .menu-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#top-menu', { visible: true } );
+
+			await expect( page ).toClick( '.main-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '.main-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#top-menu', { visible: false } );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toClick( '.main-navigation .menu-toggle' );
+
+			const menuItemWithSubmenu = await page.$( '.main-navigation .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=true]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentysixteen.js
+++ b/tests/e2e/specs/core-themes/twentysixteen.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Sixteen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentysixteen' );
+		await activateTheme( 'twentysixteen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '#menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '#menu-toggle' );
+			await expect( page ).toMatchElement( '#menu-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: true } );
+
+			await expect( page ).toClick( '#menu-toggle' );
+			await expect( page ).toMatchElement( '#menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation', { visible: false } );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toClick( '#menu-toggle' );
+
+			const menuItemWithSubmenu = await page.$( '#site-navigation .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=true]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentythirteen.js
+++ b/tests/e2e/specs/core-themes/twentythirteen.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Thirteen theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentythirteen' );
+		await activateTheme( 'twentythirteen' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '#site-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: true } );
+
+			await expect( page ).toClick( '#site-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: false } );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toClick( '#site-navigation .menu-toggle' );
+
+			const menuItemWithSubmenu = await page.$( '#site-navigation .nav-menu .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=true]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.dropdown-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.dropdown-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentytwelve.js
+++ b/tests/e2e/specs/core-themes/twentytwelve.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Twelve theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentytwelve' );
+		await activateTheme( 'twentytwelve' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '#site-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: true } );
+
+			// Submenus are expanded by default on twentytwelve mobile.
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu .menu-item-has-children .sub-menu', { visible: true } );
+
+			await expect( page ).toClick( '#site-navigation .menu-toggle' );
+			await expect( page ).toMatchElement( '#site-navigation .menu-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#site-navigation .nav-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -8,7 +8,7 @@ import { activateTheme, createURL, setBrowserViewport, visitAdminPage } from '@w
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
 import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
-import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Twenty theme on AMP', () => {
 	beforeAll( async () => {
@@ -24,7 +24,7 @@ describe( 'Twenty Twenty theme on AMP', () => {
 		} );
 
 		beforeEach( async () => {
-			await setBrowserViewport( 'small' );
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
 			await page.goto( createURL( '/' ) );
 			await page.waitForSelector( '#site-header' );
 		} );

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Twenty theme on AMP', () => {
+	beforeAll( async () => {
+		await activateTheme( 'twentytwenty' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'mobile' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( 'small' );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#site-header' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
+		} );
+
+		it( 'should be toggled on a button click', async () => {
+			await expect( page ).toClick( '.mobile-nav-toggle' );
+			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '.menu-modal', { visible: true } );
+
+			await expect( page ).toClick( '.mobile-nav-toggle' );
+			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
+		} );
+
+		it( 'should have a togglable submenu', async () => {
+			await expect( page ).toClick( '.mobile-nav-toggle' );
+
+			const menuItemWithSubmenu = await page.$( '.menu-modal .menu-item-has-children' );
+
+			expect( menuItemWithSubmenu ).not.toBeNull();
+
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=true]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+			await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
+			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -67,4 +67,26 @@ describe( 'Twenty Twenty theme on AMP', () => {
 			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
 		} );
 	} );
+
+	describe( 'search modal on desktop', () => {
+		beforeEach( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#site-header' );
+		} );
+
+		it( 'should be toggled on a button click', async () => {
+			await expect( page ).toMatchElement( '.desktop-search-toggle[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '.search-modal', { visible: false } );
+
+			await expect( page ).toClick( '.desktop-search-toggle' );
+			await expect( page ).toMatchElement( '.search-toggle[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '.search-modal', { visible: true } );
+
+			await expect( page ).toMatchElement( '.search-modal .close-search-toggle[aria-expanded=true]' );
+			await expect( page ).toClick( '.search-modal .close-search-toggle' );
+			await expect( page ).toMatchElement( '.search-modal', { visible: false } );
+		} );
+	} );
 } );

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -71,12 +71,11 @@ describe( 'Twenty Twenty theme on AMP', () => {
 	describe( 'search modal on desktop', () => {
 		beforeEach( async () => {
 			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
-
 			await page.goto( createURL( '/' ) );
 			await page.waitForSelector( '#site-header' );
 		} );
 
-		it( 'should be toggled on a button click', async () => {
+		it( 'should be togglable', async () => {
 			await expect( page ).toMatchElement( '.desktop-search-toggle[aria-expanded=false]' );
 			await expect( page ).toMatchElement( '.search-modal', { visible: false } );
 

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -38,7 +38,7 @@ describe( 'Twenty Twenty theme on AMP', () => {
 			await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
 		} );
 
-		it( 'should be toggled on a button click', async () => {
+		it( 'should be togglable', async () => {
 			await expect( page ).toClick( '.mobile-nav-toggle' );
 			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=true]' );
 			await expect( page ).toMatchElement( '.menu-modal', { visible: true } );

--- a/tests/e2e/specs/core-themes/twentytwentyone.js
+++ b/tests/e2e/specs/core-themes/twentytwentyone.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Twenty-One theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentytwentyone' );
+		await activateTheme( 'twentytwentyone' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'main navigation on mobile', () => {
+		beforeAll( async () => {
+			await assignMenuToLocation( 'primary' );
+		} );
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '#page' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			await expect( page ).toMatchElement( '#primary-mobile-menu[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#primary-menu-list', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			await expect( page ).toClick( '#primary-mobile-menu' );
+			await expect( page ).toMatchElement( '#primary-mobile-menu[aria-expanded=true]' );
+			await expect( page ).toMatchElement( '#primary-menu-list', { visible: true } );
+
+			// Submenus are expanded by default on twentytwentyone mobile.
+			await expect( page ).toMatchElement( '#primary-menu-list .menu-item-has-children .sub-menu', { visible: true } );
+
+			await expect( page ).toClick( '#primary-mobile-menu' );
+			await expect( page ).toMatchElement( '#primary-mobile-menu[aria-expanded=false]' );
+			await expect( page ).toMatchElement( '#primary-menu-list', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/utils/assign-menu-to-location.js
+++ b/tests/e2e/utils/assign-menu-to-location.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
+
+export async function assignMenuToLocation( menuLocationName ) {
+	await visitAdminPage( 'nav-menus.php', '' );
+	await page.waitForSelector( `input[name="menu-locations[${ menuLocationName }]"]` );
+	await page.click( `input[name="menu-locations[${ menuLocationName }]"]` );
+	await page.click( '#save_menu_footer' );
+	await page.waitForSelector( '#message', { text: /has been updated/ } );
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5404

This PR adds end to end tests for mobile navigation toggle for the following core themes:
- Twenty Twelve
- Twenty Thirteen
- Twenty Fourteen
- Twenty Fifteen
- Twenty Sixteen
- Twenty Seventeen
- Twenty Nineteen
- Twenty Twenty (a search modal is also checked for this theme) 
- Twenty Twenty-One

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
