### PR TITLE
Use posts member of WP_Query instead of get_posts method

### DIFF
--- a/bin/add-test-widgets-to-sidebar.php
+++ b/bin/add-test-widgets-to-sidebar.php
@@ -294,7 +294,7 @@ function amp_media( $type, $count = 3 ) {
 			)
 		);
 	}
-	return $query->get_posts();
+	return $query->posts;
 }
 
 /**

--- a/bin/create-embed-test-post.php
+++ b/bin/create-embed-test-post.php
@@ -242,7 +242,7 @@ function amp_get_media_items_ids( $type, $image_count = 3 ) {
 			)
 		);
 	}
-	return implode( ',', $query->get_posts() );
+	return implode( ',', $query->posts );
 }
 
 /**

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -994,7 +994,7 @@ class AMP_Validated_URL_Post_Type {
 				'posts_per_page' => $count,
 			]
 		);
-		foreach ( $query->get_posts() as $post_id ) {
+		foreach ( $query->posts as $post_id ) {
 			if ( delete_post_meta( $post_id, self::STYLESHEETS_POST_META_KEY ) ) {
 				$deleted++;
 			}
@@ -1037,7 +1037,7 @@ class AMP_Validated_URL_Post_Type {
 				],
 			]
 		);
-		foreach ( $query->get_posts() as $post ) {
+		foreach ( $query->posts as $post ) {
 			if ( ! self::is_post_safe_to_garbage_collect( $post ) ) {
 				continue;
 			}

--- a/src/Support/SupportData.php
+++ b/src/Support/SupportData.php
@@ -679,7 +679,7 @@ class SupportData {
 			];
 
 			$query               = new WP_Query( $query_args );
-			$amp_validated_posts = $query->get_posts();
+			$amp_validated_posts = $query->posts;
 
 			foreach ( $amp_validated_posts as $amp_validated_post ) {
 				$validation_data = $this->process_raw_post_errors( $amp_validated_post );

--- a/src/Validation/ScannableURLProvider.php
+++ b/src/Validation/ScannableURLProvider.php
@@ -336,7 +336,7 @@ final class ScannableURLProvider implements Service {
 					'posts_per_page' => 1,
 				]
 			);
-			if ( count( $authored_post_query->get_posts() ) > 0 ) {
+			if ( count( $authored_post_query->posts ) > 0 ) {
 				$author_page_urls[] = get_author_posts_url( $author->ID, $author->user_nicename );
 			}
 		}
@@ -376,7 +376,7 @@ final class ScannableURLProvider implements Service {
 				'order'          => 'DESC',
 			]
 		);
-		$posts = $query->get_posts();
+		$posts = $query->posts;
 
 		$latest_post = array_shift( $posts );
 		if ( ! $latest_post ) {

--- a/tests/php/src/Validation/ScannableURLProviderTest.php
+++ b/tests/php/src/Validation/ScannableURLProviderTest.php
@@ -517,7 +517,7 @@ final class ScannableURLProviderTest extends TestCase {
 				'fields'         => 'ids',
 			]
 		);
-		foreach ( $query->get_posts() as $deleted_post ) {
+		foreach ( $query->posts as $deleted_post ) {
 			wp_delete_post( $deleted_post );
 		}
 		$this->assertNull( $this->call_private_method( $this->scannable_url_provider, 'get_date_page' ) );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -3518,8 +3518,18 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 					$this->assertStringContainsString( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
 					$this->assertStringContainsString( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
 
-					$this->assertStringContainsString( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
-					$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
+					if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '18.7', '>=' ) ) {
+						$this->assertStringContainsString( '.wp-block-audio :where(figcaption)', $amphtml_source, 'Expected block-library/style.css' );
+					} else {
+						$this->assertStringContainsString( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
+					}
+
+					if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.6', '>=' ) ) {
+						$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) > figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
+					} else {
+						$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
+					}
+
 					$amphtml_source = preg_replace( '/\s*>\s*/', '>', $amphtml_source ); // Account for variance in postcss.
 					$this->assertStringContainsString( '.amp-wp-default-form-message>p', $amphtml_source, 'Expected amp-default.css' );
 					$this->assertStringContainsString( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7781

This is just a simple search-and-replace. Changes are not tested.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
