### PR TITLE
Add type checks to fix PHPStan 1.5.4 analysis

### DIFF
--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -114,8 +114,11 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	protected function get_caption_element( DOMElement $img_element ) {
 		$figcaption_element = null;
-
-		if ( isset( $img_element->nextSibling->nodeName ) && Tag::FIGCAPTION === $img_element->nextSibling->nodeName ) {
+		if (
+			isset( $img_element->nextSibling->nodeName )
+			&& $img_element->nextSibling instanceof DOMElement
+			&& Tag::FIGCAPTION === $img_element->nextSibling->nodeName
+		) {
 			$figcaption_element = $img_element->nextSibling;
 		}
 
@@ -123,6 +126,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 		if (
 			! $figcaption_element
 			&& isset( $img_element->parentNode->nextSibling->nodeName )
+			&& $img_element->parentNode->nextSibling instanceof DOMElement
 			&& Tag::FIGCAPTION === $img_element->parentNode->nextSibling->nodeName
 		) {
 			$figcaption_element = $img_element->parentNode->nextSibling;

--- a/includes/sanitizers/class-amp-o2-player-sanitizer.php
+++ b/includes/sanitizers/class-amp-o2-player-sanitizer.php
@@ -108,7 +108,7 @@ class AMP_O2_Player_Sanitizer extends AMP_Base_Sanitizer {
 			$parent_node = $node->parentNode;
 
 			// Remove the ID from the original node so that PHP DOM doesn't fail to set it on the replacement element.
-			if ( $parent_node->hasAttribute( Attribute::ID ) ) {
+			if ( $parent_node instanceof DOMElement && $parent_node->hasAttribute( Attribute::ID ) ) {
 				$component_attributes['id'] = $parent_node->getAttribute( Attribute::ID );
 				$parent_node->removeAttribute( Attribute::ID );
 			}


### PR DESCRIPTION
This fixes static analysis issues that were newly detected with the PHPStan [1.5.4](https://github.com/phpstan/phpstan/releases/tag/1.5.4) release.

This merely adds new `instanceof` checks to ensure variables are `DOMElement` instances which were previously implied.