### PR TITLE
Test Twenty Twenty search modal on mobile breakpoint

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -9,8 +9,6 @@ import { get } from 'lodash';
 import {
 	activateTheme,
 	clearLocalStorage,
-	createMenu,
-	deleteAllMenus,
 	enablePageDialogAccept,
 	installTheme,
 	isOfflineMode,
@@ -251,36 +249,6 @@ async function createTestData() {
 }
 
 /**
- * Create test posts so that the WordPress instance has some data.
- */
-async function createTestMenus() {
-	await deleteAllMenus();
-	await createMenu(
-		{
-			name: 'Test Menu 1',
-		},
-		[
-			{
-				title: 'WordPress.org',
-				url: 'https://wordpress.org',
-				menu_order: 1,
-			},
-			{
-				title: 'Wikipedia.org',
-				url: 'https://wikipedia.org',
-				menu_order: 2,
-			},
-			{
-				title: 'Google',
-				url: 'https://google.com',
-				menu_order: 3,
-				parent: 1,
-			},
-		],
-	);
-}
-
-/**
  * Install themes and plugins needed in tests.
  */
 async function setupThemesAndPlugins() {
@@ -309,7 +277,6 @@ beforeAll( async () => {
 	await setupThemesAndPlugins();
 	await trashAllPosts();
 	await createTestData();
-	await createTestMenus();
 	await cleanUpSettings();
 	await page.setDefaultNavigationTimeout( 10000 );
 	await page.setDefaultTimeout( 10000 );

--- a/tests/e2e/specs/core-themes/twentyfifteen.js
+++ b/tests/e2e/specs/core-themes/twentyfifteen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Fifteen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Fifteen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentyfourteen.js
+++ b/tests/e2e/specs/core-themes/twentyfourteen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Fourteen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Fourteen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentynineteen.js
+++ b/tests/e2e/specs/core-themes/twentynineteen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Nineteen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Nineteen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'menu-1' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Seventeen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Seventeen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'top' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentysixteen.js
+++ b/tests/e2e/specs/core-themes/twentysixteen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Sixteen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Sixteen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentythirteen.js
+++ b/tests/e2e/specs/core-themes/twentythirteen.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Thirteen theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Thirteen theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentytwelve.js
+++ b/tests/e2e/specs/core-themes/twentytwelve.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Twelve theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Twelve theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -18,11 +18,7 @@ describe( 'Twenty Twenty theme on AMP', () => {
 		await setTemplateMode( 'standard' );
 	} );
 
-	describe( 'main navigation on mobile', () => {
-		beforeAll( async () => {
-			await assignMenuToLocation( 'mobile' );
-		} );
-
+	describe( 'for mobile breakpoint', () => {
 		beforeEach( async () => {
 			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
 			await page.goto( createURL( '/' ) );
@@ -33,59 +29,59 @@ describe( 'Twenty Twenty theme on AMP', () => {
 			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
 		} );
 
-		it( 'should be initially hidden', async () => {
-			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
-			await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
+		describe( 'main navigation', () => {
+			beforeAll( async () => {
+				await assignMenuToLocation( 'mobile' );
+			} );
+
+			it( 'should be initially hidden', async () => {
+				await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
+				await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
+			} );
+
+			it( 'should be togglable', async () => {
+				await expect( page ).toClick( '.mobile-nav-toggle' );
+				await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=true]' );
+				await expect( page ).toMatchElement( '.menu-modal', { visible: true } );
+
+				await expect( page ).toClick( '.mobile-nav-toggle' );
+				await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
+				await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
+			} );
+
+			it( 'should have a togglable submenu', async () => {
+				await expect( page ).toClick( '.mobile-nav-toggle' );
+
+				const menuItemWithSubmenu = await page.$( '.menu-modal .menu-item-has-children' );
+
+				expect( menuItemWithSubmenu ).not.toBeNull();
+
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+
+				await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=true]' );
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
+
+				await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
+				await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
+			} );
 		} );
 
-		it( 'should be togglable', async () => {
-			await expect( page ).toClick( '.mobile-nav-toggle' );
-			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=true]' );
-			await expect( page ).toMatchElement( '.menu-modal', { visible: true } );
+		describe( 'search modal', () => {
+			it( 'should be togglable', async () => {
+				await expect( page ).toMatchElement( '.mobile-search-toggle[aria-expanded=false]' );
+				await expect( page ).toMatchElement( '.search-modal', { visible: false } );
 
-			await expect( page ).toClick( '.mobile-nav-toggle' );
-			await expect( page ).toMatchElement( '.mobile-nav-toggle[aria-expanded=false]' );
-			await expect( page ).toMatchElement( '.menu-modal', { visible: false } );
-		} );
+				await expect( page ).toClick( '.mobile-search-toggle' );
+				await expect( page ).toMatchElement( '.search-toggle[aria-expanded=true]' );
+				await expect( page ).toMatchElement( '.search-modal', { visible: true } );
 
-		it( 'should have a togglable submenu', async () => {
-			await expect( page ).toClick( '.mobile-nav-toggle' );
-
-			const menuItemWithSubmenu = await page.$( '.menu-modal .menu-item-has-children' );
-
-			expect( menuItemWithSubmenu ).not.toBeNull();
-
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
-
-			await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=true]' );
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: true } );
-
-			await expect( menuItemWithSubmenu ).toClick( '.sub-menu-toggle' );
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu-toggle[aria-expanded=false]' );
-			await expect( menuItemWithSubmenu ).toMatchElement( '.sub-menu', { visible: false } );
-		} );
-	} );
-
-	describe( 'search modal on desktop', () => {
-		beforeEach( async () => {
-			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
-			await page.goto( createURL( '/' ) );
-			await page.waitForSelector( '#site-header' );
-		} );
-
-		it( 'should be togglable', async () => {
-			await expect( page ).toMatchElement( '.desktop-search-toggle[aria-expanded=false]' );
-			await expect( page ).toMatchElement( '.search-modal', { visible: false } );
-
-			await expect( page ).toClick( '.desktop-search-toggle' );
-			await expect( page ).toMatchElement( '.search-toggle[aria-expanded=true]' );
-			await expect( page ).toMatchElement( '.search-modal', { visible: true } );
-
-			await expect( page ).toMatchElement( '.search-modal .close-search-toggle[aria-expanded=true]' );
-			await expect( page ).toClick( '.search-modal .close-search-toggle' );
-			await expect( page ).toMatchElement( '.search-modal', { visible: false } );
+				await expect( page ).toMatchElement( '.search-modal .close-search-toggle[aria-expanded=true]' );
+				await expect( page ).toClick( '.search-modal .close-search-toggle' );
+				await expect( page ).toMatchElement( '.search-modal', { visible: false } );
+			} );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, setBrowserViewport, visitAdminPage } from '@w
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Twenty theme on AMP', () => {
@@ -31,6 +31,7 @@ describe( 'Twenty Twenty theme on AMP', () => {
 
 		describe( 'main navigation', () => {
 			beforeAll( async () => {
+				await createTestMenu();
 				await assignMenuToLocation( 'mobile' );
 			} );
 

--- a/tests/e2e/specs/core-themes/twentytwentyone.js
+++ b/tests/e2e/specs/core-themes/twentytwentyone.js
@@ -7,7 +7,7 @@ import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminP
  * Internal dependencies
  */
 import { setTemplateMode } from '../../utils/amp-settings-utils';
-import { assignMenuToLocation } from '../../utils/assign-menu-to-location';
+import { assignMenuToLocation, createTestMenu } from '../../utils/nav-menu-utils';
 import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
 
 describe( 'Twenty Twenty-One theme on AMP', () => {
@@ -25,6 +25,7 @@ describe( 'Twenty Twenty-One theme on AMP', () => {
 
 	describe( 'main navigation on mobile', () => {
 		beforeAll( async () => {
+			await createTestMenu();
 			await assignMenuToLocation( 'primary' );
 		} );
 

--- a/tests/e2e/specs/core-themes/twentytwentytwo.js
+++ b/tests/e2e/specs/core-themes/twentytwentytwo.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, createURL, installTheme, setBrowserViewport, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { setTemplateMode } from '../../utils/amp-settings-utils';
+import { DEFAULT_BROWSER_VIEWPORT_SIZE, MOBILE_BROWSER_VIEWPORT_SIZE } from '../../config/bootstrap';
+
+describe( 'Twenty Twenty-Two theme on AMP', () => {
+	beforeAll( async () => {
+		await installTheme( 'twentytwentytwo' );
+		await activateTheme( 'twentytwentytwo' );
+
+		await visitAdminPage( 'admin.php', 'page=amp-options' );
+		await setTemplateMode( 'standard' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwenty' );
+	} );
+
+	describe( 'header navigation on mobile', () => {
+		const pageHeaderSelector = 'header.wp-block-template-part';
+
+		beforeEach( async () => {
+			await setBrowserViewport( MOBILE_BROWSER_VIEWPORT_SIZE );
+			await page.goto( createURL( '/' ) );
+			await page.waitForSelector( '.wp-site-blocks' );
+		} );
+
+		afterAll( async () => {
+			await setBrowserViewport( DEFAULT_BROWSER_VIEWPORT_SIZE );
+		} );
+
+		it( 'should be initially hidden', async () => {
+			const pageHeaderElement = await page.$( pageHeaderSelector );
+			expect( pageHeaderElement ).not.toBeNull();
+
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container-open' );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container[aria-hidden=true]', { visible: false } );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container-close', { visible: false } );
+		} );
+
+		it( 'should be togglable', async () => {
+			const pageHeaderElement = await page.$( pageHeaderSelector );
+			expect( pageHeaderElement ).not.toBeNull();
+
+			await expect( pageHeaderElement ).toClick( '.wp-block-navigation__responsive-container-open' );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container[aria-hidden=false]' );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container-close' );
+
+			await expect( pageHeaderElement ).toClick( '.wp-block-navigation__responsive-container-close' );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container[aria-hidden=true]', { visible: false } );
+			await expect( pageHeaderElement ).toMatchElement( '.wp-block-navigation__responsive-container-close', { visible: false } );
+		} );
+	} );
+} );

--- a/tests/e2e/utils/assign-menu-to-location.js
+++ b/tests/e2e/utils/assign-menu-to-location.js
@@ -5,8 +5,14 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 export async function assignMenuToLocation( menuLocationName ) {
 	await visitAdminPage( 'nav-menus.php', '' );
-	await page.waitForSelector( `input[name="menu-locations[${ menuLocationName }]"]` );
-	await page.click( `input[name="menu-locations[${ menuLocationName }]"]` );
+
+	// Bail out if there is no menu location or it is already selected.
+	const menuLocationCheckbox = await page.$( `input:not(:checked)[name="menu-locations[${ menuLocationName }]"]` );
+	if ( ! menuLocationCheckbox ) {
+		return;
+	}
+
+	await menuLocationCheckbox.click();
 	await page.click( '#save_menu_footer' );
 	await page.waitForSelector( '#message', { text: /has been updated/ } );
 }

--- a/tests/e2e/utils/nav-menu-utils.js
+++ b/tests/e2e/utils/nav-menu-utils.js
@@ -1,7 +1,34 @@
 /**
  * WordPress dependencies
  */
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import { createMenu, deleteAllMenus, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+export async function createTestMenu() {
+	await deleteAllMenus();
+	await createMenu(
+		{
+			name: 'Test Menu 1',
+		},
+		[
+			{
+				title: 'WordPress.org',
+				url: 'https://wordpress.org',
+				menu_order: 1,
+			},
+			{
+				title: 'Wikipedia.org',
+				url: 'https://wikipedia.org',
+				menu_order: 2,
+			},
+			{
+				title: 'Google',
+				url: 'https://google.com',
+				menu_order: 3,
+				parent: 1,
+			},
+		],
+	);
+}
 
 export async function assignMenuToLocation( menuLocationName ) {
 	await visitAdminPage( 'nav-menus.php', '' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5404

> Re-opening because there's a failure for the Twenty Twenty test:
>
> <img width="959" alt="image" src="https://user-images.githubusercontent.com/134745/157349089-7faabc96-92fe-43c5-b283-9ce769a4858b.png">


As per https://github.com/ampproject/amp-wp/issues/5404#issuecomment-1062428262, the E2E tests that were recently added in #6933 are failing for Twenty Twenty theme.

This PR fixes the failing test. Instead of examining a desktop search modal, we're now testing a mobile search modal.

> Aside: if it's feasible to add a test for Twenty Twenty-Two as well, that would be great.

Also, the [request](https://github.com/ampproject/amp-wp/issues/5404#issuecomment-1062428596) for adding E2E tests for Twenty Twenty-Two theme navigation block in the header has been addressed here (0d59631).

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
