### PR TITLE
Fix collection of `noscript`-allowed attributes

### DIFF
--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -7,6 +7,7 @@
 
 use AmpProject\Dom\Document;
 use AmpProject\Html\Attribute;
+use AmpProject\Html\Tag;
 
 /**
  * Trait AMP_Noscript_Fallback
@@ -43,6 +44,15 @@ trait AMP_Noscript_Fallback {
 		);
 
 		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( $tag ) as $tag_spec ) { // Normally 1 iteration.
+			if (
+				! (
+					( isset( $tag_spec['tag_spec']['mandatory_ancestor'] ) && Tag::NOSCRIPT === $tag_spec['tag_spec']['mandatory_ancestor'] )
+					||
+					( isset( $tag_spec['tag_spec']['mandatory_parent'] ) && Tag::NOSCRIPT === $tag_spec['tag_spec']['mandatory_parent'] )
+				)
+			) {
+				continue;
+			}
 			foreach ( $tag_spec['attr_spec_list'] as $attr_name => $attr_spec ) {
 				$this->noscript_fallback_allowed_attributes[ $attr_name ] = true;
 				if ( isset( $attr_spec['alternative_names'] ) ) {

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -585,6 +585,15 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 				'<img height="1" width="1" style="display:none" alt="fbpx" src="https://facebook.com/tr?id=123456789012345&ev=PageView&noscript=1" referrerpolicy="no-referrer">',
 				'<amp-pixel src="https://facebook.com/tr?id=123456789012345&amp;ev=PageView&amp;noscript=1" layout="nodisplay" referrerpolicy="no-referrer"></amp-pixel>',
 			],
+
+
+			'hero_img_with_noscript_fallback'          => [
+				'<img data-hero width="825" height="510" src="https://placehold.it/825x510" srcset="http://placehold.it/1024x768 1024w" sizes="(max-width: 600px) 825px, 1024px" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="">',
+				'<amp-img data-hero width="825" height="510" src="https://placehold.it/825x510" srcset="http://placehold.it/1024x768 1024w" sizes="(max-width: 600px) 825px, 1024px" class="attachment-post-thumbnail size-post-thumbnail wp-post-image amp-wp-enforced-sizes" alt layout="intrinsic" disable-inline-width><noscript><img width="825" height="510" src="https://placehold.it/825x510" srcset="http://placehold.it/1024x768 1024w" sizes="(max-width: 600px) 825px, 1024px" alt></noscript></amp-img>',
+				[
+					'native_img_used' => false,
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
As discovered in a [support topic](https://wordpress.org/support/topic/couldnt-fetch-ampprojectdomelement-0-error/#post-15537945), v2.2.2 caused issues with images that have the `data-hero` attribute present. With the spec update in #6803, the `data-hero` is now among the attributes that are recognized on `img`. Because of this, this attribute was being copied onto the `amp-img > noscript > img` fallback. This then caused a fatal error in the AMP Optimizer (to be fixed by https://github.com/ampproject/amp-toolbox-php/pull/516), but even if SSR were disabled (and native images disabled too) via:

```php
add_filter('amp_enable_ssr', '__return_false');
add_filter('amp_native_img_used', '__return_false');
```

The result was still as follows where a Custom HTML block that looks as follows:

```html
<img src="https://amp-support.rt.gw/wp-content/uploads/2012/12/cropped-unicorn-wallpaper-1.jpg" width="300" height="200" data-hero="" alt="1">
```

Would be sanitized as following with the `data-hero` on the `noscript` fallback:

```html
<amp-img src="https://amp-support.rt.gw/wp-content/uploads/2012/12/cropped-unicorn-wallpaper-1.jpg" width="300" height="200" data-hero="" alt="1" class="amp-wp-enforced-sizes" layout="intrinsic">
  <noscript>
    <img src="https://amp-support.rt.gw/wp-content/uploads/2012/12/cropped-unicorn-wallpaper-1.jpg" width="300" height="200" data-hero="" alt="1">
  </noscript>
</amp-img>
```

This resulted in an AMP validation error:

> The tag 'img' may not appear as a descendant of tag 'amp-img'.

The problem is that `data-hero` is not allowed on _all_ `img` tags. Namely, it is not present in the validator spec for the [`noscript > img` spec](https://github.com/ampproject/amphtml/blob/5aa00867e7e8ec421b94b468378dbb32764045b3/validator/validator-main.protoascii#L1931-L1950), and the general [`img` tag spec](https://github.com/ampproject/amphtml/blob/5aa00867e7e8ec421b94b468378dbb32764045b3/validator/validator-main.protoascii#L1839-L1860) which does have `data-hero`, also disallows `amp-img` as its ancestor. So a validation error results.

The fix is to update `\AMP_Noscript_Fallback::initialize_noscript_allowed_attributes()` so that it only considers tag specs which specifically have `noscript` as the `mandatory_ancestor` oe `mandatory_parent`. This should have been in place from the beginning, but it only has become a problem now that native HTML elements are allowed.