### PR TITLE
Attempt to fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,12 +30,12 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ github.event.pull_request.auto_merge == null && steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: ${{ github.event.pull_request.auto_merge == null && ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' ) }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,15 +28,15 @@ jobs:
         uses: dependabot/fetch-metadata@v1.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ github.event.pull_request.auto_merge == null && ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' ) }}
         run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,12 @@
 # This is based on <https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request>.
 name: Dependabot auto-merge
-on: pull_request
+
+# Only trigger, when the build workflow succeeded, per <https://stackoverflow.com/a/65698892/93579>.
+on:
+  workflow_run:
+    workflows: ["Build, test & measure"]
+    types:
+      - completed
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

This follows up on https://github.com/ampproject/amp-wp/pull/6964#issuecomment-1062113025.

Based on https://github.com/cli/cli/discussions/3660#discussioncomment-758036 (h/t @pierlon) it seems running `gh merge --auto` it seems that the `Dependabot auto-merge` workflow may be failing due to one of the preconditions not being met. Namely, the required checks being run in the `Build, test & measure` workflow. Therefore, this PR makes it so that the `Dependabot auto-merge` workflow will only be triggered once the aforementioned workflow is completed. Additionally, the approval of the PR is now done _after_ the enabling of auto-merge as apparently enabling auto-merge can't be done if it could be merged already per https://github.com/cli/cli/discussions/3660#discussioncomment-1134008. So there seems to be two competing conditions, one for the required checks and another for the PR approval. Maybe if auto-merge is enabled in between them then it will succeed.

This PR also amends #6964 to enable auto-merge for `minor` updates as well as `patch` updates.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
