### PR TITLE
Improve author avatar resolution and fix a11y issues in legacy theme

### DIFF
--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -27,7 +27,7 @@ class AMP_Customizer_Design_Settings {
 	 *
 	 * @var string
 	 */
-	const DEFAULT_HEADER_BACKGROUND_COLOR = '#0a89c0';
+	const DEFAULT_HEADER_BACKGROUND_COLOR = '#0A5F85';
 
 	/**
 	 * Default color scheme.

--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -23,7 +23,15 @@ $post_author = $this->get( 'post_author' );
 <?php if ( $post_author ) : ?>
 	<div class="amp-wp-meta amp-wp-byline">
 		<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
-			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
+			<amp-img
+				src="<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 72 ] ) ); ?>"
+				srcset="
+					<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 24 ] ) ); ?> 1x,
+					<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 48 ] ) ); ?> 2x,
+					<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 72 ] ) ); ?> 3x
+				"
+				alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"
+			></amp-img>
 		<?php endif; ?>
 		<span class="amp-wp-author author vcard"><?php echo esc_html( $post_author->display_name ); ?></span>
 	</div>

--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -23,7 +23,7 @@ $post_author = $this->get( 'post_author' );
 <?php if ( $post_author ) : ?>
 	<div class="amp-wp-meta amp-wp-byline">
 		<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
-			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 24 ] ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
+			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
 		<?php endif; ?>
 		<span class="amp-wp-author author vcard"><?php echo esc_html( $post_author->display_name ); ?></span>
 	</div>


### PR DESCRIPTION
## Summary

- Update gravatar image resolution to use the default size(96).
- Update default header color from `#0a89c0` to `#0A5F85` for better a11y.

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7491

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
