### PR TITLE
Remove React 17 requirement for `AfterActivationSiteScan` service 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ node_modules
 
 # Generated via bin/transform-readme.php
 /readme.txt
-/tests/e2e/plugins/gutenberg.14.7.3.zip
 
 # Generated via phpstan analyse --generate-baseline temp-baseline.php
 /temp-baseline.php

--- a/bin/local-env/start.sh
+++ b/bin/local-env/start.sh
@@ -23,9 +23,6 @@ cd "$(dirname "$0")/../.."
 # done on every time `npm run test-e2e` is run.
 . "$(dirname "$0")/install-wordpress.sh"
 
-# Install specific version of Gutenberg plugin for e2e tests.
-download_gutenberg "14.7.3" "tests/e2e/plugins/gutenberg.14.7.3.zip"
-
 ! read -d '' AMP <<"EOT"
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMMMWNXK0OOkkkkOO0KXNWMMMMMMMMMMMMMMMM

--- a/src/Admin/AfterActivationSiteScan.php
+++ b/src/Admin/AfterActivationSiteScan.php
@@ -11,7 +11,6 @@
 
 namespace AmpProject\AmpWP\Admin;
 
-use _WP_Dependency;
 use AMP_Options_Manager;
 use AMP_Validation_Manager;
 use AmpProject\AmpWP\Infrastructure\Conditional;
@@ -41,13 +40,6 @@ final class AfterActivationSiteScan implements Conditional, Delayed, HasRequirem
 	 * @var string
 	 */
 	const APP_ROOT_ID = 'amp-site-scan-notice';
-
-	/**
-	 * React dependency handle.
-	 *
-	 * @var string
-	 */
-	const REACT = 'react';
 
 	/**
 	 * HTML ID for the app root sibling element.
@@ -92,16 +84,12 @@ final class AfterActivationSiteScan implements Conditional, Delayed, HasRequirem
 	public static function is_needed() {
 		global $pagenow;
 
-		$react = wp_scripts()->query( self::REACT );
-
 		return (
 			is_admin()
 			&&
 			Services::get( 'dependency_support' )->has_support()
 			&&
 			! is_network_admin()
-			&&
-			( $react instanceof _WP_Dependency && version_compare( $react->ver, '18', '<' ) )
 			&&
 			AMP_Validation_Manager::has_cap()
 			&&

--- a/tests/e2e/specs/admin/after-plugin-activation.js
+++ b/tests/e2e/specs/admin/after-plugin-activation.js
@@ -7,11 +7,6 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import { completeWizard } from '../../utils/onboarding-wizard-utils';
-import {
-	installPlugin,
-	installLocalPlugin,
-	uninstallPlugin,
-} from '../../utils/amp-settings-utils';
 
 describe('After plugin activation', () => {
 	const timeout = 30000;
@@ -27,23 +22,8 @@ describe('After plugin activation', () => {
 	}
 
 	beforeAll(async () => {
-		// Uninstall the latest Gutenberg plugin.
-		await uninstallPlugin('gutenberg');
-
-		// Install the Gutenberg 14.7.3 plugin for React 17 compatibility and test SiteScanNotice on plugins page.
-		await installLocalPlugin('gutenberg.14.7.3');
-
 		await completeWizard({ mode: 'transitional' });
 		await visitAdminPage('plugins.php', '');
-
-		await activate('gutenberg');
-	});
-
-	afterAll(async () => {
-		await uninstallPlugin('gutenberg');
-
-		// Install the latest Gutenberg plugin.
-		await installPlugin('gutenberg');
 	});
 
 	it('site scan is triggered automatically and displays no validation issues for AMP-compatible plugin', async () => {

--- a/tests/php/src/Admin/AfterActivationSiteScanTest.php
+++ b/tests/php/src/Admin/AfterActivationSiteScanTest.php
@@ -17,7 +17,6 @@ use AmpProject\AmpWP\Tests\DependencyInjectedTestCase;
 use AmpProject\AmpWP\Tests\Helpers\PrivateAccess;
 use AmpProject\AmpWP\Tests\Helpers\MockAdminUser;
 use AMP_Validation_Manager;
-use _WP_Dependency;
 
 /**
  * Tests for AfterActivationSiteScan class.
@@ -68,9 +67,6 @@ class AfterActivationSiteScanTest extends DependencyInjectedTestCase {
 
 	/** @return array */
 	public function get_data_to_test_is_needed() {
-		$react                             = wp_scripts()->query( 'react' );
-		$should_get_site_activation_notice = $react instanceof _WP_Dependency && version_compare( $react->ver, '18', '<' );
-
 		return [
 			'not_admin_screen'                           => [
 				'screen_hook'  => '',
@@ -105,7 +101,7 @@ class AfterActivationSiteScanTest extends DependencyInjectedTestCase {
 			'plugins_screen_with_get_activate'           => [
 				'screen_hook'  => 'plugins.php',
 				'query_params' => [ 'activate' ],
-				'expected'     => $should_get_site_activation_notice,
+				'expected'     => true,
 				'role'         => 'administrator',
 			],
 			'plugins_screen_with_get_activate_not_admin' => [
@@ -123,7 +119,7 @@ class AfterActivationSiteScanTest extends DependencyInjectedTestCase {
 			'plugins_screen_with_get_activate_multi'     => [
 				'screen_hook'  => 'plugins.php',
 				'query_params' => [ 'activate-multi' ],
-				'expected'     => $should_get_site_activation_notice,
+				'expected'     => true,
 				'role'         => 'administrator',
 			],
 			'plugins_screen_with_get_activated'          => [
@@ -147,7 +143,7 @@ class AfterActivationSiteScanTest extends DependencyInjectedTestCase {
 			'themes_screen_with_get_activated'           => [
 				'screen_hook'  => 'themes.php',
 				'query_params' => [ 'activated' ],
-				'expected'     => $should_get_site_activation_notice,
+				'expected'     => true,
 				'role'         => 'administrator',
 			],
 			'themes_screen_with_get_activated_not_admin' => [


### PR DESCRIPTION
## Summary 

Fixes #7489

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
