### PR TITLE
Ensure AMP is available when moderate/loose sandboxing is enabled and there are stored validation errors

### DIFF
--- a/.github/actions/plugin-build/action.yml
+++ b/.github/actions/plugin-build/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache assets directory
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+      uses: actions/cache@v4
       id: assets-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'

--- a/.github/actions/setup-node-npm/action.yml
+++ b/.github/actions/setup-node-npm/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Configure Node.js cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+      uses: actions/cache@v4
       id: node-npm-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
@@ -16,7 +16,7 @@ runs:
 
     # Since it gets downloaded with npm install, we need to cache it instantly.
     - name: Setup puppeteer cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/puppeteer
         key: ${{ runner.os }}-puppeteer

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -32,7 +32,7 @@ runs:
         tools: ${{ inputs.tools }}
 
     - name: Setup composer cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+      uses: actions/cache@v4
       id: php-composer-cache
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -173,7 +173,7 @@ jobs:
         uses: ./.github/actions/setup-node-npm
 
       - name: Setup Jest cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
+        uses: actions/cache@v4
         with:
           path: ~/.jest-cache
           key: ${{ runner.os }}-jest
@@ -221,7 +221,7 @@ jobs:
         uses: ./.github/actions/plugin-build
 
       - name: Setup Jest cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
+        uses: actions/cache@v4
         with:
           path: ~/.jest-cache
           key: ${{ runner.os }}-jest-e2e-${{ matrix.part }}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -534,8 +534,9 @@ function amp_is_available() {
 
 		// If not in an AMP-first mode, check if there are any validation errors with kept invalid markup for this URL.
 		// And if so, and if the user cannot do validation (since they can always get fresh validation results), then
-		// AMP is not available.
-		if ( ! amp_is_canonical() && ! AMP_Validation_Manager::has_cap() ) {
+		// AMP is not available. This only applies if Sandboxing is disabled or the Strict sandboxing mode is on,
+		// since in Loose or Moderate sandboxing modes, invalid AMP markup can still be served.
+		if ( ! amp_is_canonical() && ! AMP_Validation_Manager::has_cap() && in_array( amp_get_sandboxing_level(), [ 0, 3 ], true ) ) {
 			$validation_errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors(
 				amp_get_current_url(),
 				[ 'ignore_accepted' => true ]

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -931,6 +931,13 @@ class Test_AMP_Helper_Functions extends DependencyInjectedTestCase {
 			add_filter( 'amp_validation_error_sanitized', '__return_true' );
 			$this->assertTrue( amp_is_available() );
 			$assert_amphtml_link_present();
+			remove_filter( 'amp_validation_error_sanitized', '__return_true' );
+			$this->assertFalse( amp_is_available() );
+
+			// Also allow the URL when in a loose sandboxing.
+			AMP_Options_Manager::update_option( Option::SANDBOXING_ENABLED, true );
+			AMP_Options_Manager::update_option( Option::SANDBOXING_LEVEL, 1 );
+			$this->assertTrue( amp_is_available() );
 		}
 	}
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1849,83 +1849,57 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 				'name'     => 'wp-includes',
 				'function' => 'WP_Embed::autoembed',
 			],
-		];
-
-		if ( function_exists( 'gutenberg_apply_block_hooks_to_post_content' ) && has_filter( 'the_content', 'gutenberg_apply_block_hooks_to_post_content' ) ) {
-			$sources[] = [
-				'type'     => 'plugin',
-				'name'     => 'gutenberg',
-				'file'     => 'lib/compat/wordpress-6.8/blocks.php',
-				'function' => 'gutenberg_apply_block_hooks_to_post_content',
-			];
-		}
-
-		$sources = array_merge(
-			$sources,
 			[
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_blocks',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wptexturize',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wpautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'shortcode_unautop',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'prepend_attachment',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wp_replace_insecure_home_url',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'capital_P_dangit',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'do_shortcode',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'wp_filter_content_tags',
-				],
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'convert_smilies',
-				],
-			]
-		);
-
-		if ( function_exists( 'apply_block_hooks_to_content' ) && has_filter( 'the_content', 'apply_block_hooks_to_content' ) ) {
-			array_unshift(
-				$sources,
-				[
-					'type'     => 'core',
-					'name'     => 'wp-includes',
-					'function' => 'apply_block_hooks_to_content',
-				]
-			);
-		}
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'do_blocks',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wptexturize',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wpautop',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'shortcode_unautop',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'prepend_attachment',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wp_replace_insecure_home_url',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'capital_P_dangit',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'do_shortcode',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'wp_filter_content_tags',
+			],
+			[
+				'type'     => 'core',
+				'name'     => 'wp-includes',
+				'function' => 'convert_smilies',
+			],
+		];
 
 		foreach ( $sources as &$source ) {
 			$function = $source['function'];
@@ -1948,35 +1922,34 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 			$source['function'] = $function;
 		}
 
-		$source_json = wp_json_encode(
-			[
-				'hook'      => 'the_content',
-				'filter'    => true,
-				'post_id'   => get_the_ID(),
-				'post_type' => get_post_type(),
-				'sources'   => $sources,
-			]
-		);
-
 		$shortcode_fallback_reflection = new ReflectionFunction( $shortcode_fallback );
 
-		$expected_content = implode(
-			'',
-			[
-				"<!--amp-source-stack $source_json-->",
-				sprintf(
-					'<p>before<!--amp-source-stack {"type":"plugin","name":"amp","file":%1$s,"line":%2$s,"function":"{closure}","shortcode":"test"}--><b>test</b><!--/amp-source-stack {"type":"plugin","name":"amp","file":%1$s,"line":%2$s,"function":"{closure}","shortcode":"test"}-->after</p>' . "\n",
-					wp_json_encode( substr( $shortcode_fallback_reflection->getFileName(), strlen( AMP__DIR__ ) + 1 ) ),
-					$shortcode_fallback_reflection->getStartLine()
-				),
-				"<!--/amp-source-stack $source_json-->",
-			]
-		);
+		$this->assertTrue( (bool) preg_match( '/^<!--amp-source-stack (\{.+?})-->/', $filtered_content, $matches ) );
+		$json = $matches[1];
+		$source_stack = json_decode( $json, true );
+		$this->assertIsArray( $source_stack );
+		$this->assertStringEndsWith( "<!--/amp-source-stack $json-->", $filtered_content );
 
-		$this->assertEquals(
-			preg_split( '/(?=<)/', $expected_content ),
-			preg_split( '/(?=<)/', $filtered_content )
-		);
+		$expected_props = [
+			'hook'      => 'the_content',
+			'filter'    => true,
+			'post_id'   => get_the_ID(),
+			'post_type' => get_post_type(),
+		];
+		foreach ( $expected_props as $key => $value ) {
+			$this->assertEquals( $value, $source_stack[ $key ] );
+		}
+
+		foreach ( $sources as $expected_source ) {
+			$found = false;
+			foreach ( $source_stack['sources'] as $actual_source ) {
+				if ( count( array_diff( $expected_source, $actual_source ) ) === 0 ) {
+					$found = true;
+					break;
+				}
+			}
+			$this->assertTrue( $found, 'Unable to lcoate source: ' . wp_json_encode( $source ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
On my site I have the Loose sandboxing mode enabled:

![image](https://github.com/user-attachments/assets/0e28e63e-e9d3-4ccc-8d8f-a461b6b4d6e4)

I tried enabling Transitional mode, and I was confused why accessing a page was redirecting to the non-AMP version when I was not logged-in, but I was able to access the page while logged in. The URL in question had been validated and there were validation errors captured for it:

![image](https://github.com/user-attachments/assets/9cc5106e-4382-4a24-8744-a400965b2459)

It appears the problem is that the sandboxing level wasn't taken into account in the `amp_is_available()` function. When there are validation errors associated with a URL, normally it will redirect to the non-AMP version. But when Sandboxing is enabled and either the Loose or Moderate levels are used, this should not be happening.

This also fixes `test_decorate_shortcode_and_filter_source` to make it less brittle.