### PR TITLE
Scroll to selected section in AMP setting page after fetching site scan urls

### DIFF
--- a/assets/src/components/amp-setting-toggle/test/__snapshots__/index.js.snap
+++ b/assets/src/components/amp-setting-toggle/test/__snapshots__/index.js.snap
@@ -5,10 +5,10 @@ exports[`AMPSettingToggle matches snapshots 1`] = `
   className="amp-setting-toggle"
 >
   <div
-    className="components-base-control components-toggle-control css-wdf2ti-Wrapper e1puf3u4"
+    className="components-base-control components-toggle-control css-wdf2ti-Wrapper ej5x27r4"
   >
     <div
-      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField e1puf3u3"
+      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
     >
       <span
         className="components-form-toggle is-checked"
@@ -52,10 +52,10 @@ exports[`AMPSettingToggle matches snapshots 2`] = `
   className="amp-setting-toggle"
 >
   <div
-    className="components-base-control components-toggle-control css-wdf2ti-Wrapper e1puf3u4"
+    className="components-base-control components-toggle-control css-wdf2ti-Wrapper ej5x27r4"
   >
     <div
-      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField e1puf3u3"
+      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
     >
       <span
         className="components-form-toggle"

--- a/assets/src/components/dev-tools-toggle/test/__snapshots__/index.js.snap
+++ b/assets/src/components/dev-tools-toggle/test/__snapshots__/index.js.snap
@@ -5,10 +5,10 @@ exports[`DevToolsToggle matches snapshot 1`] = `
   className="amp-setting-toggle"
 >
   <div
-    className="components-base-control components-toggle-control css-wdf2ti-Wrapper e1puf3u4"
+    className="components-base-control components-toggle-control css-wdf2ti-Wrapper ej5x27r4"
   >
     <div
-      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField e1puf3u3"
+      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
     >
       <span
         className="components-form-toggle"

--- a/assets/src/components/redirect-toggle/test/__snapshots__/redirect-toggle.js.snap
+++ b/assets/src/components/redirect-toggle/test/__snapshots__/redirect-toggle.js.snap
@@ -5,10 +5,10 @@ exports[`RedirectToggle matches snapshot 1`] = `
   className="amp-setting-toggle"
 >
   <div
-    className="components-base-control components-toggle-control css-wdf2ti-Wrapper e1puf3u4"
+    className="components-base-control components-toggle-control css-wdf2ti-Wrapper ej5x27r4"
   >
     <div
-      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField e1puf3u3"
+      className="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
     >
       <span
         className="components-form-toggle is-checked"

--- a/assets/src/settings-page/index.js
+++ b/assets/src/settings-page/index.js
@@ -215,7 +215,7 @@ function Root( { appRoot } ) {
 	const { hasOptionsChanges, fetchingOptions, saveOptions } = useContext( Options );
 	const { hasDeveloperToolsOptionChange, saveDeveloperToolsOption, developerToolsOption } = useContext( User );
 	const { templateModeWasOverridden } = useContext( ReaderThemes );
-	const { isSkipped } = useContext( SiteScanContext );
+	const { isSkipped, isFetchingScannableUrls } = useContext( SiteScanContext );
 
 	/**
 	 * Handle the form submit event.
@@ -248,7 +248,7 @@ function Root( { appRoot } ) {
 		}
 
 		scrollFocusedSectionIntoView( focusedSection );
-	}, [ fetchingOptions, focusedSection, templateModeWasOverridden ] );
+	}, [ fetchingOptions, isFetchingScannableUrls, focusedSection, templateModeWasOverridden ] );
 
 	/**
 	 * Resets the focused element state when the hash changes on the page.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7005 

The changes in PR fix scrolling to the selected section on the "AMP setting" page on Chrome ( 100.0.4896.60 ) with a screen resolutions of 1440x900 and 1280×640.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
