### PR TITLE
Add `amp-story-audio-sticker` to spec

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -129,6 +129,11 @@ class AMP_Allowed_Tags_Generated {
 			'ul',
 			'use',
 		),
+		'amp-story-audio-sticker-allowed-descendants' => array(
+			'amp-img',
+			'div',
+			'span',
+		),
 		'amp-story-bookend-allowed-descendants' => array(
 			'script',
 		),
@@ -264,6 +269,9 @@ class AMP_Allowed_Tags_Generated {
 			'amp-render',
 			'amp-state',
 			'amp-story-360',
+			'amp-story-audio-sticker',
+			'amp-story-audio-sticker-pretap',
+			'amp-story-audio-sticker-posttap',
 			'amp-story-auto-analytics',
 			'amp-story-captions',
 			'amp-story-interactive-binary-poll',
@@ -6323,6 +6331,83 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-story-page',
 					'requires_extension' => array(
 						'amp-story',
+					),
+				),
+			),
+		),
+		'amp-story-audio-sticker' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'size' => array(
+						'value' => array(
+							'small',
+							'large',
+						),
+					),
+					'sticker' => array(
+						'value' => array(
+							'headphone-cat',
+							'tape-player',
+							'loud-speaker',
+							'audio-cloud',
+						),
+					),
+					'sticker-style' => array(
+						'value' => array(
+							'outline',
+							'dropshadow',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
+					'mandatory_parent' => 'amp-story-grid-layer',
+					'requires_extension' => array(
+						'amp-story-audio-sticker',
+					),
+				),
+			),
+		),
+		'amp-story-audio-sticker-posttap' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
+					'descendant_tag_list' => 'amp-story-audio-sticker-allowed-descendants',
+					'mandatory_parent' => 'amp-story-audio-sticker',
+					'requires_extension' => array(
+						'amp-story-audio-sticker',
+					),
+				),
+			),
+		),
+		'amp-story-audio-sticker-pretap' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
+					'descendant_tag_list' => 'amp-story-audio-sticker-allowed-descendants',
+					'mandatory_parent' => 'amp-story-audio-sticker',
+					'requires_extension' => array(
+						'amp-story-audio-sticker',
 					),
 				),
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

See https://github.com/ampproject/amphtml/commit/d1301d7edfedd2edabf57391fb15b9b3927d3661

See https://github.com/ampproject/amp-toolbox-php/issues/542

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
