### PR TITLE
Prevent copying PHP files from `src/` into `assets/`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,18 @@ const sharedConfig = {
 					return plugin;
 				},
 			)
-			.filter( ( plugin ) => plugin.constructor.name !== 'CleanWebpackPlugin' ),
+			.filter( ( plugin ) => ! [
+				'CleanWebpackPlugin',
+				/**
+				 * After introducing WordPress/gutenberg#38715, PHP files from the `src` folder are copied over
+				 * to the output directory (i.e. `assets`). To prevent this, the `CopyWebpackPlugin` is excluded
+				 * from the plugins list. It is safe since the only other file type the plugin copies is `block.json`
+				 * that is not used in `amp-wp`.
+				 *
+				 * @see https://github.com/ampproject/amp-wp/issues/6947
+				 */
+				'CopyWebpackPlugin',
+			].includes( plugin.constructor.name ) ),
 		new RtlCssPlugin( {
 			filename: '../css/[name]-rtl.css',
 		} ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6947

After introducing WordPress/gutenberg#38715, PHP files from the `src` folder are copied over to the output directory (i.e. `assets`). To prevent this, the `CopyWebpackPlugin` is excluded from the webpack shared plugins list.

It is safe to do so since the only other file type `CopyWebpackPlugin` copies is `block.json` that is not used in `amp-wp`.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
