### PR TITLE
Fix core navigation block validation issues

### DIFF
--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -441,6 +441,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function dequeue_block_navigation_view_script() {
 		wp_dequeue_script( 'wp-block-navigation-view' );
+		wp_dequeue_script( 'wp-block-navigation-view-2' );
 	}
 
 	/**


### PR DESCRIPTION
Dequeue the `wp-block-navigation-view-2` script handle to avoid core navigation block validation issues.

## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7322'

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
