### PR TITLE
Revert #6952 and bump `@wordpress/scripts` to 22.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4458,9 +4458,9 @@
       }
     },
     "@types/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-mTClfhq5cuGyW4jthaFuig6Q8OVfB3IRyZfN/9SCyJtiM5H0SubwM89cHoT9UngO6HyUFic88HvT1zSNLNyxWA==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5826,9 +5826,9 @@
       }
     },
     "@wordpress/scripts": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-22.0.1.tgz",
-      "integrity": "sha512-G7S4IxZXUr9xHawWXMs/Tu0vz9LexEg5rgUYxT5lZMcTZSx1g622KcGun27PKPDRc8C7w49ae1kM7cWXA9IEOA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-22.1.0.tgz",
+      "integrity": "sha512-Jonw10TWx/eo1ZJz62dX5wLDOWVgKsoScouFf/SDB4SBfFcuSUiPcCHfVQnpT+ImM2wF+N5Dlm0Vx+JeB0MgDA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.16.0",
@@ -6035,12 +6035,6 @@
             "klona": "^2.0.5",
             "semver": "^7.3.5"
           }
-        },
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "4.0.0",
@@ -8754,9 +8748,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
-      "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -17699,9 +17693,9 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.4.0.tgz",
-      "integrity": "sha512-TcGT5Qgq9tgI0msFrIhq70N1+WrnGowjn0hc4vtzEIizJETXOZVrQZVWy051lO/nxEVGyqRXHwtpWjv4/fRbUw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.4.1.tgz",
+      "integrity": "sha512-AgRIWgIkUXXnbvoRhyveZnyoEYr3wTunSk2/evOfWvFs65GUzsrxnUTUSLgPM4MRshCQmRABW7qE1hDN1AD7nA==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
@@ -18586,9 +18580,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.49.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
-      "integrity": "sha512-NoGOjvDDOU9og9oAxhRnap71QaTjjlzrvLnKecUJ3GxhaQBrV6e7gPuSPF28u1OcVAArVojPAe4ZhOXwwC4tGw==",
+      "version": "1.49.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
+      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -19886,9 +19880,9 @@
       }
     },
     "terser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
-      "integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+      "integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
       "dev": true,
       "requires": {
         "acorn": "^8.5.0",
@@ -20448,9 +20442,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.69.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+      "version": "5.70.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -20462,7 +20456,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.9.2",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@wordpress/hooks": "3.3.1",
     "@wordpress/jest-puppeteer-axe": "4.0.1",
     "@wordpress/plugins": "4.1.3",
-    "@wordpress/scripts": "22.0.1",
+    "@wordpress/scripts": "22.1.0",
     "axios": "0.26.0",
     "babel-plugin-inline-react-svg": "2.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,18 +50,7 @@ const sharedConfig = {
 					return plugin;
 				},
 			)
-			.filter( ( plugin ) => ! [
-				'CleanWebpackPlugin',
-				/**
-				 * After introducing WordPress/gutenberg#38715, PHP files from the `src` folder are copied over
-				 * to the output directory (i.e. `assets`). To prevent this, the `CopyWebpackPlugin` is excluded
-				 * from the plugins list. It is safe since the only other file type the plugin copies is `block.json`
-				 * that is not used in `amp-wp`.
-				 *
-				 * @see https://github.com/ampproject/amp-wp/issues/6947
-				 */
-				'CopyWebpackPlugin',
-			].includes( plugin.constructor.name ) ),
+			.filter( ( plugin ) => plugin.constructor.name !== 'CleanWebpackPlugin' ),
 		new RtlCssPlugin( {
 			filename: '../css/[name]-rtl.css',
 		} ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes https://github.com/ampproject/amp-wp/pull/6952
Fixes #6947

Revert #6952 and bump `@wordpress/scripts` to 22.1.0. This will prevent copying PHP files from `src/` to `assets/` directory.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
