### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-run:
     name: 'Pre run'
@@ -110,6 +113,10 @@ jobs:
 #-----------------------------------------------------------------------------------------------------------------------
 
   lint-js:
+    permissions:
+      checks: write  # for ataylorme/eslint-annotate-action to create checks
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for ataylorme/eslint-annotate-action to get changed PR files
     name: 'Lint: JS'
     needs: pre-run
     if: needs.pre-run.outputs.changed-js-count > 0 || needs.pre-run.outputs.changed-gha-workflow-count > 0
@@ -752,6 +759,8 @@ jobs:
 #-----------------------------------------------------------------------------------------------------------------------
 
   upload-to-gcs:
+    permissions:
+      contents: none
     name: Upload plugin ZIPs to Google Cloud Storage
     runs-on: ubuntu-latest
     needs:
@@ -784,6 +793,9 @@ jobs:
 #-----------------------------------------------------------------------------------------------------------------------
 
   comment-on-pr:
+    permissions:
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     name: Comment on PR with links to plugin ZIPs
     # Only run this job if it's a PR. One way to check for that is if `github.head_ref` is not empty.
     if: ${{ github.head_ref && github.head_ref != null }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,8 +27,15 @@ on:
       # Include all release branches.
       - '[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
