### PR TITLE
Downgrade PHP version from 8.0 to 5.6 for development builds

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -703,7 +703,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '5.6'
 
       - name: Setup Node
         uses: actions/setup-node@v3.1.0


### PR DESCRIPTION
See https://wordpress.org/support/topic/version-2-2-2-parse-error-syntax-error-unexpected/