### PR TITLE
Add AMP Settings label for gallery block toggle settings

### DIFF
--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -8,7 +8,7 @@ import { isFunction, isObject, isString } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, PanelBody } from '@wordpress/components';
+import { ToggleControl, PanelBody, BaseControl } from '@wordpress/components';
 import {
 	InspectorControls,
 	InspectorAdvancedControls,
@@ -344,13 +344,13 @@ ImageBlockLayoutAttributes.propTypes = {
  */
 const GalleryBlockLayoutAttributes = (props) => (
 	<InspectorAdvancedControls>
-		<div>
-			<p className="components-base-control__label">
+		<BaseControl __nextHasNoMarginBottom>
+			<BaseControl.VisualLabel>
 				{__('AMP Settings', 'amp')}
-			</p>
+			</BaseControl.VisualLabel>
 			<AmpLightboxToggle {...props} />
 			<AmpCarouselToggle {...props} />
-		</div>
+		</BaseControl>
 	</InspectorAdvancedControls>
 );
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -344,8 +344,13 @@ ImageBlockLayoutAttributes.propTypes = {
  */
 const GalleryBlockLayoutAttributes = (props) => (
 	<InspectorAdvancedControls>
-		<AmpLightboxToggle {...props} />
-		<AmpCarouselToggle {...props} />
+		<div>
+			<p className="components-base-control__label">
+				{__('AMP Settings', 'amp')}
+			</p>
+			<AmpLightboxToggle {...props} />
+			<AmpCarouselToggle {...props} />
+		</div>
 	</InspectorAdvancedControls>
 );
 


### PR DESCRIPTION
## Summary

Add a label for gallery block AMP carousel and lightbox toggle settings.

![image](https://user-images.githubusercontent.com/54371619/217096016-71baa48c-1ed1-470d-bafb-e6dab6c57db1.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
