### PR TITLE
Use zero instead of null as empty arg for `header()` for PHP 8.1+ compat

### DIFF
--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -92,7 +92,7 @@ class AMP_HTTP {
 		header(
 			sprintf( '%s: %s', $name, $value ),
 			$args['replace'],
-			$args['status_code']
+			empty( $args['status_code'] ) ? 0 : (int) $args['status_code']
 		);
 		return true;
 	}

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -79,7 +79,7 @@ class AMP_HTTP {
 		$args = array_merge(
 			[
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			$args
 		);

--- a/tests/php/src/Instrumentation/ServerTimingTest.php
+++ b/tests/php/src/Instrumentation/ServerTimingTest.php
@@ -244,7 +244,7 @@ final class ServerTimingTest extends DependencyInjectedTestCase {
 				'name'        => 'Server-Timing',
 				'value'       => 'event-10;desc="Event N°10";dur="12345.7"',
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -275,7 +275,7 @@ final class ServerTimingTest extends DependencyInjectedTestCase {
 				'name'        => 'Server-Timing',
 				'value'       => 'event-11;desc="Event N°11";dur="3.1"',
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -357,7 +357,7 @@ final class ServerTimingTest extends DependencyInjectedTestCase {
 				'name'        => 'Server-Timing',
 				'value'       => 'main-event;desc="Main Event";dur="1.2"',
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -385,7 +385,7 @@ final class ServerTimingTest extends DependencyInjectedTestCase {
 				'name'        => 'Server-Timing',
 				'value'       => 'main-event;desc="Main Event";dur="1.2",verbose-event;desc="Verbose Event";dur="3.4"',
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);

--- a/tests/php/test-class-amp-http.php
+++ b/tests/php/test-class-amp-http.php
@@ -47,7 +47,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'Foo',
 				'value'       => 'Bar',
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -71,7 +71,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'Foo',
 				'value'       => 'Bar',
 				'replace'     => false,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -116,7 +116,7 @@ class Test_AMP_HTTP extends TestCase {
 		$this->assertEquals( 'desc="Description"', $values[1] );
 		$this->assertStringStartsWith( 'dur=123000.', $values[2] );
 		$this->assertFalse( AMP_HTTP::$headers_sent[0]['replace'] );
-		$this->assertNull( AMP_HTTP::$headers_sent[0]['status_code'] );
+		$this->assertSame( 0, AMP_HTTP::$headers_sent[0]['status_code'] );
 	}
 
 	/**
@@ -133,7 +133,7 @@ class Test_AMP_HTTP extends TestCase {
 		$this->assertEquals( 'name', $values[0] );
 		$this->assertStringStartsWith( 'dur=0.', $values[1] );
 		$this->assertFalse( AMP_HTTP::$headers_sent[0]['replace'] );
-		$this->assertNull( AMP_HTTP::$headers_sent[0]['status_code'] );
+		$this->assertSame( 0, AMP_HTTP::$headers_sent[0]['status_code'] );
 	}
 
 	/**
@@ -295,19 +295,19 @@ class Test_AMP_HTTP extends TestCase {
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => home_url(),
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 			],
 			AMP_HTTP::$headers_sent
@@ -326,31 +326,31 @@ class Test_AMP_HTTP extends TestCase {
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'AMP-Access-Control-Allow-Source-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => true,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Access-Control-Expose-Headers',
 					'value'       => 'AMP-Access-Control-Allow-Source-Origin',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 			],
 			AMP_HTTP::$headers_sent
@@ -369,31 +369,31 @@ class Test_AMP_HTTP extends TestCase {
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'AMP-Access-Control-Allow-Source-Origin',
 					'value'       => home_url(),
 					'replace'     => true,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 				[
 					'name'        => 'Access-Control-Expose-Headers',
 					'value'       => 'AMP-Access-Control-Allow-Source-Origin',
 					'replace'     => false,
-					'status_code' => null,
+					'status_code' => 0,
 				],
 			],
 			AMP_HTTP::$headers_sent
@@ -453,7 +453,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'AMP-Redirect-To',
 				'value'       => $url,
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -462,7 +462,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'Access-Control-Expose-Headers',
 				'value'       => 'AMP-Redirect-To',
 				'replace'     => false,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -478,7 +478,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'AMP-Redirect-To',
 				'value'       => preg_replace( '#^\w+:#', '', $url ),
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -487,7 +487,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'Access-Control-Expose-Headers',
 				'value'       => 'AMP-Redirect-To',
 				'replace'     => false,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -502,7 +502,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url( '/new-location/' ), 'https' ),
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -518,7 +518,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url( '/new-location/' ), 'https' ),
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);
@@ -533,7 +533,7 @@ class Test_AMP_HTTP extends TestCase {
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url(), 'https' ),
 				'replace'     => true,
-				'status_code' => null,
+				'status_code' => 0,
 			],
 			AMP_HTTP::$headers_sent
 		);


### PR DESCRIPTION
See https://github.com/ampproject/amp-wp/pull/7225#issuecomment-1419577908

See also docs for `header()`: https://www.php.net/manual/en/function.header.php

The `$response_code` parameter is define as follows:

> Forces the HTTP response code to the specified value. Note that this parameter only has an effect if the header is not empty.

Note _empty_ here. So `0` and `null` should work the same since they are both `empty`.

Note also the function signature:

```php
header(string $header, bool $replace = true, int $response_code = 0): void
```

The default value of `$response_code` is `0`.