### PR TITLE
Update `Google Analytics` analytics vendor 

### DIFF
--- a/assets/src/settings-page/analytics.js
+++ b/assets/src/settings-page/analytics.js
@@ -27,7 +27,11 @@ import {
  * Internal dependencies
  */
 import { Options } from '../components/options-context-provider';
-import { AMPNotice, NOTICE_SIZE_SMALL } from '../components/amp-notice';
+import {
+	AMPNotice,
+	NOTICE_SIZE_SMALL,
+	NOTICE_TYPE_WARNING,
+} from '../components/amp-notice';
 import vendorConfigs from './vendor-configs';
 
 const GOOGLE_ANALYTICS_VENDOR = 'googleanalytics';
@@ -157,6 +161,15 @@ function AnalyticsEntry({
 				{vendorConfigs[type]?.notice && (
 					<AMPNotice size={NOTICE_SIZE_SMALL}>
 						<span>{vendorConfigs[type].notice}</span>
+					</AMPNotice>
+				)}
+
+				{vendorConfigs[type]?.warning && (
+					<AMPNotice
+						size={NOTICE_SIZE_SMALL}
+						type={NOTICE_TYPE_WARNING}
+					>
+						<span>{vendorConfigs[type].warning}</span>
 					</AMPNotice>
 				)}
 

--- a/assets/src/settings-page/vendor-configs.js
+++ b/assets/src/settings-page/vendor-configs.js
@@ -31,6 +31,25 @@ const GOOGLE_ANALYTICS_NOTICE = createInterpolateElement(
 	}
 );
 
+const GOOGLE_ANALYTICS_DEPRECATION_NOTICE = createInterpolateElement(
+	__(
+		'The <Code>googleanalytics</Code> type is obsolete as Google Analytics has switched to use gtag in the transition from Universal Analytics (UA) to GA4. Please use gtag instead. Learn more about <GA4AMP>GA4 in AMP</GA4AMP>.',
+		'amp'
+	),
+	{
+		/* eslint-disable jsx-a11y/anchor-has-content -- Anchor has content defined in the translated string. */
+		GA4AMP: (
+			<a
+				href="https://support.google.com/analytics/topic/13706307?hl=en&ref_topic=9303319&sjid=7478006548081699185-NA"
+				target="_blank"
+				rel="noreferrer"
+			/>
+		),
+		Code: <code />,
+		/* eslint-enable jsx-a11y/anchor-has-content */
+	}
+);
+
 export default {
 	'': {
 		sample: '{}',
@@ -175,6 +194,7 @@ export default {
 	},
 	[GOOGLE_ANALYTICS_VENDOR]: {
 		notice: GOOGLE_ANALYTICS_NOTICE,
+		warning: GOOGLE_ANALYTICS_DEPRECATION_NOTICE,
 		sample: JSON.stringify(
 			{
 				vars: {

--- a/bin/update-analytics-vendors.js
+++ b/bin/update-analytics-vendors.js
@@ -168,7 +168,13 @@ class UpdateAnalyticsVendors {
 
 		if (this.vendors) {
 			this.vendors = Object.entries(this.vendors).map(
-				([value, label]) => ({ value, label })
+				([value, label]) => {
+					if ('googleanalytics' === value) {
+						label = 'Google Analytics (Legacy)';
+					}
+
+					return { value, label };
+				}
 			);
 
 			// Sort vendors by label.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-libxml": "*",
     "ext-spl": "*",
     "ampproject/amp-toolbox": "0.11.3",
-    "cweagans/composer-patches": "~1.0",
+    "cweagans/composer-patches": "^1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#cc791ad"
   },
@@ -28,7 +28,7 @@
     "mustache/mustache": "^2",
     "php-stubs/wordpress-stubs": "^6.0.0",
     "phpcompatibility/phpcompatibility-wp": "2.1.4",
-    "phpdocumentor/reflection": "~3.0",
+    "phpdocumentor/reflection": "^3.0",
     "roave/security-advisories": "dev-latest",
     "sirbrillig/phpcs-variable-analysis": "2.11.16",
     "wp-cli/export-command": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a64d6a92517ac7710de6d09c686b85a6",
+    "content-hash": "f10abe9a51dff7dd7ecd659c19475958",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",

--- a/includes/ecosystem-data/analytics-vendors.php
+++ b/includes/ecosystem-data/analytics-vendors.php
@@ -272,195 +272,200 @@ return array (
   ),
   52 => 
   array (
+    'value' => 'neodata',
+    'label' => 'Neodata',
+  ),
+  53 => 
+  array (
     'value' => 'newrelic',
     'label' => 'New Relic',
   ),
-  53 => 
+  54 => 
   array (
     'value' => 'nielsen',
     'label' => 'Nielsen',
   ),
-  54 => 
+  55 => 
   array (
     'value' => 'nielsen-marketing-cloud',
     'label' => 'Nielsen Marketing Cloud',
   ),
-  55 => 
+  56 => 
   array (
     'value' => 'oewa',
     'label' => 'OEWA',
   ),
-  56 => 
+  57 => 
   array (
     'value' => 'oewadirect',
     'label' => 'oewadirect',
   ),
-  57 => 
+  58 => 
   array (
     'value' => 'oracleInfinityAnalytics',
     'label' => 'Oracle Infinity Analytics',
   ),
-  58 => 
+  59 => 
   array (
     'value' => 'parsely',
     'label' => 'Parsely',
   ),
-  59 => 
+  60 => 
   array (
     'value' => 'permutive',
     'label' => 'Permutive',
   ),
-  60 => 
+  61 => 
   array (
     'value' => 'permutive-ampscript',
     'label' => 'Permutive-ampscript',
   ),
-  61 => 
+  62 => 
   array (
     'value' => 'piano',
     'label' => 'Piano',
   ),
-  62 => 
+  63 => 
   array (
     'value' => 'pinpoll',
     'label' => 'Pinpoll',
   ),
-  63 => 
+  64 => 
   array (
     'value' => 'piStats',
     'label' => 'Pistats',
   ),
-  64 => 
+  65 => 
   array (
     'value' => 'ppasanalytics',
     'label' => 'Piwik PRO Analytics Suite',
   ),
-  65 => 
+  66 => 
   array (
     'value' => 'pressboard',
     'label' => 'Pressboard',
   ),
-  66 => 
+  67 => 
   array (
     'value' => 'quantcast',
     'label' => 'Quantcast Measurement',
   ),
-  67 => 
+  68 => 
   array (
     'value' => 'rakam',
     'label' => 'Rakam',
   ),
-  68 => 
+  69 => 
   array (
     'value' => 'top100',
     'label' => 'Rambler/TOP-100',
   ),
-  69 => 
+  70 => 
   array (
     'value' => 'reppublika',
     'label' => 'reppublika',
   ),
-  70 => 
+  71 => 
   array (
     'value' => 'retargetly',
     'label' => 'Retargetly',
   ),
-  71 => 
+  72 => 
   array (
     'value' => 'rudderstack',
     'label' => 'RudderStack',
   ),
-  72 => 
+  73 => 
   array (
     'value' => 'segment',
     'label' => 'Segment',
   ),
-  73 => 
+  74 => 
   array (
     'value' => 'sensorsanalytics',
     'label' => 'SensorsData',
   ),
-  74 => 
+  75 => 
   array (
     'value' => 'shinystat',
     'label' => 'ShinyStat',
   ),
-  75 => 
+  76 => 
   array (
     'value' => 'snowplow',
     'label' => 'Snowplow Analytics',
   ),
-  76 => 
+  77 => 
   array (
     'value' => 'snowplow_v2',
     'label' => 'Snowplow Analytics (v2)',
   ),
-  77 => 
+  78 => 
   array (
     'value' => 'mpulse',
     'label' => 'SOASTA mPulse',
   ),
-  78 => 
+  79 => 
   array (
     'value' => 'subscriptions-propensity',
     'label' => 'subscriptions-propensity',
   ),
-  79 => 
+  80 => 
   array (
     'value' => 'taboola',
     'label' => 'Taboola',
   ),
-  80 => 
+  81 => 
   array (
     'value' => 'tail',
     'label' => 'Tail',
   ),
-  81 => 
+  82 => 
   array (
     'value' => 'teaanalytics',
     'label' => 'TEA Analytics',
   ),
-  82 => 
+  83 => 
   array (
     'value' => 'tealiumcollect',
     'label' => 'Tealium Collect',
   ),
-  83 => 
+  84 => 
   array (
     'value' => 'topmailru',
     'label' => 'Top.Mail.Ru',
   ),
-  84 => 
+  85 => 
   array (
     'value' => 'treasuredata',
     'label' => 'Treasure Data',
   ),
-  85 => 
+  86 => 
   array (
     'value' => 'umenganalytics',
     'label' => 'Umeng+ Analytics',
   ),
-  86 => 
+  87 => 
   array (
     'value' => 'upscore',
     'label' => 'Upscore',
   ),
-  87 => 
+  88 => 
   array (
     'value' => 'vponanalytics',
     'label' => 'Vpon Analytics',
   ),
-  88 => 
+  89 => 
   array (
     'value' => 'webengage',
     'label' => 'Webengage',
   ),
-  89 => 
+  90 => 
   array (
     'value' => 'webtrekk_v2',
     'label' => 'Webtrekk',
   ),
-  90 => 
+  91 => 
   array (
     'value' => 'metrika',
     'label' => 'Yandex Metrica',

--- a/includes/ecosystem-data/analytics-vendors.php
+++ b/includes/ecosystem-data/analytics-vendors.php
@@ -158,7 +158,7 @@ return array (
   29 => 
   array (
     'value' => 'googleanalytics',
-    'label' => 'Google Analytics',
+    'label' => 'Google Analytics (Legacy)',
   ),
   30 => 
   array (

--- a/tests/php/src/Admin/OptionsMenuTest.php
+++ b/tests/php/src/Admin/OptionsMenuTest.php
@@ -189,7 +189,7 @@ class OptionsMenuTest extends DependencyInjectedTestCase {
 		$this->assertIndexedArrayContains(
 			[
 				'adobeanalytics:Adobe Analytics',
-				'googleanalytics:Google Analytics',
+				'googleanalytics:Google Analytics (Legacy)',
 				'gtag:gtag',
 			],
 			$pairs


### PR DESCRIPTION
## Summary
- Append `(Legacy)` to Google Analytics vendor.
- Add warning notice if using Google Analytics.
- Update analytics vendors.

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7567 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
