### PR TITLE
Fix form-label lint errors

### DIFF
--- a/assets/src/onboarding-wizard/pages/technical-background/index.js
+++ b/assets/src/onboarding-wizard/pages/technical-background/index.js
@@ -61,10 +61,7 @@ export function TechnicalBackground() {
 					className={`technical-background-option-container`}
 					selected={true === developerToolsOption}
 				>
-					<label
-						htmlFor={enableInputID}
-						className="technical-background-option"
-					>
+					<div className="technical-background-option">
 						<div className="technical-background-option__input-container">
 							<input
 								type="radio"
@@ -76,7 +73,10 @@ export function TechnicalBackground() {
 							/>
 						</div>
 						<User1 />
-						<div className="technical-background-option__description">
+						<label
+							htmlFor={enableInputID}
+							className="technical-background-option__description"
+						>
 							<h2>
 								{__('Developer or technically savvy', 'amp')}
 							</h2>
@@ -86,15 +86,15 @@ export function TechnicalBackground() {
 									'amp'
 								)}
 							</p>
-						</div>
-					</label>
+						</label>
+					</div>
 				</Selectable>
 
 				<Selectable
 					className={`technical-background-option-container`}
 					selected={false === developerToolsOption}
 				>
-					<label
+					<div
 						htmlFor={disableInputID}
 						className="technical-background-option"
 					>
@@ -109,7 +109,10 @@ export function TechnicalBackground() {
 							/>
 						</div>
 						<User2 />
-						<div className="technical-background-option__description">
+						<label
+							htmlFor={disableInputID}
+							className="technical-background-option__description"
+						>
 							<h2>
 								{__(
 									'Non-technical or wanting a simpler setup',
@@ -122,8 +125,8 @@ export function TechnicalBackground() {
 									'amp'
 								)}
 							</p>
-						</div>
-					</label>
+						</label>
+					</div>
 				</Selectable>
 			</form>
 		</div>


### PR DESCRIPTION
## Summary

Fix the following ESLint errors:

```shell
➜  amp git:(fix/eslint-errors) npm run lint:js

> lint:js
> wp-scripts lint-js


/home/thelovekesh/Desktop/work/google/wpdev/public/content/plugins/amp/assets/src/onboarding-wizard/pages/technical-background/index.js
  64:6  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
  97:6  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control

✖ 2 problems (2 errors, 0 warnings)
```

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
