### PR TITLE
Update representation of empty strings on URL validation screen

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3303,7 +3303,9 @@ class AMP_Validation_Error_Taxonomy {
 					return sprintf(
 						/* translators: %1$s is the invalid attribute value, %2$s is the attribute name */
 						esc_html__( 'Invalid value %1$s for attribute %2$s', 'amp' ),
-						'<code>' . esc_html( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) . '</code>',
+						empty( $validation_error['node_attributes'][ $validation_error['attribute'] ] )
+							? '(' . esc_html__( 'empty', 'amp' ) . ')'
+							: '<code>' . esc_html( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) . '</code>',
 						'<code>' . esc_html( $validation_error['attribute'] ) . '</code>'
 					);
 				} else {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -3304,7 +3304,7 @@ class AMP_Validation_Error_Taxonomy {
 						/* translators: %1$s is the invalid attribute value, %2$s is the attribute name */
 						esc_html__( 'Invalid value %1$s for attribute %2$s', 'amp' ),
 						empty( $validation_error['node_attributes'][ $validation_error['attribute'] ] )
-							? '(' . esc_html__( 'empty', 'amp' ) . ')'
+							? esc_html__( '(empty)', 'amp' )
 							: '<code>' . esc_html( $validation_error['node_attributes'][ $validation_error['attribute'] ] ) . '</code>',
 						'<code>' . esc_html( $validation_error['attribute'] ) . '</code>'
 					);


### PR DESCRIPTION
## Summary

Before:
![image](https://user-images.githubusercontent.com/54371619/215584180-dae1928f-ccd5-4ae2-bc3e-a33b6c52faad.png)

After:
![image](https://user-images.githubusercontent.com/54371619/215583971-b89c7339-3198-49a3-85d4-2080f584c0e4.png)

Fixes #5598

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
