### PR TITLE
Bump `ampproject/amp-toolbox`; Fix Gutenberg's validation issues with Script Modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-spl": "*",
-    "ampproject/amp-toolbox": "0.11.4",
+    "ampproject/amp-toolbox": "0.11.5",
     "cweagans/composer-patches": "^1.0",
     "fasterimage/fasterimage": "1.5.0",
     "sabberworm/php-css-parser": "dev-master#cc791ad"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fce7eaa51eae83b212188c83fb02faa9",
+    "content-hash": "c2638f309d61f5fe978e1e461346f533",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.11.4",
+            "version": "0.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "c79a0fe558a3c042aee4789bbf33376cca7a733d"
+                "reference": "78531851c59fa5f306315372719f0064b5542cf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/c79a0fe558a3c042aee4789bbf33376cca7a733d",
-                "reference": "c79a0fe558a3c042aee4789bbf33376cca7a733d",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/78531851c59fa5f306315372719f0064b5542cf4",
+                "reference": "78531851c59fa5f306315372719f0064b5542cf4",
                 "shasum": ""
             },
             "require": {
@@ -76,9 +76,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.11.4"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.11.5"
             },
-            "time": "2023-10-24T22:47:58+00:00"
+            "time": "2024-02-05T19:10:57+00:00"
         },
         {
             "name": "cweagans/composer-patches",

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -911,13 +911,20 @@ class AMP_Theme_Support {
 		remove_action( 'wp_enqueue_scripts', 'gutenberg_register_interactivity_module' );
 
 		if ( class_exists( 'Gutenberg_Modules' ) ) {
-			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_import_map' ] );
-			remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_import_map' ] );
-			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
-			remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
-			remove_action( 'wp_head', [ 'Gutenberg_Modules', 'print_module_preloads' ] );
-			remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_module_preloads' ] );
+			foreach ( [ 'wp_head', 'wp_footer' ] as $action ) {
+				remove_action( $action, [ 'Gutenberg_Modules', 'print_import_map' ] );
+				remove_action( $action, [ 'Gutenberg_Modules', 'print_enqueued_modules' ] );
+				remove_action( $action, [ 'Gutenberg_Modules', 'print_module_preloads' ] );
+			}
 			remove_action( 'wp_footer', [ 'Gutenberg_Modules', 'print_import_map_polyfill' ], 11 );
+		}
+
+		if ( function_exists( 'wp_script_modules' ) ) {
+			foreach ( [ 'wp_head', 'wp_footer' ] as $action ) {
+				remove_action( $action, [ wp_script_modules(), 'print_import_map' ] );
+				remove_action( $action, [ wp_script_modules(), 'print_enqueued_script_modules' ] );
+				remove_action( $action, [ wp_script_modules(), 'print_script_module_preloads' ] );
+			}
 		}
 	}
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1813,7 +1813,7 @@ class Test_AMP_Theme_Support extends TestCase {
 		}
 
 		$this->assertStringContainsString( '<button>no-onclick</button>', $sanitized_html );
-		$this->assertCount( 5, AMP_Validation_Manager::$validation_results );
+		$this->assertCount( 5, AMP_Validation_Manager::$validation_results, 'Actual validation results: ' . wp_json_encode( AMP_Validation_Manager::$validation_results, JSON_PRETTY_PRINT ) );
 		$this->assertEquals(
 			[
 				'onclick' => 1,

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1448,6 +1448,13 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			$rendered_block
 		);
 
+		// Remove suffix from class name in later Gutenberg versions.
+		$rendered_block = str_replace(
+			'-columns-is-layout-1',
+			'',
+			$rendered_block
+		);
+
 		$expected = str_replace(
 			[
 				'{{post_id}}',


### PR DESCRIPTION
## Summary

Fixes https://github.com/ampproject/amp-wp/issues/7737

Bump `ampproject/amp-toolbox` from 0.11.4 to 0.11.5. See https://github.com/ampproject/amp-toolbox-php/releases/tag/0.11.5

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
