### PR TITLE
Update dependabot to run monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: composer
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "17:00"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
@@ -13,7 +13,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "17:00"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
@@ -29,7 +29,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "17:00"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10


### PR DESCRIPTION
I think we can reduce some of our workload by just doing the dependabot updates monthly instead of weekly. The downside here is that the longer period of time between updates, the harder it will be to pinpoint a specific update that broke things.