### PR TITLE
Omit page caching and object caching tests for Site Health if on WP>=6.1

### DIFF
--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -355,7 +355,7 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	 */
 	public function get_good_response_time_threshold( $threshold = 600 ) {
 		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) ) {
-			/** @deprecated 2.4.3 Use `site_status_good_response_time_threshold` instead. */
+			/** This filter is documented in src/Admin/SiteHealth.php */
 			return (int) apply_filters_deprecated(
 				'amp_page_cache_good_response_time_threshold',
 				[ $threshold ],
@@ -367,6 +367,9 @@ final class SiteHealth implements Service, Registerable, Delayed {
 			 * Filters the threshold below which a response time is considered good.
 			 *
 			 * @since 2.2.1
+			 *
+			 * @deprecated 2.4.3 Use `site_status_good_response_time_threshold` instead.
+			 *
 			 * @param int $threshold Threshold in milliseconds.
 			 */
 			return (int) apply_filters( 'amp_page_cache_good_response_time_threshold', 600 );

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -103,7 +103,7 @@ final class SiteHealth implements Service, Registerable, Delayed {
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
 
 		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) && has_filter( 'amp_page_cache_good_response_time_threshold' ) ) {
-			add_filter( 'site_status_good_response_time_threshold', 'get_good_response_time_threshold' );
+			add_filter( 'site_status_good_response_time_threshold', [ $this, 'get_good_response_time_threshold' ] );
 		}
 
 		add_action( 'admin_print_styles-tools_page_health-check', [ $this, 'add_styles' ] );

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -113,12 +113,16 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	/**
 	 * Detect whether async tests can be used.
 	 *
-	 * Returns true if *not* on version of Health Check plugin which doesn't support REST async tests.
+	 * Returns true if on WP 5.6+ and *not* on version of Health Check plugin which doesn't support REST async tests.
 	 *
 	 * @param array $tests Tests.
 	 * @return bool
 	 */
 	private function supports_async_rest_tests( $tests ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.6', '<' ) ) {
+			return false;
+		}
+
 		if ( defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
 			$core_async_tests = [
 				'dotorg_communication',
@@ -350,21 +354,23 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	 * @return int Threshold.
 	 */
 	public function get_good_response_time_threshold( $threshold = 600 ) {
-		/**
-		 * Filters the threshold below which a response time is considered good.
-		 *
-		 * @since 2.2.1
-		 *
-		 * @deprecated 2.4.3 Use `site_status_good_response_time_threshold` instead.
-		 *
-		 * @param int $threshold Threshold in milliseconds.
-		 */
-		return (int) apply_filters_deprecated(
-			'amp_page_cache_good_response_time_threshold',
-			[ $threshold ],
-			'2.4.3',
-			'site_status_good_response_time_threshold'
-		);
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) ) {
+			/** @deprecated 2.4.3 Use `site_status_good_response_time_threshold` instead. */
+			return (int) apply_filters_deprecated(
+				'amp_page_cache_good_response_time_threshold',
+				[ $threshold ],
+				'2.4.3',
+				'site_status_good_response_time_threshold'
+			);
+		} else {
+			/**
+			 * Filters the threshold below which a response time is considered good.
+			 *
+			 * @since 2.2.1
+			 * @param int $threshold Threshold in milliseconds.
+			 */
+			return (int) apply_filters( 'amp_page_cache_good_response_time_threshold', 600 );
+		}
 	}
 
 	/**

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -102,6 +102,10 @@ final class SiteHealth implements Service, Registerable, Delayed {
 		add_filter( 'site_status_test_result', [ $this, 'modify_test_result' ] );
 		add_filter( 'site_status_test_php_modules', [ $this, 'add_extensions' ] );
 
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) && has_filter( 'amp_page_cache_good_response_time_threshold' ) ) {
+			add_filter( 'site_status_good_response_time_threshold', 'get_good_response_time_threshold' );
+		}
+
 		add_action( 'admin_print_styles-tools_page_health-check', [ $this, 'add_styles' ] );
 		add_action( 'admin_print_styles-site-health.php', [ $this, 'add_styles' ] );
 	}
@@ -341,16 +345,26 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	 *
 	 * @since 2.2.1
 	 *
+	 * @param int $threshold Threshold in milliseconds.
+	 *
 	 * @return int Threshold.
 	 */
-	public function get_good_response_time_threshold() {
+	public function get_good_response_time_threshold( $threshold = 600 ) {
 		/**
 		 * Filters the threshold below which a response time is considered good.
 		 *
 		 * @since 2.2.1
+		 *
+		 * @deprecated 2.4.3 Use `site_status_good_response_time_threshold` instead.
+		 *
 		 * @param int $threshold Threshold in milliseconds.
 		 */
-		return (int) apply_filters( 'amp_page_cache_good_response_time_threshold', 600 );
+		return (int) apply_filters_deprecated(
+			'amp_page_cache_good_response_time_threshold',
+			[ $threshold ],
+			'2.4.3',
+			'site_status_good_response_time_threshold'
+		);
 	}
 
 	/**

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -109,16 +109,12 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	/**
 	 * Detect whether async tests can be used.
 	 *
-	 * Returns true if on WP 5.6+ and *not* on version of Health Check plugin which doesn't support REST async tests.
+	 * Returns true if *not* on version of Health Check plugin which doesn't support REST async tests.
 	 *
 	 * @param array $tests Tests.
 	 * @return bool
 	 */
 	private function supports_async_rest_tests( $tests ) {
-		if ( version_compare( get_bloginfo( 'version' ), '5.6', '<' ) ) {
-			return false;
-		}
-
 		if ( defined( 'HEALTH_CHECK_PLUGIN_VERSION' ) ) {
 			$core_async_tests = [
 				'dotorg_communication',
@@ -180,17 +176,13 @@ final class SiteHealth implements Service, Registerable, Delayed {
 	 * @return array $tests The filtered tests, with tests for AMP.
 	 */
 	public function add_tests( $tests ) {
-		$tests['direct']['amp_persistent_object_cache'] = [
-			'label' => esc_html__( 'Persistent object cache', 'amp' ),
-			'test'  => [ $this, 'persistent_object_cache' ],
-		];
-
 		if ( ! amp_is_canonical() && QueryVar::AMP !== amp_get_slug() ) {
 			$tests['direct']['amp_slug_definition_timing'] = [
 				'label' => esc_html__( 'AMP slug (query var) definition timing', 'amp' ),
 				'test'  => [ $this, 'slug_definition_timing' ],
 			];
 		}
+
 		$tests['direct']['amp_curl_multi_functions'] = [
 			'label' => esc_html__( 'cURL multi functions', 'amp' ),
 			'test'  => [ $this, 'curl_multi_functions' ],
@@ -207,7 +199,8 @@ final class SiteHealth implements Service, Registerable, Delayed {
 			'label' => esc_html__( 'Transient caching of stylesheets', 'amp' ),
 			'test'  => [ $this, 'css_transient_caching' ],
 		];
-		$tests['direct']['amp_xdebug_extension']      = [
+
+		$tests['direct']['amp_xdebug_extension'] = [
 			'label' => esc_html__( 'Xdebug extension', 'amp' ),
 			'test'  => [ $this, 'xdebug_extension' ],
 		];
@@ -217,13 +210,21 @@ final class SiteHealth implements Service, Registerable, Delayed {
 			'test'  => [ $this, 'publisher_logo' ],
 		];
 
-		if ( $this->supports_async_rest_tests( $tests ) ) {
-			$tests['async'][ self::TEST_PAGE_CACHING ] = [
-				'label'             => esc_html__( 'Page caching', 'amp' ),
-				'test'              => rest_url( self::REST_API_NAMESPACE . self::REST_API_PAGE_CACHE_ENDPOINT ),
-				'has_rest'          => true,
-				'async_direct_test' => [ $this, 'page_cache' ],
+		// Only run page and object cache tests for WP < 6.1, since it has been a part of core now.
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '<' ) ) {
+			$tests['direct']['amp_persistent_object_cache'] = [
+				'label' => esc_html__( 'Persistent object cache', 'amp' ),
+				'test'  => [ $this, 'persistent_object_cache' ],
 			];
+
+			if ( $this->supports_async_rest_tests( $tests ) ) {
+				$tests['async'][ self::TEST_PAGE_CACHING ] = [
+					'label'             => esc_html__( 'Page caching', 'amp' ),
+					'test'              => rest_url( self::REST_API_NAMESPACE . self::REST_API_PAGE_CACHE_ENDPOINT ),
+					'has_rest'          => true,
+					'async_direct_test' => [ $this, 'page_cache' ],
+				];
+			}
 		}
 
 		return $tests;

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -359,7 +359,7 @@ final class SiteHealth implements Service, Registerable, Delayed {
 			return (int) apply_filters_deprecated(
 				'amp_page_cache_good_response_time_threshold',
 				[ $threshold ],
-				'2.4.3',
+				'AMP 2.4.3',
 				'site_status_good_response_time_threshold'
 			);
 		} else {

--- a/tests/php/src/Admin/SiteHealthTest.php
+++ b/tests/php/src/Admin/SiteHealthTest.php
@@ -153,13 +153,17 @@ class SiteHealthTest extends TestCase {
 	 */
 	public function test_add_tests() {
 		$tests = $this->instance->add_tests( [] );
-		$this->assertArrayHasKey( 'direct', $tests );
-		$this->assertArrayHasKey( 'amp_persistent_object_cache', $tests['direct'] );
 
-		if ( version_compare( get_bloginfo( 'version' ), '5.6', '>=' ) ) {
-			$this->assertArrayHasKey( 'amp_page_cache', $tests['async'] );
-		} elseif ( array_key_exists( 'async', $tests ) ) {
-			$this->assertArrayNotHasKey( 'amp_page_cache', $tests['async'] );
+		$this->assertArrayHasKey( 'direct', $tests );
+
+		if ( ! version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) ) {
+			$this->assertArrayHasKey( 'amp_persistent_object_cache', $tests['direct'] );
+
+			if ( version_compare( get_bloginfo( 'version' ), '5.6', '>=' ) ) {
+				$this->assertArrayHasKey( 'amp_page_cache', $tests['async'] );
+			} elseif ( array_key_exists( 'async', $tests ) ) {
+				$this->assertArrayNotHasKey( 'amp_page_cache', $tests['async'] );
+			}
 		}
 
 		$this->assertArrayHasKey( 'amp_curl_multi_functions', $tests['direct'] );
@@ -698,6 +702,10 @@ class SiteHealthTest extends TestCase {
 	 * @covers ::get_good_response_time_threshold()
 	 */
 	public function test_get_good_response_time_threshold() {
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) ) {
+			$this->markTestSkipped( '`amp_page_cache_good_response_time_threshold` is deprecated in WordPress 6.1 and above.' );
+		}
+
 		$this->assertSame( 600, $this->instance->get_good_response_time_threshold() );
 
 		add_filter(
@@ -918,6 +926,9 @@ class SiteHealthTest extends TestCase {
 	 * @covers ::check_for_page_caching()
 	 */
 	public function test_page_cache( $responses, $expected_status, $expected_label, $good_basic_auth = null, $delay_the_response = false ) {
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) ) {
+			$this->markTestSkipped( 'AMP plugin omits page and object caching tests for Site Health if on WP>=6.1 ' );
+		}
 
 		$badge_color = [
 			'critical'    => 'red',


### PR DESCRIPTION

## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7643 

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
