### PR TITLE
Fix margin usage of `p.has-background` in legacy theme

### DIFF
--- a/templates/style.php
+++ b/templates/style.php
@@ -94,20 +94,11 @@ $alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 	margin: 0 auto;
 }
 
-p.has-background {
+.amp-wp-article-content > p.has-background {
 	margin-left: -2.375em;
 	margin-right: -2.375em;
 	margin-block-start: 0;
 	margin-block-end: 16px;
-}
-
-div.wp-block-group > p.has-background {
-	margin-left: auto;
-	margin-right: auto;
-}
-
-div.wp-block-group > p.has-background:last-child {
-	margin-block-end: 0;
 }
 
 /* Template Styles */

--- a/templates/style.php
+++ b/templates/style.php
@@ -95,6 +95,11 @@ $alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 }
 
 .amp-wp-article-content > p.has-background {
+	/*
+	 * The 2.375 value comes from the $block-bg-padding--h SCSS variable:
+	 * https://github.com/WordPress/gutenberg/blob/22ca90c/packages/base-styles/_variables.scss#L98-L104
+	 * https://github.com/WordPress/gutenberg/blob/22ca90c/packages/block-library/src/paragraph/style.scss#L41-L43
+	 */
 	margin-left: -2.375em;
 	margin-right: -2.375em;
 	margin-block-start: 0;


### PR DESCRIPTION
## Summary
As discovered in https://github.com/ampproject/amp-wp/issues/7471#issuecomment-1477664810, updated usage(in https://github.com/ampproject/amp-wp/pull/7481/commits/7996b3a2ffe0d04bbbfa2d3a20bda2f3ce575a3e) for `p.has-background`(if font-size is xxl) is breaking other elements with `p.has-background`. This PR ensures that margins only get updated if `p.has-background` is a descendant of `.amp-wp-article-content`.

Before:
![image](https://user-images.githubusercontent.com/54371619/226671041-8ad547b4-21e3-4f8e-b445-67de272d0496.png)

After:
![image](https://user-images.githubusercontent.com/54371619/226671229-97b4cb5d-c4b8-4ad7-a4d5-84850a5fb713.png)


## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
