### PR TITLE
Fix usage of `amp_register_polyfills` hook

### DIFF
--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -330,8 +330,12 @@ class AMP_Template_Customizer {
 		$dependencies = $asset['dependencies'];
 		$version      = $asset['version'];
 
-		/** This action is documented in includes/class-amp-theme-support.php */
-		do_action( 'amp_register_polyfills' );
+		if ( ! Services::get( 'dependency_support' )->has_support() ) {
+			/**
+			 * Fires when AMP Polyfills should be registered.
+			 */
+			do_action( 'amp_register_polyfills' );
+		}
 
 		wp_enqueue_script(
 			$handle,
@@ -585,8 +589,12 @@ class AMP_Template_Customizer {
 		$dependencies = $asset['dependencies'];
 		$version      = $asset['version'];
 
-		/** This action is documented in includes/class-amp-theme-support.php */
-		do_action( 'amp_register_polyfills' );
+		if ( ! Services::get( 'dependency_support' )->has_support() ) {
+			/**
+			 * Fires when AMP Polyfills should be registered.
+			 */
+			do_action( 'amp_register_polyfills' );
+		}
 
 		wp_enqueue_script(
 			'amp-customize-controls', // Note: This is not 'amp-customize-controls-legacy' to not break existing scripts that have this dependency.
@@ -645,8 +653,12 @@ class AMP_Template_Customizer {
 			return;
 		}
 
-		/** This action is documented in includes/class-amp-theme-support.php */
-		do_action( 'amp_register_polyfills' );
+		if ( ! Services::get( 'dependency_support' )->has_support() ) {
+			/**
+			 * Fires when AMP Polyfills should be registered.
+			 */
+			do_action( 'amp_register_polyfills' );
+		}
 
 		$asset_file   = AMP__DIR__ . '/assets/js/amp-customize-preview-legacy.asset.php';
 		$asset        = require $asset_file;

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -330,11 +330,6 @@ class AMP_Template_Customizer {
 		$dependencies = $asset['dependencies'];
 		$version      = $asset['version'];
 
-		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/** This action is documented in src/Admin/PairedBrowsing.php */
-			do_action( 'amp_register_polyfills' );
-		}
-
 		wp_enqueue_script(
 			$handle,
 			amp_get_asset_url( 'js/amp-customize-controls.js' ),
@@ -587,11 +582,6 @@ class AMP_Template_Customizer {
 		$dependencies = $asset['dependencies'];
 		$version      = $asset['version'];
 
-		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/** This action is documented in src/Admin/PairedBrowsing.php */
-			do_action( 'amp_register_polyfills' );
-		}
-
 		wp_enqueue_script(
 			'amp-customize-controls', // Note: This is not 'amp-customize-controls-legacy' to not break existing scripts that have this dependency.
 			amp_get_asset_url( 'js/amp-customize-controls-legacy.js' ),
@@ -647,11 +637,6 @@ class AMP_Template_Customizer {
 		// Bail if user can't customize anyway.
 		if ( ! current_user_can( 'customize' ) ) {
 			return;
-		}
-
-		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/** This action is documented in src/Admin/PairedBrowsing.php */
-			do_action( 'amp_register_polyfills' );
 		}
 
 		$asset_file   = AMP__DIR__ . '/assets/js/amp-customize-preview-legacy.asset.php';

--- a/includes/admin/class-amp-template-customizer.php
+++ b/includes/admin/class-amp-template-customizer.php
@@ -331,9 +331,7 @@ class AMP_Template_Customizer {
 		$version      = $asset['version'];
 
 		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/**
-			 * Fires when AMP Polyfills should be registered.
-			 */
+			/** This action is documented in src/Admin/PairedBrowsing.php */
 			do_action( 'amp_register_polyfills' );
 		}
 
@@ -590,9 +588,7 @@ class AMP_Template_Customizer {
 		$version      = $asset['version'];
 
 		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/**
-			 * Fires when AMP Polyfills should be registered.
-			 */
+			/** This action is documented in src/Admin/PairedBrowsing.php */
 			do_action( 'amp_register_polyfills' );
 		}
 
@@ -654,9 +650,7 @@ class AMP_Template_Customizer {
 		}
 
 		if ( ! Services::get( 'dependency_support' )->has_support() ) {
-			/**
-			 * Fires when AMP Polyfills should be registered.
-			 */
+			/** This action is documented in src/Admin/PairedBrowsing.php */
 			do_action( 'amp_register_polyfills' );
 		}
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -16,38 +16,8 @@ use AmpProject\AmpWP\Services;
  * @internal
  */
 function amp_init_customizer() {
-
 	if ( ! Services::get( 'dependency_support' )->has_support() ) {
-		// @codeCoverageIgnoreStart
-		add_action(
-			'customize_controls_init',
-			static function () {
-				global $wp_customize;
-				if (
-					Services::get( 'reader_theme_loader' )->is_theme_overridden()
-					||
-					array_intersect( $wp_customize->get_autofocus(), [ 'panel' => AMP_Template_Customizer::PANEL_ID ] )
-					||
-					isset( $_GET[ QueryVar::AMP_PREVIEW ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				) {
-					wp_die(
-						esc_html(
-							sprintf(
-								/* translators: %s is minimum WordPress version */
-								__( 'Customizer for AMP is unavailable due to WordPress being out of date. Please upgrade to WordPress %s or greater.', 'amp' ),
-								DependencySupport::WP_MIN_VERSION
-							)
-						),
-						esc_html__( 'AMP Customizer Unavailable', 'amp' ),
-						[
-							'response'  => 503,
-							'back_link' => true,
-						]
-					);
-				}
-			}
-		);
-		// @codeCoverageIgnoreEnd
+		return; // @codeCoverageIgnore
 	}
 
 	// Fire up the AMP Customizer.

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -197,7 +197,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 			return;
 		}
 
-		/** This action is documented in includes/class-amp-theme-support.php */
+		/** This action is documented in src/Admin/PairedBrowsing.php */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/OnboardingWizardSubmenuPage.php
+++ b/src/Admin/OnboardingWizardSubmenuPage.php
@@ -197,7 +197,7 @@ final class OnboardingWizardSubmenuPage implements Delayed, Registerable, Servic
 			return;
 		}
 
-		/** This action is documented in src/Admin/PairedBrowsing.php */
+		/** This action is documented in src/Admin/OptionsMenu.php */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -213,7 +213,11 @@ class OptionsMenu implements Conditional, Service, Registerable {
 			return;
 		}
 
-		/** This action is documented in src/Admin/PairedBrowsing.php */
+		/**
+		 * Fires before registering plugin assets that may require core asset polyfills.
+		 *
+		 * @internal
+		 */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/OptionsMenu.php
+++ b/src/Admin/OptionsMenu.php
@@ -213,7 +213,7 @@ class OptionsMenu implements Conditional, Service, Registerable {
 			return;
 		}
 
-		/** This action is documented in includes/class-amp-theme-support.php */
+		/** This action is documented in src/Admin/PairedBrowsing.php */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -182,13 +182,6 @@ final class PairedBrowsing implements Service, Registerable, Conditional, Delaye
 	public function init_client() {
 		add_action( 'admin_bar_menu', [ $this, 'add_admin_bar_menu_item' ], 102 );
 
-		/**
-		 * Fires before registering plugin assets that may require core asset polyfills.
-		 *
-		 * @internal
-		 */
-		do_action( 'amp_register_polyfills' );
-
 		$handle       = 'amp-paired-browsing-client';
 		$asset        = require AMP__DIR__ . '/assets/js/amp-paired-browsing-client.asset.php';
 		$dependencies = $asset['dependencies'];
@@ -308,10 +301,6 @@ final class PairedBrowsing implements Service, Registerable, Conditional, Delaye
 	 * @return string Custom template if in paired browsing mode, else the supplied template.
 	 */
 	public function filter_template_include_for_app() {
-
-		/** This action is documented in src/Admin/PairedBrowsing.php */
-		do_action( 'amp_register_polyfills' );
-
 		$handle = 'amp-paired-browsing-app';
 		wp_enqueue_style(
 			$handle,

--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -309,7 +309,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional, Delaye
 	 */
 	public function filter_template_include_for_app() {
 
-		/** This action is documented in includes/class-amp-theme-support.php */
+		/** This action is documented in src/Admin/PairedBrowsing.php */
 		do_action( 'amp_register_polyfills' );
 
 		$handle = 'amp-paired-browsing-app';

--- a/src/Admin/SupportScreen.php
+++ b/src/Admin/SupportScreen.php
@@ -189,7 +189,7 @@ class SupportScreen implements Conditional, Delayed, Service, Registerable {
 			return;
 		}
 
-		/** This action is documented in includes/class-amp-theme-support.php */
+		/** This action is documented in src/Admin/PairedBrowsing.php */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/SupportScreen.php
+++ b/src/Admin/SupportScreen.php
@@ -189,7 +189,7 @@ class SupportScreen implements Conditional, Delayed, Service, Registerable {
 			return;
 		}
 
-		/** This action is documented in src/Admin/PairedBrowsing.php */
+		/** This action is documented in src/Admin/OptionsMenu.php */
 		do_action( 'amp_register_polyfills' );
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSET_HANDLE . '.asset.php';

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -89,7 +89,7 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * Enqueue admin assets.
 	 */
 	public function enqueue_scripts() {
-		if ( $this->is_options_menu() ) {
+		if ( $this->is_dedicated_plugin_screen() ) {
 			do_action( 'amp_register_polyfills' );
 		}
 
@@ -123,7 +123,7 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * screen related to `amp_validation_error` post type (which includes the `amp_validation_error` taxonomy).
 	 */
 	protected function maybe_add_preload_rest_paths() {
-		if ( $this->is_options_menu() ) {
+		if ( $this->is_dedicated_plugin_screen() ) {
 			$this->rest_preloader->add_preloaded_path( '/amp/v1/unreviewed-validation-counts' );
 		}
 	}
@@ -131,7 +131,7 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	/**
 	 * Whether the current screen is pages inside the AMP Options menu.
 	 */
-	public function is_options_menu() {
+	public function is_dedicated_plugin_screen() {
 		return (
 			AMP_Options_Manager::OPTION_NAME === get_admin_page_parent()
 			||

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -89,8 +89,9 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * Enqueue admin assets.
 	 */
 	public function enqueue_scripts() {
-		/** This action is documented in includes/class-amp-theme-support.php */
-		do_action( 'amp_register_polyfills' );
+		if ( $this->is_options_menu() ) {
+			do_action( 'amp_register_polyfills' );
+		}
 
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSETS_HANDLE . '.asset.php';
 		$asset        = require $asset_file;
@@ -122,12 +123,19 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * screen related to `amp_validation_error` post type (which includes the `amp_validation_error` taxonomy).
 	 */
 	protected function maybe_add_preload_rest_paths() {
-		if (
+		if ( $this->is_options_menu() ) {
+			$this->rest_preloader->add_preloaded_path( '/amp/v1/unreviewed-validation-counts' );
+		}
+	}
+
+	/**
+	 * Whether the current screen is pages inside the AMP Options menu.
+	 */
+	public function is_options_menu() {
+		return (
 			AMP_Options_Manager::OPTION_NAME === get_admin_page_parent()
 			||
 			AMP_Validated_URL_Post_Type::POST_TYPE_SLUG === get_current_screen()->post_type
-		) {
-			$this->rest_preloader->add_preloaded_path( '/amp/v1/unreviewed-validation-counts' );
-		}
+		);
 	}
 }

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -90,6 +90,7 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 */
 	public function enqueue_scripts() {
 		if ( $this->is_dedicated_plugin_screen() ) {
+			/** This action is documented in src/Admin/PairedBrowsing.php */
 			do_action( 'amp_register_polyfills' );
 		}
 

--- a/src/Admin/ValidationCounts.php
+++ b/src/Admin/ValidationCounts.php
@@ -89,11 +89,6 @@ final class ValidationCounts implements Service, Registerable, Conditional, Dela
 	 * Enqueue admin assets.
 	 */
 	public function enqueue_scripts() {
-		if ( $this->is_dedicated_plugin_screen() ) {
-			/** This action is documented in src/Admin/PairedBrowsing.php */
-			do_action( 'amp_register_polyfills' );
-		}
-
 		$asset_file   = AMP__DIR__ . '/assets/js/' . self::ASSETS_HANDLE . '.asset.php';
 		$asset        = require $asset_file;
 		$dependencies = $asset['dependencies'];

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -149,6 +149,8 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 	 * @covers ::init_client()
 	 */
 	public function test_init_frontend_client() {
+		$this->maybe_skip_test();
+
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post = self::factory()->post->create_and_get();
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
@@ -232,6 +234,8 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 
 	/** @covers ::filter_template_include_for_app() */
 	public function test_filter_template_include_for_app_when_allowed() {
+		$this->maybe_skip_test();
+
 		$include_path = $this->instance->filter_template_include_for_app();
 		$this->assertTrue( wp_style_is( 'amp-paired-browsing-app' ) );
 		$this->assertTrue( wp_script_is( 'amp-paired-browsing-app' ) );
@@ -244,5 +248,14 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		$this->assertStringContainsString( 'amp-paired-browsing-app.js', $template );
 		$this->assertStringContainsString( 'ampPairedBrowsingAppData', $template );
 		$this->assertStringContainsString( 'ampPairedBrowsingQueryVar', $template );
+	}
+
+	/**
+	 * Skip tests when wp-url and wp-dom-ready are not available.
+	 */
+	public function maybe_skip_test() {
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+			$this->markTestSkipped( 'Skipping test as PairedBrowsing can\'t be tested due to lack of wp-dom-ready and wp-url scripts in WP < 5.0' );
+		}
 	}
 }

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -142,7 +142,6 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 
 		// Check that init_client() was not called.
 		$this->assertFalse( has_action( 'admin_bar_menu', [ $this->instance, 'add_admin_bar_menu_item' ] ) );
-		$this->assertEquals( 0, did_action( 'amp_register_polyfills' ) );
 	}
 
 	/**
@@ -161,7 +160,6 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 
 		// Check that init_client() was called.
 		$this->assertEquals( 102, has_action( 'admin_bar_menu', [ $this->instance, 'add_admin_bar_menu_item' ] ) );
-		$this->assertEquals( 1, did_action( 'amp_register_polyfills' ) );
 		$this->assertTrue( wp_script_is( 'amp-paired-browsing-client' ) );
 		$printed_scripts = get_echo( 'wp_print_scripts' );
 		$this->assertStringContainsString( DevMode::DEV_MODE_ATTRIBUTE, $printed_scripts );
@@ -234,10 +232,7 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 
 	/** @covers ::filter_template_include_for_app() */
 	public function test_filter_template_include_for_app_when_allowed() {
-		$this->assertEquals( 0, did_action( 'amp_register_polyfills' ) );
-
 		$include_path = $this->instance->filter_template_include_for_app();
-		$this->assertEquals( 1, did_action( 'amp_register_polyfills' ) );
 		$this->assertTrue( wp_style_is( 'amp-paired-browsing-app' ) );
 		$this->assertTrue( wp_script_is( 'amp-paired-browsing-app' ) );
 

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -9,6 +9,7 @@ use AmpProject\AmpWP\Admin\ReaderThemes;
 use AmpProject\AmpWP\Option;
 use AmpProject\AmpWP\Tests\Helpers\LoadsCoreThemes;
 use AmpProject\AmpWP\Tests\TestCase;
+use AmpProject\AmpWP\DependencySupport;
 
 /**
  * Class Test_AMP_Admin_Includes_Functions
@@ -39,6 +40,8 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 
 	/** @covers ::amp_init_customizer() */
 	public function test_amp_init_customizer_legacy_reader() {
+		$this->maybe_skip_amp_customizer_test();
+
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, ReaderThemes::DEFAULT_READER_THEME );
 		amp_init_customizer();
@@ -50,6 +53,8 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 
 	/** @covers ::amp_init_customizer() */
 	public function test_amp_init_customizer_modern_reader() {
+		$this->maybe_skip_amp_customizer_test();
+
 		switch_theme( 'twentytwenty' );
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( Option::READER_THEME, 'twentyseventeen' );
@@ -62,6 +67,8 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 
 	/** @covers ::amp_init_customizer() */
 	public function test_amp_init_customizer_canonical() {
+		$this->maybe_skip_amp_customizer_test();
+
 		AMP_Options_Manager::update_option( Option::THEME_SUPPORT, AMP_Theme_Support::STANDARD_MODE_SLUG );
 		amp_init_customizer();
 		$this->assertTrue( amp_is_canonical() );
@@ -69,6 +76,15 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 		$this->assertEquals( 500, has_action( 'customize_register', [ 'AMP_Template_Customizer', 'init' ] ) );
 		$this->assertFalse( has_action( 'amp_init', [ 'AMP_Customizer_Design_Settings', 'init' ] ) );
 		$this->assertFalse( has_action( 'admin_menu', 'amp_add_customizer_link' ) );
+	}
+
+	/**
+	 * Check if AMP customizer test should be skipped in old WP versions.
+	 */
+	public function maybe_skip_amp_customizer_test() {
+		if ( ! version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
+			$this->markTestSkipped( sprintf( 'WordPress %s is required to run this test as AMP customizer is not available in WordPress %s.', DependencySupport::WP_MIN_VERSION, get_bloginfo( 'version' ) ) );
+		}
 	}
 
 	/** @covers ::amp_admin_get_preview_permalink() */

--- a/tests/php/test-includes-admin-functions.php
+++ b/tests/php/test-includes-admin-functions.php
@@ -83,7 +83,7 @@ class Test_AMP_Admin_Includes_Functions extends TestCase {
 	 */
 	public function maybe_skip_amp_customizer_test() {
 		if ( ! version_compare( get_bloginfo( 'version' ), DependencySupport::WP_MIN_VERSION, '>=' ) ) {
-			$this->markTestSkipped( sprintf( 'WordPress %s is required to run this test as AMP customizer is not available in WordPress %s.', DependencySupport::WP_MIN_VERSION, get_bloginfo( 'version' ) ) );
+			$this->markTestSkipped( sprintf( 'Skipping as AMP customizer is not supported in WP versions older than %s', DependencySupport::WP_MIN_VERSION ) );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR accounts for the following changes:
- Make changes to the Webpack config to fix the default export in `@wordpress/dom-ready` package.
- Remove `amp_register_polyfills` from the following services/classes:
    - PairedBrowsing -> This service has a conditional of `has_support` from `DependecySupport` which means it will work only on WP >= 5.6 so no polyfills are required. Also, this service has no dependency on React so we can keep it on our plugin.
    - ValidationCounts -> This service has a conditional of `has_support` from `DependecySupport` which means it will work only on WP >= 5.6 so no polyfills are required. Also, this service has no dependency on React so we can keep it on our plugin.
    - AMP_Template_Customizer -> We have disabled AMP customizer on WP < 5.6 so no polyfills required. Also, this service has no dependency on React so we can keep it on our plugin.
 - Disable AMP customizer on WP < 5.6
---

With this, we only have the following services left which use `amp_register_polyfills` only on their dedicated screens:
- OnboardingWizardSubmenuPage
- OptionsMenu
- SupportScreen

Fixes #7457

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
