### PR TITLE
Fix PHPStan errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ node_modules
 # Generated via bin/transform-readme.php
 /readme.txt
 /tests/e2e/plugins/gutenberg.14.7.3.zip
+
+# Generated via phpstan analyse --generate-baseline temp-baseline.php
+/temp-baseline.php

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -153,10 +153,8 @@ def GenerateHeaderPHP(out):
 def GenerateSpecVersionPHP(out, versions):
 	# Output the version of the spec file and matching validator version
 	if versions['spec_file_revision']:
-		out.append('\t// @phpstan-ignore-next-line')
 		out.append('\tprivate static $spec_file_revision = %d;' % versions['spec_file_revision'])
 	if versions['min_validator_revision_required']:
-		out.append('\t// @phpstan-ignore-next-line')
 		out.append('\tprivate static $minimum_validator_revision_required = %d;' % versions['min_validator_revision_required'])
 
 def GenerateDescendantListsPHP(out, descendant_lists):

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -551,7 +551,6 @@ function amp_is_available() {
 		}
 	} elseif ( ! (
 		$queried_object instanceof WP_Post &&
-		$wp_query instanceof WP_Query &&
 		( $wp_query->is_singular() || $wp_query->is_posts_page ) &&
 		amp_is_post_supported( $queried_object ) )
 	) {

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15,9 +15,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	// @phpstan-ignore-next-line
 	private static $spec_file_revision = 1188;
-	// @phpstan-ignore-next-line
 	private static $minimum_validator_revision_required = 475;
 
 	private static $descendant_tag_lists = array(

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -595,7 +595,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		);
 
 		// Remove element if it has illegal CDATA.
-		if ( ! empty( $cdata ) && $node instanceof DOMElement ) {
+		if ( ! empty( $cdata ) ) {
 			$validity = $this->validate_cdata_for_node( $node, $cdata );
 			if ( true !== $validity ) {
 				$sanitized = $this->remove_invalid_child(
@@ -828,7 +828,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Check if element needs amp-bind component.
-		if ( $node instanceof DOMElement && ! in_array( 'amp-bind', $this->script_components, true ) ) {
+		if ( ! in_array( 'amp-bind', $this->script_components, true ) ) {
 			foreach ( $node->attributes as $name => $value ) {
 				if ( Amp::BIND_DATA_ATTR_PREFIX === substr( $name, 0, 14 ) ) {
 					$script_components[] = 'amp-bind';
@@ -2334,7 +2334,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Ensure attributes match; if not move up to the next node.
 		foreach ( $parsed_spec_name['attributes'] as $attr_name => $attr_value ) {
-			if ( $node instanceof DOMElement && strtolower( $node->getAttribute( $attr_name ) ) !== $attr_value ) {
+			if ( strtolower( $node->getAttribute( $attr_name ) ) !== $attr_value ) {
 				return false;
 			}
 		}

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -230,7 +230,7 @@ class AMP_Image_Dimension_Extractor {
 				$image_size = ( ! empty( $image_size ) && is_array( $image_size ) ) ? $image_size : [];
 			}
 
-			if ( ( empty( $image_size ) ) && file_exists( $image_file ) ) {
+			if ( empty( $image_size ) && file_exists( $image_file ) ) {
 				if ( function_exists( 'wp_getimagesize' ) ) {
 					$image_size = wp_getimagesize( $image_file );
 				} elseif ( function_exists( 'getimagesize' ) ) {

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -230,7 +230,7 @@ class AMP_Image_Dimension_Extractor {
 				$image_size = ( ! empty( $image_size ) && is_array( $image_size ) ) ? $image_size : [];
 			}
 
-			if ( ( empty( $image_size ) || ! is_array( $image_size ) ) && file_exists( $image_file ) ) {
+			if ( ( empty( $image_size ) ) && file_exists( $image_file ) ) {
 				if ( function_exists( 'wp_getimagesize' ) ) {
 					$image_size = wp_getimagesize( $image_file );
 				} elseif ( function_exists( 'getimagesize' ) ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1798,7 +1798,7 @@ class AMP_Validated_URL_Post_Type {
 
 		// Add notice for PHP fatal error during validation request.
 		$post = get_post();
-		if ( $post instanceof WP_Post && 'post' === get_current_screen()->base && self::POST_TYPE_SLUG === get_current_screen()->post_type ) {
+		if ( $post instanceof WP_Post && 'post' === get_current_screen()->base ) {
 			self::render_php_fatal_error_admin_notice( $post );
 		}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2918,7 +2918,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		$updated_count = 0;
 		foreach ( $term_ids as $term_id ) {
-			if ( 'delete' === $action && self::delete_empty_term( $term_id ) ) {
+			if ( self::delete_empty_term( $term_id ) ) {
 				$updated_count++;
 			}
 		}
@@ -2928,7 +2928,7 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		$term_ids_count = count( $term_ids );
-		if ( 'edit.php' === $pagenow && 'delete' === $action && 1 === $updated_count ) {
+		if ( 'edit.php' === $pagenow && 1 === $updated_count ) {
 			// Redirect to error index screen if deleting an validation error with no associated validated URLs.
 			$redirect_to = add_query_arg(
 				[

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -11,6 +11,8 @@
  *
  * Please be sure to explain why the error should be ignored in the remark above the error.
  *
+ * @codeCoverageIgnore
+ *
  * @package AMP
  */
 

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -20,14 +20,14 @@
 $ignore_errors_in_class_amp_allowed_tags_generated = [
 	[
 		'message' => '#^Static property AMP_Allowed_Tags_Generated\\:\\:\\$minimum_validator_revision_required is never read, only written\\.$#',
-		'count' => 1,
-		'path' => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
+		'count'   => 1,
+		'path'    => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
 	],
 	[
 		'message' => '#^Static property AMP_Allowed_Tags_Generated\\:\\:\\$spec_file_revision is never read, only written\\.$#',
-		'count' => 1,
-		'path' => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
-	]
+		'count'   => 1,
+		'path'    => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
+	],
 ];
 
 /**
@@ -40,13 +40,13 @@ $ignore_errors_in_class_amp_allowed_tags_generated = [
 $ignore_errors_due_to_instanceof_always_evaluating_to_false = [
 	[
 		'message' => '#^Instanceof between mixed and Error will always evaluate to false\\.$#',
-		'count' => 1,
-		'path' => __DIR__ . '/src/DevTools/ErrorPage.php',
+		'count'   => 1,
+		'path'    => __DIR__ . '/src/DevTools/ErrorPage.php',
 	],
 	[
 		'message' => '#^Instanceof between mixed and Error will always evaluate to false\\.$#',
-		'count' => 1,
-		'path' => __DIR__ . '/src/DevTools/LikelyCulpritDetector.php',
+		'count'   => 1,
+		'path'    => __DIR__ . '/src/DevTools/LikelyCulpritDetector.php',
 	],
 ];
 

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * PHPStan Baseline File.
+ *
+ * PHPStan will ignore all errors included in this file.
+ *
+ * Do not re-write this file using `phpstan analyse --generate-baseline phpstan-baseline.php`.
+ * Instead use `phpstan analyse --generate-baseline temp-baseline.php` and then copy the contents
+ * of `temp-baseline.php` to this file with proper formatting.
+ *
+ * Please make sure you state the reason for ignoring the error in the comment above the error.
+ *
+ * @package AMP
+ */
+
+/**
+ * Errors to be ignored in class-amp-allowed-tags-generated.php
+ * Note: class-amp-allowed-tags-generated.php is a auto-generated file.
+ */
+$ignore_errors_in_class_amp_allowed_tags_generated = [
+	[
+		'message' => '#^Static property AMP_Allowed_Tags_Generated\\:\\:\\$minimum_validator_revision_required is never read, only written\\.$#',
+		'count' => 1,
+		'path' => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
+	],
+	[
+		'message' => '#^Static property AMP_Allowed_Tags_Generated\\:\\:\\$spec_file_revision is never read, only written\\.$#',
+		'count' => 1,
+		'path' => __DIR__ . '/includes/sanitizers/class-amp-allowed-tags-generated.php',
+	]
+];
+
+/**
+ * Errors due to `Instanceof always evaluate to false`` in PHPStan.
+ *
+ * @see https://github.com/phpstan/phpstan/issues/3632
+ *
+ * @todo Remove once this is fixed in PHPStan.
+ */
+$ignore_errors_due_to_instanceof_always_evaluating_to_false = [
+	[
+		'message' => '#^Instanceof between mixed and Error will always evaluate to false\\.$#',
+		'count' => 1,
+		'path' => __DIR__ . '/src/DevTools/ErrorPage.php',
+	],
+	[
+		'message' => '#^Instanceof between mixed and Error will always evaluate to false\\.$#',
+		'count' => 1,
+		'path' => __DIR__ . '/src/DevTools/LikelyCulpritDetector.php',
+	],
+];
+
+/**
+ * Errors due `function_exists() and method_exists() always evaluating to true` in PHPStan.
+ *
+ * @see https://github.com/phpstan/phpstan/issues/8980
+ * @see https://github.com/phpstan/phpstan/issues/8980#issuecomment-1451284041
+ *
+ * @todo Remove once this is fixed in PHPStan.
+ */
+$ignore_errors_due_to_function_and_method_exists_always_evaluating_to_true = [
+	[
+		'message' => '#^Call to function method_exists\\(\\) with WP_Query and \'is_favicon\' will always evaluate to true\\.$#',
+		'count'   => 1,
+		'path'    => __DIR__ . '/includes/amp-helper-functions.php',
+	],
+	[
+		'message' => '#^Call to function function_exists\\(\\) with \'amp_activate\'\\|\'amp_backcompat_use…\'\\|\'amp_init_customizer\'\\|\'amp_load_classes\' will always evaluate to true\\.$#',
+		'count'   => 1,
+		'path'    => __DIR__ . '/includes/bootstrap.php',
+	],
+	[
+		'message' => '#^Call to function function_exists\\(\\) with \'curl_multi_add…\'\\|\'curl_multi_exec\'\\|\'curl_multi_init\' will always evaluate to true\\.$#',
+		'count'   => 1,
+		'path'    => __DIR__ . '/src/Admin/SiteHealth.php',
+	],
+	[
+		'message' => '#^Call to function method_exists\\(\\) with ReflectionType and \'isBuiltin\' will always evaluate to true\\.$#',
+		'count'   => 1,
+		'path'    => __DIR__ . '/src/Infrastructure/Injector/SimpleInjector.php',
+	],
+];
+
+return [
+	'parameters' => [
+		'ignoreErrors' => array_merge(
+			$ignore_errors_in_class_amp_allowed_tags_generated,
+			$ignore_errors_due_to_instanceof_always_evaluating_to_false,
+			$ignore_errors_due_to_function_and_method_exists_always_evaluating_to_true
+		),
+	],
+];

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,14 +1,15 @@
 <?php
 /**
  * PHPStan Baseline File.
+ * All static analysis errors included in this file will be ignored by PHPStan.
  *
- * PHPStan will ignore all errors included in this file.
+ * NOTE: `phpstan analyse —generate-baseline phpstan-baseline.php` should not be used to rewrite this file.
  *
- * Do not re-write this file using `phpstan analyse --generate-baseline phpstan-baseline.php`.
- * Instead use `phpstan analyse --generate-baseline temp-baseline.php` and then copy the contents
- * of `temp-baseline.php` to this file with proper formatting.
+ * How to include new errors to be ignored:
+ * 1. Run `phpstan analyse --generate-baseline temp-baseline.php` to generate a new temp baseline file.
+ * 2. Copy the contents of the temp baseline file to this file.
  *
- * Please make sure you state the reason for ignoring the error in the comment above the error.
+ * Please be sure to explain why the error should be ignored in the remark above the error.
  *
  * @package AMP
  */

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -34,6 +34,17 @@ $ignore_errors_in_class_amp_allowed_tags_generated = [
 ];
 
 /**
+ * Errors due to `Property _WP_Dependency::$src (string) does not accept false.` in PHPStan.
+ */
+$ignore_errors_due_to_property_wp_dependency_src_does_not_accept_false = [
+	[
+		'message' => '#^Property _WP_Dependency\\:\\:\\$src \\(string\\) does not accept false\\.$#',
+		'count'   => 1,
+		'path'    => __DIR__ . '/includes/sanitizers/class-amp-core-theme-sanitizer.php',
+	],
+];
+
+/**
  * Errors due to `Instanceof always evaluate to false`` in PHPStan.
  *
  * @see https://github.com/phpstan/phpstan/issues/3632
@@ -88,6 +99,7 @@ return [
 	'parameters' => [
 		'ignoreErrors' => array_merge(
 			$ignore_errors_in_class_amp_allowed_tags_generated,
+			$ignore_errors_due_to_property_wp_dependency_src_does_not_accept_false,
 			$ignore_errors_due_to_instanceof_always_evaluating_to_false,
 			$ignore_errors_due_to_function_and_method_exists_always_evaluating_to_true
 		),

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3,7 +3,7 @@
  * PHPStan Baseline File.
  * All static analysis errors included in this file will be ignored by PHPStan.
  *
- * NOTE: `phpstan analyse —generate-baseline phpstan-baseline.php` should not be used to rewrite this file.
+ * NOTE: `phpstan analyse --generate-baseline phpstan-baseline.php` should not be used to rewrite this file.
  *
  * How to include new errors to be ignored:
  * 1. Run `phpstan analyse --generate-baseline temp-baseline.php` to generate a new temp baseline file.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,9 +30,6 @@ parameters:
 	excludePaths:
 		# PHPStan cannot yet deal with view templates. See https://github.com/phpstan/phpstan/issues/351
 		- %currentWorkingDirectory%/includes/templates/amp-enabled-classic-editor-toggle.php
-	ignoreErrors:
-		# Setting src to false indicates a bundle of dependencies.
-		- '#^Property _WP_Dependency::\$src \(string\) does not accept false\.$#'
 	earlyTerminatingMethodCalls:
 		\WP_CLI:
 			- WP_CLI::error

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
 	# @see https://github.com/phpstan/phpstan-src/blob/b9f62d63f2deaa0a5e97f51073e41a422c48aa01/conf/bleedingEdge.neon
 	- phar://phpstan.phar/conf/bleedingEdge.neon
+	- phpstan-baseline.php
 services:
 	-
 		class: AmpProject\AmpWP\Tests\PhpStan\ServiceContainerDynamicReturnTypeExtension

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,7 @@ services:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 parameters:
 	level: 4
+	treatPhpDocTypesAsCertain: false
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- %currentWorkingDirectory%/includes/

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -134,7 +134,6 @@ final class MonitorCssTransientCaching extends RecurringBackgroundTask {
 			return;
 		}
 
-		// @phpstan-ignore-next-line
 		$date = isset( $args[0] ) && $args[0] instanceof DateTimeInterface ? $args[0] : new DateTimeImmutable();
 
 		$transient_count = isset( $args[1] ) ? (int) $args[1] : $this->query_css_transient_count();

--- a/src/DevTools/ErrorPage.php
+++ b/src/DevTools/ErrorPage.php
@@ -129,7 +129,6 @@ final class ErrorPage implements Service {
 	 * @return self
 	 */
 	public function with_throwable( $throwable ) {
-		// @phpstan-ignore-next-line
 		if ( ! ( $throwable instanceof Exception || $throwable instanceof Error ) ) {
 			throw new InvalidArgumentException( 'Parameter must be Throwable (Exception or Error).' );
 		}

--- a/src/DevTools/LikelyCulpritDetector.php
+++ b/src/DevTools/LikelyCulpritDetector.php
@@ -68,7 +68,6 @@ final class LikelyCulpritDetector implements Service {
 	 * }
 	 */
 	public function analyze_throwable( $throwable ) {
-		// @phpstan-ignore-next-line
 		if ( ! ( $throwable instanceof Exception || $throwable instanceof Error ) ) {
 			throw new InvalidArgumentException( 'Parameter must be Throwable (Exception or Error).' );
 		}

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -247,8 +247,7 @@ class SupportData {
 		$loopback_status = '';
 
 		if ( class_exists( 'WP_Site_Health' ) ) {
-			$site_health     = method_exists( 'WP_Site_Health', 'get_instance' ) ? WP_Site_Health::get_instance() : new WP_Site_Health();
-			$loopback_status = $site_health->can_perform_loopback();
+			$loopback_status = ( new WP_Site_Health() )->can_perform_loopback();
 			$loopback_status = ( ! empty( $loopback_status->status ) ) ? $loopback_status->status : '';
 		}
 

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -825,7 +825,7 @@ class SupportData {
 			$error_source_slugs = wp_list_pluck( $error_sources, 'error_source_slug' );
 			$error_source_slugs = array_values( array_unique( $error_source_slugs ) );
 
-			if ( ! empty( $error_source_slugs ) && is_array( $error_source_slugs ) ) {
+			if ( ! empty( $error_source_slugs ) ) {
 				$validation_errors[] = [
 					'error_slug' => $error_data['error_slug'],
 					'sources'    => $error_source_slugs,


### PR DESCRIPTION
## Summary

- Add `treatPhpDocTypesAsCertain: false` to PHPStan config so that PHPStan doesn't take doc types as certain.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
