### PR TITLE
Remove code that strip whitespace around equal signs from meta

### DIFF
--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -115,15 +115,6 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 		$meta_elements = iterator_to_array( $this->dom->getElementsByTagName( static::$tag ), false );
 
 		foreach ( $meta_elements as $meta_element ) {
-
-			// Strip whitespace around equal signs. Won't be needed after <https://github.com/ampproject/amphtml/issues/26496> is resolved.
-			if ( $meta_element->hasAttribute( Attribute::CONTENT ) ) {
-				$meta_element->setAttribute(
-					Attribute::CONTENT,
-					preg_replace( '/\s*=\s*/', '=', $meta_element->getAttribute( Attribute::CONTENT ) )
-				);
-			}
-
 			/**
 			 * Meta tag to process.
 			 *


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #4742 

Remove the code from meta sanitizer that removes white space surrounding the equals signs from meta viewport tag.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
