### PR TITLE
Disable `Exit Mobile Version` link in transitional mode if mobile redirection is disabled

### DIFF
--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -192,7 +192,7 @@ final class MobileRedirection implements Service, Registerable {
 	 * Add mobile switcher link in footer when serving an AMP page.
 	 */
 	public function maybe_add_mobile_switcher_link() {
-		if ( amp_is_request() ) {
+		if ( amp_is_request() && AMP_Theme_Support::READER_MODE_SLUG === AMP_Options_Manager::get_option( Option::THEME_SUPPORT ) ) {
 			$this->add_mobile_switcher_head_hooks();
 			$this->add_mobile_switcher_footer_hooks();
 		}


### PR DESCRIPTION
## Summary

This PR aims to disable the `Exit Mobile Version` link in the transitional mode while mobile redirection is disabled.
See: https://github.com/ampproject/amp-wp/issues/5293#issuecomment-1419339426

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
