### PR TITLE
Fix auto-merge in dependabot and Gutenberg package update PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,8 +26,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Approve and merge the PR
-        if: >
-          contains( github.event.workflow_run.head_commit.message, 'version-update:semver-minor' ) || contains( github.event.workflow_run.head_commit.message, 'version-update:semver-patch' )
+        if: |
+          contains( github.event.workflow_run.head_commit.message, 'version-update:semver-minor' ) ||
+          contains( github.event.workflow_run.head_commit.message, 'version-update:semver-patch' )
         run: |
           gh pr review "$PR_NUMBER" --approve --body "LGTM!"
           gh pr merge "$PR_NUMBER" --auto --merge --delete-branch
@@ -38,15 +39,17 @@ jobs:
   gutenberg-packages:
     name: Gutenberg packages update PR auto-merge
     runs-on: ubuntu-latest
-    if: >
-      ( startsWith(github.event.workflow_run.head_commit.message, 'Update WordPress NPM packages based on Gutenberg release') && endsWith(github.event.workflow_run.head_commit.message, 'github-actions <github-actions@github.com>') ) && ( ${{ github.event.workflow_run.head_commit.author.name }} == 'github-actions' && ${{ github.event.workflow_run.head_commit.author.email }} == 'github-actions@github.com' )
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Approve and merge the PR
-        run: |
-          gh pr merge "$PR_NUMBER" --auto --merge --delete-branch
+        if: |
+          startsWith(github.event.workflow_run.head_commit.message, 'Update WordPress NPM packages based on Gutenberg release') &&
+          endsWith(github.event.workflow_run.head_commit.message, format('{0} {1}', 'github-actions', '<github-actions@github.com>')) &&
+          github.event.workflow_run.head_commit.author.name == 'github-actions' &&
+          github.event.workflow_run.head_commit.author.email == 'github-actions@github.com'
+        run: gh pr merge "$PR_NUMBER" --auto --merge --delete-branch
         env:
           PR_NUMBER: ${{github.event.workflow_run.pull_requests[0].number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -34,3 +34,19 @@ jobs:
         env:
           PR_NUMBER: ${{github.event.workflow_run.pull_requests[0].number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  gutenberg-packages:
+    name: Gutenberg packages update PR auto-merge
+    runs-on: ubuntu-latest
+    if: >
+      ( startsWith(github.event.workflow_run.head_commit.message, 'Update WordPress NPM packages based on Gutenberg release') && endsWith(github.event.workflow_run.head_commit.message, 'github-actions <github-actions@github.com>') ) && ( ${{ github.event.workflow_run.head_commit.author.name }} == 'github-actions' && ${{ github.event.workflow_run.head_commit.author.email }} == 'github-actions@github.com' )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Approve and merge the PR
+        run: |
+          gh pr merge "$PR_NUMBER" --auto --merge --delete-branch
+        env:
+          PR_NUMBER: ${{github.event.workflow_run.pull_requests[0].number}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,5 @@
-# This is based on <https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request>.
-name: Dependabot auto-merge
+name: Pull Requests auto-merge
 
-# Only trigger, when the build workflow succeeded, per <https://stackoverflow.com/a/65698892/93579>.
 on:
   workflow_run:
     workflows: ["Build, test & measure"]
@@ -20,23 +18,19 @@ concurrency:
 
 jobs:
   dependabot:
+    name: Dependabot PR auto-merge
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1.3.3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ github.event.pull_request.auto_merge == null && ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' ) }}
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Approve and merge the PR
+        if: >
+          contains( github.event.workflow_run.head_commit.message, 'version-update:semver-minor' ) || contains( github.event.workflow_run.head_commit.message, 'version-update:semver-patch' )
+        run: |
+          gh pr review "$PR_NUMBER" --approve --body "LGTM!"
+          gh pr merge "$PR_NUMBER" --auto --merge --delete-branch
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
+          PR_NUMBER: ${{github.event.workflow_run.pull_requests[0].number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -177,7 +177,7 @@ jobs:
           VERSION: ${{ needs.check-gutenberg-release.outputs.latest-version }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           BASE_BRANCH: ${{ steps.branches.outputs.base }}
-          HEAD_BRANCH: ${{ steps.branches.outputs.head }}"
+          HEAD_BRANCH: ${{ steps.branches.outputs.head }}
 
       # Make PR ready using personal access token to allow workflow to be triggered.
       - name: Make PR ready

--- a/.github/workflows/gutenberg-packages-update.yml
+++ b/.github/workflows/gutenberg-packages-update.yml
@@ -112,9 +112,10 @@ jobs:
           cache: npm
 
       - name: Configure git user
+        # Setting up github-action bot as git user <https://github.com/actions/checkout#push-a-commit-using-the-built-in-token>.
         run: |
-          git config user.email "pierregordon@protonmail.com"
-          git config user.name "Pierre Gordon"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - name: Check if remote branch exists
         id: remote-branch
@@ -138,7 +139,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.branches.outputs.head }}
 
       - name: Install Node dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         env:
           CI: true
 
@@ -159,19 +160,37 @@ jobs:
         if: steps.packages.outputs.list != 0
         run: |
           git add --all .
-          git commit -m "Update Gutenberg package dependencies"
-          git push origin "$HEAD_BRANCH"
+          git commit -m "Update WordPress NPM packages based on Gutenberg release v$VERSION" -m "Signed-off-by: $(git config user.name) <$(git config user.email)>"
+          git push -u origin "$HEAD_BRANCH"
         env:
+          VERSION: ${{ needs.check-gutenberg-release.outputs.latest-version }}
           HEAD_BRANCH: ${{ steps.branches.outputs.head }}
 
-      - name: Create pull request
+      - name: Draft a pull request
+        id: pr-create
         if: steps.packages.outputs.list != 0 && steps.remote-branch.outputs.exists == 0
         run: |
-          git push -u origin "$HEAD_BRANCH"
-          PR_URL=$(gh pr create --base "$BASE_BRANCH" --title "Update Gutenberg packages after v$VERSION release" --body "" --label dependencies | grep https://)
-          gh pr merge --auto --merge "$PR_URL"
+          PR_BODY=$(node bin/gutenberg-packages-update-pr-body.js "${{ steps.packages.outputs.list }}")
+          PR_URL=$(gh pr create --draft --base "$BASE_BRANCH" --title "Update Gutenberg packages after v$VERSION release" --body "$PR_BODY" --label dependencies | grep https://)
+          echo "::set-output name=pr-url::$PR_URL"
         env:
           VERSION: ${{ needs.check-gutenberg-release.outputs.latest-version }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           BASE_BRANCH: ${{ steps.branches.outputs.base }}
-          HEAD_BRANCH: ${{ steps.branches.outputs.head }}
+          HEAD_BRANCH: ${{ steps.branches.outputs.head }}"
+
+      # Make PR ready using personal access token to allow workflow to be triggered.
+      - name: Make PR ready
+        if: steps.pr-create.outputs.pr-url != ''
+        run: gh pr ready "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PR_URL: ${{ steps.pr-create.outputs.pr-url }}
+
+      - name: Add PR reviewers
+        if: steps.pr-create.outputs.pr-url != ''
+        # Add a PR reviewer so that a notification can be sent to the concerned person.
+        run: gh pr edit "$PR_URL" --add-reviewer ${{ secrets.PR_REVIEWER }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr-create.outputs.pr-url }}

--- a/bin/gutenberg-packages-update-pr-body.js
+++ b/bin/gutenberg-packages-update-pr-body.js
@@ -13,7 +13,7 @@
 
 const args = process.argv.slice( 2 );
 const npmURL = 'https://www.npmjs.com/package/';
-let bodyMessage = '**Following packages were updated:**<br/><br/>';
+let bodyMessage = '**Following packages were updated:**\n\n';
 
 if ( args[ 0 ] ) {
 	args[ 0 ].split( ' ' ).forEach( ( packageName, index ) => {

--- a/bin/gutenberg-packages-update-pr-body.js
+++ b/bin/gutenberg-packages-update-pr-body.js
@@ -1,0 +1,31 @@
+/**
+ * Script to construct PR body for updating gutenberg packages from list of packages.
+ *
+ * Usage:
+ * node bin/gutenberg-packages-update-pr-body.js [packages-list]
+ *
+ * Example:
+ * node bin/gutenberg-packages-update-pr-body.js "@wordpress/api-fetch@6.8.0 @wordpress/autop@3.11.0"
+ *
+ * Would Output: **Following packages were updated:**<br/><br/>1. [@wordpress/api-fetch@6.8.0](https://www.npmjs.com/package/@wordpress/api-fetch/v/6.8.0)<br>2. [@wordpress/autop@3.11.0](https://www.npmjs.com/package/@wordpress/autop/v/3.11.0)<br>
+ *
+ */
+
+const args = process.argv.slice( 2 );
+const npmURL = 'https://www.npmjs.com/package/';
+let bodyMessage = '**Following packages were updated:**<br/><br/>';
+
+if ( args[ 0 ] ) {
+	args[ 0 ].split( ' ' ).forEach( ( packageName, index ) => {
+		let occur = 0;
+		const packageURL = `${ npmURL }${ packageName.replace( /@/g, ( match ) => ++occur > 1 ? '/v/' : match ) }`;
+		bodyMessage += `${ index + 1 }. [${ packageName }](${ packageURL })<br>`;
+	} );
+
+	/* eslint-disable no-console */
+	console.log( bodyMessage );
+} else {
+	console.error( 'Please provide packages list as argument.' );
+	/* eslint-enable no-console */
+	process.exit( 1 );
+}


### PR DESCRIPTION
## Summary
This PR aims to fix an issue due to which auto-merge feature was not working for:
- PRs created by Dependabot.
- PRs created by Gutenberg Package Updates.

Now auto-merge will take place only when `Build Test & Measure` is completed successfully so no more intervention is required on dependabot and `Gutenberg Package Updates` PRs.

## Technical Details
- With this PR merge we need to add two secrets under actions:
    - `GH_PAT` -> Personal access token which is needed when making a PR ready for review and hence workflows will be triggered in `Gutenberg package update` PRs.
    - `PR_REVIEWER` -> Username which needs to be added as a reviewer on PRs created by `Gutenberg package update`. Doing so helps in sending a notification as well keep track of such PRs. 

Fixes #

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
