### PR TITLE
Fix `SiteScanContextProvider`'s `getSourcesFromScannableUrls()` to handle null `validationError.sources`

### DIFF
--- a/assets/src/components/site-scan-context-provider/get-sources-from-scannable-urls.js
+++ b/assets/src/components/site-scan-context-provider/get-sources-from-scannable-urls.js
@@ -37,6 +37,10 @@ export function getSourcesFromScannableUrls(
 			}
 
 			for (const source of validationError.sources) {
+				if (!source?.type) {
+					continue;
+				}
+
 				if (source.type === 'plugin') {
 					const pluginSlug = getPluginSlugFromFile(source.name);
 

--- a/assets/src/components/site-scan-context-provider/test/get-slugs-from-validation-results.js
+++ b/assets/src/components/site-scan-context-provider/test/get-slugs-from-validation-results.js
@@ -186,4 +186,102 @@ describe('getSourcesFromScannableUrls', () => {
 			},
 		]);
 	});
+
+	it('should continue if validation sources length is null', () => {
+		const scannableUrls = [
+			{
+				url: 'https://foo.example.com/',
+				amp_url: 'https://foo.example.com/?amp=1',
+				validation_errors: [
+					{
+						sources: [{ type: 'plugin', name: 'foo' }],
+					},
+				],
+			},
+			{
+				url: 'https://bar.example.com/',
+				amp_url: 'https://bar.example.com/?amp=1',
+				validation_errors: [
+					{
+						sources: [],
+					},
+				],
+			},
+		];
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: false })
+				.plugins
+		).toStrictEqual([
+			{
+				slug: 'foo',
+				urls: ['https://foo.example.com/'],
+			},
+		]);
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: true })
+				.plugins
+		).toStrictEqual([
+			{
+				slug: 'foo',
+				urls: ['https://foo.example.com/?amp=1'],
+			},
+		]);
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: false })
+				.plugins
+		).not.toStrictEqual([
+			{
+				slug: 'foo',
+				urls: ['https://bar.example.com/'],
+			},
+		]);
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: true })
+				.plugins
+		).not.toStrictEqual([
+			{
+				slug: 'foo',
+				urls: ['https://bar.example.com/?amp=1'],
+			},
+		]);
+	});
+
+	it('should continue if it validation sources contains null keys', () => {
+		const scannableUrls = [
+			{
+				url: 'https://foo.example.com/',
+				amp_url: 'https://foo.example.com/?amp=1',
+				validation_errors: [
+					{
+						sources: [
+							{ type: 'plugin', name: 'foo' },
+							null,
+							{ type: 'plugin', name: 'bar' },
+							null,
+						],
+					},
+				],
+			},
+		];
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: false })
+				.plugins
+		).toStrictEqual([
+			{ slug: 'foo', urls: ['https://foo.example.com/'] },
+			{ slug: 'bar', urls: ['https://foo.example.com/'] },
+		]);
+
+		expect(
+			getSourcesFromScannableUrls(scannableUrls, { useAmpUrls: true })
+				.plugins
+		).toStrictEqual([
+			{ slug: 'foo', urls: ['https://foo.example.com/?amp=1'] },
+			{ slug: 'bar', urls: ['https://foo.example.com/?amp=1'] },
+		]);
+	});
 });


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7380

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
