### PR TITLE
Ignore codecov action to be run on @dependabot PRs

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -273,6 +273,7 @@ jobs:
         run: npm run test:js -- --ci --cacheDirectory="$HOME/.jest-cache" --collectCoverage
 
       - name: Upload code coverage report
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v3
         with:
           file: build/logs/lcov.info
@@ -563,7 +564,7 @@ jobs:
           WP_TESTS_DIR: /tmp/wordpress-tests-lib
 
       - name: Upload code coverage report
-        if: ${{ matrix.coverage == true && needs.pre-run.outputs.changed-php-count > 0 }}
+        if: ${{ matrix.coverage == true && needs.pre-run.outputs.changed-php-count > 0 && github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v3
         with:
           file: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp/build/logs/clover.xml
@@ -771,7 +772,7 @@ jobs:
           echo "COVERAGE_FILES=$FILES" >> $GITHUB_ENV
 
       - name: Upload code coverage report
-        if: ${{ matrix.coverage == true }}
+        if: ${{ matrix.coverage == true && github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v3
         with:
           files: ${{ env.COVERAGE_FILES }}


### PR DESCRIPTION
## Summary

Avoid code coverage report uploads to Codecov on @dependabot PRs.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
