### PR TITLE
Fix PHP 8.1/8.2 deprecation warnings

### DIFF
--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -92,7 +92,7 @@ class AMP_HTTP {
 		header(
 			sprintf( '%s: %s', $name, $value ),
 			$args['replace'],
-			$args['status_code']
+			null === $args['status_code'] ? 0 : (int) $args['status_code']
 		);
 		return true;
 	}


### PR DESCRIPTION
## Summary

Update `AMP_HTTP::send_header()` to pass the third param as int in `header()` which was causing this deprecation warning:
```bash
PHP Deprecated:  header(): Passing null to parameter #3 ($response_code) of type int is deprecated in C:\Users\win 10\Local Sites\php8amp\app\public\wp-content\plugins\amp\includes\class-amp-http.php on line 95
```
Fixes #

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
