### PR TITLE
Display mobile switcher link when mobile redirection is disabled

### DIFF
--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -190,7 +190,7 @@ final class MobileRedirection implements Service, Registerable {
 	}
 
 	/**
-	 * Maybe add mobile switcher link in footer.
+	 * Add mobile switcher link in footer when serving an AMP page.
 	 */
 	public function maybe_add_mobile_switcher_link() {
 		if ( amp_is_request() ) {

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -68,6 +68,7 @@ final class MobileRedirection implements Service, Registerable {
 			$sandboxing_level           = amp_get_sandboxing_level();
 			$is_mobile_redirect_enabled = AMP_Options_Manager::get_option( Option::MOBILE_REDIRECT );
 
+			// Add alternative link if mobile redirection is enabled or sandboxing level is set to loose or moderate.
 			if ( $is_mobile_redirect_enabled || ( 1 === $sandboxing_level || 2 === $sandboxing_level ) ) {
 				add_action( 'wp_head', [ $this, 'add_mobile_alternative_link' ] );
 			}

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -452,6 +452,33 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * @covers ::maybe_add_mobile_switcher_link()
+	 */
+	public function test_maybe_add_mobile_switcher_link() {
+		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
+
+		$this->go_to( '/' );
+		$this->instance->maybe_add_mobile_switcher_link();
+
+		$this->assertFalse( amp_is_request() );
+		$this->assertFalse( has_action( 'wp_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
+		$this->assertFalse( has_action( 'amp_post_template_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
+		$this->assertFalse( has_action( 'wp_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
+		$this->assertFalse( has_action( 'amp_post_template_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
+
+
+		$this->go_to( '/' );
+		set_query_var( QueryVar::AMP, '1' );
+		$this->instance->maybe_add_mobile_switcher_link();
+
+		$this->assertTrue( amp_is_request() );
+		$this->assertEquals( 10, has_action( 'wp_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
+		$this->assertEquals( 10, has_action( 'amp_post_template_head', [ $this->instance, 'add_mobile_version_switcher_styles' ] ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
+		$this->assertEquals( 10, has_action( 'amp_post_template_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
+	}
+
+	/**
 	 * @covers ::add_mobile_switcher_head_hooks()
 	 * @covers ::add_mobile_switcher_footer_hooks()
 	 * @covers ::add_a2a_linking_hooks()

--- a/tests/php/src/MobileRedirectionTest.php
+++ b/tests/php/src/MobileRedirectionTest.php
@@ -466,7 +466,6 @@ final class MobileRedirectionTest extends DependencyInjectedTestCase {
 		$this->assertFalse( has_action( 'wp_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
 		$this->assertFalse( has_action( 'amp_post_template_footer', [ $this->instance, 'add_mobile_version_switcher_link' ] ) );
 
-
 		$this->go_to( '/' );
 		set_query_var( QueryVar::AMP, '1' );
 		$this->instance->maybe_add_mobile_switcher_link();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #5293 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
