### PR TITLE
Fix failure to parse complex CSS values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ampproject/amp-toolbox": "0.11.3",
     "cweagans/composer-patches": "~1.0",
     "fasterimage/fasterimage": "1.5.0",
-    "sabberworm/php-css-parser": "8.4.0"
+    "sabberworm/php-css-parser": "dev-master#cc791ad"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.2",
@@ -94,9 +94,9 @@
         "Remove 'match' keyword from uses <https://github.com/sebastianbergmann/phpunit/issues/4373>": "patches/remove-match-keyword.patch"
       },
       "sabberworm/php-css-parser": {
-        "1. Add additional validation for size unit <https://github.com/sabberworm/PHP-CSS-Parser/pull/350>": "https://github.com/westonruter/PHP-CSS-Parser/commit/5b1d6a4abe43f4311d9b4674913ca665ed8c43aa.diff",
-        "2. Validate name-start code points for identifier <https://github.com/westonruter/PHP-CSS-Parser/pull/2>": "https://github.com/westonruter/PHP-CSS-Parser/commit/9f96bc97fcb1e848a2f6ca6f658009996883dffc.diff",
-        "3. Fix parsing CSS selectors which contain commas <https://github.com/westonruter/PHP-CSS-Parser/pull/1>": "https://github.com/westonruter/PHP-CSS-Parser/commit/dc18ba737fd6a611189a5b83729396500676f8dd.diff"
+        "1. Validate name-start code points for identifier <https://github.com/westonruter/PHP-CSS-Parser/pull/2>": "https://github.com/sabberworm/PHP-CSS-Parser/compare/cc791ad...westonruter:PHP-CSS-Parser:fix/malformed-identifier-without-tests.diff",
+        "2. Fix parsing CSS selectors which contain commas <https://github.com/westonruter/PHP-CSS-Parser/pull/1>": "https://github.com/sabberworm/PHP-CSS-Parser/compare/cc791ad...westonruter:PHP-CSS-Parser:fix/selector-comma-parsing-without-tests.diff",
+        "3. Parse simple expressions <https://github.com/sabberworm/PHP-CSS-Parser/pull/389>": "https://github.com/sabberworm/PHP-CSS-Parser/compare/cc791ad...westonruter:PHP-CSS-Parser:fix/expression-parsing-without-tests.diff"
       }
     }
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c6e09b38bd063e56d8c90370dc616c8",
+    "content-hash": "abf0f7e4b07a55bcf3324dc738966f99",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
@@ -189,16 +189,16 @@
         },
         {
             "name": "sabberworm/php-css-parser",
-            "version": "8.4.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
-                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30"
+                "reference": "cc791ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/e41d2140031d533348b2192a83f02d8dd8a71d30",
-                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30",
+                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/cc791ad",
+                "reference": "cc791ad",
                 "shasum": ""
             },
             "require": {
@@ -206,12 +206,13 @@
                 "php": ">=5.6.20"
             },
             "require-dev": {
-                "codacy/coverage": "^1.4",
-                "phpunit/phpunit": "^4.8.36"
+                "codacy/coverage": "^1.4.3",
+                "phpunit/phpunit": "^5.7.27"
             },
             "suggest": {
                 "ext-mbstring": "for parsing UTF-8 CSS"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -236,9 +237,9 @@
             ],
             "support": {
                 "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
-                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.4.0"
+                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/master"
             },
-            "time": "2021-12-11T13:40:54+00:00"
+            "time": "2023-01-25T01:20:01+00:00"
         },
         {
             "name": "willwashburn/stream",
@@ -6844,6 +6845,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "sabberworm/php-css-parser": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,
@@ -6863,5 +6865,5 @@
     "platform-overrides": {
         "php": "7.0.8"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1658,7 +1658,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function get_parsed_stylesheet( $stylesheet, $options = [] ) {
 		$cached         = true;
-		$cache_group    = 'amp-parsed-stylesheet-v39'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group    = 'amp-parsed-stylesheet-v40'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 		$use_transients = $this->should_use_transient_caching();
 
 		// @todo If ValidationExemption::is_px_verified_for_node( $this->current_node ) then keep !important.

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -860,6 +860,44 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 				],
 				[],
 			],
+			'complex_css_values' => [
+				'
+				<html>
+					<head>
+						<style>
+							body {
+								background: green;
+								width: calc((100vw - 100px) / 2);
+								height: 100px;
+							}
+						</style>
+						<style>
+							:where(body) {
+								width: min(var(--container-max-width), 100% - calc(var(--container-padding) * 2));
+								margin-inline: auto;
+							}
+						</style>
+						<style>
+							body {
+								--wp--preset--font-size--huge: 42px;
+								--wp--preset--font-size--small: clamp(.875rem,.875rem + ((1vw - .48rem)*0.24),1rem);
+								--wp--preset--font-size--medium: clamp(1rem,1rem + ((1vw - .48rem)*0.24),1.125rem);
+								--wp--preset--font-size--large: clamp(1.5rem,1.5rem + ((1vw - .48rem)*0.24),1.625rem);
+								--wp--preset--font-size--normal: 16px;
+							}
+						</style>
+					</head>
+					<body>
+					</body>
+				</html>
+				',
+				[
+					'body{background:green;width:calc(( 100vw - 100px ) / 2);height:100px}',
+					':where(body){width:min(var(--container-max-width),100% - calc(var(--container-padding) * 2));margin-inline:auto}',
+					'body{--wp--preset--font-size--huge:42px;--wp--preset--font-size--small:clamp(.875rem,.875rem + ((1vw - .48rem) * .24),1rem);--wp--preset--font-size--medium:clamp(1rem,1rem + ((1vw - .48rem) * .24),1.125rem);--wp--preset--font-size--large:clamp(1.5rem,1.5rem + ((1vw - .48rem) * .24),1.625rem);--wp--preset--font-size--normal:16px}',
+				],
+				[],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7291

* Updates php-css-parser from [`8.4.0`](https://github.com/sabberworm/PHP-CSS-Parser/releases/tag/8.4.0) to `dev-master`, pinning at the [most recent commit](https://github.com/sabberworm/PHP-CSS-Parser/commit/cc791adc7f968faa522b4f6934d83375f8751038). Note that php-css-parser hasn't seen a <del>release</del><ins>tag</ins> since December 11, 2021. The update is done in order to benefit from the many PRs merged since ([95 commits](https://github.com/sabberworm/PHP-CSS-Parser/compare/8.4.0...cc791adc7f968faa522b4f6934d83375f8751038)) then and to use latest PR patches.
* Add composer patch for https://github.com/sabberworm/PHP-CSS-Parser/pull/389 which resolves the failure to parse complex CSS expression values.
* Eliminates composer patch for https://github.com/sabberworm/PHP-CSS-Parser/pull/350 which has been merged into `master`.
* Update composer patch from https://github.com/westonruter/PHP-CSS-Parser/pull/2 to fix merge conflicts with `master`.
* Update composer patch from https://github.com/westonruter/PHP-CSS-Parser/pull/1 to fix merge conflicts with `master`.