### PR TITLE
Add 'data-amp-auto-lightbox-disable' attribute to HTML tag instead of body tag to disable auto-lightbox

### DIFF
--- a/includes/sanitizers/class-amp-auto-lightbox-disable-sanitizer.php
+++ b/includes/sanitizers/class-amp-auto-lightbox-disable-sanitizer.php
@@ -19,6 +19,6 @@ class AMP_Auto_Lightbox_Disable_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return void
 	 */
 	public function sanitize() {
-		$this->dom->body->setAttributeNode( $this->dom->createAttribute( 'data-amp-auto-lightbox-disable' ) );
+		$this->dom->html->setAttributeNode( $this->dom->createAttribute( 'data-amp-auto-lightbox-disable' ) );
 	}
 }

--- a/tests/e2e/specs/block-editor/featured-image-notice.js
+++ b/tests/e2e/specs/block-editor/featured-image-notice.js
@@ -35,6 +35,8 @@ describe( 'Featured Image Notice', () => {
 
 		// This should not suggest cropping.
 		await expect( page ).not.toMatch( cropImageText );
+
+		await clickButton( 'Featured image' );
 	} );
 
 	it( 'should display a notice when the image is too small, but not suggest cropping', async () => {

--- a/tests/php/test-class-amp-auto-lightbox-disable-sanitizer.php
+++ b/tests/php/test-class-amp-auto-lightbox-disable-sanitizer.php
@@ -25,6 +25,6 @@ class AMP_Auto_Lightbox_Disable_Sanitizer_Test extends TestCase {
 		$sanitizer = new AMP_Auto_Lightbox_Disable_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
-		$this->assertTrue( $dom->body->hasAttribute( 'data-amp-auto-lightbox-disable' ) );
+		$this->assertTrue( $dom->html->hasAttribute( 'data-amp-auto-lightbox-disable' ) );
 	}
 }

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1906,7 +1906,7 @@ class Test_AMP_Theme_Support extends TestCase {
 
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ ConfigurationArgument::ENABLE_OPTIMIZER => false ] );
 
-		$this->assertStringContainsString( '<html>', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
+		$this->assertStringContainsString( '<html ', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
 		$this->assertStringContainsString( '<button onclick="alert', $sanitized_html, 'Invalid AMP is present in the response.' );
 		if ( $with_amp_live_list ) {
 			$this->assertStringContainsString( 'document.write = function', $sanitized_html, 'Override of document.write() is present.' );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1906,7 +1906,7 @@ class Test_AMP_Theme_Support extends TestCase {
 
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ ConfigurationArgument::ENABLE_OPTIMIZER => false ] );
 
-		$this->assertStringContainsString( '<html ', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
+		$this->assertDoesNotMatchRegularExpression( '/<html[^>]*[\s]amp[^>]*>/', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
 		$this->assertStringContainsString( '<button onclick="alert', $sanitized_html, 'Invalid AMP is present in the response.' );
 		if ( $with_amp_live_list ) {
 			$this->assertStringContainsString( 'document.write = function', $sanitized_html, 'Override of document.write() is present.' );


### PR DESCRIPTION

## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7057 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
