### PR TITLE
Add margins to buttons on Settings screen

### DIFF
--- a/assets/src/settings-page/style.css
+++ b/assets/src/settings-page/style.css
@@ -580,6 +580,10 @@ li.error-kept {
 	padding-right: 2.25rem;
 }
 
+.amp .settings-site-scan__footer .components-button + .components-button {
+	margin-left: 1rem;
+}
+
 /* Review. */
 #site-review {
 	margin-bottom: 2.5rem;
@@ -637,6 +641,10 @@ li.error-kept {
 	height: 40px;
 	padding-left: 2.25rem;
 	padding-right: 2.25rem;
+}
+
+.amp .settings-site-review__actions .components-button + .components-button {
+	margin-left: 1rem;
 }
 
 /* Other Settings */


### PR DESCRIPTION
Fixes #7001.

With keyboard focus on the "Browse Site" button:

Before | After
-------|------
<img width="497" alt="image" src="https://user-images.githubusercontent.com/134745/160721757-525172f3-d81d-4aec-9aac-9b45a81ed909.png"> | <img width="500" alt="image" src="https://user-images.githubusercontent.com/134745/160721723-ff3b21b9-4343-4e6a-a019-e11ca03686d3.png">