### PR TITLE
Remove postcss-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15756,19 +15756,6 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
-    "postcss-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
-      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.4"
-      }
-    },
     "postcss-logical": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.21",
     "postcss-import": "15.1.0",
-    "postcss-loader": "4.3.0",
     "postcss-nested": "6.0.0",
     "postcss-preset-env": "8.0.0",
     "prettier": "2.8.2",


### PR DESCRIPTION
## Summary

- Remove `postcss-loader` as this dependency is handled by `@wordpress/scripts` package.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
