### PR TITLE
Remove sixth tag from WordPress.org plugin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An easier path to great Page Experience for everyone. Powered by AMP.
 
 **Contributors:** [google](https://profiles.wordpress.org/google), [xwp](https://profiles.wordpress.org/xwp), [rtcamp](https://profiles.wordpress.org/rtcamp), [automattic](https://profiles.wordpress.org/automattic), [westonruter](https://profiles.wordpress.org/westonruter), [albertomedina](https://profiles.wordpress.org/albertomedina), [schlessera](https://profiles.wordpress.org/schlessera), [delawski](https://profiles.wordpress.org/delawski/), [swissspidy](https://profiles.wordpress.org/swissspidy), [pierlo](https://profiles.wordpress.org/pierlo), [joshuawold](https://profiles.wordpress.org/joshuawold), [thelovekesh](https://profiles.wordpress.org/thelovekesh/)  
-**Tags:** [page experience](https://wordpress.org/plugins/tags/page-experience), [performance](https://wordpress.org/plugins/tags/performance), [amp](https://wordpress.org/plugins/tags/amp), [mobile](https://wordpress.org/plugins/tags/mobile), [optimization](https://wordpress.org/plugins/tags/optimization), [accelerated mobile pages](https://wordpress.org/plugins/tags/accelerated-mobile-pages)  
+**Tags:** [page experience](https://wordpress.org/plugins/tags/page-experience), [performance](https://wordpress.org/plugins/tags/performance), [amp](https://wordpress.org/plugins/tags/amp), [mobile](https://wordpress.org/plugins/tags/mobile), [optimization](https://wordpress.org/plugins/tags/optimization)  
 **Requires at least:** 5.3  
 **Tested up to:** 6.5  
 **Stable tag:** 2.5.3  


### PR DESCRIPTION
On the WordPress.org plugin page, I'm currently seeing an error:

![image](https://github.com/ampproject/amp-wp/assets/134745/9d1a8a21-8d97-42c8-95ac-abce6e8b04bf)

I see we have 6 tags rather than 5. So This removes the 6th one.

Fixes #7780