### PR TITLE
Use more efficient string replacement and prevent validation errors from Interactivity API experiment

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -909,6 +909,10 @@ class AMP_Theme_Support {
 		// Prevent Interactivity API from being enqueued in the form of modules.
 		// TODO: This will need to be updated once Interactivity API is merged from Gutenberg into core.
 		remove_action( 'wp_enqueue_scripts', 'gutenberg_register_interactivity_module' );
+		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_import_map' ] );
+		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
+		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_module_preloads' ] );
+		remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_import_map_polyfill' ], 11 );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -905,6 +905,10 @@ class AMP_Theme_Support {
 			},
 			0
 		);
+
+		// Prevent Interactivity API from being enqueued in the form of modules.
+		// TODO: This will need to be updated once Interactivity API is merged from Gutenberg into core.
+		remove_action( 'wp_enqueue_scripts', 'gutenberg_register_interactivity_module' );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -906,13 +906,16 @@ class AMP_Theme_Support {
 			0
 		);
 
-		// Prevent Interactivity API from being enqueued in the form of modules.
+		// Prevent Interactivity API scripts from being enqueued.
 		// TODO: This will need to be updated once Interactivity API is merged from Gutenberg into core.
 		remove_action( 'wp_enqueue_scripts', 'gutenberg_register_interactivity_module' );
-		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_import_map' ] );
-		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
-		remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_module_preloads' ] );
-		remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_import_map_polyfill' ], 11 );
+
+		if ( class_exists( 'Gutenberg_Modules' ) ) {
+			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_import_map' ] );
+			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
+			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_module_preloads' ] );
+			remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_import_map_polyfill' ], 11 );
+		}
 	}
 
 	/**

--- a/src/DevTools/UserAccess.php
+++ b/src/DevTools/UserAccess.php
@@ -208,7 +208,7 @@ final class UserAccess implements Service, Registerable {
 	 * Provides the user's dev tools enabled setting.
 	 *
 	 * @param array $user Array of user data prepared for REST.
-	 * @return null|boolean Whether tools are enabled for the user, or null if the option has not been set.
+	 * @return bool Whether dev tools are enabled for the user.
 	 */
 	public function rest_get_dev_tools_enabled( $user ) {
 		return $this->is_user_enabled( $user['id'] );

--- a/src/MobileRedirection.php
+++ b/src/MobileRedirection.php
@@ -440,7 +440,7 @@ final class MobileRedirection implements Service, Registerable {
 			'isAmpDevMode'       => amp_is_dev_mode(),
 		];
 
-		$source = preg_replace( '/\bAMP_MOBILE_REDIRECTION\b/', wp_json_encode( $exports ), $source );
+		$source = str_replace( 'AMP_MOBILE_REDIRECTION', wp_json_encode( $exports ), $source );
 
 		if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 			wp_print_inline_script_tag( $source );

--- a/src/OptionsRESTController.php
+++ b/src/OptionsRESTController.php
@@ -257,7 +257,7 @@ final class OptionsRESTController extends WP_REST_Controller implements Delayed,
 	 * Updates AMP plugin options.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return array|WP_Error Array on success, or error object on failure.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function update_items( $request ) {
 		$params = $request->get_params();

--- a/src/ReaderThemeLoader.php
+++ b/src/ReaderThemeLoader.php
@@ -314,7 +314,7 @@ final class ReaderThemeLoader implements Service, Registerable {
 	 *
 	 * The theme that was active before switching to the Reader theme.
 	 *
-	 * @return WP_Theme|null
+	 * @return WP_Theme WP_Theme instance.
 	 */
 	public function get_active_theme() {
 		return $this->active_theme;


### PR DESCRIPTION
Since the string `AMP_MOBILE_REDIRECTION` only occurs once in the JS file, there's no need for the more expensive regex match. A simple string replacement will suffice.

This also fixes unit tests and prevents validation errors from being reported from scripts added by the Interactivity API experiment in Gutenberg.

This also fixes static analysis errors reported by PHPStan.