### PR TITLE
Add guard to avoid type errors due to null validation sources

### DIFF
--- a/assets/src/components/site-scan-results/site-scan-sources-detail.js
+++ b/assets/src/components/site-scan-results/site-scan-sources-detail.js
@@ -27,7 +27,7 @@ import ClipboardButton from '../clipboard-button';
  */
 function getAssociatedSources(sources, slug) {
 	return sources.filter((source) => {
-		return slug === getPluginSlugFromFile(source.name);
+		return slug === getPluginSlugFromFile(source?.name);
 	});
 }
 

--- a/assets/src/components/site-scan-results/site-scan-sources-detail.js
+++ b/assets/src/components/site-scan-results/site-scan-sources-detail.js
@@ -27,7 +27,7 @@ import ClipboardButton from '../clipboard-button';
  */
 function getAssociatedSources(sources, slug) {
 	return sources.filter((source) => {
-		return slug === getPluginSlugFromFile(source?.name);
+		return source?.name && slug === getPluginSlugFromFile(source.name);
 	});
 }
 


### PR DESCRIPTION
## Summary

Previously discovered in #7380 there were some type errors due to null validation sources in SiteScan. This PR aims to fix the same issue in the `<SiteScanSourcesDetail />` component.

<details><summary>Screencast</summary>

https://user-images.githubusercontent.com/54371619/226964069-a5f4534c-afb0-484a-bda3-451454f841a2.mp4


</details> 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
