### PR TITLE
Fix deprecation warning on AMP validation post edit screen

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -167,7 +167,7 @@ class AMP_Validated_URL_Post_Type {
 					'not_found'          => __( 'No validated URLs found', 'amp' ),
 					'not_found_in_trash' => __( 'No forgotten validated URLs', 'amp' ),
 					'search_items'       => __( 'Search validated URLs', 'amp' ),
-					'edit_item'          => '', // Overwritten in JS, so this prevents the page header from appearing and changing.
+					'edit_item'          => ' ', // Overwritten in JS, so this prevents the page header from appearing and changing.
 				],
 				'supports'     => false,
 				'public'       => false,


### PR DESCRIPTION
## Summary

On a post-edit screen, the title is determined using the `edit_item` label in the post object and post title which returns a string for the title like `Edit post "Post title"`. 

In our case, `edit_item` is being set as an empty string which causes a deprecation warning with the PHP 8.1+ version.

![image](https://github.com/ampproject/amp-wp/assets/54371619/9dd432e5-cd97-4d34-8e66-ca946d47f84a)

Since we want to stop the `passing null` deprecation warning, this PR is a space in the string(`''` -> `' '`) that stops the warning.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
