### PR TITLE
Prevent `BlockUniqidTransformer` from running on WP>=5.9.3

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -779,7 +779,7 @@ jobs:
           path: builds/prod
 
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCS_PROJECT_ID }}
           service_account_key: ${{ secrets.GCS_APPLICATION_CREDENTIALS }}

--- a/src/BlockUniqidTransformer.php
+++ b/src/BlockUniqidTransformer.php
@@ -79,8 +79,6 @@ final class BlockUniqidTransformer implements Service, Registerable {
 	 * The affected WordPress version is 5.9. However, the duotone filter was first
 	 * introduced in WordPress 5.8 and it makes use of the `uniqid`, too.
 	 *
-	 * @todo Once the `uniqid` to `wp_unique_id` fix is backported to core, upper version boundary should be updated (it's set to 6.0 for now).
-	 *
 	 * @param string|null $version WordPress core version to check. If null, current version is used.
 	 * @return bool Whether affected WP version.
 	 */
@@ -91,7 +89,7 @@ final class BlockUniqidTransformer implements Service, Registerable {
 		return (
 			version_compare( $version, '5.8', '>=' )
 			&&
-			version_compare( $version, '6.0', '<' )
+			version_compare( $version, '5.9.3', '<' )
 		);
 	}
 

--- a/tests/php/src/BlockUniqidTransformerTest.php
+++ b/tests/php/src/BlockUniqidTransformerTest.php
@@ -106,6 +106,7 @@ final class BlockUniqidTransformerTest extends DependencyInjectedTestCase {
 			'5.9.0' => [ '5.9.0', true ],
 			'5.9.1' => [ '5.9.1', true ],
 			'5.9.2' => [ '5.9.2', true ],
+			'5.9.3' => [ '5.9.3', false ],
 			'6.0.0' => [ '6.0.0', false ],
 		];
 	}


### PR DESCRIPTION
See #6925.

The Gutenberg fix has been backported to the WordPress `5.9` branch: https://github.com/WordPress/wordpress-develop/commit/f4837d7b6297ec47dc12035de813b5801ce514fd

See Trac ticket milestoned for 5.9.3: https://core.trac.wordpress.org/ticket/55474

So it will be included in WordPRess 5.9.3.