### PR TITLE
Add default configuration for analytic vendors.

### DIFF
--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -10,7 +10,7 @@ import { ANALYTICS_VENDORS_LIST } from 'amp-settings';
  */
 import { Icon, plus, trash } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { createInterpolateElement, useContext, useEffect, useRef } from '@wordpress/element';
 import { Button, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
 
 /**

--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -10,7 +10,7 @@ import { ANALYTICS_VENDORS_LIST } from 'amp-settings';
  */
 import { Icon, plus, trash } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { createInterpolateElement, useContext, useEffect, useRef } from '@wordpress/element';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 import { Button, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/components';
 
 /**
@@ -18,61 +18,9 @@ import { Button, PanelRow, BaseControl, VisuallyHidden } from '@wordpress/compon
  */
 import { Options } from '../components/options-context-provider';
 import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
+import vendorConfigs from './vendor-configs';
 
 const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
-
-const GOOGLE_ANALYTICS_NOTICE = createInterpolateElement(
-	__( 'For Google Analytics or Google Tag Manager please consider using <GoogleSiteKitLink>Site Kit by Google</GoogleSiteKitLink>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <GoogleAnalyticsDevGuideLink>Adding Analytics to your AMP pages</GoogleAnalyticsDevGuideLink>.', 'amp' ),
-	{
-		/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
-		GoogleSiteKitLink: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
-		GoogleAnalyticsDevGuideLink: <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank" rel="noreferrer" />,
-		/* eslint-enable jsx-a11y/anchor-has-content */
-	},
-);
-
-const vendorConfigs = {
-	'': {
-		sample: '{}',
-	},
-	[ GOOGLE_ANALYTICS_VENDOR ]: {
-		notice: GOOGLE_ANALYTICS_NOTICE,
-		sample: JSON.stringify(
-			{
-				vars: {
-					account: '👉 ' + __( 'Provide site tracking ID here (e.g. UA-XXXXX-Y)', 'amp' ) + ' 👈',
-				},
-				triggers: {
-					trackPageview: {
-						on: 'visible',
-						request: 'pageview',
-					},
-				},
-			},
-			null,
-			'\t',
-		),
-	},
-	gtag: {
-		notice: GOOGLE_ANALYTICS_NOTICE,
-		sample: JSON.stringify(
-			{
-				vars: {
-					gtag_id: '<GA_MEASUREMENT_ID>',
-					config: {
-						'<GA_MEASUREMENT_ID>': { groups: 'default' },
-					},
-				},
-			},
-			null,
-			'\t',
-		),
-	},
-	googletagmanager: { // Throw notice to if user enters googletagmanager as vendor.
-		notice: GOOGLE_ANALYTICS_NOTICE,
-		sample: '{}',
-	},
-};
 
 // Array of analytics vendors that AMP supports.
 const vendorsDatalistOptions = [];

--- a/assets/src/settings-page/vendor-configs.js
+++ b/assets/src/settings-page/vendor-configs.js
@@ -59,8 +59,8 @@ export default {
 		sample: JSON.stringify(
 			{
 				vars: {
-					atrk_acct: 'YOURACCOUNT',
-					domain: 'YOURDOMAIN',
+					atrk_acct: '<YOURACCOUNT>',
+					domain: '<YOURDOMAIN>',
 				},
 			},
 			null,
@@ -72,7 +72,7 @@ export default {
 		sample: JSON.stringify(
 			{
 				vars: {
-					token: 'your-token',
+					token: '👉 ' + __( 'Provide Token.', 'amp' ) + ' 👈',
 				},
 				triggers: {
 					pageview: {
@@ -90,39 +90,12 @@ export default {
 		sample: JSON.stringify(
 			{
 				vars: {
-					pixelId: '1760516960931795',
+					pixelId: '👉 ' + __( 'Provide Facebook Pixel ID here.', 'amp' ) + ' 👈',
 				},
 				triggers: {
 					trackPageview: {
 						on: 'visible',
 						request: 'pageview',
-					},
-					trackEvent: {
-						on: 'click',
-						selector: '#test1',
-						request: 'event',
-						vars: {
-							eventName: 'ClickedBtn-x',
-						},
-					},
-					trackSearch: {
-						on: 'visible',
-						request: 'eventSearch',
-						vars: {
-							search_string: 'How to use Facebook Pixel in AMP Pages',
-						},
-					},
-					trackAddToWishlist: {
-						on: 'click',
-						selector: '#test1',
-						request: 'eventAddToWishlist',
-						vars: {
-							content_ids: [ '1234' ],
-							content_name: 'The Avengers',
-							content_category: 'Entertainment',
-							value: 1.50,
-							currency: 'USD',
-						},
 					},
 				},
 			},
@@ -130,7 +103,6 @@ export default {
 			'\t',
 		),
 	},
-
 	[ GOOGLE_ANALYTICS_VENDOR ]: {
 		notice: GOOGLE_ANALYTICS_NOTICE,
 		sample: JSON.stringify(
@@ -173,8 +145,8 @@ export default {
 		sample: JSON.stringify(
 			{
 				vars: {
-					appId: '555555',
-					licenseKey: '2fffffffff',
+					appId: '👉 ' + __( 'Provide App ID here.', 'amp' ) + ' 👈',
+					licenseKey: '<LICENSE_KEY>',
 				},
 			},
 			null,
@@ -186,24 +158,23 @@ export default {
 		sample: JSON.stringify(
 			{
 				vars: {
-					apid: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+					apid: '👉 ' + __( 'Provide App ID here.', 'amp' ) + ' 👈',
 					apv: '1.0',
 					section: 'Entertainment',
 					segA: 'Music',
-					segB: 'News',
-					segC: 'Branded_Content',
 				},
 			},
 			null,
 			'\t',
 		),
 	},
+	// Yandex Metrika
 	metrika: {
 		notice: '',
 		sample: JSON.stringify(
 			{
 				vars: {
-					counterId: '71129776',
+					counterId: '<COUNTER_ID>',
 					yaParams: '{\'key\': \'value\'}',
 				},
 				requests: {},

--- a/assets/src/settings-page/vendor-configs.js
+++ b/assets/src/settings-page/vendor-configs.js
@@ -21,7 +21,14 @@ export default {
 		sample: '{}',
 	},
 	adobeanalytics: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Adobe Analytics in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://experienceleague.adobe.com/docs/analytics/implementation/other/amp.html" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				requests: {
@@ -55,7 +62,14 @@ export default {
 		),
 	},
 	alexametrics: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Alexa metrics in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://support.alexa.com/hc/en-us/articles/115004090654-Does-Alexa-have-a-Certify-Code-for-AMP" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -68,7 +82,14 @@ export default {
 		),
 	},
 	baiduanalytics: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Baidu Analytics in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://tongji.baidu.com/web/help/article?id=268&castk=LTE%3D" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -86,7 +107,14 @@ export default {
 		),
 	},
 	facebookpixel: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Facebook Pixel in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://developers.facebook.com/docs/meta-pixel" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -141,7 +169,14 @@ export default {
 		sample: '{}',
 	},
 	newrelic: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about New Relic in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -154,7 +189,14 @@ export default {
 		),
 	},
 	nielsen: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Nielsen in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://engineeringportal.nielsen.com/docs/DCR_Static_Google_AMP_Cloud_API" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {
@@ -170,7 +212,14 @@ export default {
 	},
 	// Yandex Metrika
 	metrika: {
-		notice: '',
+		notice: createInterpolateElement(
+			__( '<a>Learn more</a> about Yandex Metrika in AMP.' ),
+			{
+				/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+				a: <a href="https://yandex.com/support/metrica/code/install-counter-amp.html" target="_blank" rel="noreferrer" />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+			},
+		),
 		sample: JSON.stringify(
 			{
 				vars: {

--- a/assets/src/settings-page/vendor-configs.js
+++ b/assets/src/settings-page/vendor-configs.js
@@ -1,0 +1,247 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
+
+const GOOGLE_ANALYTICS_NOTICE = createInterpolateElement(
+	__( 'For Google Analytics please consider using <GoogleSiteKitLink>Site Kit by Google</GoogleSiteKitLink>. This plugin configures analytics for both non-AMP and AMP pages alike, avoiding the need to manually provide a separate AMP configuration here. Nevertheless, for documentation on manual configuration see <GoogleAnalyticsDevGuideLink>Adding Analytics to your AMP pages</GoogleAnalyticsDevGuideLink>.', 'amp' ),
+	{
+		/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+		GoogleSiteKitLink: <a href="https://wordpress.org/plugins/google-site-kit/" target="_blank" rel="noreferrer" />,
+		GoogleAnalyticsDevGuideLink: <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank" rel="noreferrer" />,
+		/* eslint-enable jsx-a11y/anchor-has-content */
+	},
+);
+
+export default {
+	'': {
+		sample: '{}',
+	},
+	adobeanalytics: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				requests: {
+					myClick: '{click}&v1={eVar1}',
+				},
+				vars: {
+					host: 'metrics.example.com',
+					reportSuites: 'reportSuiteID',
+				},
+				triggers: {
+					pageLoad: {
+						on: 'visible',
+						request: 'pageview',
+					},
+					click: {
+						on: 'click',
+						selector: '#test1',
+						request: 'myClick',
+						vars: {
+							eVar1: 'button clicked',
+						},
+					},
+					linkers: {
+						enabled: true,
+						destinationDomains: [ 'localhost' ],
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	alexametrics: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					atrk_acct: 'YOURACCOUNT',
+					domain: 'YOURDOMAIN',
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	baiduanalytics: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					token: 'your-token',
+				},
+				triggers: {
+					pageview: {
+						on: 'visible',
+						request: 'pageview',
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	facebookpixel: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					pixelId: '1760516960931795',
+				},
+				triggers: {
+					trackPageview: {
+						on: 'visible',
+						request: 'pageview',
+					},
+					trackEvent: {
+						on: 'click',
+						selector: '#test1',
+						request: 'event',
+						vars: {
+							eventName: 'ClickedBtn-x',
+						},
+					},
+					trackSearch: {
+						on: 'visible',
+						request: 'eventSearch',
+						vars: {
+							search_string: 'How to use Facebook Pixel in AMP Pages',
+						},
+					},
+					trackAddToWishlist: {
+						on: 'click',
+						selector: '#test1',
+						request: 'eventAddToWishlist',
+						vars: {
+							content_ids: [ '1234' ],
+							content_name: 'The Avengers',
+							content_category: 'Entertainment',
+							value: 1.50,
+							currency: 'USD',
+						},
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+
+	[ GOOGLE_ANALYTICS_VENDOR ]: {
+		notice: GOOGLE_ANALYTICS_NOTICE,
+		sample: JSON.stringify(
+			{
+				vars: {
+					account: '👉 ' + __( 'Provide site tracking ID here (e.g. UA-XXXXX-Y)', 'amp' ) + ' 👈',
+				},
+				triggers: {
+					trackPageview: {
+						on: 'visible',
+						request: 'pageview',
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	gtag: {
+		notice: GOOGLE_ANALYTICS_NOTICE,
+		sample: JSON.stringify(
+			{
+				vars: {
+					gtag_id: '<GA_MEASUREMENT_ID>',
+					config: {
+						'<GA_MEASUREMENT_ID>': { groups: 'default' },
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	googletagmanager: { // Throw notice to if user enters googletagmanager as vendor.
+		notice: GOOGLE_ANALYTICS_NOTICE,
+		sample: '{}',
+	},
+	newrelic: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					appId: '555555',
+					licenseKey: '2fffffffff',
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	nielsen: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					apid: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+					apv: '1.0',
+					section: 'Entertainment',
+					segA: 'Music',
+					segB: 'News',
+					segC: 'Branded_Content',
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+	metrika: {
+		notice: '',
+		sample: JSON.stringify(
+			{
+				vars: {
+					counterId: '71129776',
+					yaParams: '{\'key\': \'value\'}',
+				},
+				requests: {},
+				triggers: {
+					notBounce: {
+						on: 'timer',
+						timerSpec: {
+							immediate: false,
+							interval: 15,
+							maxTimerLength: 14,
+						},
+						request: 'notBounce',
+					},
+					someGoalReach: {
+						on: 'click',
+						selector: '#test1',
+						request: 'reachGoal',
+						vars: {
+							goalId: 'superGoalId',
+							yaParams: '{\'inner-key\': \'inner-value\'}',
+						},
+					},
+					halfScroll: {
+						on: 'scroll',
+						scrollSpec: {
+							verticalBoundaries: [
+								50,
+							],
+						},
+						request: 'reachGoal',
+						vars: {
+							goalId: 'halfScrollGoal',
+						},
+					},
+				},
+			},
+			null,
+			'\t',
+		),
+	},
+};

--- a/tests/e2e/specs/admin/analytics-options.js
+++ b/tests/e2e/specs/admin/analytics-options.js
@@ -56,6 +56,7 @@ describe( 'AMP analytics options', () => {
 		// Delete entries.
 		await expect( page ).toClick( '.amp-analytics__delete-button' );
 		await expect( page ).toClick( '.amp-analytics__delete-button' );
+		await expect( page ).toClick( '.amp-analytics__delete-button' );
 
 		await expect( page ).not.toMatchElement( '.amp-analytics-entry' );
 

--- a/tests/e2e/specs/admin/analytics-options.js
+++ b/tests/e2e/specs/admin/analytics-options.js
@@ -30,6 +30,24 @@ describe( 'AMP analytics options', () => {
 		await expect( '.amp-analytics-entry' ).countToBe( 2 );
 		await expect( page ).toFill( '#amp-analytics-entry-2 input', 'googleanalytics-2' );
 
+		// Add third entry.
+		await expect( page ).toClick( '#amp-analytics-add-entry' );
+		await expect( '.amp-analytics-entry' ).countToBe( 3 );
+		await expect( page ).toFill( '#amp-analytics-entry-3 input', 'alexametrics' );
+
+		await expect( page ).toMatchElement( '#analytics-textarea-control-3', {
+			value: JSON.stringify(
+				{
+					vars: {
+						atrk_acct: '<YOURACCOUNT>',
+						domain: '<YOURDOMAIN>',
+					},
+				},
+				null,
+				'\t',
+			),
+		} );
+
 		// Save.
 		await expect( page ).toClick( '.amp-settings-nav button[type="submit"]' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7019 

Pre-fill default config when the user selects analytic vendor on the AMP setting page.

https://user-images.githubusercontent.com/8168027/162701033-ac8aa66a-8cb1-4f26-aca4-4cb016c21b73.mov

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
