### PR TITLE
Replace use of `dangerouslySetInnerHTML` with `createInterpolateElement`

### DIFF
--- a/assets/src/admin/site-scan-notice/plugins-with-amp-incompatibility.js
+++ b/assets/src/admin/site-scan-notice/plugins-with-amp-incompatibility.js
@@ -7,7 +7,7 @@ import { AMP_COMPATIBLE_PLUGINS_URL, SETTINGS_LINK } from 'amp-site-scan-notice'
 /**
  * WordPress dependencies
  */
-import { useContext, useMemo } from '@wordpress/element';
+import { createInterpolateElement, useContext, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
@@ -57,22 +57,26 @@ export function PluginsWithAmpIncompatibility( { pluginsWithAmpIncompatibility }
 					key={ pluginWithAmpIncompatibility.slug }
 					className="amp-site-scan-notice__source-details"
 				>
-					<summary
-						className="amp-site-scan-notice__source-summary"
-						dangerouslySetInnerHTML={ {
-							__html: sprintf(
-								/* translators: 1: plugin name; 2: number of URLs with AMP validation issues. */
-								_n(
-									'<b>%1$s</b> on %2$d URL',
-									'<b>%1$s</b> on %2$d URLs',
+					<summary className="amp-site-scan-notice__source-summary">
+						{
+							createInterpolateElement(
+								sprintf(
+									/* translators: 1: plugin name; 2: number of URLs with AMP validation issues. */
+									_n(
+										'<b>%1$s</b> on %2$d URL',
+										'<b>%1$s</b> on %2$d URLs',
+										pluginWithAmpIncompatibility.urls.length,
+										'amp',
+									),
+									pluginNames[ pluginWithAmpIncompatibility.slug ],
 									pluginWithAmpIncompatibility.urls.length,
-									'amp',
 								),
-								pluginNames[ pluginWithAmpIncompatibility.slug ],
-								pluginWithAmpIncompatibility.urls.length,
-							),
-						} }
-					/>
+								{
+									b: <b />,
+								},
+							)
+						}
+					</summary>
 					<ul className="amp-site-scan-notice__urls-list">
 						{ pluginWithAmpIncompatibility.urls.map( ( url ) => (
 							<li key={ url }>

--- a/assets/src/admin/site-scan-notice/themes-with-amp-incompatibility.js
+++ b/assets/src/admin/site-scan-notice/themes-with-amp-incompatibility.js
@@ -7,7 +7,7 @@ import { AMP_COMPATIBLE_THEMES_URL } from 'amp-site-scan-notice'; // From WP inl
 /**
  * WordPress dependencies
  */
-import { useContext, useMemo } from '@wordpress/element';
+import { createInterpolateElement, useContext, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
@@ -52,22 +52,26 @@ export function ThemesWithAmpIncompatibility( { themesWithAmpIncompatibility } )
 					key={ themeWithAmpIncompatibility.slug }
 					className="amp-site-scan-notice__source-details"
 				>
-					<summary
-						className="amp-site-scan-notice__source-summary"
-						dangerouslySetInnerHTML={ {
-							__html: sprintf(
-								/* translators: 1: theme name; 2: number of URLs with AMP validation issues. */
-								_n(
-									'<b>%1$s</b> on %2$d URL',
-									'<b>%1$s</b> on %2$d URLs',
+					<summary className="amp-site-scan-notice__source-summary">
+						{
+							createInterpolateElement(
+								sprintf(
+									/* translators: 1: theme name; 2: number of URLs with AMP validation issues. */
+									_n(
+										'<b>%1$s</b> on %2$d URL',
+										'<b>%1$s</b> on %2$d URLs',
+										themeWithAmpIncompatibility.urls.length,
+										'amp',
+									),
+									themeNames[ themeWithAmpIncompatibility.slug ],
 									themeWithAmpIncompatibility.urls.length,
-									'amp',
 								),
-								themeNames[ themeWithAmpIncompatibility.slug ],
-								themeWithAmpIncompatibility.urls.length,
-							),
-						} }
-					/>
+								{
+									b: <b />,
+								},
+							)
+						}
+					</summary>
 					<ul className="amp-site-scan-notice__urls-list">
 						{ themeWithAmpIncompatibility.urls.map( ( url ) => (
 							<li key={ url }>

--- a/assets/src/components/amp-support/index.js
+++ b/assets/src/components/amp-support/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
 import { Button, ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
@@ -85,16 +85,17 @@ export function AMPSupport( props ) {
 				<h2 className="amp-support__heading">
 					{ __( 'AMP Support', 'amp' ) }
 				</h2>
-				{ /* dangerouslySetInnerHTML reason: Injection of links. */ }
-				<p dangerouslySetInnerHTML={
+				<p>
 					{
-						__html: sprintf(
-							/* translators: %s is the URL to create a new support topic */
-							__( 'In order to best assist you, please tap the Send Data button below to send the following site information to our private database. Once you have done so, copy the the resulting Support UUID in the blue box that appears and include the ID in a new <a href="%s" rel="noreferrer" target="_blank">support forum topic</a>. You do not have to submit data to get support, but our team will be able to help you more effectively if you do so.', 'amp' ),
-							'https://wordpress.org/support/plugin/amp/#new-topic-0',
-						),
+						createInterpolateElement(
+							__( 'In order to best assist you, please tap the Send Data button below to send the following site information to our private database. Once you have done so, copy the the resulting Support UUID in the blue box that appears and include the ID in a new <a>support forum topic</a>. You do not have to submit data to get support, but our team will be able to help you more effectively if you do so.', 'amp' ),
+							{
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+								a: <a href="https://wordpress.org/support/plugin/amp/#new-topic-0" rel="noreferrer" target="_blank" />,
+							},
+						)
 					}
-				} />
+				</p>
 
 				<ValidationResultsNotice data={ data } args={ args } ampValidatedPostCount={ ampValidatedPostCount } />
 

--- a/assets/src/components/amp-support/index.js
+++ b/assets/src/components/amp-support/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { Button, ExternalLink } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';

--- a/assets/src/components/error-screen/index.js
+++ b/assets/src/components/error-screen/index.js
@@ -6,9 +6,9 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Panel } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,14 +41,17 @@ export function ErrorScreen( { error, finishLinkLabel, finishLinkUrl, title } ) 
 					__html: message || __( 'There was an error loading the page.', 'amp' ),
 				} } />
 
-				{ /* dangerouslySetInnerHTML reason: The message contains a link to the AMP support forum. */ }
-				<p dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						// translators: %s is the AMP support forum URL.
-						__( 'Please submit details to our <a href="%s" target="_blank" rel="noreferrer noopener">support forum</a>.', 'amp' ),
-						__( 'https://wordpress.org/support/plugin/amp/', 'amp' ),
-					),
-				} } />
+				<p>
+					{
+						createInterpolateElement(
+							__( 'Please submit details to our <a>support forum</a>.', 'amp' ),
+							{
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+								a: <a href="https://wordpress.org/support/plugin/amp/" target="_blank" rel="noreferrer noopener" />,
+							},
+						)
+					}
+				</p>
 
 				{ stack && (
 					<details>

--- a/assets/src/components/error-screen/test/__snapshots__/index.js.snap
+++ b/assets/src/components/error-screen/test/__snapshots__/index.js.snap
@@ -17,13 +17,17 @@ exports[`ErrorScreen matches snapshot 1`] = `
         }
       }
     />
-    <p
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Please submit details to our <a href=\\"https://wordpress.org/support/plugin/amp/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">support forum</a>.",
-        }
-      }
-    />
+    <p>
+      Please submit details to our 
+      <a
+        href="https://wordpress.org/support/plugin/amp/"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        support forum
+      </a>
+      .
+    </p>
     <details>
       <summary>
         Details

--- a/assets/src/components/template-mode-option/index.js
+++ b/assets/src/components/template-mode-option/index.js
@@ -79,14 +79,14 @@ export function getId( mode ) {
 /**
  * An individual mode selection component.
  *
- * @param {Object}        props                    Component props.
- * @param {string|Object} props.children           Section content.
- * @param {string|Array}  props.details            The template mode details.
- * @param {string}        props.detailsUrl         Mode details URL.
- * @param {string}        props.mode               The template mode.
- * @param {boolean}       props.previouslySelected Optional. Whether the option was selected previously.
- * @param {Object}        props.labelExtra         Optional. Extra content to display on the right side of the option label.
- * @param {boolean}       props.initialOpen        Whether the panel should be open when the component renders.
+ * @param {Object}              props                    Component props.
+ * @param {string|Object}       props.children           Section content.
+ * @param {string|Array|Object} props.details            The template mode details.
+ * @param {string}              props.detailsUrl         Mode details URL.
+ * @param {string}              props.mode               The template mode.
+ * @param {boolean}             props.previouslySelected Optional. Whether the option was selected previously.
+ * @param {Object}              props.labelExtra         Optional. Extra content to display on the right side of the option label.
+ * @param {boolean}             props.initialOpen        Whether the panel should be open when the component renders.
  */
 export function TemplateModeOption( { children, details, detailsUrl, initialOpen, labelExtra = null, mode, previouslySelected = false } ) {
 	const { editedOptions, updateOptions } = useContext( Options );

--- a/assets/src/components/template-mode-option/index.js
+++ b/assets/src/components/template-mode-option/index.js
@@ -143,15 +143,17 @@ export function TemplateModeOption( { children, details, detailsUrl, initialOpen
 							<li
 								key={ index }
 								className="template-mode-selection__details-list-item"
-								/* dangerouslySetInnerHTML reason: `detail` may contain `strong` elements. */
-								dangerouslySetInnerHTML={ { __html: detail } }
-							/>
+							>
+								{ detail }
+							</li>
 						) ) }
 					</ul>
 				) }
 				{ details && ! Array.isArray( details ) && (
 					<p>
-						<span dangerouslySetInnerHTML={ { __html: details } } />
+						<span>
+							{ details }
+						</span>
 						{ detailsUrl && (
 							<>
 								{ ' ' }
@@ -171,7 +173,8 @@ TemplateModeOption.propTypes = {
 	children: PropTypes.any,
 	details: PropTypes.oneOfType( [
 		PropTypes.string,
-		PropTypes.arrayOf( PropTypes.string ),
+		PropTypes.array,
+		PropTypes.object,
 	] ),
 	detailsUrl: PropTypes.string,
 	initialOpen: PropTypes.bool,

--- a/assets/src/components/template-mode-option/test/__snapshots__/index.js.snap
+++ b/assets/src/components/template-mode-option/test/__snapshots__/index.js.snap
@@ -432,13 +432,9 @@ exports[`TemplateModeOption matches snapshot 2`] = `
         className="template-mode-selection__details"
       >
         <p>
-          <span
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Reader info",
-              }
-            }
-          />
+          <span>
+            Reader info
+          </span>
            
           <a
             href="https://amp-wp.org/documentation/getting-started/reader/"
@@ -728,13 +724,9 @@ exports[`TemplateModeOption matches snapshot 3`] = `
         className="template-mode-selection__details"
       >
         <p>
-          <span
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "Component details",
-              }
-            }
-          />
+          <span>
+            Component details
+          </span>
            
           <a
             href="https://amp-wp.org/documentation/getting-started/reader/"

--- a/assets/src/components/use-template-mode-recommendation/index.js
+++ b/assets/src/components/use-template-mode-recommendation/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useLayoutEffect, useState } from '@wordpress/element';
+import { createInterpolateElement, useContext, useLayoutEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -78,9 +78,24 @@ export function getTemplateModeRecommendation( {
 } ) {
 	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const mobileRedirectionNote = __( 'If automatic mobile redirection is enabled, the AMP version of the content will be served on mobile devices. If AMP-to-AMP linking is enabled, once users are on an AMP page, they will continue navigating your AMP content.', 'amp' );
-	const readerModeDescription = __( 'In Reader mode <b>your site will have a non-AMP and an AMP version</b>, and <b>each version will use its own theme</b>.', 'amp' ) + ' ' + mobileRedirectionNote;
-	const transitionalModeDescription = __( 'In Transitional mode <b>your site will have a non-AMP and an AMP version</b>, and <b>both will use the same theme</b>.', 'amp' ) + ' ' + mobileRedirectionNote;
-	const standardModeDescription = __( 'In Standard mode <b>your site will be completely AMP</b> (except in cases where you opt-out of AMP for specific parts of your site), and <b>it will use a single theme</b>.', 'amp' );
+	const readerModeDescription = createInterpolateElement(
+		__( 'In Reader mode <b>your site will have a non-AMP and an AMP version</b>, and <b>each version will use its own theme</b>.', 'amp' ) + ' ' + mobileRedirectionNote,
+		{
+			b: <b />,
+		},
+	);
+	const transitionalModeDescription = createInterpolateElement(
+		__( 'In Transitional mode <b>your site will have a non-AMP and an AMP version</b>, and <b>both will use the same theme</b>.', 'amp' ) + ' ' + mobileRedirectionNote,
+		{
+			b: <b />,
+		},
+	);
+	const standardModeDescription = createInterpolateElement(
+		__( 'In Standard mode <b>your site will be completely AMP</b> (except in cases where you opt-out of AMP for specific parts of your site), and <b>it will use a single theme</b>.', 'amp' ),
+		{
+			b: <b />,
+		},
+	);
 	const pluginIncompatibilityNote = __( 'To address plugin compatibility issue(s), you may need to use Plugin Suppression to disable incompatible plugins on AMP pages or else select an alternative AMP-compatible plugin.', 'amp' );
 	const readerNoteWhenThemeIssuesPresent = __( 'Recommended if you want to enable AMP on your site despite the detected compatibility issue(s).', 'amp' );
 	const transitionalNoteWhenThemeIssuesPresent = __( 'Recommended so you can progressively enable AMP on your site while still making the non-AMP version available to visitors for functionality that is not AMP-compatible. Choose this mode if compatibility issues can be fixed or if your theme degrades gracefully when JavaScript is disabled.', 'amp' );

--- a/assets/src/onboarding-wizard/pages/done/index.js
+++ b/assets/src/onboarding-wizard/pages/done/index.js
@@ -6,8 +6,8 @@ import { SETTINGS_LINK } from 'amp-settings'; // From WP inline script.
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useContext, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useContext, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -198,30 +198,39 @@ export function Done() {
 					{ __( 'Need help?', 'amp' ) }
 				</h2>
 				<ul className="done__list">
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is a link to support forum. */
-							__( 'Reach out in the <a href="%s" target="_blank" rel="noreferrer noopener">support forums</a>', 'amp' ),
-							'https://wordpress.org/support/plugin/amp/#new-topic-0',
-						),
-					} } />
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is a link to the settings page. */
-							__( 'Try a different template mode <a href="%s" target="_blank" rel="noreferrer noopener">in settings</a>', 'amp' ),
-							SETTINGS_LINK,
-						),
-					} } />
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is a link to the plugin site. */
-							__( '<a href="%s" target="_blank" rel="noreferrer noopener">Learn more</a> how the AMP plugin works', 'amp' ),
-							'https://amp-wp.org/documentation/how-the-plugin-works/',
-						),
-					} } />
+					<li>
+						{
+							createInterpolateElement(
+								__( 'Reach out in the <a>support forums</a>', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="https://wordpress.org/support/plugin/amp/#new-topic-0" target="_blank" rel="noreferrer noopener" />,
+								},
+							)
+						}
+					</li>
+					<li>
+						{
+							createInterpolateElement(
+								__( 'Try a different template mode <a>in settings</a>', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href={ SETTINGS_LINK } target="_blank" rel="noreferrer noopener" />,
+								},
+							)
+						}
+					</li>
+					<li>
+						{
+							createInterpolateElement(
+								__( '<a>Learn more</a> how the AMP plugin works', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="https://amp-wp.org/documentation/how-the-plugin-works/" target="_blank" rel="noreferrer noopener" />,
+								},
+							)
+						}
+					</li>
 				</ul>
 			</div>
 		</div>

--- a/assets/src/onboarding-wizard/pages/template-mode/index.js
+++ b/assets/src/onboarding-wizard/pages/template-mode/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect, useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/src/onboarding-wizard/pages/template-mode/index.js
+++ b/assets/src/onboarding-wizard/pages/template-mode/index.js
@@ -42,11 +42,11 @@ export function TemplateMode() {
 				<p>
 					{
 						createInterpolateElement(
-							__( 'Based on site scan results the AMP plugin provides the following choices. Learn more about the <GettingStartedUrl>AMP experience with different modes</GettingStartedUrl> and availability of <EcosystemUrl>AMP components in the ecosystem</EcosystemUrl>.', 'amp' ),
+							__( 'Based on site scan results the AMP plugin provides the following choices. Learn more about the <GettingStartedLink>AMP experience with different modes</GettingStartedLink> and availability of <EcosystemLink>AMP components in the ecosystem</EcosystemLink>.', 'amp' ),
 							{
 								/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
-								GettingStartedUrl: <a href="https://amp-wp.org/documentation/getting-started/template-modes/" target="_blank" rel="noreferrer noopener" />,
-								EcosystemUrl: <a href="https://amp-wp.org/ecosystem/" target="_blank" rel="noreferrer noopener" />,
+								GettingStartedLink: <a href="https://amp-wp.org/documentation/getting-started/template-modes/" target="_blank" rel="noreferrer noopener" />,
+								EcosystemLink: <a href="https://amp-wp.org/ecosystem/" target="_blank" rel="noreferrer noopener" />,
 								/* eslint-enable jsx-a11y/anchor-has-content */
 							},
 						)

--- a/assets/src/onboarding-wizard/pages/template-mode/index.js
+++ b/assets/src/onboarding-wizard/pages/template-mode/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useContext, createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -39,15 +39,19 @@ export function TemplateMode() {
 				<h1>
 					{ __( 'Template Modes', 'amp' ) }
 				</h1>
-				{ /* dangerouslySetInnerHTML reason: Injection of links. */ }
-				<p dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						/* translators: placeholders are links to amp-wp.org website. */
-						__( 'Based on site scan results the AMP plugin provides the following choices. Learn more about the <a href="%1$s" target="_blank" rel="noreferrer noopener">AMP experience with different modes</a> and availability of <a href="%2$s" target="_blank" rel="noreferrer noopener">AMP components in the ecosystem</a>.', 'amp' ),
-						'https://amp-wp.org/documentation/getting-started/template-modes/',
-						'https://amp-wp.org/ecosystem/',
-					),
-				} } />
+				<p>
+					{
+						createInterpolateElement(
+							__( 'Based on site scan results the AMP plugin provides the following choices. Learn more about the <GettingStartedUrl>AMP experience with different modes</GettingStartedUrl> and availability of <EcosystemUrl>AMP components in the ecosystem</EcosystemUrl>.', 'amp' ),
+							{
+								/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+								GettingStartedUrl: <a href="https://amp-wp.org/documentation/getting-started/template-modes/" target="_blank" rel="noreferrer noopener" />,
+								EcosystemUrl: <a href="https://amp-wp.org/ecosystem/" target="_blank" rel="noreferrer noopener" />,
+								/* eslint-enable jsx-a11y/anchor-has-content */
+							},
+						)
+					}
+				</p>
 			</div>
 			<ScreenUI
 				currentMode={ themeSupport }

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -239,8 +239,6 @@ export function Analytics() {
 								'<code>amp-analytics</code>',
 								'<code>{</code>',
 								'<code>}</code>',
-								'<code>&lt;amp-analytics&gt;</code>',
-								'<code>&lt;script&gt;</code>',
 								`<code>${ GOOGLE_ANALYTICS_VENDOR }</code>`,
 							),
 							{
@@ -251,6 +249,16 @@ export function Analytics() {
 								SiteKitUrl: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
 								/* eslint-enable jsx-a11y/anchor-has-content */
 								code: <code />,
+								AmpAnalyticsTag: (
+									<code>
+										{ '<amp-analytics>' }
+									</code>
+								),
+								ScriptTag: (
+									<code>
+										{ '<script>' }
+									</code>
+								),
 							},
 						)
 					}

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -11,7 +11,7 @@ import { ANALYTICS_VENDORS_LIST } from 'amp-settings';
 import { Icon, plus, trash } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, useContext, useEffect, useRef } from '@wordpress/element';
-import { Button, TextControl, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
+import { Button, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -235,7 +235,7 @@ export function Analytics() {
 						createInterpolateElement(
 							sprintf(
 								/* translators: 1: amp-analytics, 2: {, 3: }, 4: amp-analytics tag, 5: script tag, 6: googleanalytics. */
-								__( 'Please see AMP project\'s <AnalyticsDocsUrl>documentation</AnalyticsDocsUrl> for %1$s as well as the <PluginAnalyticsDocsUrl>plugin\'s analytics documentation</PluginAnalyticsDocsUrl>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %2$s and ending with a %3$s. Do not include any HTML tags like %4$s or %5$s. For the type field, supply one of the <VendorDocsUrl>available analytics vendors</VendorDocsUrl> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %6$s.  For Google Tag Manager please consider using <SiteKitUrl>Site Kit by Google</SiteKitUrl> plugin.', 'amp' ),
+								__( 'Please see AMP project\'s <AnalyticsDocsUrl>documentation</AnalyticsDocsUrl> for %1$s as well as the <PluginAnalyticsDocsUrl>plugin\'s analytics documentation</PluginAnalyticsDocsUrl>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %2$s and ending with a %3$s. Do not include any HTML tags like %4$s or %5$s. For the type field, supply one of the <VendorDocsUrl>available analytics vendors</VendorDocsUrl> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %6$s. For Google Tag Manager please consider using <SiteKitUrl>Site Kit by Google</SiteKitUrl> plugin.', 'amp' ),
 								'<code>amp-analytics</code>',
 								'<code>{</code>',
 								'<code>}</code>',

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -10,8 +10,8 @@ import { ANALYTICS_VENDORS_LIST } from 'amp-settings';
  */
 import { Icon, plus, trash } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { useContext, useEffect, useRef } from '@wordpress/element';
-import { Button, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
+import { createInterpolateElement, useContext, useEffect, useRef } from '@wordpress/element';
+import { Button, TextControl, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -226,24 +226,31 @@ export function Analytics() {
 				<summary>
 					{ __( 'Learn about analytics for AMP.', 'amp' ) }
 				</summary>
-				<p dangerouslySetInnerHTML={
-					{ __html:
-						sprintf(
-							/* translators: 1: AMP Analytics docs URL, 2: amp-analytics, 3: plugin analytics docs URL, 4: {, 5: }, 6: amp-analytics tag, 7: script tag, 8: AMP analytics vendor docs URL, 9: googleanalytics. */
-							__( 'Please see AMP project\'s <a href="%1$s" target="_blank">documentation</a> for %2$s as well as the <a href="%3$s" target="_blank">plugin\'s analytics documentation</a>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %4$s and ending with a %5$s. Do not include any HTML tags like %6$s or %7$s. For the type field, supply one of the <a href="%8$s" target="_blank">available analytics vendors</a> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %9$s. For Google Tag Manager please consider using <a href="%10$s" target="_blank" rel="noreferrer">Site Kit by Google</a> plugin.', 'amp' ),
-							__( 'https://amp.dev/documentation/components/amp-analytics/', 'amp' ),
-							'<code>amp-analytics</code>',
-							__( 'https://amp-wp.org/documentation/getting-started/analytics/', 'amp' ),
-							'<code>{</code>',
-							'<code>}</code>',
-							'<code>&lt;amp-analytics&gt;</code>',
-							'<code>&lt;script&gt;</code>',
-							__( 'https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors/', 'amp' ),
-							`<code>${ GOOGLE_ANALYTICS_VENDOR }</code>`,
-							__( 'https://wordpress.org/plugins/google-site-kit/', 'amp' ),
-						),
-					} }
-				/>
+				<p>
+					{
+						createInterpolateElement(
+							sprintf(
+								/* translators: 1: amp-analytics, 2: {, 3: }, 4: amp-analytics tag, 5: script tag, 6: googleanalytics. */
+								__( 'Please see AMP project\'s <AnalyticsDocsUrl>documentation</AnalyticsDocsUrl> for %1$s as well as the <PluginAnalyticsDocsUrl>plugin\'s analytics documentation</PluginAnalyticsDocsUrl>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %2$s and ending with a %3$s. Do not include any HTML tags like %4$s or %5$s. For the type field, supply one of the <VendorDocsUrl>available analytics vendors</VendorDocsUrl> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %6$s.  For Google Tag Manager please consider using <SiteKitUrl>Site Kit by Google</SiteKitUrl> plugin.', 'amp' ),
+								'<code>amp-analytics</code>',
+								'<code>{</code>',
+								'<code>}</code>',
+								'<code>&lt;amp-analytics&gt;</code>',
+								'<code>&lt;script&gt;</code>',
+								`<code>${ GOOGLE_ANALYTICS_VENDOR }</code>`,
+							),
+							{
+								/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+								AnalyticsDocsUrl: <a href="https://amp.dev/documentation/components/amp-analytics/" target="_blank" rel="noreferrer" />,
+								PluginAnalyticsDocsUrl: <a href="https://amp-wp.org/documentation/getting-started/analytics/" target="_blank" rel="noreferrer" />,
+								VendorDocsUrl: <a href="https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors/" target="_blank" rel="noreferrer" />,
+								SiteKitUrl: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
+								/* eslint-enable jsx-a11y/anchor-has-content */
+								code: <code />,
+							},
+						)
+					}
+				</p>
 			</details>
 			{ Object.entries( analytics || {} ).map( ( [ key, { type, config } ], index ) => (
 				<AnalyticsEntry

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -21,11 +21,14 @@ import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
 
 const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
 
-const GOOGLE_ANALYTICS_NOTICE = sprintf(
-	/* translators: 1: URL to Site Kit plugin directory page, 2: Google Analytics dev guide URL */
-	__( 'For Google Analytics or Google Tag Manager please consider using <a href="%1$s" target="_blank" rel="noreferrer">Site Kit by Google</a>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <a href="%2$s" target="_blank" rel="noreferrer">Adding Analytics to your AMP pages</a>.', 'amp' ),
-	__( 'https://wordpress.org/plugins/google-site-kit/', 'amp' ),
-	__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
+const GOOGLE_ANALYTICS_NOTICE = createInterpolateElement(
+	__( 'For Google Analytics or Google Tag Manager please consider using <GoogleSiteKitUrl>Site Kit by Google</GoogleSiteKitUrl>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <GoogleAnalyticsDevGuideUrl>Adding Analytics to your AMP pages</GoogleAnalyticsDevGuideUrl>.', 'amp' ),
+	{
+		/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+		GoogleSiteKitUrl: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
+		GoogleAnalyticsDevGuideUrl: <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank" rel="noreferrer" />,
+		/* eslint-enable jsx-a11y/anchor-has-content */
+	},
 );
 
 const vendorConfigs = {
@@ -164,8 +167,9 @@ function AnalyticsEntry( { entryIndex, onChange, onDelete, type = '', config = '
 				{
 					vendorConfigs[ type ]?.notice && (
 						<AMPNotice size={ NOTICE_SIZE_SMALL }>
-							{ /* dangerouslySetInnerHTML reason: Injection of links. */ }
-							<span dangerouslySetInnerHTML={ { __html: vendorConfigs[ type ].notice } } />
+							<span>
+								{ vendorConfigs[ type ].notice }
+							</span>
 						</AMPNotice>
 					)
 				}

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -22,11 +22,11 @@ import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
 const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
 
 const GOOGLE_ANALYTICS_NOTICE = createInterpolateElement(
-	__( 'For Google Analytics or Google Tag Manager please consider using <GoogleSiteKitUrl>Site Kit by Google</GoogleSiteKitUrl>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <GoogleAnalyticsDevGuideUrl>Adding Analytics to your AMP pages</GoogleAnalyticsDevGuideUrl>.', 'amp' ),
+	__( 'For Google Analytics or Google Tag Manager please consider using <GoogleSiteKitLink>Site Kit by Google</GoogleSiteKitLink>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <GoogleAnalyticsDevGuideLink>Adding Analytics to your AMP pages</GoogleAnalyticsDevGuideLink>.', 'amp' ),
 	{
 		/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
-		GoogleSiteKitUrl: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
-		GoogleAnalyticsDevGuideUrl: <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank" rel="noreferrer" />,
+		GoogleSiteKitLink: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
+		GoogleAnalyticsDevGuideLink: <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank" rel="noreferrer" />,
 		/* eslint-enable jsx-a11y/anchor-has-content */
 	},
 );

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -235,7 +235,7 @@ export function Analytics() {
 						createInterpolateElement(
 							sprintf(
 								/* translators: 1: amp-analytics, 2: {, 3: }, 4: amp-analytics tag, 5: script tag, 6: googleanalytics. */
-								__( 'Please see AMP project\'s <AnalyticsDocsUrl>documentation</AnalyticsDocsUrl> for %1$s as well as the <PluginAnalyticsDocsUrl>plugin\'s analytics documentation</PluginAnalyticsDocsUrl>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %2$s and ending with a %3$s. Do not include any HTML tags like %4$s or %5$s. For the type field, supply one of the <VendorDocsUrl>available analytics vendors</VendorDocsUrl> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %6$s. For Google Tag Manager please consider using <SiteKitUrl>Site Kit by Google</SiteKitUrl> plugin.', 'amp' ),
+								__( 'Please see AMP project\'s <AnalyticsDocsLink>documentation</AnalyticsDocsLink> for %1$s as well as the <PluginAnalyticsDocsLink>plugin\'s analytics documentation</PluginAnalyticsDocsLink>. Each analytics configuration supplied below must take the form of a JSON object beginning with a %2$s and ending with a %3$s. Do not include any HTML tags like %4$s or %5$s. For the type field, supply one of the <VendorDocsLink>available analytics vendors</VendorDocsLink> or leave it blank for in-house analytics. For Google Analytics specifically, the type should be %6$s. For Google Tag Manager please consider using <SiteKitLink>Site Kit by Google</SiteKitLink> plugin.', 'amp' ),
 								'<code>amp-analytics</code>',
 								'<code>{</code>',
 								'<code>}</code>',
@@ -243,10 +243,10 @@ export function Analytics() {
 							),
 							{
 								/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
-								AnalyticsDocsUrl: <a href="https://amp.dev/documentation/components/amp-analytics/" target="_blank" rel="noreferrer" />,
-								PluginAnalyticsDocsUrl: <a href="https://amp-wp.org/documentation/getting-started/analytics/" target="_blank" rel="noreferrer" />,
-								VendorDocsUrl: <a href="https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors/" target="_blank" rel="noreferrer" />,
-								SiteKitUrl: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
+								AnalyticsDocsLink: <a href="https://amp.dev/documentation/components/amp-analytics/" target="_blank" rel="noreferrer" />,
+								PluginAnalyticsDocsLink: <a href="https://amp-wp.org/documentation/getting-started/analytics/" target="_blank" rel="noreferrer" />,
+								VendorDocsLink: <a href="https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors/" target="_blank" rel="noreferrer" />,
+								SiteKitLink: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
 								/* eslint-enable jsx-a11y/anchor-has-content */
 								code: <code />,
 								AmpAnalyticsTag: (

--- a/assets/src/settings-page/paired-url-structure.js
+++ b/assets/src/settings-page/paired-url-structure.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
+import { createInterpolateElement, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -330,15 +330,18 @@ export function PairedUrlStructure( { focusedSection } ) {
 				</AMPNotice>
 			) }
 
-			<p dangerouslySetInnerHTML={
-				{ __html:
-					sprintf(
-						/* translators: 1: AMP Paired URL Structure documentation URL */
-						__( 'When using the Transitional or Reader template modes, your site is in a “Paired AMP” configuration. Your site\'s canonical URLs are non-AMP, and the separate AMP versions of your pages have AMP-specific URLs. The structure of a paired AMP URL is not important, whether using a query parameter or path suffix. The use of a query parameter is the most compatible across various sites and it has the benefit of not resulting in a 404 if the AMP plugin is deactivated. <em>Note: Changing the paired URL structure can cause AMP pages to temporarily disappear from search results until your site is re-indexed.</em> If you\'re migrating from another AMP plugin with a different paired URL structure, then you may want to change this setting. Otherwise we recommend leaving it as is. <a href="%1$s" target="_blank">Learn more</a>', 'amp' ),
-						__( 'https://amp-wp.org/?p=10004', 'amp' ),
-					),
-				} }
-			/>
+			<p>
+				{
+					createInterpolateElement(
+						__( 'When using the Transitional or Reader template modes, your site is in a “Paired AMP” configuration. Your site\'s canonical URLs are non-AMP, and the separate AMP versions of your pages have AMP-specific URLs. The structure of a paired AMP URL is not important, whether using a query parameter or path suffix. The use of a query parameter is the most compatible across various sites and it has the benefit of not resulting in a 404 if the AMP plugin is deactivated. <em>Note: Changing the paired URL structure can cause AMP pages to temporarily disappear from search results until your site is re-indexed.</em> If you\'re migrating from another AMP plugin with a different paired URL structure, then you may want to change this setting. Otherwise we recommend leaving it as is. <a>Learn more</a>', 'amp' ),
+						{
+							em: <em />,
+							// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+							a: <a href="https://amp-wp.org/?p=10004" target="_blank" rel="noreferrer" />,
+						},
+					)
+				}
+			</p>
 
 			{ ! endpointSuffixAvailable && (
 				<SlugConflictsNotice slug={ slug } conflicts={ editedOptions.endpoint_path_slug_conflicts } />

--- a/assets/src/settings-page/plugin-suppression.js
+++ b/assets/src/settings-page/plugin-suppression.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useContext, Fragment } from '@wordpress/element';
+import { useContext, Fragment, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { autop } from '@wordpress/autop';
 import { format, dateI18n } from '@wordpress/date';
@@ -158,7 +158,16 @@ function ValidationErrorDetails( { errors } ) {
 							) }>
 							<WrapperElement>
 								<a href={ error.edit_url } target="_blank" rel="noreferrer" title={ error.tooltip }>
-									<span dangerouslySetInnerHTML={ { __html: error.title } } />
+									<span>
+										{
+											createInterpolateElement(
+												error.title,
+												{
+													code: <code />,
+												},
+											)
+										}
+									</span>
 								</a>
 							</WrapperElement>
 						</li>

--- a/assets/src/settings-page/site-review.js
+++ b/assets/src/settings-page/site-review.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useContext } from '@wordpress/element';
+import { createInterpolateElement, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -74,30 +74,39 @@ export function SiteReview() {
 					{ __( 'Need help?', 'amp' ) }
 				</h3>
 				<ul className="settings-site-review__list">
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is a link to support forum. */
-							__( 'Reach out in the <a href="%s" target="_blank" rel="noreferrer noopener">support forums</a>', 'amp' ),
-							'https://wordpress.org/support/plugin/amp/#new-topic-0',
-						),
-					} } />
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is the template mode section anchor. */
-							__( 'Try a different <a href="%s">template mode</a>', 'amp' ),
-							'#template-modes',
-						),
-					} } />
-					{ /* dangerouslySetInnerHTML reason: Injection of a link. */ }
-					<li dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							/* translators: placeholder is a link to the plugin site. */
-							__( '<a href="%s" target="_blank" rel="noreferrer noopener">Learn more</a> how the AMP plugin works', 'amp' ),
-							'https://amp-wp.org/documentation/how-the-plugin-works/',
-						),
-					} } />
+					<li>
+						{
+							createInterpolateElement(
+								__( 'Reach out in the <a>support forums</a>', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="https://wordpress.org/support/plugin/amp/#new-topic-0" target="_blank" rel="noreferrer noopener" />,
+								},
+							)
+						}
+					</li>
+					<li>
+						{
+							createInterpolateElement(
+								__( 'Try a different <a>template mode</a>', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="#template-modes" />,
+								},
+							)
+						}
+					</li>
+					<li>
+						{
+							createInterpolateElement(
+								__( '<a>Learn more</a> how the AMP plugin works', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="https://amp-wp.org/documentation/how-the-plugin-works/" target="_blank" rel="noreferrer noopener" />,
+								},
+							)
+						}
+					</li>
 				</ul>
 				<div className="settings-site-review__actions">
 					{ previewPermalink && (

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useContext } from '@wordpress/element';
 import { CheckboxControl } from '@wordpress/components';
 
 /**

--- a/assets/src/settings-page/supported-templates.js
+++ b/assets/src/settings-page/supported-templates.js
@@ -6,8 +6,8 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useContext, createInterpolateElement } from '@wordpress/element';
 import { CheckboxControl } from '@wordpress/components';
 
 /**
@@ -246,16 +246,17 @@ export function SupportedTemplatesFieldset() {
 
 			{ ! allTemplatesSupported ? (
 				<>
-					{ /* dangerouslySetInnerHTML reason: Link embedded in translation string. */ }
-					<p
-						dangerouslySetInnerHTML={ {
-							__html: sprintf(
-								/* translators: placeholder is link to WordPress handbook page about the template hierarchy. */
-								__( 'Limit AMP on a subset of the WordPress <a href="%s" target="_blank" rel="noreferrer">Template Hierarchy</a>:', 'amp' ),
-								'https://developer.wordpress.org/themes/basics/template-hierarchy/',
-							),
-						} }
-					/>
+					<p>
+						{
+							createInterpolateElement(
+								__( 'Limit AMP on a subset of the WordPress <a>Template Hierarchy</a>:', 'amp' ),
+								{
+									// eslint-disable-next-line jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string.
+									a: <a href="https://developer.wordpress.org/themes/basics/template-hierarchy/" target="_blank" rel="noreferrer" />,
+								},
+							)
+						}
+					</p>
 
 					<SupportedTemplatesCheckboxes supportableTemplates={ supportableTemplates } />
 				</>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #6759

Replace use of `dangerouslySetInnerHTML` with `createInterpolateElement`

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
