### PR TITLE
Fix react unique key prop error in `<SiteScanNotice />` component

### DIFF
--- a/assets/src/admin/site-scan-notice/notice.js
+++ b/assets/src/admin/site-scan-notice/notice.js
@@ -71,6 +71,7 @@ export function SiteScanNotice() {
 		let elements = [
 			pluginsWithAmpIncompatibility.length > 0 ? (
 				<PluginsWithAmpIncompatibility
+					key={pluginsWithAmpIncompatibility.length}
 					pluginsWithAmpIncompatibility={
 						pluginsWithAmpIncompatibility
 					}
@@ -78,6 +79,7 @@ export function SiteScanNotice() {
 			) : null,
 			themesWithAmpIncompatibility.length > 0 ? (
 				<ThemesWithAmpIncompatibility
+					key={themesWithAmpIncompatibility.length}
 					themesWithAmpIncompatibility={themesWithAmpIncompatibility}
 				/>
 			) : null,

--- a/assets/src/admin/site-scan-notice/notice.js
+++ b/assets/src/admin/site-scan-notice/notice.js
@@ -71,7 +71,7 @@ export function SiteScanNotice() {
 		let elements = [
 			pluginsWithAmpIncompatibility.length > 0 ? (
 				<PluginsWithAmpIncompatibility
-					key={pluginsWithAmpIncompatibility.length}
+					key={`plugins-${pluginsWithAmpIncompatibility.length}`}
 					pluginsWithAmpIncompatibility={
 						pluginsWithAmpIncompatibility
 					}
@@ -79,7 +79,7 @@ export function SiteScanNotice() {
 			) : null,
 			themesWithAmpIncompatibility.length > 0 ? (
 				<ThemesWithAmpIncompatibility
-					key={themesWithAmpIncompatibility.length}
+					key={`themes-${themesWithAmpIncompatibility.length}`}
 					themesWithAmpIncompatibility={themesWithAmpIncompatibility}
 				/>
 			) : null,


### PR DESCRIPTION
## Summary

Fix the react unique key prop error while rendering `<SiteScanNotice />` in the plugin's admin screen which is usually triggered when someone activates a plugin.

Error:
![image](https://user-images.githubusercontent.com/54371619/216611387-2c59ea38-8c14-471e-bcd0-a52dd2260d09.png)

Originally discovered in https://github.com/ampproject/amp-wp/pull/7421#issuecomment-1405672781 while working on #7421.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
