### PR TITLE
Bump GH Actions to latest version with SHA-pinned versioning

### DIFF
--- a/.github/actions/determine-changed-files/action.yml
+++ b/.github/actions/determine-changed-files/action.yml
@@ -50,7 +50,7 @@ runs:
         PHP_FILE_COUNT=$(php -f ./.github/actions/determine-changed-files/determine-modified-files-count.php ".+\.php|composer\.(json|lock)|phpstan\.neon\.dist" "$MODIFIED_FILES")
         CSS_FILE_COUNT=$(php -f ./.github/actions/determine-changed-files/determine-modified-files-count.php ".+\.s?css|package\.json|package-lock\.json" "$MODIFIED_FILES")
         JS_FILE_COUNT=$(php -f ./.github/actions/determine-changed-files/determine-modified-files-count.php ".+\.(js|snap)|package\.json|package-lock\.json" "$MODIFIED_FILES")
-        GHA_WORKFLOW_COUNT=$(php -f ./.github/actions/determine-changed-files/determine-modified-files-count.php "(\.github\/workflows\/.+\.yml)" "$MODIFIED_FILES")
+        GHA_WORKFLOW_COUNT=$(php -f ./.github/actions/determine-changed-files/determine-modified-files-count.php "(\.github\/workflows\/.+\.yml|\.github\/actions\/.+\.yml)" "$MODIFIED_FILES")
 
         # Set output variables.
         echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT

--- a/.github/actions/plugin-build/action.yml
+++ b/.github/actions/plugin-build/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache assets directory
-      uses: actions/cache@v3
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
       id: assets-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'

--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Configure Node.js cache
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
       id: node-npm-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -16,13 +16,13 @@ runs:
 
     # Since it gets downloaded with npm install, we need to cache it instantly.
     - name: Setup puppeteer cache
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
       with:
         path: ~/.cache/puppeteer
         key: ${{ runner.os }}-puppeteer
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
       with:
         node-version-file: '.nvmrc'
 

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -24,7 +24,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d #2.30.0
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.extensions }}
@@ -32,7 +32,7 @@ runs:
         tools: ${{ inputs.tools }}
 
     - name: Setup composer cache
-      uses: actions/cache@v3
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
       id: php-composer-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,49 @@
 version: 2
 updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "17:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    groups:
+      wp-cli-packages:
+        patterns:
+          - "wp-cli/*"
+    ignore:
+      # @see <https://github.com/ampproject/amp-wp/issues/7501#issuecomment-1656231088>.
+      - dependency-name: phpdocumentor/reflection
 
-# Config for AMP plugin.
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "17:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  groups:
-    wp-cli-packages:
-      patterns:
-        - "wp-cli/*"
-  ignore:
-    # @see <https://github.com/ampproject/amp-wp/issues/7501#issuecomment-1656231088>.
-    - dependency-name: phpdocumentor/reflection
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "17:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    groups:
+      wordpress-packages:
+        patterns:
+          - "@wordpress/*"
+    ignore:
+    # Need to be updated based on `@wordpress/element` react peer dependency version.
+    - dependency-name: react
+    - dependency-name: react-dom
 
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "17:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  groups:
-    wordpress-packages:
-      patterns:
-        - "@wordpress/*"
-  ignore:
-  # Need to be updated based on `@wordpress/element` react peer dependency version.
-  - dependency-name: react
-  - dependency-name: react-dom
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "17:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
 
-# Config for GitHub Actions.
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "17:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
+  # Config for composite GitHub Actions.
+  - package-ecosystem: github-actions
+    directory: "/.github/actions"
+    schedule:
+      interval: monthly
+      time: "17:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Checkout including last 2 commits
         # Fetch last 2 commits if it's not a PR, so that we can determine the list of modified files.
         if: ${{ github.base_ref == null }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           fetch-depth: 2
 
       - name: Checkout
         # Do usual checkout if it's a PR.
         if: ${{ github.base_ref != null }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Determine modified files
         id: determine-file-counts
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup NodeJS and NPM
         uses: ./.github/actions/setup-node-npm
@@ -76,7 +76,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup NodeJS and NPM
         uses: ./.github/actions/setup-node-npm
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup PHP and Composer
         uses: ./.github/actions/setup-php-composer
@@ -145,7 +145,7 @@ jobs:
     if: needs.pre-run.outputs.changed-php-count > 0 || needs.pre-run.outputs.changed-gha-workflow-count > 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup PHP and Composer
         uses: ./.github/actions/setup-php-composer
@@ -165,7 +165,7 @@ jobs:
     if: needs.pre-run.outputs.changed-js-count > 0 || needs.pre-run.outputs.changed-gha-workflow-count > 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup NodeJS and NPM
         uses: ./.github/actions/setup-node-npm
@@ -207,7 +207,7 @@ jobs:
           totalParts: [2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup NodeJS and NPM
         uses: ./.github/actions/setup-node-npm
@@ -370,7 +370,7 @@ jobs:
 
       - name: Checkout
         if: needs.pre-run.outputs.changed-php-count > 0
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup PHP and Composer
         if: needs.pre-run.outputs.changed-php-count > 0
@@ -534,7 +534,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup PHP and Composer
         uses: ./.github/actions/setup-php-composer
@@ -585,7 +585,7 @@ jobs:
         build: ['dev', 'prod']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup NodeJS and NPM
         uses: ./.github/actions/setup-node-npm

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -103,7 +103,7 @@ jobs:
         if: >
           ! ( github.event.pull_request.head.repo.fork == true ||
           github.event.pull_request.user.login == 'dependabot[bot]' )
-        uses: ataylorme/eslint-annotate-action@2.2.0
+        uses: ataylorme/eslint-annotate-action@5f4dc2e3af8d3c21b727edb597e5503510b1dc9c #2.2.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'lint-js-report.json'
@@ -171,7 +171,7 @@ jobs:
         uses: ./.github/actions/setup-node-npm
 
       - name: Setup Jest cache
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
         with:
           path: ~/.jest-cache
           key: ${{ runner.os }}-jest
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload code coverage report
         if: github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab #v4.1.0
         with:
           file: build/logs/lcov.info
           flags: javascript
@@ -219,7 +219,7 @@ jobs:
         uses: ./.github/actions/plugin-build
 
       - name: Setup Jest cache
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
         with:
           path: ~/.jest-cache
           key: ${{ runner.os }}-jest-e2e-${{ matrix.part }}
@@ -249,7 +249,7 @@ jobs:
           COMPOSE_INTERACTIVE_NO_CLI: true
 
       - name: Archive debug artifacts (screenshots, HTML snapshots)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         if: always()
         with:
           name: e2e-failure-artifacts
@@ -457,7 +457,7 @@ jobs:
 
       - name: Upload code coverage report
         if: ${{ matrix.coverage == true && needs.pre-run.outputs.changed-php-count > 0 && github.actor != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab #v4.1.0
         with:
           file: ${{ env.WP_CORE_DIR }}/src/wp-content/plugins/amp/build/logs/clover.xml
           flags: php,unit
@@ -622,7 +622,7 @@ jobs:
         run: echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
 
       - name: Upload build as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: amp-${{ steps.retrieve-branch-name.outputs.branch_name }}-${{ steps.retrieve-git-sha-8.outputs.sha8 }}-${{ matrix.build }}
           path: builds/${{ matrix.build }}
@@ -641,19 +641,19 @@ jobs:
       prod-checksum: ${{ steps.output-checksums.outputs.prod-checksum }}
     steps:
       - name: Download dev build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
         with:
           name: amp-${{ needs.build-zip.outputs.branch-name }}-${{ needs.build-zip.outputs.git-sha-8 }}-dev
           path: builds/dev
 
       - name: Download prod build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
         with:
           name: amp-${{ needs.build-zip.outputs.branch-name }}-${{ needs.build-zip.outputs.git-sha-8 }}-prod
           path: builds/prod
 
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@20c93dacc1d70ddbce76c63ab32c35595345bdd1 #v0
         with:
           project_id: ${{ secrets.GCS_PROJECT_ID }}
           service_account_key: ${{ secrets.GCS_APPLICATION_CREDENTIALS }}
@@ -691,7 +691,7 @@ jobs:
     steps:
       - name: Check if a comment was already made
         id: find-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const { data: comments } = await github.rest.issues.listComments({
@@ -735,7 +735,7 @@ jobs:
 
       - name: Create comment on PR with links to plugin builds
         if: ${{ steps.find-comment.outputs.result == 'null' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             github.rest.issues.createComment({
@@ -747,7 +747,7 @@ jobs:
 
       - name: Update comment on PR with links to plugin builds
         if: ${{ steps.find-comment.outputs.result != 'null' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             github.rest.issues.updateComment({

--- a/.github/workflows/cache-buster.yml
+++ b/.github/workflows/cache-buster.yml
@@ -22,7 +22,7 @@ jobs:
       actions: write
     steps:
       - name: Bust cache
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const caches = await github.rest.actions.getActionsCacheList({

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@1b1aada464948af03b950897e5eb522f92603cc2 #v3.24.9
         with:
           languages: javascript, python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@1b1aada464948af03b950897e5eb522f92603cc2 #v3.24.9


### PR DESCRIPTION
## Summary

- Update @dependabot config to update composite GH Actions.
- Bump GH actions to the latest version.
- Update GH Actions versioning strategy to SHA based. This is also supported by @dependabot - https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
