### PR TITLE
Migrate PHPUnit XML configuration from deprecated to latest schema

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -60,7 +60,7 @@ jobs:
           echo -e "Modified files:\n$MODIFIED_FILES\n"
 
           FILE_COUNT=$(php -f bin/determine-modified-files-count.php "$IGNORE_PATH_REGEX" "$MODIFIED_FILES" --invert)
-          PHP_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.php|composer\.(json|lock)|phpstan\.neon\.dist" "$MODIFIED_FILES")
+          PHP_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.php|composer\.(json|lock)|phpstan\.neon\.dist|phpunit\.xml\.dist" "$MODIFIED_FILES")
           CSS_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.s?css|package\.json|package-lock\.json" "$MODIFIED_FILES")
           JS_FILE_COUNT=$(php -f bin/determine-modified-files-count.php ".+\.(js|snap)|package\.json|package-lock\.json" "$MODIFIED_FILES")
           GHA_WORKFLOW_COUNT=$(php -f bin/determine-modified-files-count.php "(\.github\/workflows\/.+\.yml)" "$MODIFIED_FILES")

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,33 @@
 <phpunit
-	bootstrap="tests/php/bootstrap.php"
-	backupGlobals="false"
 	colors="true"
-	convertDeprecationsToExceptions="false"
+	backupGlobals="false"
+	defaultTestSuite="default"
 	convertErrorsToExceptions="false"
 	convertNoticesToExceptions="false"
+	bootstrap="tests/php/bootstrap.php"
 	convertWarningsToExceptions="false"
-	defaultTestSuite="default"
+	convertDeprecationsToExceptions="false"
 	>
+	<coverage processUncoveredFiles="false">
+		<include>
+			<directory suffix=".php">./</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">assets</directory>
+			<directory suffix=".php">back-compat</directory>
+			<directory suffix=".php">bin</directory>
+			<directory suffix=".php">build</directory>
+			<directory suffix=".php">docs</directory>
+			<directory suffix=".php">node_modules</directory>
+			<directory suffix=".php">svn</directory>
+			<directory suffix=".php">tests</directory>
+			<directory suffix=".php">vendor</directory>
+			<directory suffix=".php">includes/ecosystem-data</directory>
+			<file>.phpstorm.meta.php</file>
+		</exclude>
+	</coverage>
 	<php>
-		<const name="WP_TEST_ACTIVATED_PLUGINS" value="gutenberg/gutenberg.php,pwa/pwa.php" />
+		<const name="WP_TEST_ACTIVATED_PLUGINS" value="gutenberg/gutenberg.php,pwa/pwa.php"/>
 	</php>
 	<testsuites>
 		<!-- Default test suite to run all tests -->
@@ -26,22 +44,4 @@
 			<group>external-http</group>
 		</exclude>
 	</groups>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">./</directory>
-			<exclude>
-				<directory suffix=".php">assets</directory>
-				<directory suffix=".php">back-compat</directory>
-				<directory suffix=".php">bin</directory>
-				<directory suffix=".php">build</directory>
-				<directory suffix=".php">docs</directory>
-				<directory suffix=".php">node_modules</directory>
-				<directory suffix=".php">svn</directory>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">includes/ecosystem-data</directory>
-				<file>.phpstorm.meta.php</file>
-			</exclude>
-		</whitelist>
-	</filter>
 </phpunit>


### PR DESCRIPTION
## Summary

This PR aims to fix the warning raised by PHPUnit while running unit tests.

![image](https://user-images.githubusercontent.com/54371619/216292486-1f243de3-b21c-46c6-8d93-10d0ebb49b43.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
