### PR TITLE
Fix `check_for_page_caching()` to account for `wp_remote_retrieve_header()` returning arrays

### DIFF
--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -624,17 +624,21 @@ final class SiteHealth implements Service, Registerable, Delayed {
 			$response_headers = [];
 
 			foreach ( $caching_headers as $header => $callback ) {
-				$header_value = wp_remote_retrieve_header( $http_response, $header );
+				$header_values = wp_remote_retrieve_header( $http_response, $header );
+				if ( empty( $header_values ) ) {
+					continue;
+				}
+				$header_values = (array) $header_values;
 				if (
-					$header_value
-					&&
+					empty( $callback )
+					||
 					(
-						empty( $callback )
-						||
-						( is_callable( $callback ) && true === $callback( $header_value ) )
+						is_callable( $callback )
+						&&
+						count( array_filter( $header_values, $callback ) ) > 0
 					)
 				) {
-					$response_headers[ $header ] = $header_value;
+					$response_headers[ $header ] = $header_values;
 				}
 			}
 

--- a/tests/php/src/Admin/SiteHealthTest.php
+++ b/tests/php/src/Admin/SiteHealthTest.php
@@ -751,6 +751,11 @@ class SiteHealthTest extends TestCase {
 				'expected_status' => 'recommended',
 				'expected_label'  => $recommended_label,
 			],
+			'no-cache-arrays'                          => [
+				'responses'       => array_fill( 0, 3, [ 'cache-control' => [ 'no-cache', 'no-store' ] ] ),
+				'expected_status' => 'recommended',
+				'expected_label'  => $recommended_label,
+			],
 			'no-cache-with-delayed-response'           => [
 				'responses'          => array_fill( 0, 3, [ 'cache-control' => 'no-cache' ] ),
 				'expected_status'    => 'critical',


### PR DESCRIPTION
Fixes #6937.