### PR TITLE
Add guard to avoid fatal error in case logo height/width is zero

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -591,8 +591,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					return $html;
 				}
 
-				$img_width  = $src[1] ? (int) $src[1] : 0;
-				$img_height = $src[2] ? (int) $src[2] : 0;
+				$img_width  = (int) $src[1];
+				$img_height = (int) $src[2];
 
 				// If height is zero, bail.
 				if ( 0 === $img_height ) {

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -594,8 +594,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$img_width  = $src[1] ? (int) $src[1] : 0;
 				$img_height = $src[2] ? (int) $src[2] : 0;
 
-				// If height or width is zero, bail.
-				if ( 0 === $img_width || 0 === $img_height ) {
+				// If height is zero, bail.
+				if ( 0 === $img_height ) {
 					return $html;
 				}
 
@@ -889,8 +889,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					$width  = (int) $matches['width'];
 					$height = (int) $matches['height'];
 
-					// If height or width is zero, bail.
-					if ( 0 === $height || 0 === $width ) {
+					// If height is zero, bail.
+					if ( 0 === $height ) {
 						return $html;
 					}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -595,7 +595,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				$img_height = (int) $src[2];
 
 				// If height is zero, bail.
-				if ( 0 === $img_height ) {
+				if ( 0 === $img_height || 0 === $img_width ) {
 					return $html;
 				}
 
@@ -890,7 +890,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					$height = (int) $matches['height'];
 
 					// If height is zero, bail.
-					if ( 0 === $height ) {
+					if ( 0 === $height || 0 === $width ) {
 						return $html;
 					}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -591,12 +591,20 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					return $html;
 				}
 
+				$img_width  = $src[1] ? (int) $src[1] : 0;
+				$img_height = $src[2] ? (int) $src[2] : 0;
+
+				// If height or width is zero, bail.
+				if ( 0 === $img_width || 0 === $img_height ) {
+					return $html;
+				}
+
 				if ( 'blank' === get_header_textcolor() && has_custom_header() ) {
 					$height = 200;
 				} else {
 					$height = 80;
 				}
-				$width = $height * ( $src[1] / $src[2] ); // Note that float values are allowed.
+				$width = $height * ( $img_width / $img_height ); // Note that float values are allowed.
 
 				$html = preg_replace( '/(?<=width=")\d+(?=")/', $width, $html );
 				$html = preg_replace( '/(?<=height=")\d+(?=")/', $height, $html );
@@ -880,6 +888,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				if ( isset( $matches['width'], $matches['height'] ) ) {
 					$width  = (int) $matches['width'];
 					$height = (int) $matches['height'];
+
+					// If height or width is zero, bail.
+					if ( 0 === $height || 0 === $width ) {
+						return $html;
+					}
 
 					$desktop_height = 9; // in rem; see <https://github.com/WordPress/wordpress-develop/blob/ad8d01a7e9e13144d1676b8e6d70c3e81ef703af/src/wp-content/themes/twentytwenty/style.css#L4887>.
 					$mobile_height  = 6; // in rem; see <https://github.com/WordPress/wordpress-develop/blob/ad8d01a7e9e13144d1676b8e6d70c3e81ef703af/src/wp-content/themes/twentytwenty/style.css#L1424>.

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -113,6 +113,28 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 	}
 
 	/**
+	 * Test add_twentyseventeen_attachment_image_attributes() with zero height logo.
+	 *
+	 * @covers ::add_twentyseventeen_attachment_image_attributes()
+	 */
+	public function test_add_twentyseventeen_attachment_image_attributes_with_zero_height_width() {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg', 0 );
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			[
+				'height' => 0,
+			]
+		);
+		set_theme_mod( 'custom_logo', $attachment_id );
+
+		AMP_Core_Theme_Sanitizer::add_twentyseventeen_attachment_image_attributes( [] );
+		$logo = get_custom_logo();
+
+		$this->assertStringNotContainsString( 'height=', $logo );
+	}
+
+	/**
 	 * @dataProvider get_data_for_using_native_img
 	 * @covers::add_twentytwenty_masthead_styles()
 	 * @param bool $native_img_used Use native img.
@@ -486,6 +508,26 @@ class AMP_Core_Theme_Sanitizer_Test extends TestCase {
 		} else {
 			$this->assertStringContainsString( $needle, $logo );
 		}
+	}
+
+	/**
+	 * Test add_twentytwenty_custom_logo_fix() with zero height logo.
+	 *
+	 * @covers ::add_twentytwenty_custom_logo_fix()
+	 */
+	public function test_add_twentytwenty_custom_logo_fix_with_zero_height_width() {
+		add_filter(
+			'get_custom_logo',
+			static function () {
+				return '<img src="https://example.com/logo.jpg" width="200" height="0">';
+			}
+		);
+
+		AMP_Core_Theme_Sanitizer::add_twentytwenty_custom_logo_fix( [] );
+		$logo = get_custom_logo();
+
+		$this->assertStringContainsString( 'width="200"', $logo );
+		$this->assertStringContainsString( 'height="0"', $logo );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7427

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
