### PR TITLE
Fix test_add_block_source_comments after Gutenberg 20.5

### DIFF
--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1429,6 +1429,7 @@ class Test_AMP_Validation_Manager extends DependencyInjectedTestCase {
 
 		// Remove unique layout ID.
 		$rendered_block = preg_replace( '/\s*(?<= class=")?has-\d+-columns-columns-layout-\d+\s*/', ' has-2-columns', $rendered_block );
+		$rendered_block = preg_replace( '/\s*(?<= class=")?has-\d+-columns-columns-is-layout-[0-9a-f]+\s*/', ' has-2-columns', $rendered_block );
 
 		// Remove layout class name and ID.
 		$rendered_block = str_replace(


### PR DESCRIPTION
This is a follow-up to https://github.com/ampproject/amp-wp/pull/7997.

This addresses a change introduced in Gutenberg 20.5: https://github.com/WordPress/gutenberg/pull/68210.