### PR TITLE
Update amp-toolbox-php to dev-main (0.11.2-alpha)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.11.1",
+    "ampproject/amp-toolbox": "dev-main",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "8.4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fd6292577e257a09b6b3155ad9f771b",
+    "content-hash": "b2ccbd1eb8a9afd970b04d04cbe7acd5",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.11.1",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "8392ee46e9e241081b8e9fb1f67c16124d2fcf99"
+                "reference": "8fa158845c980437831397100ca7133eee76c61d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/8392ee46e9e241081b8e9fb1f67c16124d2fcf99",
-                "reference": "8392ee46e9e241081b8e9fb1f67c16124d2fcf99",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/8fa158845c980437831397100ca7133eee76c61d",
+                "reference": "8fa158845c980437831397100ca7133eee76c61d",
                 "shasum": ""
             },
             "require": {
@@ -48,6 +48,7 @@
                 "mck89/peast": "Needed to minify the AMP script.",
                 "nette/php-generator": "Needed to generate the validator spec PHP classes and interfaces."
             },
+            "default-branch": true,
             "bin": [
                 "bin/amp"
             ],
@@ -76,9 +77,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.11.1"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/main"
             },
-            "time": "2022-04-08T05:35:07+00:00"
+            "time": "2022-05-19T09:49:09+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -6779,6 +6780,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "ampproject/amp-toolbox": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
Ran:

```bash
composer require ampproject/amp-toolbox:dev-main
```

This is for the sake of QA while waiting for the [0.11.2 release](https://github.com/ampproject/amp-toolbox-php/milestone/22?closed=1) to be made.

Fixes #7130.