### PR TITLE
Remove postcss loader from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,23 +23,6 @@ const sharedConfig = {
 		filename: '[name].js',
 		chunkFilename: '[name].js',
 	},
-	// TODO: Remove the `module` override once @wordpress/scripts upgrades to PostCSS 8.
-	module: {
-		...defaultConfig.module,
-		rules: defaultConfig.module.rules.map(
-			( rule ) => {
-				const postCssLoader = Array.isArray( rule.use ) && rule.use.find(
-					( loader ) => loader.loader && loader.loader.includes( 'postcss-loader' ),
-				);
-
-				if ( postCssLoader ) {
-					postCssLoader.loader = 'postcss-loader';
-				}
-
-				return rule;
-			},
-		),
-	},
 	plugins: [
 		...defaultConfig.plugins
 			.map(


### PR DESCRIPTION
## Summary

This PR removes explicitly added `postcss-loader` as `@wordpress/scripts` now uses PostCSS 8 in the webpack config.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
