### PR TITLE
Disable experimental Bento integration in Sandboxing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 /amphtml
 /.env
 /.idea/
+/.vscode/
 /phpcs.xml
 /phpunit.xml
 /*.sql

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -144,7 +144,6 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 		// When custom scripts are on the page, use Bento AMP components whenever possible and turn off some CSS
 		// processing is unnecessary for a valid AMP page and which can break custom scripts.
 		if ( $this->px_verified_kept_node_count > 0 || $this->kept_script_count > 0 ) {
-			$sanitizer_arg_updates[ AMP_Tag_And_Attribute_Sanitizer::class ]['prefer_bento']       = true;
 			$sanitizer_arg_updates[ AMP_Style_Sanitizer::class ]['transform_important_qualifiers'] = false;
 			$sanitizer_arg_updates[ AMP_Style_Sanitizer::class ]['allow_excessive_css']            = true;
 			$sanitizer_arg_updates[ AMP_Form_Sanitizer::class ]['native_post_forms_allowed']       = 'always';

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -639,8 +639,8 @@ class AMP_Script_Sanitizer_Test extends TestCase {
 			$this->assertArrayHasKey( Extension::FACEBOOK_PAGE, $scripts );
 			$this->assertArrayNotHasKey( Extension::FACEBOOK, $scripts );
 		} else {
-			$this->assertArrayNotHasKey( Extension::FACEBOOK_PAGE, $scripts );
-			$this->assertArrayHasKey( Extension::FACEBOOK, $scripts );
+			$this->assertArrayHasKey( Extension::FACEBOOK_PAGE, $scripts );
+			$this->assertArrayNotHasKey( Extension::FACEBOOK, $scripts );
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR aims to disable experimental Bento integration in Sandboxing which was enabled by default and has buggy behavior in loose/moderate sandboxing levels.

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7267 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
