### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/tests/e2e/specs/core-themes/twentyfifteen.js
+++ b/tests/e2e/specs/core-themes/twentyfifteen.js
@@ -81,6 +81,10 @@ describe('Twenty Fifteen theme on AMP', () => {
 		it('should have a togglable submenu', async () => {
 			await expect(page).toClick('.site-header .secondary-toggle');
 
+			await page.waitForSelector(
+				'#site-navigation .menu-item-has-children'
+			);
+
 			const menuItemWithSubmenu = await page.$(
 				'#site-navigation .menu-item-has-children'
 			);

--- a/tests/e2e/specs/core-themes/twentynineteen.js
+++ b/tests/e2e/specs/core-themes/twentynineteen.js
@@ -54,6 +54,10 @@ describe('Twenty Nineteen theme on AMP', () => {
 		it('should have a togglable submenu', async () => {
 			await expect(page).toMatchElement('.main-navigation');
 
+			await page.waitForSelector(
+				'.main-navigation .menu-item-has-children'
+			);
+
 			const menuItemWithSubmenu = await page.$(
 				'.main-navigation .menu-item-has-children'
 			);

--- a/tests/e2e/specs/core-themes/twentyseventeen.js
+++ b/tests/e2e/specs/core-themes/twentyseventeen.js
@@ -75,6 +75,10 @@ describe('Twenty Seventeen theme on AMP', () => {
 		it('should have a togglable submenu', async () => {
 			await expect(page).toClick('.main-navigation .menu-toggle');
 
+			await page.waitForSelector(
+				'.main-navigation .menu-item-has-children'
+			);
+
 			const menuItemWithSubmenu = await page.$(
 				'.main-navigation .menu-item-has-children'
 			);

--- a/tests/e2e/specs/core-themes/twentysixteen.js
+++ b/tests/e2e/specs/core-themes/twentysixteen.js
@@ -81,6 +81,10 @@ describe('Twenty Sixteen theme on AMP', () => {
 		it('should have a togglable submenu', async () => {
 			await expect(page).toClick('#menu-toggle');
 
+			await page.waitForSelector(
+				'#site-navigation .menu-item-has-children'
+			);
+
 			const menuItemWithSubmenu = await page.$(
 				'#site-navigation .menu-item-has-children'
 			);

--- a/tests/e2e/specs/core-themes/twentythirteen.js
+++ b/tests/e2e/specs/core-themes/twentythirteen.js
@@ -81,6 +81,10 @@ describe('Twenty Thirteen theme on AMP', () => {
 		it('should have a togglable submenu', async () => {
 			await expect(page).toClick('#site-navigation .menu-toggle');
 
+			await page.waitForSelector(
+				'#site-navigation .nav-menu .menu-item-has-children'
+			);
+
 			const menuItemWithSubmenu = await page.$(
 				'#site-navigation .nav-menu .menu-item-has-children'
 			);

--- a/tests/e2e/specs/core-themes/twentytwenty.js
+++ b/tests/e2e/specs/core-themes/twentytwenty.js
@@ -76,6 +76,10 @@ describe('Twenty Twenty theme on AMP', () => {
 			it('should have a togglable submenu', async () => {
 				await expect(page).toClick('.mobile-nav-toggle');
 
+				await page.waitForSelector(
+					'.menu-modal .menu-item-has-children'
+				);
+
 				const menuItemWithSubmenu = await page.$(
 					'.menu-modal .menu-item-has-children'
 				);

--- a/tests/e2e/specs/core-themes/twentytwentytwo.js
+++ b/tests/e2e/specs/core-themes/twentytwentytwo.js
@@ -62,6 +62,8 @@ describe('Twenty Twenty-Two theme on AMP', () => {
 		});
 
 		it('should be togglable', async () => {
+			await page.waitForSelector(pageHeaderSelector);
+
 			const pageHeaderElement = await page.$(pageHeaderSelector);
 			expect(pageHeaderElement).not.toBeNull();
 


### PR DESCRIPTION
## Summary

- Fix core-themes flaky e2e tests.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
