### PR TITLE
Update test cases after Gutenberg 15.4.0 release

### DIFF
--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -351,6 +351,9 @@ class Test_AMP_Core_Block_Handler extends TestCase {
 		$expected = preg_replace( '/ data-id="\d+"/', '', $expected );
 		$actual   = preg_replace( '/ data-id="\d+"/', '', $actual );
 
+		// Remove `wp-block-gallery-is-layout-flex` class name injected by block editor layout styles.
+		$actual = preg_replace( '/\s*(?<= class=")?wp-block-gallery-is-layout-flex\s*/', '', $actual );
+
 		// Remove `is-layout-flex` class name injected by block editor layout styles.
 		$actual = preg_replace( '/\s*(?<= class=")?is-layout-flex\s*/', '', $actual );
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1393,6 +1393,9 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 		$rendered_block = do_blocks( AMP_Validation_Manager::add_block_source_comments( $content ) );
 
+		// Remove `wp-block-columns-is-layout-flex` class name injected by block editor layout styles.
+		$rendered_block = preg_replace( '/\s*(?<= class=")?wp-block-columns-is-layout-flex\s*/', '', $rendered_block );
+
 		// Remove `is-layout-flex` class name injected by block editor layout styles.
 		$rendered_block = preg_replace( '/\s*(?<= class=")?is-layout-flex\s*/', '', $rendered_block );
 


### PR DESCRIPTION
## Summary
Fixed failing test cases after Gutenberg 15.4.0 release.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
