### PR TITLE
Bump minimum WordPress version to 6.6

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -408,6 +408,9 @@ jobs:
         # The JSON file is provided by the `shivammathur/setup-php` action. See https://github.com/shivammathur/setup-php#problem-matchers.
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Install SVN
+        run: sudo apt-get install subversion
+
       - name: Install WP tests
         if: needs.pre-run.outputs.changed-php-count > 0
         run: bash bin/ci/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -335,11 +335,11 @@ jobs:
             external-http: true
 
           - php: '7.4'
-            wp: '6.5'
+            wp: '6.6'
             phpunit: '7'
 
           - php: '7.4'
-            wp: '6.5'
+            wp: '6.6'
             phpunit: '7'
             external-http: true
     steps:
@@ -518,7 +518,7 @@ jobs:
             wp: 'latest'
 
           - php: '7.4'
-            wp: '6.5'
+            wp: '6.6'
     steps:
       - name: Shutdown default MySQL service
         if: needs.pre-run.outputs.changed-php-count > 0

--- a/amp.php
+++ b/amp.php
@@ -8,7 +8,7 @@
  * Version: 2.5.6-alpha
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP: 7.4
  * Text Domain: amp
  *

--- a/src/DependencySupport.php
+++ b/src/DependencySupport.php
@@ -30,7 +30,7 @@ class DependencySupport implements Service {
 	 *
 	 * @var string
 	 */
-	const WP_MIN_VERSION = '6.5';
+	const WP_MIN_VERSION = '6.6';
 
 	/**
 	 * Determines whether core or Gutenberg provides minimal support.

--- a/tests/php/src/Admin/AmpPluginsTest.php
+++ b/tests/php/src/Admin/AmpPluginsTest.php
@@ -161,7 +161,7 @@ class AmpPluginsTest extends TestCase {
 		$this->assertFalse( AmpPlugins::is_needed() );
 
 		// Test 3: Admin request in supported WordPress .
-		$wp_version = '6.5';
+		$wp_version = '6.6';
 		set_current_screen( 'index.php' );
 		$this->assertTrue( AmpPlugins::is_needed() );
 

--- a/tests/php/src/Admin/AmpThemesTest.php
+++ b/tests/php/src/Admin/AmpThemesTest.php
@@ -83,7 +83,7 @@ class AmpThemesTest extends TestCase {
 		$this->assertFalse( AmpThemes::is_needed() );
 
 		// Test 3: Admin request.
-		$wp_version = '6.5';
+		$wp_version = '6.6';
 		set_current_screen( 'index.php' );
 		$this->assertTrue( is_admin() );
 		$this->assertTrue( AmpThemes::is_needed() );

--- a/tests/php/src/PluginRegistryTest.php
+++ b/tests/php/src/PluginRegistryTest.php
@@ -87,12 +87,8 @@ final class PluginRegistryTest extends TestCase {
 			'Title',
 			'AuthorName',
 			'UpdateURI',
+			'RequiresPlugins',
 		];
-
-		// Add `RequiresPlugins` for WP 6.5+.
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.5', '>=' ) ) {
-			$expected_keys[] = 'RequiresPlugins';
-		}
 
 		$plugins = $this->call_private_method( $plugin_registry, 'get_mu_plugins_data' );
 		$this->assertIsArray( $plugins );

--- a/tests/php/test-amp-soundcloud-embed-handler.php
+++ b/tests/php/test-amp-soundcloud-embed-handler.php
@@ -31,7 +31,7 @@ class AMP_SoundCloud_Embed_Handler_Test extends TestCase {
 	 *
 	 * @var string
 	 */
-	protected $playlist_url = 'https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection';
+	protected $playlist_url = 'https://soundcloud.com/hasnaa-tabra/sets/classical-music';
 
 	/**
 	 * Response for track oEmbed request.
@@ -47,7 +47,7 @@ class AMP_SoundCloud_Embed_Handler_Test extends TestCase {
 	 * @see AMP_SoundCloud_Embed_Test::$playlist_url
 	 * @var string
 	 */
-	protected $playlist_oembed_response = '{"version":1.0,"type":"rich","provider_name":"SoundCloud","provider_url":"http://soundcloud.com","height":450,"width":500,"title":"Classical Music - The Essential Collection by Classical Music","description":"Classical Music - The Essential Collection features 50 of the finest Classical Masterpieces ever written. Definitely not to working to! ","thumbnail_url":"http://i1.sndcdn.com/artworks-000083473866-mno23j-t500x500.jpg","html":"\u003Ciframe width=\"500\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true\u0026url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F40936190\u0026show_artwork=true\u0026maxwidth=500\u0026maxheight=750\u0026dnt=1\"\u003E\u003C/iframe\u003E","author_name":"Classical Music","author_url":"https://soundcloud.com/classical-music-playlist"}';
+	protected $playlist_oembed_response = '{"version":1.0,"type":"rich","provider_name":"SoundCloud","provider_url":"https://soundcloud.com","height":450,"width":"500","title":"Classical Music by Hasnaa Tabra","description":"","thumbnail_url":"https://i1.sndcdn.com/artworks-000092720295-kjpq3h-t500x500.jpg","html":"<iframe width=\"500\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F53337986&show_artwork=true\"></iframe>","author_name":"Hasnaa Tabra","author_url":"https://soundcloud.com/hasnaa-tabra"}';
 
 	/**
 	 * Set up.
@@ -121,7 +121,7 @@ class AMP_SoundCloud_Embed_Handler_Test extends TestCase {
 
 			'playlist_simple' => [
 				$this->playlist_url . PHP_EOL,
-				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
+				'<p><amp-soundcloud data-playlistid="53337986" data-visual="true" height="450" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/hasnaa-tabra/sets/classical-music">Classical Music by Hasnaa Tabra</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
 			],
 		];
 	}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -3517,12 +3517,7 @@ class AMP_Style_Sanitizer_Test extends TestCase {
 					$this->assertInstanceOf( 'DOMElement', $original_dom->getElementById( 'admin-bar-css' ), 'Expected admin bar CSS to be present originally.' );
 					$this->assertStringContainsString( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
 					$this->assertStringContainsString( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
-
-					if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '18.7', '>=' ) ) {
-						$this->assertStringContainsString( '.wp-block-audio :where(figcaption)', $amphtml_source, 'Expected block-library/style.css' );
-					} else {
-						$this->assertStringContainsString( '.wp-block-audio figcaption', $amphtml_source, 'Expected block-library/style.css' );
-					}
+					$this->assertStringContainsString( '.wp-block-audio :where(figcaption)', $amphtml_source, 'Expected block-library/style.css' );
 
 					$this->assertStringContainsString(
 						'[class^="wp-block-"]:not(.wp-block-gallery) figcaption',

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1838,137 +1838,79 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 		$filtered_content = apply_filters( 'the_content', 'before[test]after' );
 
-		if ( has_filter( 'the_content', 'do_blocks' ) ) {
-			$sources = [
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'WP_Embed::run_shortcode',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'WP_Embed::autoembed',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_blocks',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wptexturize',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wpautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'shortcode_unautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'prepend_attachment',
-				],
-			];
-		} else {
-			$sources = [
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'WP_Embed::run_shortcode',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'WP_Embed::autoembed',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wptexturize',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wpautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'shortcode_unautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'prepend_attachment',
-				],
-			];
-		}
-
-		// This will be called after `do_shortcode` in WP 6.4 and later.
-		// @see <https://core.trac.wordpress.org/ticket/58853>.
-		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.4', '<' ) ) {
-			$sources[] = [
+		$sources = [
+			[
 				'type'     => 'core',
 				'name'     => 'wp-includes',
-				'function' => 'wp_filter_content_tags',
-			];
-		}
-
-		if ( function_exists( 'wp_replace_insecure_home_url' ) ) {
-			$sources[] = [
+				'function' => 'WP_Embed::run_shortcode',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'WP_Embed::autoembed',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'do_blocks',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wptexturize',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wpautop',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'shortcode_unautop',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'prepend_attachment',
+			],
+			[
 				'type'     => 'core',
 				'name'     => 'wp-includes',
 				'function' => 'wp_replace_insecure_home_url',
-			];
-		}
-
-		if ( function_exists( 'gutenberg_trim_footnotes' ) ) {
-			$sources[] = [
-				'type'     => 'plugin',
-				'name'     => 'gutenberg',
-				'function' => 'gutenberg_trim_footnotes',
-			];
-		}
-
-		$sources = array_merge(
-			$sources,
+			],
 			[
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'capital_P_dangit',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_shortcode',
-				],
-			]
-		);
-
-		// `wp_filter_content_tags` is called after `do_shortcode` in WP 6.4 and later.
-		// @see <https://core.trac.wordpress.org/ticket/58853>.
-		if ( version_compare( get_bloginfo( 'version' ), '6.4-alpha', '>=' ) ) {
-			$sources[] = [
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'capital_P_dangit',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'do_shortcode',
+			],
+			[
 				'type'     => 'core',
 				'name'     => 'wp-includes',
 				'function' => 'wp_filter_content_tags',
-			];
-		}
-
-		// `wp_filter_content_tags` is called before `convert_smilies` in WP 6.4 and later.
-		$sources[] = [
-			'type'     => 'core',
-			'name'     => 'wp-includes',
-			'function' => 'convert_smilies',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'convert_smilies',
+			],
 		];
+
+		if ( function_exists( 'apply_block_hooks_to_content' ) ) {
+			array_unshift(
+				$sources,
+				[
+					'type'     => 'core',
+					'name'     => 'wp-includes',
+					'function' => 'apply_block_hooks_to_content',
+				]
+			);
+		}
 
 		foreach ( $sources as &$source ) {
 			$function = $source['function'];

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1901,7 +1901,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			],
 		];
 
-		if ( function_exists( 'apply_block_hooks_to_content' ) ) {
+		if ( function_exists( 'apply_block_hooks_to_content' ) && has_filter( 'the_content', 'apply_block_hooks_to_content' ) ) {
 			array_unshift(
 				$sources,
 				[


### PR DESCRIPTION
Gutenberg now requires WP 6.6, so updating the AMP plugin to require the same means we'll be able to avoiding workarounds for WP 6.5 sites that don't have Gutenberg installed.