### PR TITLE
Add isset() check in case source type is absent

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -328,11 +328,11 @@ jobs:
             external-http: true
 
           - php: '7.4'
-            wp: '6.3'
+            wp: '6.5'
             phpunit: '7'
 
           - php: '7.4'
-            wp: '6.3'
+            wp: '6.5'
             phpunit: '7'
             external-http: true
     steps:
@@ -507,7 +507,7 @@ jobs:
             wp: 'latest'
 
           - php: '7.4'
-            wp: '6.3'
+            wp: '6.5'
     steps:
       - name: Shutdown default MySQL service
         if: needs.pre-run.outputs.changed-php-count > 0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An easier path to great Page Experience for everyone. Powered by AMP.
 
 **Contributors:** [google](https://profiles.wordpress.org/google), [xwp](https://profiles.wordpress.org/xwp), [rtcamp](https://profiles.wordpress.org/rtcamp), [automattic](https://profiles.wordpress.org/automattic), [westonruter](https://profiles.wordpress.org/westonruter), [albertomedina](https://profiles.wordpress.org/albertomedina), [schlessera](https://profiles.wordpress.org/schlessera), [delawski](https://profiles.wordpress.org/delawski/), [swissspidy](https://profiles.wordpress.org/swissspidy), [pierlo](https://profiles.wordpress.org/pierlo), [joshuawold](https://profiles.wordpress.org/joshuawold), [thelovekesh](https://profiles.wordpress.org/thelovekesh/)  
 **Tags:** [page experience](https://wordpress.org/plugins/tags/page-experience), [performance](https://wordpress.org/plugins/tags/performance), [amp](https://wordpress.org/plugins/tags/amp), [mobile](https://wordpress.org/plugins/tags/mobile), [optimization](https://wordpress.org/plugins/tags/optimization)  
-**Requires at least:** 6.3  
+**Requires at least:** 6.5  
 **Tested up to:** 6.6  
 **Stable tag:** 2.5.4  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  

--- a/amp.php
+++ b/amp.php
@@ -7,7 +7,7 @@
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
  * Version: 2.5.5-alpha
  * License: GPLv2 or later
- * Requires at least: 6.3
+ * Requires at least: 6.5
  * Requires PHP: 7.4
  *
  * @package AMP

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1166,7 +1166,7 @@ class AMP_Validation_Manager {
 
 						$has_non_core = false;
 						foreach ( $extra_sources as $extra_source ) {
-							if ( 'core' !== $extra_source['type'] ) {
+							if ( isset( $extra_source['type'] ) && 'core' !== $extra_source['type'] ) {
 								$has_non_core = true;
 								break;
 							}

--- a/src/DependencySupport.php
+++ b/src/DependencySupport.php
@@ -30,7 +30,7 @@ class DependencySupport implements Service {
 	 *
 	 * @var string
 	 */
-	const WP_MIN_VERSION = '6.3';
+	const WP_MIN_VERSION = '6.5';
 
 	/**
 	 * Determines whether core or Gutenberg provides minimal support.

--- a/tests/php/src/Admin/AmpPluginsTest.php
+++ b/tests/php/src/Admin/AmpPluginsTest.php
@@ -161,7 +161,7 @@ class AmpPluginsTest extends TestCase {
 		$this->assertFalse( AmpPlugins::is_needed() );
 
 		// Test 3: Admin request in supported WordPress .
-		$wp_version = '6.3';
+		$wp_version = '6.5';
 		set_current_screen( 'index.php' );
 		$this->assertTrue( AmpPlugins::is_needed() );
 

--- a/tests/php/src/Admin/AmpThemesTest.php
+++ b/tests/php/src/Admin/AmpThemesTest.php
@@ -83,7 +83,7 @@ class AmpThemesTest extends TestCase {
 		$this->assertFalse( AmpThemes::is_needed() );
 
 		// Test 3: Admin request.
-		$wp_version = '6.3';
+		$wp_version = '6.5';
 		set_current_screen( 'index.php' );
 		$this->assertTrue( is_admin() );
 		$this->assertTrue( AmpThemes::is_needed() );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -3524,11 +3524,11 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 						$this->assertStringContainsString( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
 					}
 
-					if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.6', '>=' ) ) {
-						$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) > figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
-					} else {
-						$this->assertStringContainsString( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
-					}
+					$this->assertStringContainsString(
+						'[class^="wp-block-"]:not(.wp-block-gallery) figcaption',
+						str_replace( '> figcaption', 'figcaption', $amphtml_source ),  // Account for recent CSS changes.
+						'Expected twentyten/blocks.css'
+					);
 
 					$amphtml_source = preg_replace( '/\s*>\s*/', '>', $amphtml_source ); // Account for variance in postcss.
 					$this->assertStringContainsString( '.amp-wp-default-form-message>p', $amphtml_source, 'Expected amp-default.css' );


### PR DESCRIPTION
Fixes #7862

The only behavioral change in this PR is 66ca42e4490601c2235377859843d85e2a64e39e, the addition of an `isset()` check. (However, it's not clear why the key isn't set in the first place.)

Otherwise, it just bumps the minimum version of WP from 6.3 to 6.5 due to Gutenberg increasing its minimum required version of WP. And it fixes a test breakage due to a CSS change in the Twenty Ten theme.