### PR TITLE
Fix 'install command is DEPRECATED' from husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "package:prod": "cross-env NODE_ENV=production npm-run-all build:prod 'package:!(dev|prod)'",
     "package:run": "grunt build",
     "package:zip": "grunt create-build-zip",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "wp-scripts start",
     "test": "npm-run-all --parallel test:*",
     "test:e2e": "cross-env JEST_PUPPETEER_CONFIG=./tests/e2e/puppeteer.config.js wp-scripts test-e2e --config=tests/e2e/jest.config.js",


### PR DESCRIPTION
This is a follow-up to #7890. 

When doing `npm install`, the following appears in the terminal:

```
> prepare
> husky install

install command is DEPRECATED
```

This eliminates that.