### PR TITLE
It's always showing posted 1 seconds ago when post_date_gmt is '0000-00-00 00:00:00'

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -305,7 +305,7 @@ class AMP_Post_Template {
 		$format = 'U';
 
 		if ( empty( $this->post->post_date_gmt ) || '0000-00-00 00:00:00' === $this->post->post_date_gmt ) {
-			$timestamp = time();
+			$timestamp =  (int) get_the_time('U');
 		} else {
 			$timestamp = (int) get_post_time( $format, true, $this->post, true );
 		}

--- a/templates/meta-time.php
+++ b/templates/meta-time.php
@@ -26,7 +26,7 @@
 			sprintf(
 				/* translators: %s: the human-readable time difference. */
 				__( '%s ago', 'amp' ),
-				human_time_diff( $this->get( 'post_publish_timestamp' ), time() )
+				human_time_diff( $this->get( 'post_publish_timestamp' ), current_time('timestamp') )
 			)
 		);
 		?>


### PR DESCRIPTION
## Summary

When the post_date_gmt value is '0000-00-00 00:00:00'  it's always showing posted `1 seconds ago`.  This fix shows the actual time for the post.

Fixes #

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
