### PR TITLE
Fix static-analysis and PHPUnit tests errors

### DIFF
--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -42,8 +42,6 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param AMP_Base_Sanitizer[] $sanitizers Sanitizers.
 	 */
 	public function init( $sanitizers ) {
-		parent::init( $sanitizers );
-
 		if (
 			array_key_exists( AMP_Style_Sanitizer::class, $sanitizers )
 			&&

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -99,8 +99,6 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param AMP_Base_Sanitizer[] $sanitizers Sanitizers.
 	 */
 	public function init( $sanitizers ) {
-		parent::init( $sanitizers );
-
 		$this->sanitizers = $sanitizers;
 	}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -891,8 +891,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param AMP_Base_Sanitizer[] $sanitizers Sanitizers.
 	 */
 	public function init( $sanitizers ) {
-		parent::init( $sanitizers );
-
 		$this->sanitizers = $sanitizers;
 	}
 

--- a/src/ReaderThemeSupportFeatures.php
+++ b/src/ReaderThemeSupportFeatures.php
@@ -517,7 +517,7 @@ final class ReaderThemeSupportFeatures implements Service, Registerable {
 		 */
 		$is_wp_generating_spacing_sizes = $spacing[ self::KEY_DEFAULT_SPACING_SIZES ] ?? false;
 
-		if ( isset( $spacing_scale[ self::KEY_STEPS ] ) ) {
+		if ( array_key_exists( self::KEY_STEPS, $spacing_scale ) ) {
 			$is_wp_generating_spacing_sizes = 0 !== $spacing_scale[ self::KEY_STEPS ];
 		}
 

--- a/src/ReaderThemeSupportFeatures.php
+++ b/src/ReaderThemeSupportFeatures.php
@@ -152,7 +152,7 @@ final class ReaderThemeSupportFeatures implements Service, Registerable {
 	const KEY_CUSTOM_SPACING_SIZE = 'customSpacingSize';
 
 	/**
-	 * Key for `defaultSpacingSizes` boolean in theme.json (v3)
+	 * Key for `defaultSpacingSizes` boolean in theme.json (v3).
 	 *
 	 * @var string
 	 */
@@ -509,7 +509,7 @@ final class ReaderThemeSupportFeatures implements Service, Registerable {
 		$custom_spacing_size = $spacing[ self::KEY_CUSTOM_SPACING_SIZE ] ?? false;
 		$spacing_scale       = $spacing[ self::KEY_SPACING_SCALE ] ?? [];
 
-		/*
+		/**
 		 * By default check for `defaultSpacingSizes` boolean introduced in theme.json (v3)
 		 * and if it's false, then check for `steps` in `spacingScale` which is v2 default.
 		 *

--- a/src/ReaderThemeSupportFeatures.php
+++ b/src/ReaderThemeSupportFeatures.php
@@ -152,6 +152,13 @@ final class ReaderThemeSupportFeatures implements Service, Registerable {
 	const KEY_CUSTOM_SPACING_SIZE = 'customSpacingSize';
 
 	/**
+	 * Key for `defaultSpacingSizes` boolean in theme.json (v3)
+	 *
+	 * @var string
+	 */
+	const KEY_DEFAULT_SPACING_SIZES = 'defaultSpacingSizes';
+
+	/**
 	 * Action fired when the cached primary_theme_support should be updated.
 	 *
 	 * @var string
@@ -496,10 +503,23 @@ final class ReaderThemeSupportFeatures implements Service, Registerable {
 	 * Print spacing sizes custom properties.
 	 */
 	private function print_spacing_sizes_custom_properties() {
-		$custom_properties              = [];
-		$spacing_sizes                  = wp_get_global_settings( [ self::KEY_SPACING, self::KEY_SPACING_SIZES ], self::KEY_THEME );
-		$is_wp_generating_spacing_sizes = 0 !== wp_get_global_settings( [ self::KEY_SPACING, self::KEY_SPACING_SCALE ], self::KEY_THEME )[ self::KEY_STEPS ];
-		$custom_spacing_size            = wp_get_global_settings( [ self::KEY_SPACING, self::KEY_CUSTOM_SPACING_SIZE ], self::KEY_THEME );
+		$custom_properties   = [];
+		$spacing             = wp_get_global_settings( [ self::KEY_SPACING ], self::KEY_THEME );
+		$spacing_sizes       = $spacing[ self::KEY_SPACING_SIZES ] ?? [];
+		$custom_spacing_size = $spacing[ self::KEY_CUSTOM_SPACING_SIZE ] ?? false;
+		$spacing_scale       = $spacing[ self::KEY_SPACING_SCALE ] ?? [];
+
+		/*
+		 * By default check for `defaultSpacingSizes` boolean introduced in theme.json (v3)
+		 * and if it's false, then check for `steps` in `spacingScale` which is v2 default.
+		 *
+		 * @see <https://github.com/WordPress/gutenberg/pull/58409#issuecomment-2078077477>.
+		 */
+		$is_wp_generating_spacing_sizes = $spacing[ self::KEY_DEFAULT_SPACING_SIZES ] ?? false;
+
+		if ( isset( $spacing_scale[ self::KEY_STEPS ] ) ) {
+			$is_wp_generating_spacing_sizes = 0 !== $spacing_scale[ self::KEY_STEPS ];
+		}
 
 		if ( ! $is_wp_generating_spacing_sizes && $custom_spacing_size ) {
 			if ( isset( $spacing_sizes[ self::KEY_THEME ] ) ) {


### PR DESCRIPTION
## Summary

### PHPStan

The latest PHPStan version (1.11.3) is showing a few errors:

<details><summary>[errors]</summary>

```
 ------ ---------------------------------------------------------------------- 
  Line   includes/sanitizers/class-amp-comments-sanitizer.php                  
 ------ ---------------------------------------------------------------------- 
  45     Call to AMP_Base_Sanitizer::init() on a separate line has no effect.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   includes/sanitizers/class-amp-script-sanitizer.php                    
 ------ ---------------------------------------------------------------------- 
  102    Call to AMP_Base_Sanitizer::init() on a separate line has no effect.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   includes/sanitizers/class-amp-style-sanitizer.php                     
 ------ ---------------------------------------------------------------------- 
  894    Call to AMP_Base_Sanitizer::init() on a separate line has no effect.  
 ------ ---------------------------------------------------------------------- 
```

</details> 

This PR includes the fix to resolve these static analysis errors.

### PHPUnit

A few tests for `ReaderThemeSupportFeatures` failed due to new changes introduced in `theme.json` v3. The new versions introduce a new `settings.spacing.defaultSpacingSizes` property which decides if default space sizing needs to be preferred over the default ones. This PR adds support for this property in reader themes as well. Also see the dev notes for this new change - https://github.com/WordPress/gutenberg/pull/58409#issuecomment-2078077477

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
