### PR TITLE
Fix static analysis and trunk unit tests errors

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1630,8 +1630,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		$body_id = $this->dom->getElementId( $this->dom->body, 'body' );
 
-		$open_xpaths  = isset( $args['open_button_xpath'] ) ? $args['open_button_xpath'] : [];
-		$close_xpaths = isset( $args['close_button_xpath'] ) ? $args['close_button_xpath'] : [];
+		$open_xpaths  = $args['open_button_xpath'];
+		$close_xpaths = $args['close_button_xpath'];
 
 		$modal_actions = [
 			"{$modal_id}.open"  => $open_xpaths,

--- a/tests/php/test-amp-gallery-embed-handler.php
+++ b/tests/php/test-amp-gallery-embed-handler.php
@@ -275,6 +275,11 @@ class AMP_Gallery_Embed_Handler_Test extends TestCase {
 		// Normalize auto-incrementing ID.
 		$content = preg_replace( '/\bgallery-\d+/', 'gallery-1', $content );
 
+		// @TODO: Handle this more appropriately when webp is supported in WP core.
+		// replace .webp with .jpg.
+		$content = str_replace( '-jpg.webp', '.jpg', $content );
+		$content = str_replace( 'jpg.webp', '.jpg', $content );
+
 		$this->assertEquals(
 			$this->normalize( $expected ),
 			$this->normalize( $content )


### PR DESCRIPTION
## Summary
This PR aims to fix the following issues flagged in #7254
- Static analysis error
- Unit tests failing on the trunk due to `.webp` support integrated into the core.

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
