### PR TITLE
Fix phpunit tests after postcss update and changes in WP 6.0-alpha

### DIFF
--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -3495,6 +3495,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 
 					$this->assertStringContainsString( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
 					$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
+					$amphtml_source = preg_replace( '/\s*>\s*/', '>', $amphtml_source ); // Account for variance in postcss.
 					$this->assertStringContainsString( '.amp-wp-default-form-message>p', $amphtml_source, 'Expected amp-default.css' );
 					$this->assertStringContainsString( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );
 					$this->assertStringNotContainsString( 'earlyprintstyle', $amphtml_source, 'Expected early print style to not be present.' );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1222,13 +1222,12 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 					'//script[ @id = "jquery-core-js-before" ]',
 					'//script[ @id = "jquery-core-js-after" ]',
 					'//script[ @id = "wp-dom-ready-js" ]',
-					'//script[ @id = "wp-dom-ready-js-translations" ]',
 					'//script[ @id = "quicktags-js" ]',
 					'//script[ @id = "quicktags-js-extra" ]',
 					'//script[ contains( text(), "window.wpActiveEditor" ) ]',
 				],
 				function ( ...$sources_sets ) {
-					$this->assertCount( 7, $sources_sets );
+					$this->assertCount( 6, $sources_sets );
 					foreach ( $sources_sets as $sources ) {
 						$amp_source_count = 0;
 						foreach ( $sources as $source ) {


### PR DESCRIPTION
* Follow-up on `postcss` dependency update in https://github.com/ampproject/amp-wp/pull/6980 which seems to have retained whitespace in descendant selectors (or I was testing with dev build).
* Account for avoiding sending empty string translations in https://core.trac.wordpress.org/ticket/55250 which is currently in WP trunk for 6.0-alpha.