### PR TITLE
Update paired browsing script dependencies array

### DIFF
--- a/src/Admin/PairedBrowsing.php
+++ b/src/Admin/PairedBrowsing.php
@@ -218,7 +218,7 @@ final class PairedBrowsing implements Service, Registerable, Conditional, Delaye
 		// Mark enqueued script for AMP dev mode so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
 		$dev_mode_handles = array_merge(
-			[ $handle, 'wp-i18n', 'wp-hooks', 'regenerator-runtime', 'wp-polyfill' ],
+			[ $handle, 'regenerator-runtime', 'wp-polyfill', 'wp-polyfill-inert' ],
 			$dependencies
 		);
 		add_filter(

--- a/tests/php/src/Admin/PairedBrowsingTest.php
+++ b/tests/php/src/Admin/PairedBrowsingTest.php
@@ -163,6 +163,8 @@ class PairedBrowsingTest extends DependencyInjectedTestCase {
 		// Check that init_client() was called.
 		$this->assertEquals( 102, has_action( 'admin_bar_menu', [ $this->instance, 'add_admin_bar_menu_item' ] ) );
 		$this->assertTrue( wp_script_is( 'amp-paired-browsing-client' ) );
+		$this->assertTrue( wp_script_is( 'wp-dom-ready' ) );
+
 		$printed_scripts = get_echo( 'wp_print_scripts' );
 		$this->assertStringContainsString( DevMode::DEV_MODE_ATTRIBUTE, $printed_scripts );
 		$this->assertStringContainsString( 'ampPairedBrowsingClientData', $printed_scripts );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7595 

## Checklist
PairedBrowsing depends on the `wp-dom-ready` script which requires:
- `wp-polyfill`
    - `wp-polyfill-inert`
    - `regenerator-runtime`

This PR updates the paired browsing script dependencies array.

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
