### PR TITLE
Fix check for empty dependencies on admin bar style loader tag filter

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1379,7 +1379,7 @@ class AMP_Theme_Support {
 	 */
 	public static function filter_admin_bar_style_loader_tag( $tag, $handle ) {
 		if (
-			is_array( wp_styles()->registered['admin-bar']->deps ) && in_array( $handle, wp_styles()->registered['admin-bar']->deps, true ) ?
+			! empty( wp_styles()->registered['admin-bar']->deps ) && is_array( wp_styles()->registered['admin-bar']->deps ) && in_array( $handle, wp_styles()->registered['admin-bar']->deps, true ) ?
 				self::is_exclusively_dependent( wp_styles(), $handle, 'admin-bar' ) :
 				self::has_dependency( wp_styles(), $handle, 'admin-bar' )
 		) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1378,8 +1378,12 @@ class AMP_Theme_Support {
 	 * @return string Tag.
 	 */
 	public static function filter_admin_bar_style_loader_tag( $tag, $handle ) {
+		// Get Admin bar styles.
+		$admin_bar_dep = wp_styles()->query( 'admin-bar' );
+
+		// Check if the handle is a dependency of the admin-bar. If so, add the data-ampdevmode attribute.
 		if (
-			! empty( wp_styles()->registered['admin-bar']->deps ) && is_array( wp_styles()->registered['admin-bar']->deps ) && in_array( $handle, wp_styles()->registered['admin-bar']->deps, true ) ?
+			$admin_bar_dep && in_array( $handle, $admin_bar_dep->deps, true ) ?
 				self::is_exclusively_dependent( wp_styles(), $handle, 'admin-bar' ) :
 				self::has_dependency( wp_styles(), $handle, 'admin-bar' )
 		) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1402,9 +1402,15 @@ class AMP_Theme_Support {
 	 * @return string Tag.
 	 */
 	public static function filter_customize_preview_style_loader_tag( $tag, $handle ) {
+		// Handle for customize-preview.
 		$customize_preview = 'customize-preview';
+
+		// Registered styles for customize-preview.
+		$customize_preview_dep = wp_styles()->query( $customize_preview );
+
+		// Check if the handle is a dependency of the customize-preview. If so, add the data-ampdevmode attribute.
 		if (
-			is_array( wp_styles()->registered[ $customize_preview ]->deps ) && in_array( $handle, wp_styles()->registered[ $customize_preview ]->deps, true )
+			in_array( $handle, $customize_preview_dep->deps, true )
 				? self::is_exclusively_dependent( wp_styles(), $handle, $customize_preview )
 				: self::has_dependency( wp_styles(), $handle, $customize_preview )
 		) {
@@ -1424,8 +1430,12 @@ class AMP_Theme_Support {
 	 * @return string Tag.
 	 */
 	public static function filter_admin_bar_script_loader_tag( $tag, $handle ) {
+		// Get Admin bar scripts.
+		$admin_bar_dep = wp_scripts()->query( 'admin-bar' );
+
+		// Check if the handle is a dependency of the admin-bar. If so, add the data-ampdevmode attribute.
 		if (
-			is_array( wp_scripts()->registered['admin-bar']->deps ) && in_array( $handle, wp_scripts()->registered['admin-bar']->deps, true ) ?
+			in_array( $handle, $admin_bar_dep->deps, true ) ?
 				self::is_exclusively_dependent( wp_scripts(), $handle, 'admin-bar' ) :
 				self::has_dependency( wp_scripts(), $handle, 'admin-bar' )
 		) {

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1285,13 +1285,13 @@ class Test_AMP_Theme_Support extends TestCase {
 	}
 
 	/**
-	 * Test filter_admin_bar_script_loader_tag when ->deps is not an array.
+	 * Test filter_admin_bar_script_loader_tag when ->deps is an empty array.
 	 *
 	 * @covers \AMP_Theme_Support::filter_admin_bar_script_loader_tag()
 	 */
-	public function test_filter_admin_bar_script_loader_tag_non_array() {
+	public function test_filter_admin_bar_script_loader_tag_empty_array() {
 		wp_enqueue_script( 'admin-bar' );
-		$GLOBALS['wp_scripts']->registered['admin-bar']->deps = null;
+		$GLOBALS['wp_scripts']->registered['admin-bar']->deps = [];
 		$tag = '<script src="https://example.com/wp-includes/js/admin-bar.js?ver=5.3.2"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_script_loader_tag( $tag, 'example' ) );
 	}

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1205,13 +1205,13 @@ class Test_AMP_Theme_Support extends TestCase {
 	}
 
 	/**
-	 * Test filter_admin_bar_style_loader_tag when ->deps is not an array.
+	 * Test filter_admin_bar_style_loader_tag when ->deps is an empty array.
 	 *
 	 * @covers \AMP_Theme_Support::filter_admin_bar_style_loader_tag()
 	 */
-	public function test_filter_admin_bar_style_loader_tag_non_array() {
+	public function test_filter_admin_bar_style_loader_tag_empty_array() {
 		wp_enqueue_style( 'admin-bar' );
-		$GLOBALS['wp_styles']->registered['admin-bar']->deps = null;
+		$GLOBALS['wp_styles']->registered['admin-bar']->deps = [];
 		$tag = '<link rel="stylesheet" id="dashicons-css" href="https://example.com/wp-includes/css/dashicons.css?ver=5.3.2" media="all" />'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_style_loader_tag( $tag, 'baz' ) );
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->
Fixes #7766 

- Added check for empty since `deps` is a non-nullable property of WP_Styles.

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
