### PR TITLE
Update `mask-type` attribute with `mask-type` mask element css property

### DIFF
--- a/assets/src/components/amp-notice/index.js
+++ b/assets/src/components/amp-notice/index.js
@@ -31,7 +31,7 @@ function getNoticeIcon( type ) {
 			Icon = () => (
 				<svg width="35" height="36" viewBox="0 0 35 36" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<rect x="1.90112" y="1.98828" width="32.0691" height="32.0691" rx="16.0345" stroke="#00A02F" strokeWidth="2" />
-					<mask id="mask-notice-success" mask-type="alpha" maskUnits="userSpaceOnUse" x="10" y="12" width="16" height="12">
+					<mask id="mask-notice-success" style={ { maskType: 'alpha' } } maskUnits="userSpaceOnUse" x="10" y="12" width="16" height="12">
 						<path d="M15.0921 21.461L11.3924 17.7613L10.1326 19.0122L15.0921 23.9718L25.7387 13.3252L24.4877 12.0742L15.0921 21.461Z" fill="white" />
 					</mask>
 					<g mask="url(#mask-notice-success)">

--- a/assets/src/components/amp-notice/test/__snapshots__/index.js.snap
+++ b/assets/src/components/amp-notice/test/__snapshots__/index.js.snap
@@ -26,8 +26,12 @@ exports[`AMPNotice matches snapshots 1`] = `
       <mask
         height="12"
         id="mask-notice-success"
-        mask-type="alpha"
         maskUnits="userSpaceOnUse"
+        style={
+          Object {
+            "maskType": "alpha",
+          }
+        }
         width="16"
         x="10"
         y="12"

--- a/assets/src/components/svg/check.js
+++ b/assets/src/components/svg/check.js
@@ -11,7 +11,7 @@ export function Check() {
 
 	return (
 		<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<mask id={ `mask-${ id }` } mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="5" width="16" height="12">
+			<mask id={ `mask-${ id }` } style={ { maskType: 'alpha' } } maskUnits="userSpaceOnUse" x="2" y="5" width="16" height="12">
 				<path d="M7.32923 14.137L3.85423 10.662L2.6709 11.837L7.32923 16.4953L17.3292 6.49531L16.1542 5.32031L7.32923 14.137Z" fill="white" />
 			</mask>
 			<g mask={ `url(#mask-${ id })` }>

--- a/assets/src/onboarding-wizard/components/nav/index.js
+++ b/assets/src/onboarding-wizard/components/nav/index.js
@@ -34,7 +34,7 @@ export function CloseLink( { closeLink } ) {
 	return (
 		<Button isLink href={ closeLink }>
 			<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<mask id="close-icon" mask-type="alpha" maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="19">
+				<mask id="close-icon" style={ { maskType: 'alpha' } } maskUnits="userSpaceOnUse" x="3" y="3" width="19" height="19">
 					<path fillRule="evenodd" clipRule="evenodd" d="M19.895 3.71875H5.89502C4.79502 3.71875 3.89502 4.61875 3.89502 5.71875V19.7188C3.89502 20.8188 4.79502 21.7188 5.89502 21.7188H19.895C21.005 21.7188 21.895 20.8188 21.895 19.7188V15.7188H19.895V19.7188H5.89502V5.71875H19.895V9.71875H21.895V5.71875C21.895 4.61875 21.005 3.71875 19.895 3.71875ZM13.395 17.7188L14.805 16.3088L12.225 13.7188H21.895V11.7188H12.225L14.805 9.12875L13.395 7.71875L8.39502 12.7188L13.395 17.7188Z" fill="white" />
 				</mask>
 				<g mask="url(#close-icon)">

--- a/assets/src/onboarding-wizard/components/nav/test/__snapshots__/index.js.snap
+++ b/assets/src/onboarding-wizard/components/nav/test/__snapshots__/index.js.snap
@@ -25,8 +25,12 @@ exports[`Nav matches snapshot 1`] = `
           <mask
             height="19"
             id="close-icon"
-            mask-type="alpha"
             maskUnits="userSpaceOnUse"
+            style={
+              Object {
+                "maskType": "alpha",
+              }
+            }
             width="19"
             x="3"
             y="3"

--- a/assets/src/onboarding-wizard/components/stepper/test/__snapshots__/index.js.snap
+++ b/assets/src/onboarding-wizard/components/stepper/test/__snapshots__/index.js.snap
@@ -14,8 +14,12 @@ exports[`StepperBullet matches snaphnot when neither index nor active index are 
     <mask
       height="12"
       id="mask-1"
-      mask-type="alpha"
       maskUnits="userSpaceOnUse"
+      style={
+        Object {
+          "maskType": "alpha",
+        }
+      }
       width="16"
       x="2"
       y="5"
@@ -61,8 +65,12 @@ exports[`StepperBullet matches snapshot when index is 0 and active index is some
     <mask
       height="12"
       id="mask-0"
-      mask-type="alpha"
       maskUnits="userSpaceOnUse"
+      style={
+        Object {
+          "maskType": "alpha",
+        }
+      }
       width="16"
       x="2"
       y="5"

--- a/assets/src/settings-page/welcome.js
+++ b/assets/src/settings-page/welcome.js
@@ -61,7 +61,7 @@ export function Welcome() {
 									{ __( 'AMP Settings Configured', 'amp' ) }
 
 									<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-										<mask id="check-circle-mask" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="21">
+										<mask id="check-circle-mask" style={ { maskType: 'alpha' } } maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="21">
 											<path fillRule="evenodd" clipRule="evenodd" d="M12.7537 2.60938C7.23366 2.60938 2.75366 7.08938 2.75366 12.6094C2.75366 18.1294 7.23366 22.6094 12.7537 22.6094C18.2737 22.6094 22.7537 18.1294 22.7537 12.6094C22.7537 7.08938 18.2737 2.60938 12.7537 2.60938ZM12.7537 20.6094C8.34366 20.6094 4.75366 17.0194 4.75366 12.6094C4.75366 8.19938 8.34366 4.60938 12.7537 4.60938C17.1637 4.60938 20.7537 8.19938 20.7537 12.6094C20.7537 17.0194 17.1637 20.6094 12.7537 20.6094ZM10.7537 14.7794L17.3437 8.18937L18.7537 9.60938L10.7537 17.6094L6.75366 13.6094L8.16366 12.1994L10.7537 14.7794Z" fill="white" />
 										</mask>
 										<g mask="url(#check-circle-mask)">


### PR DESCRIPTION
## Summary
This PR aims to update the `mask-type` attribute in `<mask>` elements with the `mask-type` CSS property. 

Originally identified in #7242 where `eslint-plugin-react@7.31.7` flags this attribute as unidentifiable.

Ref: 
- [Attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask#attributes) allowed in `<mask>` element.
- [`mask-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-type) CSS property for `<mask>` element.

See #7242

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
