### PR TITLE
Add PWA scripts sanitizer

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1527,7 +1527,6 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		AMP_O2_Player_Sanitizer::class         => [],
 		AMP_Playbuzz_Sanitizer::class          => [],
-		AMP_PWA_Script_Sanitizer::class        => [], // Add PWA plugin sanitizer before Core theme sanitizers as it can contain offline/500 templates.
 		AMP_Core_Theme_Sanitizer::class        => [
 			'template'        => get_template(),
 			'stylesheet'      => get_stylesheet(),
@@ -1542,6 +1541,10 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 
 		AMP_Bento_Sanitizer::class             => [],
+
+		// The AMP_PWA_Script_Sanitizer run before AMP_Script_Sanitizer, to prevent the script tags
+		// from getting removed in PWA plugin offline/500 templates.
+		AMP_PWA_Script_Sanitizer::class        => [],
 
 		// The AMP_Script_Sanitizer runs here because based on whether it allows custom scripts
 		// to be kept, it may impact the behavior of other sanitizers. For example, if custom
@@ -1707,9 +1710,9 @@ function amp_get_content_sanitizers( $post = null ) {
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
 		AMP_Auto_Lightbox_Disable_Sanitizer::class,
-		AMP_PWA_Script_Sanitizer::class, // Must come before core theme sanitizer as it can contains offline/500 templates.
 		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
 		AMP_Bento_Sanitizer::class, // Bento scripts may be preserved here.
+		AMP_PWA_Script_Sanitizer::class, // Must come before script sanitizer since PWA offline page scripts are removed.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for images, videos, audios, comments, forms, and styles.
 		AMP_Form_Sanitizer::class, // Must come before comments sanitizer.
 		AMP_Comments_Sanitizer::class, // Also must come after the form sanitizer.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1527,7 +1527,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		],
 		AMP_O2_Player_Sanitizer::class         => [],
 		AMP_Playbuzz_Sanitizer::class          => [],
-
+		AMP_PWA_Script_Sanitizer::class        => [], // Add PWA plugin sanitizer before Core theme sanitizers as it can contain offline/500 templates.
 		AMP_Core_Theme_Sanitizer::class        => [
 			'template'        => get_template(),
 			'stylesheet'      => get_stylesheet(),
@@ -1707,6 +1707,7 @@ function amp_get_content_sanitizers( $post = null ) {
 	// Force core essential sanitizers to appear at the end at the end, with non-essential and third-party sanitizers appearing before.
 	$expected_final_sanitizer_order = [
 		AMP_Auto_Lightbox_Disable_Sanitizer::class,
+		AMP_PWA_Script_Sanitizer::class, // Must come before core theme sanitizer as it can contains offline/500 templates.
 		AMP_Core_Theme_Sanitizer::class, // Must come before script sanitizer since onclick attributes are removed.
 		AMP_Bento_Sanitizer::class, // Bento scripts may be preserved here.
 		AMP_Script_Sanitizer::class, // Must come before sanitizers for images, videos, audios, comments, forms, and styles.

--- a/includes/sanitizers/class-amp-pwa-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-pwa-script-sanitizer.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PWA Plugin Sanitizer
+ *
+ * @since 2.3
+ * @package AMP
+ */
+
+use AmpProject\AmpWP\ValidationExemption;
+
+/**
+ * Class AMP_PWA_Script_Sanitizer
+ *
+ * @since 2.3
+ * @internal
+ */
+class AMP_PWA_Script_Sanitizer extends AMP_Base_Sanitizer {
+
+	/**
+	 * Sanitize the AMP response for offline/500 error pages.
+	 *
+	 * @since 2.3
+	 */
+	public function sanitize() {
+		if (
+			! ( function_exists( 'is_offline' ) && is_offline() ) &&
+			! ( function_exists( 'is_500' ) && is_500() )
+		) {
+			return;
+		}
+
+		$scripts = $this->dom->xpath->query( '//script[@id="wp-navigation-request-properties" or @id="wp-offline-page-reload"]' );
+
+		foreach ( $scripts as $script ) {
+			ValidationExemption::mark_node_as_px_verified( $script );
+		}
+	}
+}

--- a/includes/sanitizers/class-amp-pwa-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-pwa-script-sanitizer.php
@@ -7,6 +7,8 @@
  */
 
 use AmpProject\AmpWP\ValidationExemption;
+use AmpProject\Dom\Element;
+use AmpProject\Html\Attribute;
 
 /**
  * Class AMP_PWA_Script_Sanitizer
@@ -29,7 +31,11 @@ class AMP_PWA_Script_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$scripts = $this->dom->xpath->query( '//script[@id="wp-navigation-request-properties" or @id="wp-offline-page-reload"]' );
+		$scripts = $this->dom->xpath->query( '//script[ @id = "wp-navigation-request-properties" or ( @type = "module" and contains( text(), "checkNetworkAndReload()" ) ) ]' );
+
+		if ( ! $scripts->length ) {
+			return;
+		}
 
 		foreach ( $scripts as $script ) {
 			ValidationExemption::mark_node_as_px_verified( $script );

--- a/includes/sanitizers/class-amp-pwa-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-pwa-script-sanitizer.php
@@ -33,12 +33,10 @@ class AMP_PWA_Script_Sanitizer extends AMP_Base_Sanitizer {
 
 		$scripts = $this->dom->xpath->query( '//script[ @id = "wp-navigation-request-properties" or ( @type = "module" and contains( text(), "checkNetworkAndReload()" ) ) ]' );
 
-		if ( ! $scripts->length ) {
-			return;
-		}
-
-		foreach ( $scripts as $script ) {
-			ValidationExemption::mark_node_as_px_verified( $script );
+		if ( $scripts instanceof DOMNodeList ) {
+			foreach ( $scripts as $script ) {
+				ValidationExemption::mark_node_as_px_verified( $script );
+			}
 		}
 	}
 }

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -228,10 +228,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.7
 	 * @see amp_register_default_scripts()
 	 *
-	 * @return array() Returns component name as array key and true as value (or JavaScript URL string),
-	 *                  respectively. When true then the default component script URL will be used.
-	 *                  Will return an empty array if sanitization has yet to be run
-	 *                  or if it did not find any HTML elements to convert to AMP equivalents.
+	 * @return array Returns component name as array key and true as value (or JavaScript URL string),
+	 *               respectively. When true then the default component script URL will be used.
+	 *               Will return an empty array if sanitization has yet to be run
+	 *               or if it did not find any HTML elements to convert to AMP equivalents.
 	 */
 	public function get_scripts() {
 		return array_fill_keys( array_unique( $this->script_components ), true );
@@ -1623,7 +1623,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string     $attr_name      Attribute name.
 	 * @param array[]    $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name is mandatory and it exists
 	 *      - AMP_Rule_Spec::FAIL - $attr_name is mandatory, but doesn't exist
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name is not mandatory
@@ -1673,7 +1673,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string     $attr_name      Attribute name.
 	 * @param array      $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1748,7 +1748,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string       $attr_name      Attribute name.
 	 * @param array|string $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1793,7 +1793,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1826,7 +1826,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1856,7 +1856,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1928,7 +1928,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -1999,7 +1999,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -2057,7 +2057,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there
@@ -2088,7 +2088,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string           $attr_name      Attribute name.
 	 * @param array[]|string[] $attr_spec_rule Attribute spec rule.
 	 *
-	 * @return int:
+	 * @return int
 	 *      - AMP_Rule_Spec::PASS - $attr_name has a value that matches the rule.
 	 *      - AMP_Rule_Spec::FAIL - $attr_name has a value that does *not* match rule.
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name does not exist or there

--- a/includes/widgets/class-amp-widget-archives.php
+++ b/includes/widgets/class-amp-widget-archives.php
@@ -34,7 +34,7 @@ class AMP_Widget_Archives extends WP_Widget_Archives {
 	 *
 	 * @param array $args Widget display data.
 	 * @param array $instance Data for widget.
-	 * @return void.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		if ( ! amp_is_request() ) {

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -71,6 +71,7 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 	public function get_conversion_data() {
 		$amp_carousel_caption = '<figcaption class="amp-wp-gallery-caption"> ' . self::CAPTION_TEXT . ' </figcaption>';
 		$loading_attribute    = version_compare( get_bloginfo( 'version' ), '5.5-alpha', '>' ) ? 'loading="lazy"' : '';
+		$decoding_attribute   = version_compare( get_bloginfo( 'version' ), '6.0', '>' ) ? 'decoding="async"' : '';
 
 		return [
 			'shortcode_with_invalid_id'               => [
@@ -81,9 +82,9 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'[gallery ids={{id1}},{{id2}},{{id3}}]',
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
-					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
-					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
 				true,
 			],
@@ -92,14 +93,14 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
 						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<br style="clear: both">
 				</div>',
@@ -108,18 +109,18 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'[gallery amp-lightbox=false amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
-					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
-					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file_url2}}"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
 			],
 			'shortcode_with_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=false amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive">
-					<figure class="slide"><a href="{{file1}}.jpg"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
-					<figure class="slide"><a href="{{file2}}.jpg"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
-					<figure class="slide"><a href="{{file3}}.jpg"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file1}}.jpg"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover"></a>' . $amp_carousel_caption . '</figure>
+					<figure class="slide"><a href="{{file2}}.jpg"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></a></figure>
+					<figure class="slide"><a href="{{file3}}.jpg"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' layout="fill" object-fit="cover"></a></figure>
 				</amp-carousel>',
 			],
 			'shortcode_with_lightbox'                 => [
@@ -127,13 +128,13 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<div data-amp-lightbox="true" id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
+						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
 					</dt><dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
+						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
+						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
 					<br style="clear: both">
 				</div>',
@@ -143,13 +144,13 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<div data-amp-lightbox="true" id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
+						<img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" lightbox="">
 					</dt><dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
+						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
 					<dl class="gallery-item"><dt class="gallery-icon landscape">
-						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' lightbox="">
+						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' lightbox="">
 					</dt></dl>
 					<br style="clear: both">
 				</div>',
@@ -158,18 +159,18 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive" lightbox="">' .
-					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
-					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
-					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
+					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_lightbox_and_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<amp-carousel width="640" height="480" type="slides" layout="responsive" lightbox="">' .
-					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
-					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
-					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}" layout="fill" object-fit="cover">' . $amp_carousel_caption . '</figure>' .
+					'<figure class="slide"><img width="640" height="480" src="{{file2}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" sizes="(max-width: 640px) 100vw, 640px" layout="fill" object-fit="cover"></figure>' .
+					'<figure class="slide"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-large size-large" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' layout="fill" object-fit="cover"></figure>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_no_attributes'            => [
@@ -178,14 +179,14 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 				'<style type="text/css"> #gallery-1 { margin: auto; } #gallery-1 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-1 img { border: 2px solid #cfcfcf; } #gallery-1 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
 				<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail">
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url1}}"><img width="100" height="100" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . ' ' . $loading_attribute . ' aria-describedby="gallery-1-{{id1}}"></a></dt>
 						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<br style="clear: both">
 				</div>',

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -97,10 +97,10 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $decoding_attribute ? ( ' ' . $decoding_attribute ) : '' ) . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $decoding_attribute ? ( ' ' . $decoding_attribute ) : '' ) . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<br style="clear: both">
 				</div>',
@@ -183,10 +183,10 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 						<dd class="wp-caption-text gallery-caption" id="gallery-1-{{id1}}"> ' . self::CAPTION_TEXT . ' </dd>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url2}}"><img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $decoding_attribute ? ( ' ' . $decoding_attribute ) : '' ) . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<dl class="gallery-item">
-						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" ' . $decoding_attribute . '' . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
+						<dt class="gallery-icon landscape"><a href="{{file_url3}}"><img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text"' . ( $decoding_attribute ? ( ' ' . $decoding_attribute ) : '' ) . ( $loading_attribute ? ( ' ' . $loading_attribute ) : '' ) . '></a></dt>
 					</dl>
 					<br style="clear: both">
 				</div>',

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1905,6 +1905,10 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 			array_search( AMP_Core_Theme_Sanitizer::class, $ordered_sanitizers, true ),
 			array_search( AMP_Script_Sanitizer::class, $ordered_sanitizers, true )
 		);
+		$this->assertGreaterThan(
+			array_search( AMP_PWA_Script_Sanitizer::class, $ordered_sanitizers, true ),
+			array_search( AMP_Script_Sanitizer::class, $ordered_sanitizers, true )
+		);
 		$this->assertEquals( AMP_Layout_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 4 ] );
 		$this->assertEquals( AMP_Style_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
 		$this->assertEquals( AMP_Meta_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 2 ] );

--- a/tests/php/test-class-amp-pwa-script-sanitizer.php
+++ b/tests/php/test-class-amp-pwa-script-sanitizer.php
@@ -29,7 +29,10 @@ class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		if ( ! function_exists( 'wp_service_workers' ) ) {
+		if (
+			! ( function_exists( 'is_offline' ) && is_offline() ) &&
+			! ( function_exists( 'is_500' ) && is_500() )
+		) {
 			$this->markTestSkipped( 'PWA plugin not active.' );
 		}
 	}

--- a/tests/php/test-class-amp-pwa-script-sanitizer.php
+++ b/tests/php/test-class-amp-pwa-script-sanitizer.php
@@ -18,68 +18,32 @@ use AmpProject\AmpWP\Tests\TestCase;
 class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 
 	/**
-	 * @covers::sanitize
+	 * XPath query to find the scripts element.
+	 *
+	 * @var string
 	 */
-	public function test_sanitize() {
+	const SCRIPT_XPATH = '//script[ @id = "wp-navigation-request-properties" or ( @type = "module" and contains( text(), "checkNetworkAndReload()" ) ) ]';
+
+	/**
+	 * Get offline or 500 page markup.
+	 *
+	 * @return string
+	 */
+	public function get_offline_or_500_page_markup() {
+		return '<html><head></head><body><script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script><script type="module">const shouldRetry=()=>{if (new URLSearchParams(location.search.substring(1)).has(\'wp_error_template\')){return false;}const navigationRequestProperties=JSON.parse(document.getElementById(\'wp-navigation-request-properties\').text);if (\'GET\' !==navigationRequestProperties.method){return false;}return true;};if (shouldRetry()){/** * Listen to changes in the network state, reload when online. * This handles the case when the device is completely offline. */window.addEventListener(\'online\', ()=>{window.location.reload();});// Create a counter to implement exponential backoff.let count=0;/** * Check if the server is responding and reload the page if it is. * This handles the case when the device is online, but the server is offline or misbehaving. */async function checkNetworkAndReload(){try{const response=await fetch(location.href,{method: \'HEAD\',});// Verify we get a valid response from the serverif (response.status >=200 && response.status < 500){window.location.reload();return;}}catch{// Unable to connect so do nothing.}window.setTimeout(checkNetworkAndReload, Math.pow(2, count++) * 2500);}checkNetworkAndReload();}</script></body></html>';
+	}
+
+	/**
+	 * Do not PX verify script tag if page is not being offline or 500.
+	 *
+	 * @covers ::sanitize
+	 */
+	public function test_do_not_px_verify_script_tag() {
 		$dom = new Document();
-		$dom->loadHTML(
-			'<html>
-			<head></head>
-			<body>
-			<script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script>
-			<script id="wp-offline-page-reload" type="module">
-				const shouldRetry = () => {
-					if (new URLSearchParams(location.search.substring(1)).has(\'wp_error_template\')) {
-						return false;
-					}
-					const navigationRequestProperties = JSON.parse(document.getElementById(\'wp-navigation-request-properties\').text);
-					if (\'GET\' !== navigationRequestProperties.method) {
-						return false;
-					}
-					return true;
-				};
-				if (shouldRetry()) {
-				/**
-				 * Listen to changes in the network state, reload when online.
-				 * This handles the case when the device is completely offline.
-				 */
-				window.addEventListener(\'online\', () => {
-					window.location.reload();
-				});
-				// Create a counter to implement exponential backoff.
-				let count = 0;
-				/**
-				 * Check if the server is responding and reload the page if it is.
-				 * This handles the case when the device is online, but the server is offline or misbehaving.
-				 */
-				async function checkNetworkAndReload() {
-					try {
-					const response = await fetch(location.href, {
-						method: \'HEAD\',
-					});
-					// Verify we get a valid response from the server
-					if (response.status >= 200 && response.status < 500) {
-						window.location.reload();
-						return;
-					}
-					} catch {
-					// Unable to connect so do nothing.
-					}
-					window.setTimeout(checkNetworkAndReload, Math.pow(2, count++) * 2500);
-				}
-				checkNetworkAndReload();
-				}
-			</script>
-			</body>
-		</html>'
-		);
+		$dom->loadHTML( $this->get_offline_or_500_page_markup() );
 		$sanitizer = new AMP_PWA_Script_Sanitizer( $dom );
-
-		$xpath = '//script[@id="wp-navigation-request-properties" or @id="wp-offline-page-reload"]';
-
-		// If page is not offline or 500 error, no `data-px-verified-tag` should be added in scripts.
 		$sanitizer->sanitize();
-		$scripts = $dom->xpath->query( $xpath );
+		$scripts = $dom->xpath->query( self::SCRIPT_XPATH );
 
 		$this->assertFalse( is_offline() );
 		$this->assertFalse( is_500() );
@@ -88,12 +52,23 @@ class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 			$this->assertSame( Tag::SCRIPT, $script->tagName );
 			$this->assertFalse( ValidationExemption::is_px_verified_for_node( $script ) );
 		}
+	}
 
-		// If page is offline, `data-px-verified-tag` should be added in scripts.
+	/**
+	 * PX verify if page is being offline
+	 *
+	 * @covers ::sanitize
+	 */
+	public function test_px_verify_if_page_is_offline() {
+		$dom = new Document();
+		$dom->loadHTML( $this->get_offline_or_500_page_markup() );
+		$sanitizer = new AMP_PWA_Script_Sanitizer( $dom );
+
 		$error_template_url = add_query_arg( 'wp_error_template', 'offline', home_url( '/', 'relative' ) );
 		$this->go_to( $error_template_url );
+
 		$sanitizer->sanitize();
-		$scripts = $dom->xpath->query( $xpath );
+		$scripts = $dom->xpath->query( self::SCRIPT_XPATH );
 
 		$this->assertTrue( is_offline() );
 		$this->assertFalse( is_500() );
@@ -102,12 +77,23 @@ class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 			$this->assertSame( Tag::SCRIPT, $script->tagName );
 			$this->assertTrue( ValidationExemption::is_px_verified_for_node( $script ) );
 		}
+	}
 
-		// If page is 500 error, `data-px-verified-tag` should be added in scripts.
+	/**
+	 * PX verify if page is 500
+	 *
+	 * @covers ::sanitize
+	 */
+	public function test_px_verify_if_page_is_500() {
+		$dom = new Document();
+		$dom->loadHTML( $this->get_offline_or_500_page_markup() );
+		$sanitizer = new AMP_PWA_Script_Sanitizer( $dom );
+
 		$error_template_url = add_query_arg( 'wp_error_template', '500', home_url( '/', 'relative' ) );
 		$this->go_to( $error_template_url );
+
 		$sanitizer->sanitize();
-		$scripts = $dom->xpath->query( $xpath );
+		$scripts = $dom->xpath->query( self::SCRIPT_XPATH );
 
 		$this->assertFalse( is_offline() );
 		$this->assertTrue( is_500() );

--- a/tests/php/test-class-amp-pwa-script-sanitizer.php
+++ b/tests/php/test-class-amp-pwa-script-sanitizer.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Class AMP_PWA_Script_Sanitizer_Test.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+use AmpProject\AmpWP\ValidationExemption;
+use AmpProject\Dom\Document;
+use AmpProject\Html\Tag;
+use AmpProject\AmpWP\Tests\TestCase;
+
+/**
+ * Tests the PWA Plugin Sanitizer class.
+ *
+ * @coversDefaultClass AMP_PWA_Script_Sanitizer
+ */
+class AMP_PWA_Script_Sanitizer_Test extends TestCase {
+
+	/**
+	 * @covers::sanitize
+	 */
+	public function test_sanitize() {
+		$dom = new Document();
+		$dom->loadHTML(
+			'<html>
+			<head></head>
+			<body>
+			<script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script>
+			<script id="wp-offline-page-reload" type="module">
+				const shouldRetry = () => {
+					if (new URLSearchParams(location.search.substring(1)).has(\'wp_error_template\')) {
+						return false;
+					}
+					const navigationRequestProperties = JSON.parse(document.getElementById(\'wp-navigation-request-properties\').text);
+					if (\'GET\' !== navigationRequestProperties.method) {
+						return false;
+					}
+					return true;
+				};
+				if (shouldRetry()) {
+				/**
+				 * Listen to changes in the network state, reload when online.
+				 * This handles the case when the device is completely offline.
+				 */
+				window.addEventListener(\'online\', () => {
+					window.location.reload();
+				});
+				// Create a counter to implement exponential backoff.
+				let count = 0;
+				/**
+				 * Check if the server is responding and reload the page if it is.
+				 * This handles the case when the device is online, but the server is offline or misbehaving.
+				 */
+				async function checkNetworkAndReload() {
+					try {
+					const response = await fetch(location.href, {
+						method: \'HEAD\',
+					});
+					// Verify we get a valid response from the server
+					if (response.status >= 200 && response.status < 500) {
+						window.location.reload();
+						return;
+					}
+					} catch {
+					// Unable to connect so do nothing.
+					}
+					window.setTimeout(checkNetworkAndReload, Math.pow(2, count++) * 2500);
+				}
+				checkNetworkAndReload();
+				}
+			</script>
+			</body>
+		</html>'
+		);
+		$sanitizer = new AMP_PWA_Script_Sanitizer( $dom );
+
+		$xpath = '//script[@id="wp-navigation-request-properties" or @id="wp-offline-page-reload"]';
+
+		// If page is not offline or 500 error, no `data-px-verified-tag` should be added in scripts.
+		$sanitizer->sanitize();
+		$scripts = $dom->xpath->query( $xpath );
+
+		$this->assertFalse( is_offline() );
+		$this->assertFalse( is_500() );
+		$this->assertCount( 2, $scripts );
+		foreach ( $scripts as $script ) {
+			$this->assertSame( Tag::SCRIPT, $script->tagName );
+			$this->assertFalse( ValidationExemption::is_px_verified_for_node( $script ) );
+		}
+
+		// If page is offline, `data-px-verified-tag` should be added in scripts.
+		$error_template_url = add_query_arg( 'wp_error_template', 'offline', home_url( '/', 'relative' ) );
+		$this->go_to( $error_template_url );
+		$sanitizer->sanitize();
+		$scripts = $dom->xpath->query( $xpath );
+
+		$this->assertTrue( is_offline() );
+		$this->assertFalse( is_500() );
+		$this->assertCount( 2, $scripts );
+		foreach ( $scripts as $script ) {
+			$this->assertSame( Tag::SCRIPT, $script->tagName );
+			$this->assertTrue( ValidationExemption::is_px_verified_for_node( $script ) );
+		}
+
+		// If page is 500 error, `data-px-verified-tag` should be added in scripts.
+		$error_template_url = add_query_arg( 'wp_error_template', '500', home_url( '/', 'relative' ) );
+		$this->go_to( $error_template_url );
+		$sanitizer->sanitize();
+		$scripts = $dom->xpath->query( $xpath );
+
+		$this->assertFalse( is_offline() );
+		$this->assertTrue( is_500() );
+		$this->assertCount( 2, $scripts );
+		foreach ( $scripts as $script ) {
+			$this->assertSame( Tag::SCRIPT, $script->tagName );
+			$this->assertTrue( ValidationExemption::is_px_verified_for_node( $script ) );
+		}
+	}
+}

--- a/tests/php/test-class-amp-pwa-script-sanitizer.php
+++ b/tests/php/test-class-amp-pwa-script-sanitizer.php
@@ -29,10 +29,7 @@ class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		if (
-			! ( function_exists( 'is_offline' ) && is_offline() ) &&
-			! ( function_exists( 'is_500' ) && is_500() )
-		) {
+		if ( ! function_exists( 'is_offline' ) || ! function_exists( 'is_500' ) ) {
 			$this->markTestSkipped( 'PWA plugin not active.' );
 		}
 	}

--- a/tests/php/test-class-amp-pwa-script-sanitizer.php
+++ b/tests/php/test-class-amp-pwa-script-sanitizer.php
@@ -25,6 +25,16 @@ class AMP_PWA_Script_Sanitizer_Test extends TestCase {
 	const SCRIPT_XPATH = '//script[ @id = "wp-navigation-request-properties" or ( @type = "module" and contains( text(), "checkNetworkAndReload()" ) ) ]';
 
 	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		if ( ! function_exists( 'wp_service_workers' ) ) {
+			$this->markTestSkipped( 'PWA plugin not active.' );
+		}
+	}
+
+	/**
 	 * Get offline or 500 page markup.
 	 *
 	 * @return string

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -202,10 +202,9 @@ class Test_AMP_YouTube_Embed_Handler extends TestCase {
 	public function test_video_override() {
 		remove_all_filters( 'wp_video_shortcode_override' );
 		$this->handler->register_embed();
-		$decoding_attribute = version_compare( get_bloginfo( 'version' ), '6.0', '>' ) ? 'decoding="async"' : '';
-		$youtube_id         = 'XOY3ZUO6P0k';
-		$youtube_src        = 'https://youtu.be/' . $youtube_id;
-		$attr_youtube       = [
+		$youtube_id   = 'XOY3ZUO6P0k';
+		$youtube_src  = 'https://youtu.be/' . $youtube_id;
+		$attr_youtube = [
 			'src' => $youtube_src,
 		];
 

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -202,9 +202,10 @@ class Test_AMP_YouTube_Embed_Handler extends TestCase {
 	public function test_video_override() {
 		remove_all_filters( 'wp_video_shortcode_override' );
 		$this->handler->register_embed();
-		$youtube_id   = 'XOY3ZUO6P0k';
-		$youtube_src  = 'https://youtu.be/' . $youtube_id;
-		$attr_youtube = [
+		$decoding_attribute = version_compare( get_bloginfo( 'version' ), '6.0', '>' ) ? 'decoding="async"' : '';
+		$youtube_id         = 'XOY3ZUO6P0k';
+		$youtube_src        = 'https://youtu.be/' . $youtube_id;
+		$attr_youtube       = [
 			'src' => $youtube_src,
 		];
 
@@ -259,6 +260,8 @@ class Test_AMP_YouTube_Embed_Handler extends TestCase {
 
 	/** @return array */
 	public function get_conversion_data() {
+		$decoding_attribute = version_compare( get_bloginfo( 'version' ), '6.0', '>' ) ? 'decoding="async"' : '';
+
 		return [
 			'no_embed'                         => [
 				'<p>Hello world.</p>',
@@ -267,20 +270,20 @@ class Test_AMP_YouTube_Embed_Handler extends TestCase {
 
 			'url_simple'                       => [
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://www.youtube.com/watch?v=kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://www.youtube.com/watch?v=kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'url_short'                        => [
 				'https://youtu.be/kfVsfOSbJY0' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://youtu.be/kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://youtu.be/kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://youtu.be/kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://youtu.be/kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'url_with_querystring'             => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0&hl=en&fs=1&w=425&h=349' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-hl="en" data-param-fs="1" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-hl="en" data-param-fs="1"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-hl="en" data-param-fs="1" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-hl="en" data-param-fs="1"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			// Several reports of invalid URLs that have multiple `?` in the URL.
@@ -291,38 +294,38 @@ class Test_AMP_YouTube_Embed_Handler extends TestCase {
 
 			'embed_url'                        => [
 				'https://www.youtube.com/embed/kfVsfOSbJY0' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://youtube.com/watch?v=kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://youtube.com/watch?v=kfVsfOSbJY0"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" title="Rebecca Black - Friday"><a placeholder href="https://youtube.com/watch?v=kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0"><a placeholder href="https://youtube.com/watch?v=kfVsfOSbJY0"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'with_start_time'                  => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m10s' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="70" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m10s"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="70"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m10s"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="70" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m10s"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="70"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m10s"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'with_start_time_2'                => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'with_start_time_3'                => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62s' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62s"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62s"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62s"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=62s"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'with_start_time_4'                => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="60" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="60"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="60" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="60"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 
 			'with_start_time_5'                => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m2' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m2"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m2"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62" title="Rebecca Black - Friday"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m2"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube layout="responsive" width="500" height="281" data-videoid="kfVsfOSbJY0" data-param-start="62"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0#t=1m2"><img ' . $decoding_attribute . ' src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></a></amp-youtube></p>' . PHP_EOL,
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

Add PWA scripts sanitizer which adds data-px-verified-tag to the offline/500 pages scripts.

Fixes #7122 

## Screenshots
Storing offline/500 templates in cache as AMP page with offline page reload scripts.

![image](https://user-images.githubusercontent.com/54371619/172685810-26104544-ce8e-49b0-865a-eea09b73e9a6.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
