### PR TITLE
Fix lightbox effect if images are aligned

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -526,7 +526,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$media_file_url = wp_parse_url( $parent_node->getAttribute( Attribute::HREF ), PHP_URL_PATH );
-		$img_src        = wp_parse_url( $attributes['src'], PHP_URL_PATH );
+		$img_src        = wp_parse_url( $node->getAttribute( Attribute::SRC ), PHP_URL_PATH );
 
 		$is_node_wrapped_in_media_file_link = (
 			'a' === $parent_node->tagName

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -566,23 +566,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Gets whether a node has the class 'wp-block-image', meaning it is a wrapper for an Image block.
-	 *
-	 * @param Element $node A node to evaluate.
-	 * @return bool Whether the node has the class 'wp-block-image'.
-	 */
-	private function does_node_have_block_class( $node ) {
-		if ( $node instanceof Element ) {
-			$classes = preg_split( '/\s+/', $node->getAttribute( Attribute::CLASS_ ) );
-			if ( in_array( 'wp-block-image', $classes, true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Determines if a URL is considered a GIF URL
 	 *
 	 * @since 0.2

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -554,9 +554,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$attributes[ Attribute::LIGHTBOX ] = '';
 
 			/*
-			* Removes the <a> if the image is wrapped in one, as it can prevent the lightbox from working.
-			* But this only removes the <a> if it links to the media file, not the attachment page.
-			*/
+			 * Removes the <a> if the image is wrapped in one, as it can prevent the lightbox from working.
+			 * But this only removes the <a> if it links to the media file, not the attachment page.
+			 */
 			if ( $is_node_wrapped_in_media_file_link ) {
 				$node->parentNode->parentNode->replaceChild( $node, $node->parentNode );
 			}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -526,7 +526,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$media_file_url = wp_parse_url( $parent_node->getAttribute( Attribute::HREF ), PHP_URL_PATH );
-		$img_src        = wp_parse_url( $node->getAttribute( Attribute::SRC ), PHP_URL_PATH );
+
+		/** @var Element $node */
+		$img_src = wp_parse_url( $node->getAttribute( Attribute::SRC ), PHP_URL_PATH );
 
 		$is_node_wrapped_in_media_file_link = (
 			Tag::A === $parent_node->tagName

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -529,12 +529,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$img_src        = wp_parse_url( $node->getAttribute( Attribute::SRC ), PHP_URL_PATH );
 
 		$is_node_wrapped_in_media_file_link = (
-			'a' === $parent_node->tagName
+			Tag::A === $parent_node->tagName
 			&&
 			$media_file_url === $img_src
 		);
 
-		if ( 'figure' !== $parent_node->tagName && ! $is_node_wrapped_in_media_file_link ) {
+		if ( Tag::FIGURE !== $parent_node->tagName && ! $is_node_wrapped_in_media_file_link ) {
 			return $attributes;
 		}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -546,8 +546,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$parent_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $parent_node );
 		} elseif ( Tag::A === $parent_node->tagName && Tag::FIGURE === $parent_node->parentNode->tagName ) {
 			$parent_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $parent_node->parentNode );
-		} else {
-			return $attributes;
 		}
 
 		if ( isset( $parent_attributes['data-amp-lightbox'] ) && true === filter_var( $parent_attributes['data-amp-lightbox'], FILTER_VALIDATE_BOOLEAN ) ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -401,8 +401,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function adjust_and_replace_node( Element $node ) {
 		if ( $this->args['native_img_used'] || ( $node->parentNode instanceof Element && Tag::PICTURE === $node->parentNode->tagName ) ) {
-			$node_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
-			$attributes      = $this->maybe_add_lightbox_attributes( $node_attributes, $node ); // @todo AMP doesn't support lightbox on <img> yet.
+			$attributes = $this->maybe_add_lightbox_attributes( [], $node ); // @todo AMP doesn't support lightbox on <img> yet.
 
 			/*
 			 * Mark lightbox as px-verified attribute until it's supported by AMP spec.

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -668,22 +668,26 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 	public function get_data_for_test_maybe_add_lightbox_attributes() {
 		return [
 			'img_has_no_parent'        => [
-				'input'          => '<img src="https://example.com/image.jpg" />',
-				'expected_attrs' => [],
+				'<img src="https://example.com/image.jpg" />',
+				[],
 			],
 			'img_has_figure_as_parent' => [
-				'input'          => '<figure data-amp-lightbox="true" class="wp-block-image size-large"><img src="https://via.placeholder.com/150" alt="Placeholder" class="wp-image-19"/></figure>',
-				'expected_attrs' => [
+				'<figure data-amp-lightbox="true" class="wp-block-image size-large"><img src="https://via.placeholder.com/150" alt="Placeholder"/></figure>',
+				[
 					'data-amp-lightbox' => '',
 					'lightbox'          => '',
 				],
 			],
 			'img_has_a_url_as_parent'  => [
-				'input'          => '<figure data-amp-lightbox="true" class="wp-block-image size-full"><a href="https://via.placeholder.com/150"><img src="https://via.placeholder.com/150" alt="Placeholder" class="wp-image-9"/></a></figure>',
-				'expected_attrs' => [
+				'<figure data-amp-lightbox="true" class="wp-block-image size-full"><a href="https://via.placeholder.com/150"><img src="https://via.placeholder.com/150" alt="Placeholder"/></a></figure>',
+				[
 					'data-amp-lightbox' => '',
 					'lightbox'          => '',
 				],
+			],
+			'img_has_div_as_parent'    => [
+				'<div><img src="https://via.placeholder.com/150" alt="Placeholder"/></div>',
+				[],
 			],
 		];
 	}
@@ -694,11 +698,11 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 	 * @covers ::maybe_add_lightbox_attributes
 	 *
 	 * @param string $source Source.
-	 * @param array  $expected Expected Node attributes.
+	 * @param array  $expected_attributes Expected Node attributes.
 	 *
 	 * @dataProvider get_data_for_test_maybe_add_lightbox_attributes()
 	 */
-	public function test_maybe_add_lightbox_attributes( $input, $expected_attrs ) {
+	public function test_maybe_add_lightbox_attributes( $input, $expected_attributes ) {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $input );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 
@@ -706,16 +710,26 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 		$nodes = $dom->getElementsByTagName( Tag::IMG );
 
 		foreach ( $nodes as $node ) {
-			$attributes = $this->call_private_method(
+			$attrs = [];
+
+			$actual_attributes = $this->call_private_method(
 				$sanitizer,
 				'maybe_add_lightbox_attributes',
 				[
-					[],
+					$attrs,
 					$node,
-				] 
+				]
 			);
 
-			$this->assertEqualSets( $expected_attrs, $attributes );
+			if ( Tag::FIGURE === $node->parentNode->tagName ) {
+				$this->assertEqualSets( $expected_attributes, $actual_attributes );
+			} elseif ( Tag::A === $node->parentNode->tagName && Tag::FIGURE === $node->parentNode->parentNode->tagName ) {
+				$this->assertEqualSets( $expected_attributes, $actual_attributes );
+			} else {
+				$this->assertEmpty( $attrs );
+				$this->assertEmpty( $actual_attributes );
+				$this->assertEqualSets( $attrs, $actual_attributes );
+			}
 		}
 	}
 

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -483,8 +483,8 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 			],
 
 			'aligned_image_block_with_lightbox'        => [
-				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
-				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div>',
+				'<div class="wp-block-image"><figure data-amp-lightbox="true" class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
+				'<div class="wp-block-image"><figure  data-amp-lightbox="true" class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div>',
 			],
 
 			'test_with_dev_mode'                       => [
@@ -763,8 +763,9 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 	 * @covers ::sanitize()
 	 */
 	public function test_image_block_link_to_media_file_with_lightbox() {
-		$source   = sprintf( '<figure class="wp-block-image" data-amp-lightbox="true"><a href="%s"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure>', wp_get_attachment_image_url( $this->get_new_attachment_id() ) );
-		$expected = '<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure>';
+		$image_url = wp_get_attachment_image_url( $this->get_new_attachment_id() );
+		$source    = sprintf( '<figure class="wp-block-image" data-amp-lightbox="true"><a href="%1$s"><img src="%1$s" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure>', $image_url );
+		$expected  = sprintf( '<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="%1$s" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="%1$s" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure>', $image_url );
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom, [ 'native_img_used' => false ] );
@@ -803,8 +804,9 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 	 * @covers ::sanitize()
 	 */
 	public function test_image_block_link_to_media_file_and_alignment_with_lightbox() {
-		$source   = sprintf( '<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignright size-large"><a href="%s"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure></div>', wp_get_attachment_image_url( $this->get_new_attachment_id() ) );
-		$expected = '<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignright size-large"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div>';
+		$image_url = wp_get_attachment_image_url( $this->get_new_attachment_id() );
+		$source    = sprintf( '<div class="wp-block-image"><figure data-amp-lightbox="true" class="alignright size-large"><a href="%1$s"><img src="%1$s" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure></div>', $image_url );
+		$expected  = sprintf( '<div class="wp-block-image"><figure data-amp-lightbox="true" class="alignright size-large"><amp-img src="%1$s" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="%1$s" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div>', $image_url );
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom, [ 'native_img_used' => false ] );

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -817,50 +817,6 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 	}
 
 	/**
-	 * Gets test data for test_does_node_have_block_class(), using a <figure> element.
-	 *
-	 * @see AMP_Img_Sanitizer_Test::test_does_node_have_block_class()
-	 * @return array Test data for function.
-	 */
-	public function get_data_for_node_block_class_test() {
-		return [
-			'has_no_class'           => [
-				'<figure></figure>',
-				false,
-			],
-			'has_wrong_class'        => [
-				'<figure class="completely-wrong-class"></figure>',
-				false,
-			],
-			'only_has_part_of_class' => [
-				'<figure class="wp-block"></figure>',
-				false,
-			],
-			'has_correct_class'      => [
-				'<figure class="wp-block-image"></figure>',
-				true,
-			],
-		];
-	}
-
-	/**
-	 * Test does_node_have_block_class.
-	 *
-	 * @dataProvider get_data_for_node_block_class_test
-	 * @covers ::does_node_have_block_class()
-	 *
-	 * @param string $source The source markup to test.
-	 * @param string $expected The expected return of the tested function, using the source markup.
-	 */
-	public function test_does_node_have_block_class( $source, $expected ) {
-		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Img_Sanitizer( $dom );
-		$figures   = $dom->getElementsByTagName( 'figure' );
-
-		$this->assertEquals( $expected, $this->call_private_method( $sanitizer, 'does_node_have_block_class', [ $figures->item( 0 ) ] ) );
-	}
-
-	/**
 	 * Creates a new image attachment, and gets the ID.
 	 *
 	 * @return int|WP_Error The new attachment ID, or WP_Error.

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -721,15 +721,7 @@ class AMP_Img_Sanitizer_Test extends TestCase {
 				]
 			);
 
-			if ( Tag::FIGURE === $node->parentNode->tagName ) {
-				$this->assertEqualSets( $expected_attributes, $actual_attributes );
-			} elseif ( Tag::A === $node->parentNode->tagName && Tag::FIGURE === $node->parentNode->parentNode->tagName ) {
-				$this->assertEqualSets( $expected_attributes, $actual_attributes );
-			} else {
-				$this->assertEmpty( $attrs );
-				$this->assertEmpty( $actual_attributes );
-				$this->assertEqualSets( $attrs, $actual_attributes );
-			}
+			$this->assertEqualSets( $expected_attributes, $actual_attributes );
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix the lightbox effect when the images are aligned. This is due to the adding of  `data-amp-lightbox="true"` to the `<figure>` element instead of adding it in `<div>`.

Also improved the logic of determining `media` URL and replacing it for lightbox effect.

Fixes #7154 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
