### PR TITLE
Install PHPStan via composer and pin at 1.x

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -150,11 +150,13 @@ jobs:
       - name: Setup PHP and Composer
         uses: ./.github/actions/setup-php-composer
         with:
-          tools: 'composer,phpstan'
+          tools: 'composer'
           php-version: '8.1'
 
       - name: Static Analysis (PHPStan)
-        run: phpstan analyze
+        run: |
+          vendor/bin/phpstan --version
+          vendor/bin/phpstan analyze
 
 #-----------------------------------------------------------------------------------------------------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
-    "civicrm/composer-downloads-plugin": "^4.0",
     "google/cloud-storage": "^1.0",
     "mikey179/vfsstream": "1.6.12",
     "mustache/mustache": "^2",
     "php-stubs/wordpress-stubs": "^6.0",
     "phpcompatibility/phpcompatibility-wp": "2.1.5",
     "phpdocumentor/reflection": "^3.0",
+    "phpstan/phpstan": "^1.0",
     "roave/security-advisories": "dev-latest",
     "sirbrillig/phpcs-variable-analysis": "2.11.19",
     "wp-cli/export-command": "^2.0",
@@ -69,7 +69,6 @@
   },
   "config": {
     "allow-plugins": {
-      "civicrm/composer-downloads-plugin": true,
       "cweagans/composer-patches": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
@@ -80,13 +79,6 @@
   },
   "extra": {
     "composer-exit-on-patch-failure": true,
-    "downloads": {
-      "phpstan": {
-        "path": "vendor/bin/phpstan",
-        "type": "phar",
-        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar"
-      }
-    },
     "patches": {
       "sabberworm/php-css-parser": {
         "1. Validate name-start code points for identifier <https://github.com/westonruter/PHP-CSS-Parser/pull/2>": "https://github.com/sabberworm/PHP-CSS-Parser/compare/cc791ad...westonruter:PHP-CSS-Parser:fix/malformed-identifier-without-tests.diff",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "609f396f85d60e46926a06c18aa6bd63",
+    "content-hash": "2c79d998e9d0686a4caa916f5e909039",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
@@ -735,99 +735,6 @@
                 }
             ],
             "time": "2021-08-15T20:50:18+00:00"
-        },
-        {
-            "name": "civicrm/composer-downloads-plugin",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/civicrm/composer-downloads-plugin.git",
-                "reference": "7af08ca4a78607ac2bad3215c05a10390da9c673"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/7af08ca4a78607ac2bad3215c05a10390da9c673",
-                "reference": "7af08ca4a78607ac2bad3215c05a10390da9c673",
-                "shasum": ""
-            },
-            "require": {
-                "civicrm/gitignore": "~1.2.0",
-                "composer-plugin-api": "^2.0",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "composer/composer": "~2.0",
-                "friendsofphp/php-cs-fixer": "^2.3",
-                "phpunit/phpunit": "^8.5 || ^9.5",
-                "totten/process-helper": "^1.0.1"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "LastCall\\DownloadsPlugin\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "LastCall\\DownloadsPlugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rob Bayliss",
-                    "email": "rob@lastcallmedia.com"
-                },
-                {
-                    "name": "Tim Otten",
-                    "email": "totten@civicrm.org"
-                }
-            ],
-            "description": "Composer plugin for downloading additional files within any composer package.",
-            "support": {
-                "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v4.0.0"
-            },
-            "time": "2024-04-09T20:34:36+00:00"
-        },
-        {
-            "name": "civicrm/gitignore",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/civicrm/PHPGitIgnore.git",
-                "reference": "7491782ee89c4e14bbcc9b30bebb90389054cb2e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/PHPGitIgnore/zipball/7491782ee89c4e14bbcc9b30bebb90389054cb2e",
-                "reference": "7491782ee89c4e14bbcc9b30bebb90389054cb2e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "replace": {
-                "togos/gitignore": "1.*"
-            },
-            "require-dev": {
-                "togos/simpler-test": "1.1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "TOGoS_GitIgnore_": "src/main/php/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
-            "support": {
-                "source": "https://github.com/civicrm/PHPGitIgnore/tree/1.2.0"
-            },
-            "time": "2024-04-09T07:07:33+00:00"
         },
         {
             "name": "composer/semver",
@@ -3270,6 +3177,64 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
             },
             "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "fc463b5d0fe906dcf19689be692c65c50406a071"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fc463b5d0fe906dcf19689be692c65c50406a071",
+                "reference": "fc463b5d0fe906dcf19689be692c65c50406a071",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-11T15:37:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
I tried fixing the PHPStan error due this being invalid in `phpstan.neon.dist`:

```neon
	featureToggles:
		requireFileExists: false
```

But when I removed it then I got a separate PHPStan internal fatal error: https://github.com/phpstan/phpstan/issues/12005

So I'm just pinning PHPStan at 1.x for now and installing it via Composer since we no longer need to install via `civicrm/composer-downloads-plugin`.