### PR TITLE
Update `gallery` shortcode embed handler to account for no shortcode attributes

### DIFF
--- a/includes/embeds/class-amp-gallery-embed-handler.php
+++ b/includes/embeds/class-amp-gallery-embed-handler.php
@@ -46,11 +46,15 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Filter the output of gallery_shortcode().
 	 *
-	 * @param string $html  Markup to filter.
-	 * @param array  $attrs Shortcode attributes.
+	 * @param string       $html  Markup to filter.
+	 * @param array|string $attrs Shortcode attributes, or empty string if there were no shortcode attributes.
 	 * @return string Markup for the gallery.
 	 */
 	protected function filter_post_gallery_markup( $html, $attrs ) {
+		if ( ! is_array( $attrs ) ) {
+			$attrs = [];
+		}
+
 		// Use <amp-carousel> for the gallery if requested via amp-carousel shortcode attribute, or use by default if in legacy Reader mode.
 		// In AMP_Gallery_Block_Sanitizer, this is referred to as carousel_required.
 		$is_carousel = isset( $attrs['amp-carousel'] )

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -77,9 +77,9 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 			],
 			'shortcode_with_valid_ids_in_legacy_mode' => [
 				'[gallery ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-3 { margin: auto; } #gallery-3 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-3 img { border: 2px solid #cfcfcf; } #gallery-3 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-3-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
 					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
 					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
@@ -87,11 +87,11 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 			],
 			'shortcode_with_valid_ids'                => [
 				'[gallery ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-4 { margin: auto; } #gallery-4 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-4 img { border: 2px solid #cfcfcf; } #gallery-4 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
-				<div id="gallery-4" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-4-{{id1}}"></a></dt>
-						<dd class="wp-caption-text gallery-caption" id="gallery-4-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
+						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
+						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
 					</dl>
 					<dl class="gallery-item">
 						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
@@ -104,29 +104,29 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 			],
 			'shortcode_with_carousel'                 => [
 				'[gallery amp-lightbox=false amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-6 { margin: auto; } #gallery-6 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-6 img { border: 2px solid #cfcfcf; } #gallery-6 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-6-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
 					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
 					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
 			],
 			'shortcode_with_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=false amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-8 { margin: auto; } #gallery-8 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-8 img { border: 2px solid #cfcfcf; } #gallery-8 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file1}}.jpg"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-8-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file1}}.jpg"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
 					<figure class="slide"><a href="{{file2}}.jpg"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
 					<figure class="slide"><a href="{{file3}}.jpg"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
 			],
 			'shortcode_with_lightbox'                 => [
 				'[gallery amp-lightbox=true amp-carousel=false ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-10 { margin: auto; } #gallery-10 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-10 img { border: 2px solid #cfcfcf; } #gallery-10 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
-				<div data-amp-lightbox="true" id="gallery-10" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div data-amp-lightbox="true" id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-10-{{id1}}" lightbox="">
-					</dt><dd class="wp-caption-text gallery-caption" id="gallery-10-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
+						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
+					</dt><dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
 						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
@@ -138,11 +138,11 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 			],
 			'shortcode_with_lightbox_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=false link="file" ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-12 { margin: auto; } #gallery-12 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-12 img { border: 2px solid #cfcfcf; } #gallery-12 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
-				<div data-amp-lightbox="true" id="gallery-12" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div data-amp-lightbox="true" id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-12-{{id1}}" lightbox="">
-					</dt><dd class="wp-caption-text gallery-caption" id="gallery-12-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
+						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
+					</dt><dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
 						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
@@ -154,21 +154,39 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 			],
 			'shortcode_with_lightbox_and_carousel'    => [
 				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-14 { margin: auto; } #gallery-14 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-14 img { border: 2px solid #cfcfcf; } #gallery-14 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive" lightbox="">' .
-					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-14-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
 					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
 					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_lightbox_and_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
-				'<style type="text/css"> #gallery-16 { margin: auto; } #gallery-16 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-16 img { border: 2px solid #cfcfcf; } #gallery-16 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive" lightbox="">' .
-					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-16-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
 					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
 					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
 				'</amp-carousel>',
+			],
+			'shortcode_with_no_attributes'            => [
+				'[gallery]',
+				// Note the same three attachments will be used here because when the gallery shortcode lacks an ids attribute, it uses unattached photos.
+				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
+					<dl class="gallery-item">
+						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
+						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
+					</dl>
+					<dl class="gallery-item">
+						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+					</dl>
+					<dl class="gallery-item">
+						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+					</dl>
+					<br style="clear: both">
+				</div>',
 			],
 		];
 	}
@@ -247,6 +265,9 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 		$embed->sanitize_raw_embeds( $dom );
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+
+		// Normalize auto-incrementing ID.
+		$content = preg_replace( '/\bgallery-\d+/', 'gallery-1', $content );
 
 		$this->assertEquals(
 			$this->normalize( $expected ),


### PR DESCRIPTION
## Summary

As reported in a [support forum topic](https://wordpress.org/support/topic/compatibility-with-php-8-2/), when a gallery shortcode is present without any shortcode attributes, like `[gallery]`, then `\AMP_Gallery_Embed_Handler::filter_post_gallery_markup()` is passed an empty string for `$attrs` instead of an array. This causes a fatal error in the most recent versions of PHP:

```
Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /home/lemagcin/www/wp/wp-content/plugins/amp/includes/embeds/class-amp-gallery-embed-handler.php:82 Stack trace:
#0 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/embeds/class-amp-gallery-embed-handler.php(40): AMP_Gallery_Embed_Handler->filter_post_gallery_markup('', '')
#1 /home/lemagcin/www/wp/wp-includes/class-wp-hook.php(309): AMP_Gallery_Embed_Handler->generate_gallery_markup('', '')
#2 /home/lemagcin/www/wp/wp-includes/plugin.php(189): WP_Hook->apply_filters('', Array)
#3 /home/lemagcin/www/wp/wp-includes/media.php(2313): apply_filters('post_gallery', '', '', 1)
#4 /home/lemagcin/www/wp/wp-includes/shortcodes.php(356): gallery_shortcode('', '', 'gallery')
#5 [internal function]: do_shortcode_tag(Array)
#6 /home/lemagcin/www/wp/wp-includes/shortcodes.php(228): preg_replace_callback('/\\[(\\[?)(galler...', 'do_shortcode_ta...', '[gallery]<p>Am...')
#7 /home/lemagcin/www/wp/wp-includes/class-wp-hook.php(307): do_shortcode('[gallery]<p>Am...')
#8 /home/lemagcin/www/wp/wp-includes/plugin.php(189): WP_Hook->apply_filters('[gallery]<p>Am...', Array)
#9 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(366): apply_filters('the_content', '[gallery]\r<p>A...')
#10 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(147): AMP_Post_Template->build_post_content()
#11 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(192): AMP_Post_Template->set_data()
#12 /home/lemagcin/www/wp/wp-content/plugins/amp/templates/html-start.php(22): AMP_Post_Template->get('html_tag_attrib...')
#13 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(485): include('/home/lemagcin/...')
#14 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(238): AMP_Post_Template->verify_and_include('/home/lemagcin/...', 'html-start')
#15 /home/lemagcin/www/wp/wp-content/plugins/amp/templates/single.php(21): AMP_Post_Template->load_parts(Array)
#16 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(485): include('/home/lemagcin/...')
#17 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(238): AMP_Post_Template->verify_and_include('/home/lemagcin/...', 'single')
#18 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/class-amp-post-template.php(227): AMP_Post_Template->load_parts(Array)
#19 /home/lemagcin/www/wp/wp-content/plugins/amp/includes/templates/reader-template-loader.php(36): AMP_Post_Template->load()
#20 /home/lemagcin/www/wp/wp-includes/template-loader.php(106): include('/home/lemagcin/...')
#21 /home/lemagcin/www/wp/wp-blog-header.php(19): require_once('/home/lemagcin/...')
#22 /home/lemagcin/www/index.php(17): require('/home/lemagcin/...')
#23 {main} thrown in /home/lemagcin/www/wp/wp-content/plugins/amp/includes/embeds/class-amp-gallery-embed-handler.php on line 82
```

This is the line in question:

https://github.com/ampproject/amp-wp/blob/7c2b5ae700c460bea95fda7e68dde145ae6a0537/includes/embeds/class-amp-gallery-embed-handler.php#L82

To fix this issue, we just need to ensure that `$attrs` is always an array.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
